### PR TITLE
Align Hermes profiles with official worker roster

### DIFF
--- a/agents/worker-roster.md
+++ b/agents/worker-roster.md
@@ -30,6 +30,10 @@ The roster has 40 public-safe operators:
 - 4 human, release, memory and learning support workers.
 - 2 Control Tower cockpit workers.
 
+The Discord gateway profile `overkill-factory-gerente` is official, but it is
+not counted as a worker. It is an interface profile: it talks to the operator
+and registers intent through Hermes without executing product work.
+
 That number is intentionally split by ownership. It is not meant to create 40
 parallel personalities. A card should call only the operators whose surface,
 risk and phase match the work.
@@ -140,6 +144,12 @@ they get a machine-readable contract in `agents/worker-registry.public.json`.
   matches, the fallback worker is not required.
 - Solana work uses `solana-quasar-builder`, `solana-quasar-qa-engineer` and
   `solana-quasar-auditor`; build, QA and audit are separate.
+- Conceptual role names such as Method Router, Product Experience Router,
+  Security Architect, Production Readiness, Access Capability and Factory
+  Maturity Auditor are mapped to official workers in
+  `docs/agents/factory-stage-agent-map.md`. They must not exist as loose Hermes
+  executor profiles unless promoted through registry, profile, binding,
+  permission class, packet route and proof.
 
 ## Why This Roster Is Better
 

--- a/docs/agents/factory-stage-agent-map.md
+++ b/docs/agents/factory-stage-agent-map.md
@@ -79,6 +79,14 @@ roles are implemented by these registered workers:
 | Bot Health Monitor | `discord-control-tower-bridge` and bridge-health validation |
 | Factory Maturity Auditor | `skill-eval-distiller` with `independent-reviewer` for adversarial review |
 
+These conceptual role names must not be installed as separate Hermes executor
+profiles unless they go through the full worker promotion path: registry,
+profile, binding, permission class, packet route, smoke and eval proof. If they
+exist as loose profiles, they create ambiguous routing because the Kanban cannot
+know whether to call the official worker or the duplicate profile. The exception
+is `overkill-factory-gerente`, which is an official Discord interface profile,
+not a worker executor.
+
 ## Promotion Rule
 
 A new executable worker is created only when all of this is true:

--- a/docs/agents/live-agent-configuration.md
+++ b/docs/agents/live-agent-configuration.md
@@ -25,9 +25,28 @@ runtime treats them differently:
 | Reviewer/proof runner | Verifies, challenges or packages work done by another operator. | `independent-reviewer`, `autoreview-gate`, `remote-proof-runner` |
 | Specialist gate | Blocks a risk surface until evidence exists. | `codex-security`, `appsec-owasp-specialist`, `supply-chain-gate` |
 | Human-support gate | Records a real human decision. | `human-gate-clerk` |
+| Interface profile | Talks to the human and mirrors cockpit state without executing product work. | `overkill-factory-gerente` |
 
 This distinction matters. A gate can be operable without being a builder, and a
 builder can be autonomous without being allowed to approve itself.
+
+## Conceptual Role Drift Rule
+
+Some canonical-stage names are intentionally plain: Method Router, Product
+Outcome Worker, Product Experience Router, Security Architect, Production
+Readiness and similar names. In runtime they are mapped to registered workers in
+`docs/agents/factory-stage-agent-map.md`.
+
+Do not create separate Hermes executor profiles for those conceptual names by
+default. A loose profile with a good-sounding name is weaker than an official
+worker because it has no registry entry, no binding, no permission class, no
+packet route and no validation proof. If such a profile appears in Hermes, treat
+it as profile drift unless it has been promoted through the worker contract.
+
+The dedicated exception is `overkill-factory-gerente`: it is a gateway/interface
+profile for Discord. It may talk to the operator, receive inputs and register
+intent, but it must not choose specialists outside the Kanban, execute material
+work or mark cards done.
 
 ## Builder Layer
 

