### PR TITLE
Audit Discord Control Tower UX

### DIFF
--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -58,6 +58,29 @@ It asks for:
 - release approval;
 - production approval.
 
+## Project Intake UX Contract
+
+The owner can start from `#falar-com-gerente`, but a project must not live as a
+loose chat transcript.
+
+The bridge must separate two cases:
+
+```text
+short operational question -> answer in the same chat
+paper, long brief, new product or pilot -> create project thread and forum card
+```
+
+For a project intake, the Discord layer should create:
+
+- a project conversation thread tied to the intake message or intake channel;
+- a `kanban-da-fabrica` forum post with the initial phase tag;
+- a short pointer message in `#falar-com-gerente`;
+- a runtime mapping record once Hermes creates or updates the durable card.
+
+Hermes native Discord free-response channels are useful for low-friction chat,
+but they are not enough for factory intake. They can answer inline. The factory
+needs the Concierge bridge to create the project surface deliberately.
+
 ## What This Layer Must Not Do
 
 It must not:
@@ -98,6 +121,8 @@ maps structured owner responses back to durable runtime events.
 It must be idempotent.
 
 Retrying an event must not duplicate approvals, blockers or worker tasks.
+Retrying a project-intake event must not create duplicate project threads or
+duplicate forum cards.
 
 The bridge has no authority to mark factory work `ready`, `done`, released, or
 approved by itself. It can only request that the runtime records a structured

--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -169,8 +169,6 @@ O repo publico nao pode conter:
 
 | Canal | Para que serve | Quem fala ali |
 | --- | --- | --- |
-| Canal | Para que serve | Quem fala ali |
-| --- | --- | --- |
 | `#torre-de-controle` | status resumido, fase atual, previsao e proximos passos | Concierge |
 | `#falar-com-gerente` | conversa direta com o GERENTE | dono e Concierge |
 | `#novos-projetos` | entrada de novos projetos, papers e pedidos | dono e Concierge |
@@ -187,6 +185,20 @@ O canal `#falar-com-gerente` pode ser configurado como canal livre: o dono fala
 com o GERENTE sem precisar mencionar o bot. Os outros canais devem ser mais
 controlados para evitar barulho e aprovacao acidental.
 
+Essa decisao tem um detalhe importante: no Hermes nativo, canal livre responde
+inline e pode pular auto-thread. Por isso, `#falar-com-gerente` nao pode ser o
+unico mecanismo de organizacao de projetos. A experiencia certa e:
+
+```text
+mensagem curta -> resposta curta no chat
+paper/projeto/piloto -> topico do projeto + cartao no forum
+```
+
+Se `DISCORD_NO_THREAD_CHANNELS` incluir `#falar-com-gerente`, isso deve ser
+tratado como configuracao apenas para conversa curta. A fabrica ainda precisa
+do `Factory Concierge Discord Bridge` para criar topicos de projeto e cartoes
+no `kanban-da-fabrica`.
+
 ## Camada dinamica
 
 O Discord nao deve ser apenas um chat. O modelo recomendado e:
@@ -194,6 +206,7 @@ O Discord nao deve ser apenas um chat. O modelo recomendado e:
 - `#torre-de-controle` com uma mensagem fixada e atualizada em vez de spam;
 - botoes de atalho para os canais principais;
 - forum com um topico por projeto;
+- intake thread-first: paper ou briefing nunca fica apenas como mensagem solta;
 - tags de fase no forum;
 - `#aprovacoes-formais` para decisoes formais;
 - `#acessos-pendentes` como checklist do que falta para autonomia;

--- a/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
+++ b/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
@@ -130,6 +130,20 @@ O dono usa principalmente um unico canal:
 #falar-com-gerente
 ```
 
+Mas esse canal nao pode virar um corredor infinito de mensagens. A regra de UX
+da fabrica e:
+
+```text
+duvida curta -> o GERENTE responde no proprio chat
+paper, briefing ou projeto novo -> abre topico do projeto e cartao no Kanban visual
+```
+
+Isso e importante porque o Hermes nativo trata `free_response_channels` como
+chat leve: o usuario nao precisa mencionar o bot, mas a resposta tende a ficar
+inline. A fabrica nao deve depender apenas desse comportamento nativo para
+intake de projeto. O `Factory Concierge Discord Bridge` precisa reconhecer
+pedido grande, criar o topico certo e apontar o dono para la.
+
 Exemplos de pedidos naturais:
 
 ```text
