### PR TITLE
Fix Discord manager intake threading

### DIFF
--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -63,23 +63,26 @@ It asks for:
 The owner can start from `#falar-com-gerente`, but a project must not live as a
 loose chat transcript.
 
-The bridge must separate two cases:
+The manager channel is a reception desk, not the project room:
 
 ```text
-short operational question -> answer in the same chat
-paper, long brief, new product or pilot -> create project thread and forum card
+owner mentions GERENTE in #falar-com-gerente -> Discord opens an attendance thread
+short operational question -> answer inside that attendance thread
+paper, long brief, new product or pilot -> same thread becomes project intake + forum card
 ```
 
 For a project intake, the Discord layer should create:
 
-- a project conversation thread tied to the intake message or intake channel;
+- a project conversation thread under `#falar-com-gerente`;
 - a `kanban-da-fabrica` forum post with the initial phase tag;
-- a short pointer message in `#falar-com-gerente`;
+- a short pointer inside the existing attendance thread;
 - a runtime mapping record once Hermes creates or updates the durable card.
 
 Hermes native Discord free-response channels are useful for low-friction chat,
-but they are not enough for factory intake. They can answer inline. The factory
-needs the Concierge bridge to create the project surface deliberately.
+but they are not the right default for factory intake. The factory expects
+`discord.require_mention=true`, `discord.auto_thread=true` and
+`discord.thread_require_mention=false`: the owner mentions the GERENTE once in
+the reception channel, then the whole attendance continues in the thread.
 
 ## Complete UX Contract
 
@@ -89,6 +92,8 @@ asking which channel to use.
 The practical contract is:
 
 - `#falar-com-gerente` is the main door;
+- the main door stays clean: analysis, questions and project decisions happen
+  in the attendance/project thread;
 - `#torre-de-controle` is the global portfolio view, not a message dump;
 - `kanban-da-fabrica` is the project index, not the place for every detail;
 - each project topic is the project cockpit;
@@ -111,7 +116,7 @@ internals. The GERENTE explains, routes and points to the visual surface.
 | Surface | Owner meaning | Required behavior |
 | --- | --- | --- |
 | `#torre-de-controle` | "What is happening across the factory?" | Portfolio dashboard with active projects, stage, progress and alerts. |
-| `#falar-com-gerente` | "Talk to the factory" | Short questions stay inline; project intake gets project surface. |
+| `#falar-com-gerente` | "Talk to the factory" | Reception only: a mention opens an attendance thread; work continues there. |
 | `#projetos-recebidos` | "What entered?" | Registry of received projects; points to the project thread/card. |
 | `kanban-da-fabrica` | "Which projects exist?" | One topic per project; it is an index, not a detailed task board. |
 | project topic | "Where is this project, exactly?" | Project cockpit with pipeline, percent, blockers and next action. |
@@ -130,6 +135,7 @@ surface.
 Rule:
 
 ```text
+reception channel -> thread launcher only
 notification, health ping or dashboard update -> no thread required
 question, decision, access, blocker, evidence discussion, review or project
 conversation -> thread required
@@ -142,7 +148,9 @@ For active work, the bot should either:
 - point clearly to the existing thread.
 
 This keeps `#falar-com-gerente` useful without letting it become a long,
-unsearchable transcript.
+unsearchable transcript. Raw project-like messages left directly in the
+reception channel are ignored by the automation until the owner starts or uses
+an attendance thread.
 
 ## Multi-Project Kanban Rule
 
@@ -310,8 +318,8 @@ scripts/factory_concierge_discord_automation.py
 
 It composes the projector with the remaining Control Tower behavior:
 
-- scan `#falar-com-gerente` for project-like intake messages;
-- create or reuse an intake thread for project messages;
+- scan GERENTE attendance threads under `#falar-com-gerente`;
+- ignore raw project-like messages left directly in the reception channel;
 - create or reuse the project forum topic and cockpit;
 - project runtime events into the correct operational lane;
 - create threads for active events such as access, blockers and approvals;