--- a/schemas/hermes-profile-drift-cleanup.schema.json
+++ b/schemas/hermes-profile-drift-cleanup.schema.json
@@ -1,0 +1,84 @@
+{
+  "$id": "https://overkill-factory.dev/schemas/hermes-profile-drift-cleanup.schema.json",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "result",
+    "scope",
+    "runtime_ref",
+    "deleted_profile_refs",
+    "preserved_profile_refs",
+    "post_cleanup_counts",
+    "backup_ref",
+    "checks",
+    "evidence_refs",
+    "limits"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/hermes-profile-drift-cleanup.schema.json"
+    },
+    "record_type": {
+      "const": "hermes_profile_drift_cleanup"
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "result": {
+      "enum": ["PASS", "ATTENTION", "BLOCKED"]
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 3
+    },
+    "runtime_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "deleted_profile_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "preserved_profile_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "post_cleanup_counts": {
+      "type": "object",
+      "required": [
+        "public_worker_profiles",
+        "gateway_interface_profiles",
+        "unexpected_conceptual_duplicate_profiles",
+        "profile_exports_created"
+      ],
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "backup_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/hermes-vfinal-runtime-status-check.schema.json
+++ b/schemas/hermes-vfinal-runtime-status-check.schema.json
@@ -41,6 +41,7 @@
         "dedicated_gerente_gateway_running",
         "private_product_profile_not_factory_gateway",
         "factory_worker_profiles_present",
+        "factory_profile_set_has_no_conceptual_duplicates",
         "raw_private_values_omitted"
       ],
       "properties": {
@@ -51,6 +52,7 @@
         "dedicated_gerente_gateway_running": { "type": "boolean" },
         "private_product_profile_not_factory_gateway": { "type": "boolean" },
         "factory_worker_profiles_present": { "type": "boolean" },
+        "factory_profile_set_has_no_conceptual_duplicates": { "type": "boolean" },
         "raw_private_values_omitted": { "type": "boolean" }
       },
       "additionalProperties": false

