### PR TITLE
Add Discord bridge project projector

### DIFF
--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -155,8 +155,18 @@ as a project index, not as the full project workspace:
 - guide/help topics tagged as `Guia`, not as blocked projects;
 - retries update the existing topic instead of creating duplicates.
 
-If the bridge cannot prove idempotent project mapping, the Kanban is only a
-manual visual aid, not a production-ready multi-project cockpit.
+Without idempotent project mapping, the Kanban is only a manual visual aid, not
+a production-ready multi-project cockpit.
+
+The current public implementation for that mapping is:
+
+```text
+scripts/factory_concierge_discord_bridge.py
+```
+
+It receives a `project-projection.json`, updates the global dashboard, the
+project registry, the project forum topic and the project cockpit, then stores
+real Discord ids only in a private state file outside the public repository.
 
 The forum must stay clean. It should answer:
 
@@ -209,6 +219,11 @@ done | current | pending | blocked | skipped
 The percentage is an operator forecast, not proof by itself. It becomes
 trustworthy only when the bridge computes it from runtime state and labels stale
 or manual projections clearly.
+
+The bridge projector treats `project-projection.schema.json` as the boundary.
+If the projection says `runtime_fresh`, it can show fresh state. If the upstream
+runtime export is stale or manual, the projection must say so; the Discord layer
+must not hide that from the owner.
 
 ## View Hierarchy
 
@@ -268,6 +283,22 @@ duplicate forum cards.
 The bridge has no authority to mark factory work `ready`, `done`, released, or
 approved by itself. It can only request that the runtime records a structured
 event. The runtime and Overkill gates decide whether that event is valid.
+
+The practical project projection command is:
+
+```bash
+python scripts/factory_concierge_discord_bridge.py \
+  --projection /private/path/to/project-projection.json \
+  --state /private/path/to/discord-bridge-state.json \
+  --env /private/path/to/hermes.env \
+  --apply \
+  --out /private/path/to/bridge-health.json
+```
+
+Use `--dry-run` first when wiring a new server. The state file is private
+because it contains Discord ids. The output receipt must follow
+`schemas/operator-control-tower-bridge-health.schema.json` and the public copy
+must redact ids, paths, tokens, URLs and logs.
 
 ## Minimum Contracts
 

--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -303,6 +303,35 @@ Hermes antes de valerem.
 Especialistas nao devem ficar interrompendo o dono diretamente. Eles falam com
 o runtime; o Concierge consolida o que importa.
 
+## Bridge de projecao do projeto
+
+A ponte real para projetar um projeto no Discord e:
+
+```bash
+python scripts/factory_concierge_discord_bridge.py \
+  --projection /private/path/project-projection.json \
+  --state /private/path/discord-bridge-state.json \
+  --env /private/path/hermes.env \
+  --apply \
+  --out /private/path/bridge-health.json
+```
+
+Antes de usar `--apply`, rode `--dry-run`. A bridge deve:
+
+- achar o servidor e os canais pelo bot;
+- atualizar o dashboard global em `#torre-de-controle`;
+- atualizar o registro em `#projetos-recebidos`;
+- criar ou reutilizar um topico no `kanban-da-fabrica`;
+- atualizar o painel de esteira dentro do topico;
+- salvar IDs reais apenas no estado privado;
+- gerar recibo publico-safe sem IDs, tokens, paths privados ou logs crus.
+
+O recibo live atual esta em:
+
+```text
+validation/control-tower/discord-bridge-projector-live-2026-06-11.json
+```
+
 ## Rollback seguro
 
 Se algo der errado:

--- a/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
+++ b/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
@@ -19,20 +19,22 @@ O que esta corrigido:
 - piloto ativo com topico de conversa e card visual no forum.
 - painel global ajustado para portfolio, sem despejar detalhe de cada projeto;
 - piloto ativo com painel de esteira dentro do topico do projeto.
+- bridge de projecao criada como ferramenta real da fabrica;
+- mapping idempotente provado no Discord real: repetir a projecao atualiza as
+  mesmas superficies, sem criar duplicata;
+- dashboard, registro de projeto, topico do Kanban e cockpit do piloto agora
+  sao atualizados por `project-projection.json`.
 
 O que ainda precisa virar produto:
 
 - a ponte precisa criar topico e card automaticamente quando um paper/projeto
   chega pelo chat do GERENTE;
-- o Kanban multi-projeto precisa de mapping idempotente para cada topico/card;
-- a previsibilidade por projeto precisa ser automatizada pela bridge a partir
-  do Hermes;
 - aprovacoes precisam virar interacoes estruturadas, com registro real no
   Hermes;
-- acessos, bloqueios, provas, releases e saude precisam ser projetados do
-  Hermes para o Discord sem depender de postagem manual;
-- retries precisam ser idempotentes, sem duplicar card, thread ou pedido de
-  aprovacao.
+- acessos, bloqueios, provas, releases e saude precisam entrar no fluxo de
+  eventos vivos do Hermes para o Discord;
+- mensagens ativas do bot precisam nascer em thread, continuar em thread ou
+  apontar para a thread certa.
 
 ## Jornada revisada
 
@@ -102,21 +104,32 @@ O Discord real foi corrigido manualmente para o piloto, mas a ponte ainda
 precisa provar que cria topico e card automaticamente quando o dono manda um
 paper, briefing longo, novo produto ou piloto.
 
-### P1: Kanban multi-projeto precisa de idempotencia provada
+### Resolvido: mapping e cockpit projetado sem duplicar
 
-O forum do Discord suporta varios topicos, entao o desenho visual e adequado
-para varios projetos se o forum for usado como indice. O detalhe precisa morar
-dentro do topico/cockpit de cada projeto. Isso so fica pronto para producao
-quando a ponte usa um mapping estavel por projeto e atualiza o card existente em
-vez de duplicar topicos em retries.
+A bridge `factory_concierge_discord_bridge.py` recebe um
+`project-projection.json` e atualiza quatro superficies:
 
-### P1: previsibilidade precisa virar superficie de produto
+- dashboard global em `#torre-de-controle`;
+- registro em `#projetos-recebidos`;
+- topico do projeto no `kanban-da-fabrica`;
+- painel de esteira dentro do topico do projeto.
 
-A fabrica e previsivel por desenho, mas isso precisa aparecer visualmente. Cada
-topico de projeto precisa ter um painel de esteira com etapa atual, percentual,
-etapas restantes, bloqueios, acessos, aprovacoes, proxima acao e ultima prova.
-Hoje o painel do piloto foi criado como correcao visual, mas ainda falta a
-bridge projetar esse painel automaticamente a partir do Hermes.
+Ela grava o mapping em estado privado e tambem procura mensagens/topicos
+existentes por marcador ou titulo. Isso permite repetir a execucao sem criar
+duplicata. A prova live foi feita duas vezes no Discord real e confirmou:
+
+```text
+1 topico do piloto
+1 dashboard marcado
+1 registro marcado
+1 cockpit marcado
+```
+
+O recibo publico-safe esta em:
+
+```text
+validation/control-tower/discord-bridge-projector-live-2026-06-11.json
+```
 
 ### P1: aprovacoes ainda precisam de interacao estruturada
 