--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -181,17 +181,18 @@ O repo publico nao pode conter:
 | `kanban-da-fabrica` | um topico por projeto | Concierge e dono |
 | `#arquivo-projetos-antigo` | arquivo, nao uso diario | ponte |
 
-O canal `#falar-com-gerente` e a porta humana principal: o dono fala
-com o GERENTE sem precisar mencionar o bot. Os outros canais devem ser mais
-controlados para evitar barulho e aprovacao acidental.
+O canal `#falar-com-gerente` e a portaria humana principal. O dono menciona o
+GERENTE ali para abrir uma thread de atendimento. Depois disso, conversa,
+perguntas, respostas, paper e decisoes daquele atendimento ficam dentro da
+thread.
 
-Essa decisao tem um detalhe importante: no Hermes nativo, canal livre responde
-inline e pode pular auto-thread. Por isso, `#falar-com-gerente` nao pode ser o
-unico mecanismo de organizacao de projetos. A experiencia certa e:
+Essa decisao tem um detalhe importante: o canal principal nao e sala de projeto.
+Ele so abre a porta. A experiencia certa e:
 
 ```text
-mensagem curta -> resposta curta no chat
-paper/projeto/piloto -> topico do projeto + cartao no forum
+mensagem no #falar-com-gerente com mencao ao GERENTE -> thread de atendimento
+duvida curta -> resposta dentro da thread de atendimento
+paper/projeto/piloto -> mesma thread vira intake + cartao no forum
 ```
 
 `#projetos-recebidos` nao deve ser uma segunda porta humana para mandar paper.
@@ -209,10 +210,14 @@ Em outras palavras: toda mensagem do bot que convida conversa ou acao deve
 nascer com thread, estar dentro de uma thread ou apontar claramente para a
 thread certa. Apenas notificacoes puramente informativas devem ficar soltas.
 
-Se `DISCORD_NO_THREAD_CHANNELS` incluir `#falar-com-gerente`, isso deve ser
-tratado como configuracao apenas para conversa curta. A fabrica ainda precisa
-do `Factory Concierge Discord Bridge` para criar topicos de projeto e cartoes
-no `kanban-da-fabrica`.
+O GERENTE deve usar `discord.require_mention=true`,
+`discord.auto_thread=true` e `discord.thread_require_mention=false`: o dono
+menciona uma vez na portaria, o Hermes abre a thread, e dentro dela o dono nao
+precisa ficar mencionando o bot a cada resposta.
+
+Se alguem deixar um paper solto diretamente em `#falar-com-gerente`, a
+automacao publica ignora esse texto ate existir uma thread de atendimento. Isso
+evita criar um projeto novo para cada resposta do dono.
 
 ## Camada dinamica
 
@@ -224,7 +229,7 @@ O Discord nao deve ser apenas um chat. O modelo recomendado e:
 - botoes de atalho para os canais principais;
 - forum como indice limpo de projetos, com um topico por projeto;
 - cockpit detalhado dentro de cada topico de projeto;
-- intake thread-first: paper ou briefing nunca fica apenas como mensagem solta;
+- intake thread-first: paper ou briefing nasce dentro da thread de atendimento;
 - tags de fase no forum;
 - `#aprovacoes-formais` para decisoes formais;
 - `#acessos-pendentes` como checklist do que falta para autonomia;
@@ -351,7 +356,8 @@ python scripts/factory_concierge_discord_automation.py \
 
 Ela cobre:
 
-- paper/projeto no `#falar-com-gerente` vira thread de intake;
+- thread de atendimento do GERENTE vira intake quando contem paper/projeto;
+- mensagem solta no `#falar-com-gerente` nao vira projeto automaticamente;
 - projeto vira topico/cockpit no `kanban-da-fabrica`;
 - eventos de acesso, bloqueio, prova, release e health vao para os canais
   certos;