--- a/tests/test_factory_stage_agent_map.py
+++ b/tests/test_factory_stage_agent_map.py
@@ -28,6 +28,7 @@ class FactoryStageAgentMapTest(unittest.TestCase):
         allowed_non_workers = {
             "Factory Concierge",
             "factory-critic",
+            "overkill-factory-gerente",
         }
         worker_refs = {
             ref

--- a/tests/test_prepilot_master_task_readiness.py
+++ b/tests/test_prepilot_master_task_readiness.py
@@ -86,6 +86,9 @@ class PrepilotMasterTaskReadinessTest(unittest.TestCase):
         self.assertTrue(provider_audit["checks"]["private_product_profile_not_used_as_factory_gateway"])
         self.assertTrue(provider_audit["checks"]["factory_scope_uses_canonical_provider_model"])
         self.assertTrue(provider_audit["checks"]["factory_scope_auth_present"])
+        self.assertTrue(provider_audit["checks"]["no_duplicate_conceptual_profiles_present"])
+        self.assertEqual(provider_audit["counts"]["conceptual_duplicate_profiles_removed"], 17)
+        self.assertEqual(provider_audit["counts"]["unexpected_factory_duplicate_profiles"], 0)
 
         self.assertEqual(runtime_status["result"], "PASS")
         self.assertTrue(runtime_status["checks"]["hermes_status_readonly_passed"])
@@ -94,6 +97,7 @@ class PrepilotMasterTaskReadinessTest(unittest.TestCase):
         self.assertTrue(runtime_status["checks"]["discord_configured"])
         self.assertTrue(runtime_status["checks"]["dedicated_gerente_gateway_running"])
         self.assertTrue(runtime_status["checks"]["private_product_profile_not_factory_gateway"])
+        self.assertTrue(runtime_status["checks"]["factory_profile_set_has_no_conceptual_duplicates"])
         self.assertTrue(runtime_status["checks"]["raw_private_values_omitted"])
 
         self.assertEqual(bridge_readiness["result"], "PASS")

--- a/tests/test_worker_profiles.py
+++ b/tests/test_worker_profiles.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -23,9 +24,52 @@ factoryctl = load_module("factoryctl_for_profiles", ROOT / "scripts" / "factoryc
 profile_validator = load_module("validate_worker_profiles", ROOT / "scripts" / "validate_worker_profiles.py")
 
 
+CONCEPTUAL_ROLE_PROFILE_DUPLICATES = {
+    "access-capability-worker",
+    "agent-eval-worker",
+    "agentic-method-router",
+    "budget-cost-worker",
+    "data-metrics-worker",
+    "dependency-integration-worker",
+    "factory-concierge",
+    "factory-maturity-auditor",
+    "incident-support-worker",
+    "platform-devex-worker",
+    "privacy-compliance-worker",
+    "product-experience-router",
+    "product-outcome-discovery-worker",
+    "production-readiness-worker",
+    "security-architect-worker",
+    "software-development-planner",
+    "user-docs-onboarding-worker",
+}
+
+
 class WorkerProfilesTest(unittest.TestCase):
     def test_worker_profiles_are_complete_and_bound_to_hermes(self) -> None:
         self.assertEqual(profile_validator.validate(), [])
+
+    def test_conceptual_role_names_are_not_registered_as_loose_workers(self) -> None:
+        registry = json.loads((ROOT / "agents" / "worker-registry.public.json").read_text(encoding="utf-8"))
+        profiles = json.loads((ROOT / "agents" / "worker-profiles.public.json").read_text(encoding="utf-8"))
+        bindings = json.loads((ROOT / "agents" / "hermes-profile-bindings.public.json").read_text(encoding="utf-8"))
+        permissions = json.loads((ROOT / "agents" / "worker-permission-classes.public.json").read_text(encoding="utf-8"))
+
+        registered_workers = {worker["worker_id"] for worker in registry["workers"]}
+        official_profiles = set(profiles["profiles"])
+        official_bindings = set(bindings["bindings"])
+        worker_permissions = set(permissions["worker_assignments"])
+        gateway_profiles = set(permissions["gateway_profile_assignments"])
+
+        for profile_name in sorted(CONCEPTUAL_ROLE_PROFILE_DUPLICATES):
+            with self.subTest(profile_name=profile_name):
+                self.assertNotIn(profile_name, registered_workers)
+                self.assertNotIn(profile_name, official_profiles)
+                self.assertNotIn(profile_name, official_bindings)
+                self.assertNotIn(profile_name, worker_permissions)
+                self.assertNotIn(profile_name, gateway_profiles)
+
+        self.assertEqual(gateway_profiles, {"overkill-factory-gerente"})
 
     def test_worker_packet_carries_profile_binding(self) -> None:
         card_path = ROOT / "examples" / "cards" / "v35_valid_product_face.md"

--- a/validation/factory-production-readiness/current-readiness.json
+++ b/validation/factory-production-readiness/current-readiness.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/factory-production-readiness.schema.json",
   "record_type": "factory_production_readiness",
-  "created_at": "2026-06-11T06:02:47Z",
+  "created_at": "2026-06-11T09:21:21Z",
   "result": "PASS",
   "summary": "Factory vFinal production readiness evidence is complete.",
   "components": [

--- a/validation/hermes-live/factory-vfinal-profile-drift-cleanup.json
+++ b/validation/hermes-live/factory-vfinal-profile-drift-cleanup.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/hermes-profile-drift-cleanup.schema.json",
+  "record_type": "hermes_profile_drift_cleanup",
+  "created_at": "2026-06-11T09:09:35Z",
+  "result": "PASS",
+  "scope": "Public-safe receipt for removing Hermes profiles that duplicated conceptual factory roles already mapped to official workers.",
+  "runtime_ref": "redacted-real-hermes-runtime",
+  "deleted_profile_refs": [
+    "access-capability-worker",
+    "agent-eval-worker",
+    "agentic-method-router",
+    "budget-cost-worker",
+    "data-metrics-worker",
+    "dependency-integration-worker",
+    "factory-concierge",
+    "factory-maturity-auditor",
+    "incident-support-worker",
+    "platform-devex-worker",
+    "privacy-compliance-worker",
+    "product-experience-router",
+    "product-outcome-discovery-worker",
+    "production-readiness-worker",
+    "security-architect-worker",
+    "software-development-planner",
+    "user-docs-onboarding-worker"
+  ],
+  "preserved_profile_refs": [
+    "overkill-factory-gerente"
+  ],
+  "post_cleanup_counts": {
+    "public_worker_profiles": 40,
+    "gateway_interface_profiles": 1,
+    "unexpected_conceptual_duplicate_profiles": 0,
+    "profile_exports_created": 17
+  },
+  "backup_ref": "redacted-private-hermes-profile-backup/prepilot-conceptual-duplicates-20260611T090935Z",
+  "checks": {
+    "conceptual_roles_are_mapped_to_official_workers": true,
+    "deleted_profiles_were_exported_before_removal": true,
+    "dedicated_gateway_profile_preserved": true,
+    "gateway_process_still_running_after_cleanup": true,
+    "raw_private_paths_ids_tokens_and_logs_omitted": true
+  },
+  "evidence_refs": [
+    "docs/agents/factory-stage-agent-map.md#conceptual-roles-to-real-workers",
+    "agents/worker-permission-classes.public.json#gateway_profile_assignments",
+    "validation/hermes-live/factory-vfinal-runtime-status-check.json"
+  ],
+  "limits": [
+    "The private backup location and raw Hermes command output are intentionally not stored in the public repository.",
+    "This receipt does not promote conceptual role names to official workers; it records that they are covered by existing worker contracts.",
+    "If a conceptual role becomes repeated, distinct, verifiable and permission-bounded later, it must be promoted through registry, profile, binding, smoke and eval proof before use."
+  ]
+}

--- a/validation/hermes-live/factory-vfinal-provider-model-audit.json
+++ b/validation/hermes-live/factory-vfinal-provider-model-audit.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/factory-vfinal-provider-model-audit.schema.json",
   "record_type": "factory_vfinal_provider_model_audit",
-  "created_at": "2026-06-11T03:39:57Z",
+  "created_at": "2026-06-11T09:09:35Z",
   "result": "PASS",
   "scope": "Public-safe live configuration audit for the Overkill Factory public worker profiles plus the dedicated Discord GERENTE gateway profile.",
   "runtime_ref": "redacted-real-hermes-runtime",
@@ -14,26 +14,21 @@
     "public_worker_profiles": 40,
     "dedicated_gateway_profiles": 1,
     "factory_scope_profiles_checked": 41,
-    "hermes_profiles_total_observed": 78,
+    "hermes_profiles_total_observed": 42,
     "public_workers_missing_in_hermes": 0,
     "factory_scope_provider_model_mismatch": 0,
     "factory_scope_missing_auth": 0,
     "factory_scope_missing_env": 2,
-    "extra_hermes_profiles_outside_public_registry": 38
+    "extra_hermes_profiles_outside_public_registry": 2,
+    "conceptual_duplicate_profiles_removed": 17,
+    "unexpected_factory_duplicate_profiles": 0
   },
   "factory_scope_missing_env_profiles": [
     "control-tower-projection-worker",
     "discord-control-tower-bridge"
   ],
   "missing_env_interpretation": "These two are worker profiles, not the persistent Discord gateway process. The dedicated gateway profile holds the minimal Discord environment.",
-  "non_factory_provider_model_exceptions": [
-    {
-      "profile_ref": "external-nonfactory-profile",
-      "provider": "xai-oauth",
-      "model_ref": "grok-4.3",
-      "status": "outside_factory_gateway_scope_and_stopped"
-    }
-  ],
+  "non_factory_provider_model_exceptions": [],
   "checks": {
     "public_registry_count_matches_contract": true,
     "public_profiles_exist_in_hermes": true,
@@ -42,15 +37,18 @@
     "dedicated_gateway_profile_present": true,
     "dedicated_gateway_profile_uses_canonical_provider_model": true,
     "private_product_profile_not_used_as_factory_gateway": true,
+    "no_duplicate_conceptual_profiles_present": true,
+    "only_allowed_gateway_profile_outside_worker_registry": true,
     "raw_ids_paths_secrets_omitted": true
   },
   "evidence_refs": [
     "validation/hermes-live/factory12-agent-profile-smoke.json",
+    "validation/hermes-live/factory-vfinal-profile-drift-cleanup.json",
     "validation/hermes-production-update-preflight/current-update-receipt.json"
   ],
   "limits": [
     "This audit proves live profile configuration shape and auth presence without storing raw auth files, raw environment values, private runtime ids, Discord ids, local paths or raw logs.",
     "It does not prove product-specific output quality by itself.",
-    "It should be rerun after adding or removing worker profiles, changing the canonical model, or moving the Discord gateway to another profile."
+    "It should be rerun after adding or removing worker profiles, changing the canonical model, moving the Discord gateway to another profile, or restoring a backup profile."
   ]
 }