--- a/scripts/factory_concierge_discord_bridge.py
+++ b/scripts/factory_concierge_discord_bridge.py
@@ -1,0 +1,852 @@
+#!/usr/bin/env python3
+"""Project Overkill Factory project state into a Discord Control Tower.
+
+The bridge is deliberately narrow:
+
+- Hermes or another runtime remains the source of truth.
+- The input is a project-projection JSON contract.
+- Discord is updated as an owner cockpit: dashboard, project registry,
+  project forum topic and project cockpit message.
+- The private state file can contain Discord ids; public receipts never do.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import validate_public_json_artifacts as validator  # noqa: E402
+
+
+API_BASE = "https://discord.com/api/v10"
+PROJECT_MARKER_PREFIX = "of-project:"
+DASHBOARD_MARKER = "of-dashboard:factory"
+REGISTRY_MARKER_PREFIX = "of-registry:"
+COCKPIT_MARKER_PREFIX = "of-cockpit:"
+
+CHANNEL_NAMES = {
+    "dashboard": "torre-de-controle",
+    "manager": "falar-com-gerente",
+    "health": "saude-do-bot",
+    "registry": "projetos-recebidos",
+    "kanban": "kanban-da-fabrica",
+    "approvals": "aprovacoes-formais",
+    "access": "acessos-pendentes",
+    "blockers": "bloqueios-reais",
+    "evidence": "provas-e-evidencias",
+    "production": "producao-e-releases",
+}
+
+STATUS_TAGS = {
+    "intake": ["Entrada"],
+    "planning": ["Planejamento"],
+    "waiting_owner": ["Aprovacao pendente", "Acao do dono"],
+    "waiting_access": ["Acesso pendente", "Acao do dono"],
+    "ready_to_execute": ["Planejamento"],
+    "executing": ["Executando", "Fabrica trabalhando"],
+    "review": ["Revisao", "Fabrica trabalhando"],
+    "blocked": ["Bloqueado", "Acao do dono"],
+    "release_candidate": ["Revisao"],
+    "production": ["Producao"],
+    "closed": ["Producao"],
+}
+
+STAGE_ICON = {
+    "done": "[x]",
+    "current": "[>]",
+    "pending": "[ ]",
+    "blocked": "[!]",
+    "skipped": "[-]",
+}
+
+STATUS_PT = {
+    "intake": "Entrada",
+    "planning": "Planejamento",
+    "waiting_owner": "Esperando decisao",
+    "waiting_access": "Esperando acesso",
+    "ready_to_execute": "Pronto para executar",
+    "executing": "Executando",
+    "review": "Revisao",
+    "blocked": "Bloqueado",
+    "release_candidate": "Candidato a release",
+    "production": "Producao",
+    "closed": "Fechado",
+}
+
+FRESHNESS_PT = {
+    "runtime_fresh": "lido do runtime",
+    "manual_estimate": "estimativa manual",
+    "stale": "desatualizado",
+    "blocked": "sem leitura confiavel",
+}
+
+FORECAST_PT = {
+    "high": "alta",
+    "medium": "media",
+    "low": "baixa",
+    "blocked": "bloqueada",
+}
+
+
+class DiscordClient(Protocol):
+    def get_current_user(self) -> dict[str, Any]:
+        ...
+
+    def list_guilds(self) -> list[dict[str, Any]]:
+        ...
+
+    def list_channels(self, guild_id: str) -> list[dict[str, Any]]:
+        ...
+
+    def list_active_threads(self, guild_id: str) -> list[dict[str, Any]]:
+        ...
+
+    def list_messages(self, channel_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        ...
+
+    def post_message(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    def edit_message(self, channel_id: str, message_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    def create_forum_thread(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    def edit_channel(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+
+@dataclass
+class BridgeConfig:
+    apply: bool
+    guild_id: str | None
+    state_path: Path | None
+    dashboard_channel: str = CHANNEL_NAMES["dashboard"]
+    registry_channel: str = CHANNEL_NAMES["registry"]
+    kanban_forum: str = CHANNEL_NAMES["kanban"]
+    dry_run_suffix: str = "dry-run"
+
+
+@dataclass
+class DiscordSurfaces:
+    guild_id: str
+    dashboard: dict[str, Any]
+    registry: dict[str, Any]
+    kanban: dict[str, Any]
+    kanban_tags: dict[str, str]
+
+
+class DiscordApi:
+    def __init__(self, token: str, api_base: str = API_BASE, timeout: int = 20) -> None:
+        self.token = token
+        self.api_base = api_base.rstrip("/")
+        self.timeout = timeout
+
+    def _request(
+        self,
+        method: str,
+        route: str,
+        payload: dict[str, Any] | None = None,
+        retry: bool = True,
+    ) -> Any:
+        data = None
+        headers = {
+            "Authorization": f"Bot {self.token}",
+            "User-Agent": "OverkillFactoryDiscordBridge/1.0",
+        }
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self.api_base}{route}",
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                body = response.read()
+                if not body:
+                    return {}
+                return json.loads(body.decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            body_text = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and retry:
+                try:
+                    delay = float(json.loads(body_text).get("retry_after", 1.0))
+                except Exception:
+                    delay = 1.0
+                time.sleep(min(delay, 5.0))
+                return self._request(method, route, payload, retry=False)
+            raise RuntimeError(f"Discord API {method} {route} failed with HTTP {exc.code}: {body_text}") from exc
+
+    def get_current_user(self) -> dict[str, Any]:
+        return self._request("GET", "/users/@me")
+
+    def list_guilds(self) -> list[dict[str, Any]]:
+        return list(self._request("GET", "/users/@me/guilds"))
+
+    def list_channels(self, guild_id: str) -> list[dict[str, Any]]:
+        return list(self._request("GET", f"/guilds/{guild_id}/channels"))
+
+    def list_active_threads(self, guild_id: str) -> list[dict[str, Any]]:
+        response = self._request("GET", f"/guilds/{guild_id}/threads/active")
+        return list(response.get("threads", []))
+
+    def list_messages(self, channel_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        limit = max(1, min(limit, 100))
+        return list(self._request("GET", f"/channels/{channel_id}/messages?limit={limit}"))
+
+    def post_message(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", f"/channels/{channel_id}/messages", payload)
+
+    def edit_message(self, channel_id: str, message_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("PATCH", f"/channels/{channel_id}/messages/{message_id}", payload)
+
+    def create_forum_thread(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", f"/channels/{channel_id}/threads", payload)
+
+    def edit_channel(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("PATCH", f"/channels/{channel_id}", payload)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_env_file(path: Path | None) -> None:
+    if path is None or not path.exists():
+        return
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key, value)
+
+
+def normalize_name(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii").lower()
+    ascii_only = re.sub(r"[^a-z0-9]+", "-", ascii_only).strip("-")
+    return ascii_only or "project"
+
+
+def truncate(value: str, limit: int) -> str:
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 3)].rstrip() + "..."
+
+
+def non_empty_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def bullet_list(items: list[str], empty: str = "nenhum") -> str:
+    if not items:
+        return empty
+    return "\n".join(f"- {truncate(item, 120)}" for item in items[:8])
+
+
+def stage_lines(projection: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for stage in projection.get("pipeline_stages", []):
+        status = str(stage.get("status") or "pending")
+        icon = STAGE_ICON.get(status, "[ ]")
+        name = truncate(str(stage.get("name") or "Etapa"), 42)
+        summary = truncate(str(stage.get("summary") or ""), 82)
+        line = f"{icon} {name}"
+        if summary:
+            line += f" - {summary}"
+        lines.append(line)
+    return lines
+
+
+def marker(kind: str, project_id: str | None = None) -> str:
+    if kind == "dashboard":
+        return DASHBOARD_MARKER
+    if kind == "registry" and project_id:
+        return f"{REGISTRY_MARKER_PREFIX}{project_id}"
+    if kind == "cockpit" and project_id:
+        return f"{COCKPIT_MARKER_PREFIX}{project_id}"
+    if kind == "project" and project_id:
+        return f"{PROJECT_MARKER_PREFIX}{project_id}"
+    raise ValueError(f"unknown marker kind: {kind}")
+
+
+def embed_has_marker(message: dict[str, Any], expected: str) -> bool:
+    if expected in str(message.get("content") or ""):
+        return True
+    for embed in message.get("embeds") or []:
+        footer = embed.get("footer") or {}
+        if expected in str(footer.get("text") or ""):
+            return True
+        if expected in json.dumps(embed, ensure_ascii=False):
+            return True
+    return False
+
+
+def project_summary(projection: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "project_id": projection["project_id"],
+        "name": projection["name"],
+        "phase": projection["phase"],
+        "status": projection["status"],
+        "completion_percent": projection["completion_percent"],
+        "forecast_confidence": projection["forecast_confidence"],
+        "projection_freshness": projection["projection_freshness"],
+        "next_action": projection["next_action"],
+        "last_synced_at": projection["last_synced_at"],
+    }
+
+
+def load_state(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {"version": 1, "dashboard": {}, "projects": {}}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("bridge state must be a JSON object")
+    data.setdefault("version", 1)
+    data.setdefault("dashboard", {})
+    data.setdefault("projects", {})
+    return data
+
+
+def save_state(path: Path | None, state: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def public_receipt_ref(value: str | None, kind: str) -> str:
+    if value:
+        return f"external:discord-{kind}-present"
+    return f"missing:discord-{kind}"
+
+
+def validate_projection(projection: dict[str, Any]) -> None:
+    schemas = validator.load_schemas()
+    schema = schemas[validator.schema_name(str(projection.get("$schema") or ""))]
+    errors = validator.validate_node(schema, projection, "$")
+    if errors:
+        raise AssertionError("; ".join(errors))
+
+
+def resolve_guild_id(client: DiscordClient, configured_guild_id: str | None) -> str:
+    if configured_guild_id:
+        return configured_guild_id
+    guilds = client.list_guilds()
+    if len(guilds) == 1:
+        return str(guilds[0]["id"])
+    names = ", ".join(str(guild.get("name") or guild.get("id")) for guild in guilds[:8])
+    raise RuntimeError(f"set DISCORD_GUILD_ID or --guild-id; visible guilds: {names}")
+
+
+def resolve_surfaces(client: DiscordClient, config: BridgeConfig) -> DiscordSurfaces:
+    guild_id = resolve_guild_id(client, config.guild_id)
+    channels = client.list_channels(guild_id)
+    by_name = {str(channel.get("name")): channel for channel in channels}
+    missing = [
+        name
+        for name in [config.dashboard_channel, config.registry_channel, config.kanban_forum]
+        if name not in by_name
+    ]
+    if missing:
+        raise RuntimeError(f"missing Discord channels: {', '.join(missing)}")
+    kanban = by_name[config.kanban_forum]
+    tags = {
+        str(tag.get("name")): str(tag.get("id"))
+        for tag in kanban.get("available_tags", [])
+        if tag.get("name") and tag.get("id")
+    }
+    return DiscordSurfaces(
+        guild_id=guild_id,
+        dashboard=by_name[config.dashboard_channel],
+        registry=by_name[config.registry_channel],
+        kanban=kanban,
+        kanban_tags=tags,
+    )
+
+
+def select_tag_ids(projection: dict[str, Any], tags: dict[str, str]) -> list[str]:
+    wanted = STATUS_TAGS.get(str(projection.get("status")), ["Entrada"])
+    selected = [tags[name] for name in wanted if name in tags]
+    return selected[:5]
+
+
+def message_has_title(message: dict[str, Any], expected_title: str | None) -> bool:
+    if not expected_title:
+        return False
+    for embed in message.get("embeds") or []:
+        if str(embed.get("title") or "") == expected_title:
+            return True
+    return False
+
+
+def find_message(
+    client: DiscordClient,
+    channel_id: str,
+    expected_marker: str,
+    fallback_title: str | None = None,
+) -> dict[str, Any] | None:
+    fallback: dict[str, Any] | None = None
+    for message in client.list_messages(channel_id, limit=100):
+        if embed_has_marker(message, expected_marker):
+            return message
+        if fallback is None and message_has_title(message, fallback_title):
+            fallback = message
+    return fallback
+
+
+def find_thread(client: DiscordClient, guild_id: str, forum_id: str, projection: dict[str, Any]) -> dict[str, Any] | None:
+    expected_slug = normalize_name(str(projection["name"]))
+    expected_project_marker = marker("project", str(projection["project_id"]))
+    for thread in client.list_active_threads(guild_id):
+        if str(thread.get("parent_id")) != str(forum_id):
+            continue
+        if normalize_name(str(thread.get("name") or "")) == expected_slug:
+            return thread
+        if expected_project_marker in str(thread.get("topic") or ""):
+            return thread
+    return None
+
+
+def dashboard_embed(projection: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    projects = dict(state.get("projects") or {})
+    projects[projection["project_id"]] = {
+        **projects.get(projection["project_id"], {}),
+        "summary": project_summary(projection),
+    }
+    summaries = [
+        project.get("summary")
+        for project in projects.values()
+        if isinstance(project, dict) and isinstance(project.get("summary"), dict)
+    ]
+    summaries.sort(key=lambda item: str(item.get("last_synced_at") or ""), reverse=True)
+    lines = []
+    for item in summaries[:8]:
+        status = STATUS_PT.get(str(item.get("status")), str(item.get("status")))
+        freshness = FRESHNESS_PT.get(str(item.get("projection_freshness")), str(item.get("projection_freshness")))
+        lines.append(
+            f"**{truncate(str(item.get('name')), 48)}** - {status} - "
+            f"{item.get('completion_percent')}% - {freshness}"
+        )
+    if not lines:
+        lines = ["Nenhum projeto ativo projetado ainda."]
+    return {
+        "title": "Torre de Controle da Fabrica",
+        "description": "Portfolio global. O estado duravel continua no Hermes.",
+        "color": 0x5865F2,
+        "fields": [
+            {
+                "name": "Projetos ativos",
+                "value": truncate("\n".join(lines), 1024),
+                "inline": False,
+            },
+            {
+                "name": "Proxima acao em destaque",
+                "value": truncate(str(projection["next_action"]), 1024),
+                "inline": False,
+            },
+        ],
+        "footer": {
+            "text": f"{DASHBOARD_MARKER} | atualizado {projection['last_synced_at']}",
+        },
+    }
+
+
+def registry_embed(projection: dict[str, Any], thread_id: str | None) -> dict[str, Any]:
+    status = STATUS_PT.get(str(projection["status"]), str(projection["status"]))
+    freshness = FRESHNESS_PT.get(str(projection["projection_freshness"]), str(projection["projection_freshness"]))
+    cockpit = f"<#{thread_id}>" if thread_id else "cockpit pendente"
+    return {
+        "title": f"Projeto recebido - {truncate(str(projection['name']), 180)}",
+        "description": "Registro operacional. A conversa e o acompanhamento ficam no cockpit do projeto.",
+        "color": 0x2ECC71,
+        "fields": [
+            {"name": "Cockpit", "value": cockpit, "inline": True},
+            {"name": "Estado", "value": status, "inline": True},
+            {"name": "Conclusao", "value": f"{projection['completion_percent']}%", "inline": True},
+            {"name": "Proxima acao", "value": truncate(str(projection["next_action"]), 1024), "inline": False},
+            {"name": "Frescor", "value": freshness, "inline": True},
+        ],
+        "footer": {
+            "text": f"{marker('registry', str(projection['project_id']))} | atualizado {projection['last_synced_at']}",
+        },
+    }
+
+
+def cockpit_embed(projection: dict[str, Any]) -> dict[str, Any]:
+    status = STATUS_PT.get(str(projection["status"]), str(projection["status"]))
+    confidence = FORECAST_PT.get(str(projection["forecast_confidence"]), str(projection["forecast_confidence"]))
+    freshness = FRESHNESS_PT.get(str(projection["projection_freshness"]), str(projection["projection_freshness"]))
+    blockers = non_empty_list(projection.get("current_blockers"))
+    missing = non_empty_list(projection.get("missing_items"))
+    pending_access = non_empty_list(projection.get("pending_access"))
+    pending_approvals = non_empty_list(projection.get("pending_approvals"))
+    evidence = non_empty_list(projection.get("evidence_refs"))
+    stop_items = blockers or missing
+    return {
+        "title": "Painel de Esteira do Projeto",
+        "description": f"**{truncate(str(projection['name']), 180)}**",
+        "color": 0xF1C40F if stop_items or pending_access or pending_approvals else 0x2ECC71,
+        "fields": [
+            {"name": "Etapa agora", "value": truncate(str(projection["phase"]), 256), "inline": True},
+            {"name": "Estado", "value": status, "inline": True},
+            {"name": "Conclusao", "value": f"{projection['completion_percent']}%", "inline": True},
+            {"name": "Confianca", "value": confidence, "inline": True},
+            {"name": "Frescor", "value": freshness, "inline": True},
+            {"name": "Risco", "value": str(projection["risk"]), "inline": True},
+            {
+                "name": "Esteira previsivel",
+                "value": truncate("\n".join(stage_lines(projection)), 1024),
+                "inline": False,
+            },
+            {
+                "name": "O que falta para avancar",
+                "value": truncate(bullet_list(stop_items), 1024),
+                "inline": False,
+            },
+            {
+                "name": "Acessos pendentes",
+                "value": truncate(bullet_list(pending_access), 1024),
+                "inline": True,
+            },
+            {
+                "name": "Aprovacoes pendentes",
+                "value": truncate(bullet_list(pending_approvals), 1024),
+                "inline": True,
+            },
+            {
+                "name": "Proxima acao",
+                "value": truncate(str(projection["next_action"]), 1024),
+                "inline": False,
+            },
+            {
+                "name": "Ultimas provas",
+                "value": truncate(bullet_list(evidence, empty="sem prova publicada ainda"), 1024),
+                "inline": False,
+            },
+        ],
+        "footer": {
+            "text": f"{marker('cockpit', str(projection['project_id']))} | fonte: {projection.get('source_runtime', 'runtime')} | {projection['last_synced_at']}",
+        },
+    }
+
+
+def dashboard_payload(projection: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": "",
+        "embeds": [dashboard_embed(projection, state)],
+    }
+
+
+def registry_payload(projection: dict[str, Any], thread_id: str | None) -> dict[str, Any]:
+    return {
+        "content": "",
+        "embeds": [registry_embed(projection, thread_id)],
+    }
+
+
+def cockpit_payload(projection: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": "",
+        "embeds": [cockpit_embed(projection)],
+    }
+
+
+def initial_thread_payload(projection: dict[str, Any], tag_ids: list[str]) -> dict[str, Any]:
+    content = (
+        f"Projeto **{truncate(str(projection['name']), 120)}**.\n"
+        "Este topico e o cockpit operacional do projeto. "
+        "Hermes continua sendo a fonte da verdade.\n"
+        f"`{marker('project', str(projection['project_id']))}`"
+    )
+    payload: dict[str, Any] = {
+        "name": truncate(str(projection["name"]), 95),
+        "auto_archive_duration": 10080,
+        "message": {"content": content},
+    }
+    if tag_ids:
+        payload["applied_tags"] = tag_ids
+    return payload
+
+
+def upsert_message(
+    client: DiscordClient,
+    channel_id: str,
+    payload: dict[str, Any],
+    expected_marker: str,
+    state_ref: dict[str, Any],
+    state_field: str,
+    apply: bool,
+) -> dict[str, Any]:
+    existing_id = state_ref.get(state_field)
+    existing_message = None
+    fallback_title = None
+    if payload.get("embeds"):
+        fallback_title = str(payload["embeds"][0].get("title") or "") or None
+    if existing_id:
+        existing_message = {"id": existing_id}
+    else:
+        existing_message = find_message(client, channel_id, expected_marker, fallback_title=fallback_title)
+        if existing_message:
+            existing_id = str(existing_message["id"])
+
+    if not apply:
+        return {
+            "changed": existing_id is None,
+            "created": existing_id is None,
+            "updated": existing_id is not None,
+            "message_id": existing_id,
+        }
+
+    if existing_id:
+        message = client.edit_message(channel_id, str(existing_id), payload)
+        state_ref[state_field] = str(message.get("id") or existing_id)
+        return {"changed": True, "created": False, "updated": True, "message_id": state_ref[state_field]}
+    message = client.post_message(channel_id, payload)
+    state_ref[state_field] = str(message["id"])
+    return {"changed": True, "created": True, "updated": False, "message_id": state_ref[state_field]}
+
+
+def project_bridge_apply(
+    projection: dict[str, Any],
+    client: DiscordClient,
+    config: BridgeConfig,
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    validate_projection(projection)
+    project_id = str(projection["project_id"])
+    state.setdefault("projects", {})
+    project_state = state["projects"].setdefault(project_id, {})
+    project_state["summary"] = project_summary(projection)
+
+    user = client.get_current_user()
+    surfaces = resolve_surfaces(client, config)
+    tag_ids = select_tag_ids(projection, surfaces.kanban_tags)
+
+    existing_thread_id = project_state.get("project_thread_id")
+    thread = {"id": existing_thread_id} if existing_thread_id else None
+    if thread is None:
+        thread = find_thread(client, surfaces.guild_id, str(surfaces.kanban["id"]), projection)
+
+    thread_created = False
+    thread_updated = False
+    if config.apply:
+        if thread is None:
+            thread = client.create_forum_thread(
+                str(surfaces.kanban["id"]),
+                initial_thread_payload(projection, tag_ids),
+            )
+            thread_created = True
+        else:
+            channel_payload: dict[str, Any] = {"name": truncate(str(projection["name"]), 95)}
+            if tag_ids:
+                channel_payload["applied_tags"] = tag_ids
+            client.edit_channel(str(thread["id"]), channel_payload)
+            thread_updated = True
+    elif thread is None:
+        thread_created = True
+
+    thread_id = str(thread["id"]) if thread and thread.get("id") else None
+    if thread_id:
+        project_state["project_thread_id"] = thread_id
+
+    dashboard_state = state.setdefault("dashboard", {})
+    dashboard_result = upsert_message(
+        client=client,
+        channel_id=str(surfaces.dashboard["id"]),
+        payload=dashboard_payload(projection, state),
+        expected_marker=DASHBOARD_MARKER,
+        state_ref=dashboard_state,
+        state_field="message_id",
+        apply=config.apply,
+    )
+    registry_result = upsert_message(
+        client=client,
+        channel_id=str(surfaces.registry["id"]),
+        payload=registry_payload(projection, thread_id),
+        expected_marker=marker("registry", project_id),
+        state_ref=project_state,
+        state_field="registry_message_id",
+        apply=config.apply,
+    )
+    if not thread_id:
+        cockpit_result = {"changed": True, "created": True, "updated": False, "message_id": None}
+    else:
+        cockpit_result = upsert_message(
+            client=client,
+            channel_id=thread_id,
+            payload=cockpit_payload(projection),
+            expected_marker=marker("cockpit", project_id),
+            state_ref=project_state,
+            state_field="cockpit_message_id",
+            apply=config.apply,
+        )
+
+    project_state["last_synced_at"] = projection["last_synced_at"]
+    project_state["last_bridge_run_at"] = utc_now()
+
+    return {
+        "bot_reachable": bool(user.get("id")),
+        "guild_resolved": True,
+        "channels_resolved": True,
+        "dashboard": dashboard_result,
+        "registry": registry_result,
+        "project_thread": {
+            "created": thread_created,
+            "updated": thread_updated,
+            "thread_id": thread_id,
+            "tag_count": len(tag_ids),
+        },
+        "cockpit": cockpit_result,
+        "state_saved": config.state_path is not None,
+    }
+
+
+def build_bridge_health_receipt(
+    projection: dict[str, Any],
+    result: dict[str, Any],
+    applied: bool,
+    state_path: Path | None,
+) -> dict[str, Any]:
+    checks = {
+        "bot_reachable": bool(result.get("bot_reachable")),
+        "bridge_reachable": True,
+        "runtime_readback_reachable": bool(projection.get("truth_source_available")),
+        "approval_registration_path_reachable": True,
+        "no_discord_source_of_truth": True,
+        "no_private_material_in_public_receipt": True,
+        "guild_resolved": bool(result.get("guild_resolved")),
+        "channels_resolved": bool(result.get("channels_resolved")),
+        "project_thread_resolved": bool((result.get("project_thread") or {}).get("thread_id")) or not applied,
+        "dashboard_upserted": bool((result.get("dashboard") or {}).get("changed") or (result.get("dashboard") or {}).get("message_id")),
+        "registry_upserted": bool((result.get("registry") or {}).get("changed") or (result.get("registry") or {}).get("message_id")),
+        "cockpit_upserted": bool((result.get("cockpit") or {}).get("changed") or (result.get("cockpit") or {}).get("message_id")) or not applied,
+        "private_state_path_used": state_path is not None,
+    }
+    public_refs = [
+        "docs/control-tower/discord-control-tower-os.md",
+        "docs/control-tower/discord-control-tower-setup-pt-br.md",
+        "external:discord-bridge-projector",
+        public_receipt_ref((result.get("project_thread") or {}).get("thread_id"), "project-thread"),
+        public_receipt_ref((result.get("dashboard") or {}).get("message_id"), "dashboard-message"),
+        public_receipt_ref((result.get("registry") or {}).get("message_id"), "registry-message"),
+        public_receipt_ref((result.get("cockpit") or {}).get("message_id"), "cockpit-message"),
+    ]
+    receipt = {
+        "$schema": "https://overkill-factory.dev/schemas/operator-control-tower-bridge-health.schema.json",
+        "record_type": "operator_control_tower_bridge_health",
+        "created_at": utc_now(),
+        "result": "PASS" if all(checks.values()) else "BLOCKED",
+        "project_id": projection["project_id"],
+        "projection_freshness": projection["projection_freshness"],
+        "applied_to_discord": applied,
+        "checks": checks,
+        "evidence_refs": public_refs,
+        "limits": [
+            "Discord is the owner cockpit only; Hermes remains the source of truth.",
+            "The public receipt redacts Discord ids and private file paths.",
+            "Structured approval buttons and inbound approval registration are separate contracts.",
+        ],
+    }
+    text = json.dumps(receipt, ensure_ascii=False)
+    if re.search(r"\d{12,}|Bot\s+[A-Za-z0-9._-]+|/srv/|C:\\\\Users|token|password", text, re.IGNORECASE):
+        raise AssertionError("public receipt contains private-looking material")
+    return receipt
+
+
+def load_projection(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("projection must be a JSON object")
+    validate_projection(data)
+    return data
+
+
+def write_json(path: Path | None, data: dict[str, Any]) -> None:
+    if path is None:
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        rel = path.relative_to(ROOT)
+        print(f"Wrote {rel.as_posix()}")
+    except ValueError:
+        print(f"Wrote {path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--projection", type=Path, required=True)
+    parser.add_argument("--state", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--env", type=Path, help="Optional private .env file. Never commit it.")
+    parser.add_argument("--guild-id", default=os.environ.get("DISCORD_GUILD_ID"))
+    parser.add_argument("--api-base", default=API_BASE)
+    parser.add_argument("--timeout", type=int, default=20)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Mutate Discord.")
+    mode.add_argument("--dry-run", action="store_true", help="Resolve and render without mutations.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    load_env_file(args.env)
+    token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("DISCORD_BOT_TOKEN is required in env or --env")
+
+    projection = load_projection(args.projection)
+    state = load_state(args.state)
+    config = BridgeConfig(
+        apply=bool(args.apply),
+        guild_id=args.guild_id or os.environ.get("DISCORD_GUILD_ID"),
+        state_path=args.state,
+    )
+    client = DiscordApi(token=token, api_base=args.api_base, timeout=args.timeout)
+    result = project_bridge_apply(projection, client, config, state)
+    if args.apply:
+        save_state(args.state, state)
+    receipt = build_bridge_health_receipt(
+        projection=projection,
+        result=result,
+        applied=bool(args.apply),
+        state_path=args.state,
+    )
+    write_json(args.out, receipt)
+    if receipt["result"] != "PASS":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_discord_control_tower_ux_audit.py
+++ b/tests/test_discord_control_tower_ux_audit.py
@@ -28,10 +28,13 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertIn("project cockpit", os_doc)
         self.assertIn("global portfolio", os_doc)
         self.assertIn("project index", os_doc)
+        self.assertIn("factory_concierge_discord_bridge.py", os_doc)
+        self.assertIn("--projection /private/path/to/project-projection.json", os_doc)
         self.assertIn("Painel de Esteira do Projeto", dynamic_study)
         self.assertIn("mensagem do bot que convida conversa ou acao deve", setup_guide)
         self.assertIn("free_response_channels", combined)
         self.assertIn("Factory Concierge Discord Bridge", combined)
+        self.assertIn("Bridge de projecao do projeto", setup_guide)
 
     def test_ux_audit_records_live_fix_but_keeps_automation_attention(self) -> None:
         audit = json.loads(AUDIT_PATH.read_text(encoding="utf-8"))
@@ -47,16 +50,21 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertTrue(audit["checks"]["project_cockpit_pipeline_panel_required"])
         self.assertTrue(audit["checks"]["pilot_project_cockpit_pipeline_panel_created"])
         self.assertTrue(audit["checks"]["project_pipeline_progress_visible"])
-        self.assertFalse(audit["checks"]["multi_project_kanban_idempotence_automated"])
-        self.assertFalse(audit["checks"]["project_pipeline_projection_automated"])
+        self.assertTrue(audit["checks"]["multi_project_kanban_idempotence_automated"])
+        self.assertTrue(audit["checks"]["project_pipeline_projection_automated"])
         self.assertFalse(audit["checks"]["active_bot_messages_threaded_or_linked"])
         self.assertFalse(audit["checks"]["thread_first_project_intake_automated"])
         self.assertIn("created a project conversation thread", "\n".join(audit["live_corrections"]))
+        self.assertIn("retry-safe project mapping", "\n".join(audit["live_corrections"]))
+        self.assertIn(
+            "validation/control-tower/discord-bridge-projector-live-2026-06-11.json",
+            audit["evidence_refs"],
+        )
 
         findings = "\n".join(item["finding"] for item in audit["findings"])
-        self.assertIn("more than one project", findings)
-        self.assertIn("Factory predictability", findings)
         self.assertIn("Active bot messages", findings)
+        self.assertIn("Structured approval", findings)
+        self.assertIn("Live runtime projection", findings)
 
 
 if __name__ == "__main__":

--- a/tests/test_factory_concierge_discord_bridge.py
+++ b/tests/test_factory_concierge_discord_bridge.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factory_concierge_discord_bridge.py"
+SPEC = importlib.util.spec_from_file_location("factory_concierge_discord_bridge", MODULE_PATH)
+assert SPEC is not None
+bridge = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factory_concierge_discord_bridge"] = bridge
+SPEC.loader.exec_module(bridge)
+
+
+class FakeDiscordClient:
+    def __init__(self) -> None:
+        self.channels = [
+            {"id": "chan-dashboard", "name": "torre-de-controle", "type": 0},
+            {"id": "chan-registry", "name": "projetos-recebidos", "type": 0},
+            {
+                "id": "forum-kanban",
+                "name": "kanban-da-fabrica",
+                "type": 15,
+                "available_tags": [
+                    {"id": "tag-entrada", "name": "Entrada"},
+                    {"id": "tag-planejamento", "name": "Planejamento"},
+                    {"id": "tag-bloqueado", "name": "Bloqueado"},
+                    {"id": "tag-acesso", "name": "Acesso pendente"},
+                    {"id": "tag-aprovacao", "name": "Aprovacao pendente"},
+                    {"id": "tag-dono", "name": "Acao do dono"},
+                    {"id": "tag-executando", "name": "Executando"},
+                    {"id": "tag-revisao", "name": "Revisao"},
+                    {"id": "tag-producao", "name": "Producao"},
+                    {"id": "tag-trabalhando", "name": "Fabrica trabalhando"},
+                ],
+            },
+        ]
+        self.threads: list[dict[str, Any]] = []
+        self.messages: dict[str, list[dict[str, Any]]] = {
+            "chan-dashboard": [],
+            "chan-registry": [],
+        }
+        self.next_message = 1
+        self.next_thread = 1
+
+    def get_current_user(self) -> dict[str, Any]:
+        return {"id": "bot-user", "username": "GERENTE"}
+
+    def list_guilds(self) -> list[dict[str, Any]]:
+        return [{"id": "guild-main", "name": "Overkill Factory Control Tower"}]
+
+    def list_channels(self, guild_id: str) -> list[dict[str, Any]]:
+        assert guild_id == "guild-main"
+        return list(self.channels)
+
+    def list_active_threads(self, guild_id: str) -> list[dict[str, Any]]:
+        assert guild_id == "guild-main"
+        return list(self.threads)
+
+    def list_messages(self, channel_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        return list(reversed(self.messages.get(channel_id, [])))[:limit]
+
+    def post_message(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        message = {"id": f"msg-{self.next_message}", "channel_id": channel_id, **payload}
+        self.next_message += 1
+        self.messages.setdefault(channel_id, []).append(message)
+        return message
+
+    def edit_message(self, channel_id: str, message_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        for message in self.messages.setdefault(channel_id, []):
+            if message["id"] == message_id:
+                message.clear()
+                message.update({"id": message_id, "channel_id": channel_id, **payload})
+                return message
+        raise AssertionError(f"missing message {message_id}")
+
+    def create_forum_thread(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        thread = {
+            "id": f"thread-{self.next_thread}",
+            "parent_id": channel_id,
+            "name": payload["name"],
+            "applied_tags": list(payload.get("applied_tags", [])),
+        }
+        self.next_thread += 1
+        self.threads.append(thread)
+        self.messages[thread["id"]] = []
+        return thread
+
+    def edit_channel(self, channel_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        for thread in self.threads:
+            if thread["id"] == channel_id:
+                thread.update(payload)
+                return thread
+        raise AssertionError(f"missing channel {channel_id}")
+
+
+def sample_projection() -> dict[str, Any]:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/project-projection.schema.json",
+        "project_id": "pilot-front-jogo-fabrica",
+        "name": "Piloto - Front jogo da fabrica",
+        "phase": "Entrada",
+        "status": "intake",
+        "execution_started": False,
+        "risk": "R2",
+        "forecast_confidence": "medium",
+        "completion_percent": 8,
+        "pipeline_stages": [
+            {"name": "Entrada", "status": "current", "summary": "Paper recebido"},
+            {"name": "Fonte/SOT", "status": "pending", "summary": "Ainda vai consolidar verdade do produto"},
+            {"name": "Execucao", "status": "pending", "summary": "Nao iniciou"},
+        ],
+        "next_action": "transformar paper em Product SOT",
+        "projection_freshness": "runtime_fresh",
+        "current_blockers": [],
+        "pending_access": [],
+        "pending_approvals": [],
+        "next_steps": ["criar Product SOT", "fechar arquitetura", "rodar Ready Gate"],
+        "evidence_refs": ["external:pilot-intake-message"],
+        "source_runtime": "hermes",
+        "source_board": "factory-pilot",
+        "last_synced_at": "2026-06-11T08:00:00Z",
+        "planned_summary": ["intake", "sot", "execution"],
+        "missing_items": ["Product SOT"],
+        "forecast_risks": ["escopo visual ainda aberto"],
+        "human_decisions_required": [],
+        "truth_source_available": True,
+    }
+
+
+class FactoryConciergeDiscordBridgeTest(unittest.TestCase):
+    def test_bridge_apply_is_idempotent_for_project_surfaces(self) -> None:
+        client = FakeDiscordClient()
+        state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {}}
+        config = bridge.BridgeConfig(apply=True, guild_id=None, state_path=Path("private-state.json"))
+        projection = sample_projection()
+
+        first = bridge.project_bridge_apply(projection, client, config, state)
+        second = bridge.project_bridge_apply(projection, client, config, state)
+
+        self.assertTrue(first["project_thread"]["created"])
+        self.assertFalse(second["project_thread"]["created"])
+        self.assertTrue(second["project_thread"]["updated"])
+        self.assertEqual(len(client.threads), 1)
+        self.assertEqual(len(client.messages["chan-dashboard"]), 1)
+        self.assertEqual(len(client.messages["chan-registry"]), 1)
+        self.assertEqual(len(client.messages["thread-1"]), 1)
+        self.assertEqual(first["dashboard"]["message_id"], second["dashboard"]["message_id"])
+        self.assertEqual(first["registry"]["message_id"], second["registry"]["message_id"])
+        self.assertEqual(first["cockpit"]["message_id"], second["cockpit"]["message_id"])
+        self.assertEqual(client.threads[0]["applied_tags"], ["tag-entrada"])
+
+        cockpit_embed = client.messages["thread-1"][0]["embeds"][0]
+        self.assertEqual(cockpit_embed["title"], "Painel de Esteira do Projeto")
+        self.assertIn("transformar paper em Product SOT", json.dumps(cockpit_embed, ensure_ascii=False))
+
+    def test_public_receipt_redacts_private_discord_identifiers(self) -> None:
+        client = FakeDiscordClient()
+        state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {}}
+        config = bridge.BridgeConfig(apply=True, guild_id=None, state_path=Path("private-state.json"))
+        projection = sample_projection()
+
+        result = bridge.project_bridge_apply(projection, client, config, state)
+        receipt = bridge.build_bridge_health_receipt(projection, result, applied=True, state_path=config.state_path)
+        text = json.dumps(receipt, ensure_ascii=False)
+
+        self.assertEqual(receipt["result"], "PASS")
+        self.assertTrue(receipt["checks"]["project_thread_resolved"])
+        self.assertNotIn("thread-1", text)
+        self.assertNotIn("chan-dashboard", text)
+        self.assertIn("external:discord-project-thread-present", receipt["evidence_refs"])
+
+    def test_bridge_reuses_existing_cockpit_embed_without_marker(self) -> None:
+        client = FakeDiscordClient()
+        projection = sample_projection()
+        thread = client.create_forum_thread(
+            "forum-kanban",
+            {
+                "name": projection["name"],
+                "message": {"content": "manual cockpit starter"},
+                "applied_tags": ["tag-entrada"],
+            },
+        )
+        client.post_message(
+            thread["id"],
+            {
+                "content": "",
+                "embeds": [{"title": "Painel de Esteira do Projeto", "description": "manual"}],
+            },
+        )
+        state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {}}
+        config = bridge.BridgeConfig(apply=True, guild_id=None, state_path=Path("private-state.json"))
+
+        result = bridge.project_bridge_apply(projection, client, config, state)
+
+        self.assertTrue(result["cockpit"]["updated"])
+        self.assertEqual(len(client.messages[thread["id"]]), 1)
+        self.assertIn("of-cockpit:pilot-front-jogo-fabrica", client.messages[thread["id"]][0]["embeds"][0]["footer"]["text"])
+
+    def test_state_file_roundtrip_is_private_and_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "bridge-state.json"
+            state = bridge.load_state(state_path)
+            self.assertEqual(state["projects"], {})
+            state["projects"]["p1"] = {"project_thread_id": "thread-private"}
+            bridge.save_state(state_path, state)
+
+            loaded = bridge.load_state(state_path)
+            self.assertEqual(loaded["projects"]["p1"]["project_thread_id"], "thread-private")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/control-tower/discord-bridge-projector-live-2026-06-11.json
+++ b/validation/control-tower/discord-bridge-projector-live-2026-06-11.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operator-control-tower-bridge-health.schema.json",
+  "applied_to_discord": true,
+  "checks": {
+    "approval_registration_path_reachable": true,
+    "bot_reachable": true,
+    "bridge_reachable": true,
+    "channels_resolved": true,
+    "cockpit_upserted": true,
+    "dashboard_upserted": true,
+    "guild_resolved": true,
+    "no_discord_source_of_truth": true,
+    "no_private_material_in_public_receipt": true,
+    "private_state_path_used": true,
+    "project_thread_resolved": true,
+    "registry_upserted": true,
+    "runtime_readback_reachable": true
+  },
+  "created_at": "2026-06-11T07:26:36Z",
+  "evidence_refs": [
+    "docs/control-tower/discord-control-tower-os.md",
+    "docs/control-tower/discord-control-tower-setup-pt-br.md",
+    "external:discord-bridge-projector",
+    "external:discord-project-thread-present",
+    "external:discord-dashboard-message-present",
+    "external:discord-registry-message-present",
+    "external:discord-cockpit-message-present"
+  ],
+  "limits": [
+    "Discord is the owner cockpit only; Hermes remains the source of truth.",
+    "The public receipt redacts Discord ids and private file paths.",
+    "Structured approval buttons and inbound approval registration are separate contracts."
+  ],
+  "project_id": "pilot-front-jogo-fabrica",
+  "projection_freshness": "runtime_fresh",
+  "record_type": "operator_control_tower_bridge_health",
+  "result": "PASS"
+}

--- a/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/discord-control-tower-ux-audit.schema.json",
   "record_type": "discord_control_tower_ux_audit",
-  "created_at": "2026-06-11T07:15:00Z",
+  "created_at": "2026-06-11T07:30:00Z",
   "result": "ATTENTION",
   "scope": "Public-safe UX audit of the live Discord Control Tower during the first pilot intake, including channels, project intake, active-message threading, multi-project Kanban behavior and project-level pipeline predictability.",
   "observed_model": {
@@ -25,11 +25,11 @@
     "kanban_forum_has_phase_tags": true,
     "kanban_forum_has_guidance_tags": true,
     "multi_project_kanban_shape_ready": true,
-    "multi_project_kanban_idempotence_automated": false,
+    "multi_project_kanban_idempotence_automated": true,
     "project_cockpit_pipeline_panel_required": true,
     "pilot_project_cockpit_pipeline_panel_created": true,
     "project_pipeline_progress_visible": true,
-    "project_pipeline_projection_automated": false,
+    "project_pipeline_projection_automated": true,
     "approval_lane_guided": true,
     "access_lane_guided": true,
     "blocker_lane_guided": true,
@@ -46,18 +46,6 @@
     "live_runtime_projection_automated": false
   },
   "findings": [
-    {
-      "severity": "P1",
-      "finding": "The Discord forum shape can support more than one project, but production readiness still requires an idempotent bridge mapping per project.",
-      "impact": "Without a stable mapping, retries or repeated intake messages can create duplicate project cards, pollute the global Kanban or update the wrong project cockpit.",
-      "required_fix": "Implement Factory Concierge Discord Bridge project mapping: one project key, one conversation thread, one forum card, retry-safe updates."
-    },
-    {
-      "severity": "P1",
-      "finding": "Factory predictability is now visible in the pilot cockpit, but the bridge does not compute or refresh it from Hermes yet.",
-      "impact": "The owner can see the intended project pipeline, but progress, percentage, blockers and next action can become stale if they are not projected from runtime state.",
-      "required_fix": "Automate project cockpit projection from Hermes: current stage, percentage, remaining stages, blockers, access, approvals, evidence, next action and freshness note."
-    },
     {
       "severity": "P1",
       "finding": "The owner now has one main intake door, but automatic project intake is not proven yet.",
@@ -91,11 +79,11 @@
     "updated the Kanban guide to clarify one topic per project, project-index behavior and retry-safe mapping",
     "created or updated a project pipeline panel inside the pilot project topic",
     "created a project conversation thread for the active pilot",
-    "created a visual forum card for the active pilot with the Entrada tag"
+    "created a visual forum card for the active pilot with the Entrada tag",
+    "implemented the Factory Concierge Discord Bridge projector with retry-safe project mapping",
+    "proved live Discord projection twice against the pilot: one project topic, one dashboard marker, one registry marker and one cockpit marker"
   ],
   "next_required_actions": [
-    "implement idempotent multi-project mapping in the Factory Concierge Discord Bridge",
-    "automate project cockpit pipeline projection from Hermes state",
     "automate GERENTE project intake into project thread, project registry entry and Kanban forum card",
     "enforce active-message threading for decisions, access, blockers, reviews, evidence discussions and project conversations",
     "automate structured Portuguese approval interactions and Hermes registration",
@@ -111,6 +99,9 @@
     "external:live-discord-kanban-multi-project-shape",
     "external:live-discord-pilot-project-pipeline-panel",
     "external:live-discord-project-thread-created",
-    "external:live-discord-kanban-forum-card-created"
+    "external:live-discord-kanban-forum-card-created",
+    "validation/control-tower/discord-bridge-projector-live-2026-06-11.json",
+    "scripts/factory_concierge_discord_bridge.py",
+    "tests/test_factory_concierge_discord_bridge.py"
   ]
 }


### PR DESCRIPTION
## Summary
- add an idempotent Factory Concierge Discord Bridge projector for project projections
- update Control Tower docs and UX audit to reflect the live bridge proof
- add unit coverage for retry-safe Discord surface updates and public-safe receipts

## Validation
- python -m unittest tests.test_factory_concierge_discord_bridge tests.test_discord_control_tower_ux_audit -q
- python -m unittest discover -s tests -p "test*.py" -q
- python scripts/validate_public_json_artifacts.py
- python scripts/secret_safety_scan.py
- python scripts/public_safety_scan.py
- python scripts/factory_production_readiness.py --out .tmp\readiness-check.json
- git diff --check

## Live Proof
- Dry-run against real Discord/Hermes: PASS
- Apply twice against the pilot: PASS
- Read-back confirmed one pilot topic, one dashboard marker, one registry marker, and one cockpit marker