--- a/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
+++ b/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
@@ -103,13 +103,17 @@ dono fala com o GERENTE
 ### Resolvido: intake thread-first pelo GERENTE
 
 A automacao `factory_concierge_discord_automation.py` escaneia
-`#falar-com-gerente`, detecta mensagens com cara de projeto/paper e cria ou
-reutiliza:
+threads de atendimento abaixo de `#falar-com-gerente`, detecta mensagens com
+cara de projeto/paper dentro dessas threads e cria ou reutiliza:
 
-- thread de intake no canal do GERENTE;
+- a propria thread de atendimento como thread de intake;
 - registro em `#projetos-recebidos`;
 - topico/cockpit no `kanban-da-fabrica`;
 - dashboard global atualizado.
+
+Mensagem de projeto solta diretamente em `#falar-com-gerente` e ignorada pela
+automacao. O canal principal fica como portaria: o dono menciona o GERENTE,
+entra na thread, e a conversa do projeto continua ali.
 
 ### Resolvido: mapping e cockpit projetado sem duplicar
 

--- a/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
+++ b/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
@@ -136,19 +136,20 @@ Paper, piloto, pedido novo e duvida comecam pelo GERENTE. O canal
 `#projetos-recebidos` existe como registro operacional, nao como segundo lugar
 para o dono mandar o paper.
 
-Mas o chat principal nao pode virar um corredor infinito de mensagens. A regra
-de UX da fabrica e:
+Mas o chat principal nao pode virar um corredor infinito de mensagens. Ele e
+portaria, nao sala de projeto. A regra de UX da fabrica e:
 
 ```text
-duvida curta -> o GERENTE responde no proprio chat
-paper, briefing ou projeto novo -> abre topico do projeto e cartao no Kanban visual
+@GERENTE no #falar-com-gerente -> abre thread de atendimento
+duvida curta -> o GERENTE responde dentro da thread
+paper, briefing ou projeto novo -> a mesma thread vira intake + cartao no Kanban visual
 ```
 
 Isso e importante porque o Hermes nativo trata `free_response_channels` como
-chat leve: o usuario nao precisa mencionar o bot, mas a resposta tende a ficar
-inline. A fabrica nao deve depender apenas desse comportamento nativo para
-intake de projeto. O `Factory Concierge Discord Bridge` precisa reconhecer
-pedido grande, criar o topico certo e apontar o dono para la.
+chat leve. Para a fabrica, o melhor comportamento e o oposto: o dono menciona
+o GERENTE uma vez no canal principal, o Hermes abre a thread, e a conversa
+continua ali sem nova mencao a cada resposta. A bridge reconhece o pedido
+grande dentro da thread, cria o topico certo e aponta o dono para la.
 
 Exemplos de pedidos naturais:
 
@@ -225,10 +226,9 @@ trabalha em mais de um produto ao mesmo tempo.
 
 Todo paper, briefing longo, novo produto ou pedido de piloto precisa gerar:
 
-1. um topico de conversa ligado a mensagem original ou ao canal de intake;
+1. uma thread de atendimento ligada ao `#falar-com-gerente`;
 2. um cartao no forum `kanban-da-fabrica`;
-3. uma resposta curta no `#falar-com-gerente` dizendo onde o projeto passou a
-   morar;
+3. uma resposta curta dentro da thread dizendo onde o projeto passou a morar;
 4. uma ligacao public-safe com o estado real no Hermes quando o runtime criar
    ou atualizar a card graph.
 
@@ -241,6 +241,10 @@ pergunta / decisao / acesso / bloqueio / revisao / projeto -> thread
 
 Se a mensagem chama o dono para uma acao ou conversa, ela deve abrir thread,
 estar dentro de uma thread ou apontar para a thread certa.