@@ -186,6 +200,26 @@ Projeto A    Projeto B         Projeto C       Projeto D      Projeto E    Proje
 
 Essa mensagem deve ser atualizada pela ponte. Se o Hermes mudar, o Discord
 muda. Se o Discord estiver desatualizado, o Hermes continua valendo.
+
+## Regra thread-first para projeto
+
+Todo paper, briefing longo, novo produto ou pedido de piloto precisa gerar:
+
+1. um topico de conversa ligado a mensagem original ou ao canal de intake;
+2. um cartao no forum `kanban-da-fabrica`;
+3. uma resposta curta no `#falar-com-gerente` dizendo onde o projeto passou a
+   morar;
+4. uma ligacao public-safe com o estado real no Hermes quando o runtime criar
+   ou atualizar a card graph.
+
+O nome do topico deve ser humano e curto, por exemplo:
+
+```text
+Piloto - Front jogo da fabrica
+```
+
+O topico nao substitui o Hermes. Ele e a sala visual do projeto para o dono.
+O forum e o quadro visual. Hermes continua sendo a fonte de verdade.
 
 ## Modelo visual recomendado
 
@@ -317,6 +351,10 @@ Cada projeto no forum deve ter:
 - proximas etapas previstas;
 - evidencias principais;
 - historico resumido.
+
+Esse topico deve nascer no intake, nao depois que o projeto ja virou um bloco
+de conversa perdido no chat. Se o dono mandar o paper em `#falar-com-gerente`,
+a ponte deve criar o topico e o cartao automaticamente.
 
 ### 3. Aprovacao com botao e formulario
 