--- a/validation/hermes-live/factory-vfinal-runtime-status-check.json
+++ b/validation/hermes-live/factory-vfinal-runtime-status-check.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/hermes-vfinal-runtime-status-check.schema.json",
   "record_type": "hermes_vfinal_runtime_status_check",
-  "created_at": "2026-06-11T05:43:25Z",
+  "created_at": "2026-06-11T09:09:35Z",
   "result": "PASS",
   "scope": "Public-safe read-only check of the real Hermes runtime after vFinal prepilot alignment.",
   "checks": {
@@ -12,16 +12,18 @@
     "dedicated_gerente_gateway_running": true,
     "private_product_profile_not_factory_gateway": true,
     "factory_worker_profiles_present": true,
+    "factory_profile_set_has_no_conceptual_duplicates": true,
     "raw_private_values_omitted": true
   },
   "evidence_refs": [
     "external:read-only-hermes-status-script",
     "validation/hermes-live/factory-vfinal-provider-model-audit.json",
+    "validation/hermes-live/factory-vfinal-profile-drift-cleanup.json",
     "validation/hermes-production-update-preflight/current-update-receipt.json"
   ],
   "limits": [
     "This receipt is public-safe and omits raw Discord ids, runtime ids, local paths, tokens, logs and private board identifiers.",
-    "It proves current runtime shape only; rerun after profile, gateway, model, credential or Discord changes.",
+    "It proves current runtime shape only; rerun after profile, gateway, model, credential, Discord or backup-restore changes.",
     "It does not prove that a future product paper has the required access, approvals or product-specific worker evidence."
   ]
 }