+
+Mensagem de projeto deixada solta no `#falar-com-gerente` nao deve ser
+processada como novo projeto. O dono precisa iniciar ou usar a thread de
+atendimento; isso evita que uma resposta de pergunta vire um segundo projeto.
 
 O nome do topico deve ser humano e curto, por exemplo:
 
@@ -319,7 +323,7 @@ Lugar para ver e falar com a fabrica.
 | Canal | Uso |
 | --- | --- |
 | `#torre-de-controle` | painel fixo com status, fase, pendencias e atalhos |
-| `#falar-com-gerente` | conversa direta com o GERENTE, sem precisar mencionar |
+| `#falar-com-gerente` | portaria: mencione o GERENTE para abrir atendimento |
 | `#saude-do-bot` | health do bot, Hermes, gateway e ponte |
 | `sala-de-voz-gerente` | conversa por voz quando fizer sentido |
 
@@ -444,8 +448,9 @@ Cada projeto no forum deve ter:
 - historico resumido.
 
 Esse topico deve nascer no intake, nao depois que o projeto ja virou um bloco
-de conversa perdido no chat. Se o dono mandar o paper em `#falar-com-gerente`,
-a ponte deve criar o topico e o cartao automaticamente.
+de conversa perdido no chat. O dono menciona o GERENTE no `#falar-com-gerente`,
+o Hermes abre a thread de atendimento, e a ponte cria o topico e o cartao a
+partir do conteudo dessa thread.
 
 ### 3. Aprovacao com botao e formulario
 

--- a/schemas/discord-control-tower-ux-audit.schema.json
+++ b/schemas/discord-control-tower-ux-audit.schema.json
@@ -83,6 +83,8 @@
         "kanban_guide_not_marked_as_blocked_project",
         "active_bot_messages_threaded_or_linked",
         "free_response_threading_conflict_documented",
+        "manager_reception_thread_launcher_only",
+        "project_conversation_stays_in_single_thread",
         "thread_first_project_intake_automated",
         "structured_approval_interactions_automated",
         "live_runtime_projection_automated"
@@ -118,6 +120,8 @@
         "kanban_guide_not_marked_as_blocked_project": { "type": "boolean" },
         "active_bot_messages_threaded_or_linked": { "type": "boolean" },
         "free_response_threading_conflict_documented": { "type": "boolean" },
+        "manager_reception_thread_launcher_only": { "type": "boolean" },
+        "project_conversation_stays_in_single_thread": { "type": "boolean" },
         "thread_first_project_intake_automated": { "type": "boolean" },
         "structured_approval_interactions_automated": { "type": "boolean" },
         "live_runtime_projection_automated": { "type": "boolean" }

