### PR TITLE
Fix Discord runner idle health

### DIFF
--- a/scripts/factory_concierge_discord_automation.py
+++ b/scripts/factory_concierge_discord_automation.py
@@ -741,6 +741,9 @@ def run_automation(args: argparse.Namespace) -> dict[str, Any]:
 
     projections = [item for item in [load_json(args.projection)] if item]
     projections.extend(load_json_dir(args.projection_dir))
+    has_projection_inputs = bool(projections)
+    if not has_projection_inputs:
+        results["live_runtime_projection_automated"] = True
     for projection in projections:
         bridge_result = bridge.project_bridge_apply(projection, client, config, state)
         results["live_runtime_projection_automated"] = bool((bridge_result.get("project_thread") or {}).get("thread_id")) or not args.apply
@@ -756,6 +759,8 @@ def run_automation(args: argparse.Namespace) -> dict[str, Any]:
 
     events = [item for item in [load_json(args.event)] if item]
     events.extend(load_json_dir(args.event_dir))
+    if not events:
+        results["operational_channels_projected"] = True
     for event in events:
         event_result = sync_event(event, client, config, state, apply=bool(args.apply))
         results["event"] = event_result
@@ -768,6 +773,8 @@ def run_automation(args: argparse.Namespace) -> dict[str, Any]:
     approvals = [item for item in [load_json(args.approval)] if item]
     approvals.extend(load_json_dir(args.approval_dir))
     approval = approvals[0] if approvals else None
+    if not approvals:
+        results["structured_approval_interactions_automated"] = True
     for approval_item in approvals:
         approval_result = post_approval_request(approval_item, client, config, state, apply=bool(args.apply))
         results["approval"] = approval_result
@@ -799,7 +806,7 @@ def run_automation(args: argparse.Namespace) -> dict[str, Any]:
             extra_checks={
                 "threading_rule_ready": bool(results["active_bot_messages_threaded_or_linked"]),
                 "approval_components_ready": bool(results["structured_approval_interactions_automated"] or not approval),
-                "projection_ready": bool(results["live_runtime_projection_automated"] or not projection),
+                "projection_ready": bool(results["live_runtime_projection_automated"] or not has_projection_inputs),
             },
         )
         results["health"] = health_result

--- a/tests/test_factory_concierge_discord_automation.py
+++ b/tests/test_factory_concierge_discord_automation.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -249,6 +252,45 @@ class FactoryConciergeDiscordAutomationTest(unittest.TestCase):
         self.assertTrue(health["message_resolved"])
         self.assertEqual(receipt["result"], "PASS")
         self.assertNotIn("chan-health", json.dumps(receipt))
+
+    def test_run_automation_empty_inboxes_posts_idle_health_receipt(self) -> None:
+        client = FakeDiscordClient()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name in ("projections", "events", "approvals"):
+                (root / name).mkdir()
+            args = argparse.Namespace(
+                projection=None,
+                projection_dir=root / "projections",
+                event=None,
+                event_dir=root / "events",
+                approval=None,
+                approval_dir=root / "approvals",
+                decision=None,
+                decision_time=None,
+                scan_intake=True,
+                post_health=True,
+                max_messages=20,
+                state=root / "state.json",
+                out=root / "receipt.json",
+                env=None,
+                guild_id=None,
+                api_base="https://discord.test/api",
+                timeout=1.0,
+                apply=True,
+            )
+            with patch.dict(automation.os.environ, {"DISCORD_BOT_TOKEN": "test-token"}), patch.object(
+                automation.bridge, "DiscordApi", return_value=client
+            ):
+                receipt = automation.run_automation(args)
+
+        self.assertEqual(receipt["result"], "PASS")
+        self.assertTrue(receipt["checks"]["thread_first_project_intake_automated"])
+        self.assertTrue(receipt["checks"]["active_bot_messages_threaded_or_linked"])
+        self.assertTrue(receipt["checks"]["structured_approval_interactions_automated"])
+        self.assertTrue(receipt["checks"]["live_runtime_projection_automated"])
+        self.assertTrue(receipt["checks"]["operational_channels_projected"])
+        self.assertTrue(receipt["checks"]["health_anti_stale_posted"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix the Discord Control Tower runner when projection/event/approval inboxes are empty
- treat empty inboxes as idle-ready instead of crashing or reporting a false block
- add a regression test for the cron-style idle health run

## Validation
- python -m unittest tests.test_factory_concierge_discord_automation tests.test_discord_control_tower_ux_audit -q
- python -m unittest discover -s tests -p "test*.py" -q
- python scripts/validate_public_json_artifacts.py
- python scripts/secret_safety_scan.py
- python scripts/public_safety_scan.py
- python scripts/factory_production_readiness.py --out .tmp\readiness-check-discord-runner-hotfix.json
- git diff --check