--- a/validation/prepilot/master-task-readiness.json
+++ b/validation/prepilot/master-task-readiness.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/prepilot-master-task-readiness.schema.json",
   "record_type": "prepilot_master_task_readiness",
-  "created_at": "2026-06-11T01:35:00Z",
+  "created_at": "2026-06-11T09:09:35Z",
   "result": "PASS",
   "readiness_level": "PASS_PREPILOT_READY_WITH_REDACTED_PRIVATE_PROOF",
   "source_plan": "Chat-approved 9-task prepilot plan: agents, GERENTE, Discord bridge, private profile separation, provider/model lock, public repo alignment, permissions, reference repo execution and prepilot battery.",
@@ -12,7 +12,7 @@
       "task_id": "classify_vfinal_agents",
       "plain_goal": "Classify vFinal agents as required core, optional pack, private, backlog or remove.",
       "status": "PASS_PUBLIC_CONTRACT",
-      "implementation_summary": "The public roster, registry, profiles and capability packs separate core workers from optional packs and document ownership for each canonical stage.",
+      "implementation_summary": "The public roster, registry, profiles and capability packs separate core workers from optional packs, document ownership for each canonical stage and block conceptual role names from becoming loose executor profiles.",
       "evidence_refs": [
         {
           "kind": "worker_roster",
@@ -38,6 +38,11 @@
           "kind": "test",
           "path": "tests/test_worker_profiles.py",
           "covers": "profile integrity checks"
+        },
+        {
+          "kind": "validation_artifact",
+          "path": "validation/hermes-live/factory-vfinal-profile-drift-cleanup.json",
+          "covers": "public-safe proof that duplicate conceptual Hermes profiles were exported, removed and kept out of the worker layer"
         },
         {
           "kind": "test",
@@ -152,7 +157,7 @@
       "task_id": "lock_canonical_provider_model",
       "plain_goal": "Lock the canonical provider/model and prove auth per profile.",
       "status": "PASS_PRIVATE_PROOF_REDACTED",
-      "implementation_summary": "The provider/model audit and profile smoke prove the public worker set and dedicated gateway profile against the canonical model with private details redacted.",
+      "implementation_summary": "The provider/model audit, profile smoke and drift cleanup prove the public worker set and dedicated gateway profile against the canonical model with private details redacted.",
       "evidence_refs": [
         {
           "kind": "schema",
@@ -173,6 +178,11 @@
           "kind": "validation_artifact",
           "path": "validation/hermes-live/factory-vfinal-runtime-status-check.json",
           "covers": "current read-only runtime status confirms profile list and gateway state"
+        },
+        {
+          "kind": "validation_artifact",
+          "path": "validation/hermes-live/factory-vfinal-profile-drift-cleanup.json",
+          "covers": "conceptual duplicate profile cleanup and preserved GERENTE gateway"
         },
         {
           "kind": "script",


### PR DESCRIPTION
## Summary
- remove drift between live Hermes profiles and the official worker roster by documenting conceptual-role duplicates as non-workers
- add a public-safe drift-cleanup receipt and schema for the 17 exported/removed duplicate profiles
- preserve overkill-factory-gerente as the official Discord interface profile, not an executor worker
- add tests so conceptual role names cannot silently become loose workers again

## Validation
- python -m unittest discover -s tests -p "test*.py" -q
- python scripts/validate_worker_profiles.py
- python scripts/validate_public_json_artifacts.py
- python scripts/secret_safety_scan.py
- python scripts/public_safety_scan.py
- python scripts/factory_production_readiness.py --out validation/factory-production-readiness/current-readiness.json
- git diff --check