--- a/scripts/factory_concierge_discord_automation.py
+++ b/scripts/factory_concierge_discord_automation.py
@@ -218,6 +218,25 @@ def find_named_thread(
     return None
 
 
+def list_child_threads(
+    client: bridge.DiscordClient,
+    guild_id: str,
+    parent_id: str,
+) -> list[dict[str, Any]]:
+    return [
+        thread
+        for thread in client.list_active_threads(guild_id)
+        if str(thread.get("parent_id")) == str(parent_id)
+    ]
+
+
+def first_project_intake_message(messages: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for message in reversed(messages):
+        if looks_like_project_intake(message):
+            return message
+    return None
+
+
 def ensure_thread_from_message(
     client: bridge.DiscordClient,
     guild_id: str,
@@ -276,34 +295,35 @@ def process_intake_messages(
     guild_id, channels = resolve_channels(client, config)
     manager_id = str(channels["manager"]["id"])
     state.setdefault("intake", {}).setdefault("processed_messages", {})
+    state.setdefault("intake", {}).setdefault("processed_threads", {})
     results: list[dict[str, Any]] = []
-    messages = client.list_messages(manager_id, limit=max_messages)
-    for message in reversed(messages):
+    reception_messages = client.list_messages(manager_id, limit=max_messages)
+    ignored_reception_messages = sum(1 for message in reception_messages if looks_like_project_intake(message))
+    manager_threads = list_child_threads(client, guild_id, manager_id)
+    for thread in manager_threads:
+        thread_id = str(thread.get("id") or "")
+        if not thread_id or thread_id in state["intake"]["processed_threads"]:
+            continue
+        thread_messages = client.list_messages(thread_id, limit=max_messages)
+        message = first_project_intake_message(thread_messages)
+        if not message:
+            continue
         message_id = str(message.get("id") or "")
         if not message_id or message_id in state["intake"]["processed_messages"]:
-            continue
-        if not looks_like_project_intake(message):
             continue
         projection = default_projection_from_intake(message)
         project_id = str(projection["project_id"])
         state.setdefault("projects", {}).setdefault(project_id, {})
         project_state = state["projects"][project_id]
-        intake_thread = ensure_thread_from_message(
-            client,
-            guild_id,
-            manager_id,
-            message_id,
-            str(projection["name"]),
-            project_state,
-            "intake_thread_id",
-            apply,
-        )
+        if apply:
+            project_state["intake_thread_id"] = thread_id
+            project_state["intake_thread_source"] = "manager_thread"
         bridge_result = bridge.project_bridge_apply(projection, client, config, state)
         cockpit_thread_id = (bridge_result.get("project_thread") or {}).get("thread_id")
-        if intake_thread.get("thread_id"):
+        if thread_id:
             bridge.upsert_message(
                 client=client,
-                channel_id=str(intake_thread["thread_id"]),
+                channel_id=thread_id,
                 payload=intake_message_payload(projection, cockpit_thread_id),
                 expected_marker=f"{INTAKE_MARKER_PREFIX}{project_id}",
                 state_ref=project_state,
@@ -315,17 +335,25 @@ def process_intake_messages(
                 "project_id": project_id,
                 "processed_at": utc_now(),
             }
+            state["intake"]["processed_threads"][thread_id] = {
+                "project_id": project_id,
+                "processed_at": utc_now(),
+            }
         results.append(
             {
                 "project_id": project_id,
                 "message_processed": True,
-                "intake_thread_created": bool(intake_thread.get("created")),
-                "intake_thread_resolved": bool(intake_thread.get("thread_id")),
+                "thread_first": True,
+                "intake_thread_created": False,
+                "intake_thread_resolved": bool(thread_id),
                 "project_surface_resolved": bool(cockpit_thread_id),
             }
         )
     return {
-        "scanned": len(messages),
+        "scanned": len(manager_threads),
+        "scanned_threads": len(manager_threads),
+        "scanned_reception_messages": len(reception_messages),
+        "ignored_reception_messages": ignored_reception_messages,
         "processed": len(results),
         "results": results,
     }

--- a/templates/discord-control-tower-ux-audit.json
+++ b/templates/discord-control-tower-ux-audit.json
@@ -41,6 +41,8 @@
     "kanban_guide_not_marked_as_blocked_project": false,
     "active_bot_messages_threaded_or_linked": false,
     "free_response_threading_conflict_documented": false,
+    "manager_reception_thread_launcher_only": false,
+    "project_conversation_stays_in_single_thread": false,
     "thread_first_project_intake_automated": false,
     "structured_approval_interactions_automated": false,
     "live_runtime_projection_automated": false

--- a/tests/test_discord_control_tower_ux_audit.py
+++ b/tests/test_discord_control_tower_ux_audit.py
@@ -20,9 +20,10 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         os_doc = read_text("docs/control-tower/discord-control-tower-os.md")
         combined = "\n".join([dynamic_study, setup_guide, os_doc])
 
-        self.assertIn("paper, briefing ou projeto novo -> abre topico do projeto", dynamic_study)
-        self.assertIn("paper/projeto/piloto -> topico do projeto + cartao no forum", setup_guide)
-        self.assertIn("paper, long brief, new product or pilot -> create project thread and forum card", os_doc)
+        self.assertIn("@GERENTE no #falar-com-gerente -> abre thread de atendimento", dynamic_study)
+        self.assertIn("mensagem no #falar-com-gerente com mencao ao GERENTE -> thread de atendimento", setup_guide)
+        self.assertIn("owner mentions GERENTE in #falar-com-gerente -> Discord opens an attendance thread", os_doc)
+        self.assertIn("raw project-like messages left directly in the", os_doc)
         self.assertIn("#projetos-recebidos", combined)
         self.assertIn("not a second owner intake", os_doc)
         self.assertIn("project cockpit", os_doc)
@@ -55,10 +56,13 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertTrue(audit["checks"]["multi_project_kanban_idempotence_automated"])
         self.assertTrue(audit["checks"]["project_pipeline_projection_automated"])
         self.assertTrue(audit["checks"]["active_bot_messages_threaded_or_linked"])
+        self.assertTrue(audit["checks"]["manager_reception_thread_launcher_only"])
+        self.assertTrue(audit["checks"]["project_conversation_stays_in_single_thread"])
         self.assertTrue(audit["checks"]["thread_first_project_intake_automated"])
         self.assertTrue(audit["checks"]["structured_approval_interactions_automated"])
         self.assertTrue(audit["checks"]["live_runtime_projection_automated"])
-        self.assertIn("created a project conversation thread", "\n".join(audit["live_corrections"]))
+        self.assertIn("created and reused a project conversation thread", "\n".join(audit["live_corrections"]))
+        self.assertIn("raw reception message ignore behavior", "\n".join(audit["live_corrections"]))
         self.assertIn("retry-safe project mapping", "\n".join(audit["live_corrections"]))
         self.assertIn(
             "validation/control-tower/discord-bridge-projector-live-2026-06-11.json",

--- a/tests/test_factory_concierge_discord_automation.py
+++ b/tests/test_factory_concierge_discord_automation.py
@@ -65,6 +65,23 @@ class FakeDiscordClient:
             {"content": content, "author": {"id": "owner", "bot": False}, "attachments": []},
         )
 
+    def seed_manager_thread_message(
+        self,
+        content: str,
+        thread_name: str = "atendimento-gerente",
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        starter = self.seed_manager_message("@GERENTE iniciar atendimento")
+        thread = self.create_thread_from_message(
+            "chan-manager",
+            starter["id"],
+            {"name": thread_name, "auto_archive_duration": 10080},
+        )
+        message = self.post_message(
+            thread["id"],
+            {"content": content, "author": {"id": "owner", "bot": False}, "attachments": []},
+        )
+        return thread, message
+
     def get_current_user(self) -> dict[str, Any]:
         return {"id": "bot-user", "username": "GERENTE"}
 
@@ -149,9 +166,9 @@ def approval_request() -> dict[str, Any]:
 
 
 class FactoryConciergeDiscordAutomationTest(unittest.TestCase):
-    def test_intake_scan_creates_manager_thread_and_project_surfaces(self) -> None:
+    def test_intake_scan_uses_existing_manager_thread_and_project_surfaces(self) -> None:
         client = FakeDiscordClient()
-        client.seed_manager_message(
+        intake_thread, _ = client.seed_manager_thread_message(
             "Paper do projeto: quero criar o front jogo da fabrica. "
             "Este piloto precisa acompanhar a esteira da Overkill Factory com UX visual."
         )
@@ -162,11 +179,30 @@ class FactoryConciergeDiscordAutomationTest(unittest.TestCase):
 
         self.assertEqual(result["processed"], 1)
         item = result["results"][0]
+        self.assertTrue(item["thread_first"])
+        self.assertFalse(item["intake_thread_created"])
         self.assertTrue(item["intake_thread_resolved"])
         self.assertTrue(item["project_surface_resolved"])
         self.assertEqual(len([t for t in client.threads if t["parent_id"] == "chan-manager"]), 1)
+        self.assertEqual(state["projects"]["pilot-front-jogo-fabrica"]["intake_thread_id"], intake_thread["id"])
         self.assertEqual(len([t for t in client.threads if t["parent_id"] == "forum-kanban"]), 1)
         self.assertIn("pilot-front-jogo-fabrica", state["projects"])
+
+    def test_intake_scan_ignores_reception_messages_without_thread(self) -> None:
+        client = FakeDiscordClient()
+        client.seed_manager_message(
+            "Paper do projeto: quero criar o front jogo da fabrica. "
+            "Este piloto precisa acompanhar a esteira da Overkill Factory com UX visual."
+        )
+        state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {}}
+        config = bridge.BridgeConfig(apply=True, guild_id=None, state_path=Path("private.json"))
+
+        result = automation.process_intake_messages(client, config, state, apply=True)
+
+        self.assertEqual(result["processed"], 0)
+        self.assertEqual(result["ignored_reception_messages"], 1)
+        self.assertEqual(len([t for t in client.threads if t["parent_id"] == "chan-manager"]), 0)
+        self.assertEqual(state["projects"], {})
 
     def test_active_event_sync_posts_lane_message_and_thread(self) -> None:
         client = FakeDiscordClient()

--- a/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
@@ -3,7 +3,7 @@
   "record_type": "discord_control_tower_ux_audit",
   "created_at": "2026-06-11T08:00:00Z",
   "result": "PASS",
-  "scope": "Public-safe UX audit of the live Discord Control Tower during the first pilot intake, including channels, project intake, active-message threading, multi-project Kanban behavior and project-level pipeline predictability.",
+  "scope": "Public-safe UX audit of the live Discord Control Tower during the first pilot intake, including channels, GERENTE thread-first reception, project intake, active-message threading, multi-project Kanban behavior and project-level pipeline predictability.",
   "observed_model": {
     "runtime": "Hermes",
     "owner_language": "pt-BR",
@@ -41,6 +41,8 @@
     "kanban_guide_not_marked_as_blocked_project": true,
     "active_bot_messages_threaded_or_linked": true,
     "free_response_threading_conflict_documented": true,
+    "manager_reception_thread_launcher_only": true,
+    "project_conversation_stays_in_single_thread": true,
     "thread_first_project_intake_automated": true,
     "structured_approval_interactions_automated": true,
     "live_runtime_projection_automated": true
@@ -56,18 +58,20 @@
   "live_corrections": [
     "renamed the project intake lane to a project registry lane so the GERENTE remains the single owner intake door",
     "updated the main dashboard to act as a global portfolio view instead of a detail dump",
-    "updated the GERENTE channel guide to say papers and pilots start there",
+    "updated the GERENTE channel guide to say the channel is reception only and project conversation continues inside the attendance thread",
     "updated the project registry guide to say it is not a second paper submission channel",
     "updated the Kanban guide to clarify one topic per project, project-index behavior and retry-safe mapping",
     "created or updated a project pipeline panel inside the pilot project topic",
-    "created a project conversation thread for the active pilot",
+    "created and reused a project conversation thread for the active pilot",
     "created a visual forum card for the active pilot with the Entrada tag",
     "implemented the Factory Concierge Discord Bridge projector with retry-safe project mapping",
     "proved live Discord projection twice against the pilot: one project topic, one dashboard marker, one registry marker and one cockpit marker",
-    "implemented thread-first GERENTE intake scan",
+    "implemented thread-first GERENTE intake scan over manager attendance threads",
+    "implemented raw reception message ignore behavior so loose project-like messages do not create duplicate projects",
     "implemented active event lane projection with thread creation",
     "implemented Portuguese structured approval buttons and decision validation",
     "implemented bridge health projection",
+    "proved live Discord automation after the GERENTE thread contract update with thread-first and health checks passing",
     "proved live Discord automation twice: one manager thread, one forum topic, one dashboard marker, one registry marker, one event marker, one approval marker and one health marker"
   ],
   "next_required_actions": [
@@ -87,6 +91,7 @@
     "external:live-discord-kanban-forum-card-created",
     "validation/control-tower/discord-bridge-projector-live-2026-06-11.json",
     "validation/control-tower/discord-control-tower-automation-live-2026-06-11.json",
+    "validation/control-tower/discord-gerente-thread-intake-contract-2026-06-11.json",
     "scripts/factory_concierge_discord_bridge.py",
     "scripts/factory_concierge_discord_automation.py",
     "tests/test_factory_concierge_discord_bridge.py"

--- a/validation/control-tower/discord-gerente-thread-intake-contract-2026-06-11.json
+++ b/validation/control-tower/discord-gerente-thread-intake-contract-2026-06-11.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/hermes-update-receipt.schema.json",
+  "record_type": "hermes_update_receipt",
+  "created_at": "2026-06-11T09:30:00Z",
+  "scope": "Public-safe receipt for the live GERENTE Discord intake contract update.",
+  "before": {
+    "gerente_profile_exists": true,
+    "discord_require_mention": true,
+    "discord_auto_thread": true,
+    "discord_thread_require_mention": false,
+    "discord_free_response_channels_empty": true,
+    "soul_had_explicit_reception_thread_contract": false
+  },
+  "after": {
+    "soul_has_explicit_reception_thread_contract": true,
+    "manager_channel_role": "reception_thread_launcher_only",
+    "project_intake_location": "manager_attendance_thread",
+    "project_questions_location": "same_manager_attendance_thread",
+    "loose_reception_project_messages_create_project": false,
+    "gateway_reloaded": true
+  },
+  "adapter_patch": {
+    "public_automation": "factory_concierge_discord_automation now scans GERENTE attendance threads and ignores loose project-like reception messages.",
+    "live_profile": "GERENTE SOUL now documents the reception/thread contract.",
+    "live_config": "Discord require_mention, auto_thread and thread_require_mention were read back as the expected values."
+  },
+  "checks": {
+    "backup_created_before_live_soul_update": true,
+    "public_docs_updated": true,
+    "public_schema_updated": true,
+    "unit_tests_updated": true,
+    "live_readback_passed": true,
+    "live_discord_automation_smoke_passed": true,
+    "public_safe": true
+  },
+  "decision": {
+    "result": "PASS",
+    "operator_effect": "The owner starts in the GERENTE reception channel, Discord/Hermes opens one attendance thread, and the project conversation remains in that thread."
+  },
+  "evidence_refs": [
+    "scripts/factory_concierge_discord_automation.py",
+    "tests/test_factory_concierge_discord_automation.py",
+    "tests/test_discord_control_tower_ux_audit.py",
+    "docs/control-tower/discord-control-tower-os.md",
+    "docs/control-tower/discord-control-tower-setup-pt-br.md",
+    "validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json",
+    "external:live-discord-thread-contract-smoke"
+  ]
+}


### PR DESCRIPTION
## Summary
- Makes the GERENTE intake automation process existing attendance threads instead of loose messages in #falar-com-gerente.
- Documents the new Discord UX contract: main channel is reception only; project conversation stays in one thread.
- Adds audit checks and a public-safe Hermes update receipt for the live GERENTE thread contract.

## Validation
- python -m unittest discover -s tests -p "test*.py" -q
- python scripts/validate_public_json_artifacts.py
- python scripts/secret_safety_scan.py
- python scripts/public_safety_scan.py
- python scripts/factory_production_readiness.py --out .tmp/readiness-discord-thread-contract.json
- live Discord/Hermes smoke: thread-first, active-message and health checks PASS