--- a/schemas/discord-control-tower-ux-audit.schema.json
+++ b/schemas/discord-control-tower-ux-audit.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/discord-control-tower-ux-audit.schema.json",
+  "title": "Overkill Factory Discord Control Tower UX Audit",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "result",
+    "scope",
+    "observed_model",
+    "checks",
+    "findings",
+    "live_corrections",
+    "next_required_actions",
+    "evidence_refs"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/discord-control-tower-ux-audit.schema.json"
+    },
+    "record_type": {
+      "const": "discord_control_tower_ux_audit"
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "result": {
+      "enum": ["PASS", "ATTENTION", "BLOCKED"]
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 3
+    },
+    "observed_model": {
+      "type": "object",
+      "required": [
+        "runtime",
+        "owner_language",
+        "source_of_truth",
+        "discord_role"
+      ],
+      "properties": {
+        "runtime": { "type": "string", "minLength": 3 },
+        "owner_language": { "type": "string", "minLength": 2 },
+        "source_of_truth": { "type": "string", "minLength": 3 },
+        "discord_role": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "checks": {
+      "type": "object",
+      "required": [
+        "portuguese_first_structure",
+        "gerente_channel_exists",
+        "kanban_forum_exists",
+        "kanban_forum_has_phase_tags",
+        "pilot_project_thread_created",
+        "pilot_forum_card_created",
+        "free_response_threading_conflict_documented",
+        "thread_first_project_intake_automated"
+      ],
+      "properties": {
+        "portuguese_first_structure": { "type": "boolean" },
+        "gerente_channel_exists": { "type": "boolean" },
+        "kanban_forum_exists": { "type": "boolean" },
+        "kanban_forum_has_phase_tags": { "type": "boolean" },
+        "pilot_project_thread_created": { "type": "boolean" },
+        "pilot_forum_card_created": { "type": "boolean" },
+        "free_response_threading_conflict_documented": { "type": "boolean" },
+        "thread_first_project_intake_automated": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["severity", "finding", "impact", "required_fix"],
+        "properties": {
+          "severity": { "enum": ["P0", "P1", "P2", "P3"] },
+          "finding": { "type": "string", "minLength": 3 },
+          "impact": { "type": "string", "minLength": 3 },
+          "required_fix": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "live_corrections": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "next_required_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/templates/discord-control-tower-ux-audit.json
+++ b/templates/discord-control-tower-ux-audit.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/discord-control-tower-ux-audit.schema.json",
+  "record_type": "discord_control_tower_ux_audit",
+  "created_at": "2026-06-11T00:00:00Z",
+  "result": "ATTENTION",
+  "scope": "Public-safe UX audit of a Discord Control Tower setup.",
+  "observed_model": {
+    "runtime": "Hermes",
+    "owner_language": "pt-BR",
+    "source_of_truth": "Hermes/Kanban",
+    "discord_role": "owner cockpit and project conversation surface"
+  },
+  "checks": {
+    "portuguese_first_structure": false,
+    "gerente_channel_exists": false,
+    "kanban_forum_exists": false,
+    "kanban_forum_has_phase_tags": false,
+    "pilot_project_thread_created": false,
+    "pilot_forum_card_created": false,
+    "free_response_threading_conflict_documented": false,
+    "thread_first_project_intake_automated": false
+  },
+  "findings": [
+    {
+      "severity": "P1",
+      "finding": "todo",
+      "impact": "todo",
+      "required_fix": "todo"
+    }
+  ],
+  "live_corrections": [],
+  "next_required_actions": [
+    "todo"
+  ],
+  "evidence_refs": [
+    "external:private-discord-audit"
+  ]
+}

--- a/tests/test_discord_control_tower_ux_audit.py
+++ b/tests/test_discord_control_tower_ux_audit.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_PATH = ROOT / "validation" / "control-tower" / "discord-control-tower-ux-audit-2026-06-11.json"
+
+
+def read_text(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+class DiscordControlTowerUxAuditTest(unittest.TestCase):
+    def test_project_intake_is_thread_first_in_docs(self) -> None:
+        dynamic_study = read_text("docs/control-tower/discord-dynamic-control-tower-study-pt-br.md")
+        setup_guide = read_text("docs/control-tower/discord-control-tower-setup-pt-br.md")
+        os_doc = read_text("docs/control-tower/discord-control-tower-os.md")
+        combined = "\n".join([dynamic_study, setup_guide, os_doc])
+
+        self.assertIn("paper, briefing ou projeto novo -> abre topico do projeto", dynamic_study)
+        self.assertIn("paper/projeto/piloto -> topico do projeto + cartao no forum", setup_guide)
+        self.assertIn("paper, long brief, new product or pilot -> create project thread and forum card", os_doc)
+        self.assertIn("free_response_channels", combined)
+        self.assertIn("Factory Concierge Discord Bridge", combined)
+
+    def test_ux_audit_records_live_fix_but_keeps_automation_attention(self) -> None:
+        audit = json.loads(AUDIT_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(audit["record_type"], "discord_control_tower_ux_audit")
+        self.assertEqual(audit["result"], "ATTENTION")
+        self.assertTrue(audit["checks"]["pilot_project_thread_created"])
+        self.assertTrue(audit["checks"]["pilot_forum_card_created"])
+        self.assertFalse(audit["checks"]["thread_first_project_intake_automated"])
+        self.assertIn("created a project conversation thread", "\n".join(audit["live_corrections"]))
+
+        findings = "\n".join(item["finding"] for item in audit["findings"])
+        self.assertIn("loose messages", findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/discord-control-tower-ux-audit.schema.json",
+  "record_type": "discord_control_tower_ux_audit",
+  "created_at": "2026-06-11T06:35:00Z",
+  "result": "ATTENTION",
+  "scope": "Public-safe UX audit of the live Discord Control Tower during the first pilot intake.",
+  "observed_model": {
+    "runtime": "Hermes",
+    "owner_language": "pt-BR",
+    "source_of_truth": "Hermes/Kanban",
+    "discord_role": "owner cockpit and project conversation surface"
+  },
+  "checks": {
+    "portuguese_first_structure": true,
+    "gerente_channel_exists": true,
+    "kanban_forum_exists": true,
+    "kanban_forum_has_phase_tags": true,
+    "pilot_project_thread_created": true,
+    "pilot_forum_card_created": true,
+    "free_response_threading_conflict_documented": true,
+    "thread_first_project_intake_automated": false
+  },
+  "findings": [
+    {
+      "severity": "P1",
+      "finding": "Project intake in the owner chat was able to remain as loose messages instead of becoming a project surface immediately.",
+      "impact": "The owner can lose the project context in a linear chat, and the visual Kanban no longer reflects the real pilot start.",
+      "required_fix": "Implement thread-first intake in the Factory Concierge Discord Bridge: paper, long brief, new product or pilot creates a project thread and a forum card."
+    },
+    {
+      "severity": "P1",
+      "finding": "The GERENTE channel is configured as a free-response channel, and Hermes native free-response behavior can answer inline instead of creating threads.",
+      "impact": "Relying only on native Hermes auto-thread is not enough for project intake.",
+      "required_fix": "Keep the low-friction owner chat, but make project/thread/card creation an explicit factory bridge responsibility."
+    },
+    {
+      "severity": "P2",
+      "finding": "The current Discord structure is usable, but the owner still has to infer the difference between chat, project topic, approval channel and Kanban forum.",
+      "impact": "The cockpit can feel like multiple chats instead of one guided control surface.",
+      "required_fix": "Add one pinned Portuguese onboarding message that explains the cockpit after the thread-first project flow is automated."
+    }
+  ],
+  "live_corrections": [
+    "created a project conversation thread for the active pilot",
+    "created a visual forum card for the active pilot with the Entrada tag",
+    "posted a short pointer in the owner chat so the pilot no longer lives only as loose chat"
+  ],
+  "next_required_actions": [
+    "build or configure the Factory Concierge Discord Bridge to create project threads and forum cards automatically",
+    "make project-intake creation idempotent so retries do not duplicate threads or cards",
+    "add a private bridge health receipt proving the real Discord mapping, project thread and forum card round-trip",
+    "only after the flow is stable, update the pinned onboarding message in Discord"
+  ],
+  "evidence_refs": [
+    "docs/control-tower/discord-control-tower-os.md",
+    "docs/control-tower/discord-control-tower-setup-pt-br.md",
+    "docs/control-tower/discord-dynamic-control-tower-study-pt-br.md",
+    "external:live-discord-project-thread-created",
+    "external:live-discord-kanban-forum-card-created"
+  ]
+}


### PR DESCRIPTION
## O que este PR ajusta

Audita a UX real do Discord Control Tower durante o inicio do piloto e transforma a falha encontrada em contrato rastreavel.

- Documenta que paper/projeto/piloto nao pode ficar como mensagem solta no `#falar-com-gerente`.
- Explica a limitacao real do Hermes: canal `free_response` responde inline e nao deve ser tratado como solucao de thread-first intake.
- Define que o `Factory Concierge Discord Bridge` deve criar topico de projeto + cartao no forum `kanban-da-fabrica`.
- Registra recibo public-safe da correcao ao vivo feita no Discord real, sem IDs crus.
- Adiciona schema, template e teste para auditorias futuras de UX do Discord.

## Validacao local

- `python -m unittest tests.test_discord_control_tower_ux_audit -q` -> OK
- `python -m unittest discover -s tests -p "test*.py" -q` -> OK
- `python scripts/validate_public_json_artifacts.py` -> OK
- `python scripts/secret_safety_scan.py` -> OK
- `python scripts/public_safety_scan.py` -> OK
- `git diff --check` -> OK

## Observacao operacional

No Discord real, ja foram criados um topico de projeto e um cartao visual no forum para o piloto ativo. A automacao completa ainda precisa ser implementada na bridge.