### PR TITLE
Document Discord thread env overrides

### DIFF
--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -84,6 +84,12 @@ but they are not the right default for factory intake. The factory expects
 `discord.thread_require_mention=false`: the owner mentions the GERENTE once in
 the reception channel, then the whole attendance continues in the thread.
 
+Important runtime detail: Hermes Discord env vars override `config.yaml`. A
+production GERENTE profile must not put the manager channel in
+`DISCORD_NO_THREAD_CHANNELS` or `DISCORD_FREE_RESPONSE_CHANNELS`, and
+`DISCORD_THREAD_REQUIRE_MENTION` must be `false`. Otherwise the bot can answer
+mentions correctly while still failing to open the attendance thread.
+
 ## Complete UX Contract
 
 The Discord layer is good only when the owner understands the system without

--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -215,6 +215,13 @@ O GERENTE deve usar `discord.require_mention=true`,
 menciona uma vez na portaria, o Hermes abre a thread, e dentro dela o dono nao
 precisa ficar mencionando o bot a cada resposta.
 
+Detalhe critico do runtime: no Hermes, variaveis do `.env` ganham do
+`config.yaml`. Entao o perfil de producao do GERENTE nao pode deixar o canal do
+GERENTE dentro de `DISCORD_NO_THREAD_CHANNELS` ou
+`DISCORD_FREE_RESPONSE_CHANNELS`, e `DISCORD_THREAD_REQUIRE_MENTION` precisa
+ser `false`. Se isso ficar errado, o bot responde por mencao, mas nao abre a
+thread de atendimento.
+
 Se alguem deixar um paper solto diretamente em `#falar-com-gerente`, a
 automacao publica ignora esse texto ate existir uma thread de atendimento. Isso
 evita criar um projeto novo para cada resposta do dono.

--- a/tests/test_discord_control_tower_ux_audit.py
+++ b/tests/test_discord_control_tower_ux_audit.py
@@ -24,6 +24,8 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertIn("mensagem no #falar-com-gerente com mencao ao GERENTE -> thread de atendimento", setup_guide)
         self.assertIn("owner mentions GERENTE in #falar-com-gerente -> Discord opens an attendance thread", os_doc)
         self.assertIn("raw project-like messages left directly in the", os_doc)
+        self.assertIn("env vars override `config.yaml`", os_doc)
+        self.assertIn("variaveis do `.env` ganham do", setup_guide)
         self.assertIn("#projetos-recebidos", combined)
         self.assertIn("not a second owner intake", os_doc)
         self.assertIn("project cockpit", os_doc)
@@ -63,6 +65,7 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertTrue(audit["checks"]["live_runtime_projection_automated"])
         self.assertIn("created and reused a project conversation thread", "\n".join(audit["live_corrections"]))
         self.assertIn("raw reception message ignore behavior", "\n".join(audit["live_corrections"]))
+        self.assertIn("env overrides", "\n".join(audit["live_corrections"]))
         self.assertIn("retry-safe project mapping", "\n".join(audit["live_corrections"]))
         self.assertIn(
             "validation/control-tower/discord-bridge-projector-live-2026-06-11.json",

--- a/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
@@ -68,6 +68,7 @@
     "proved live Discord projection twice against the pilot: one project topic, one dashboard marker, one registry marker and one cockpit marker",
     "implemented thread-first GERENTE intake scan over manager attendance threads",
     "implemented raw reception message ignore behavior so loose project-like messages do not create duplicate projects",
+    "corrected live GERENTE Discord env overrides that were disabling auto-thread in the manager channel",
     "implemented active event lane projection with thread creation",
     "implemented Portuguese structured approval buttons and decision validation",
     "implemented bridge health projection",

--- a/validation/control-tower/discord-gerente-thread-intake-contract-2026-06-11.json
+++ b/validation/control-tower/discord-gerente-thread-intake-contract-2026-06-11.json
@@ -1,18 +1,24 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/hermes-update-receipt.schema.json",
   "record_type": "hermes_update_receipt",
-  "created_at": "2026-06-11T09:30:00Z",
+  "created_at": "2026-06-11T10:25:00Z",
   "scope": "Public-safe receipt for the live GERENTE Discord intake contract update.",
   "before": {
     "gerente_profile_exists": true,
-    "discord_require_mention": true,
-    "discord_auto_thread": true,
-    "discord_thread_require_mention": false,
-    "discord_free_response_channels_empty": true,
+    "yaml_discord_require_mention": true,
+    "yaml_discord_auto_thread": true,
+    "yaml_discord_thread_require_mention": false,
+    "live_env_overrode_yaml_thread_require_mention": true,
+    "live_env_blocked_manager_auto_thread": true,
     "soul_had_explicit_reception_thread_contract": false
   },
   "after": {
     "soul_has_explicit_reception_thread_contract": true,
+    "live_env_discord_require_mention": true,
+    "live_env_discord_auto_thread": true,
+    "live_env_discord_thread_require_mention": false,
+    "live_env_no_thread_channels_empty": true,
+    "live_env_free_response_channels_empty": true,
     "manager_channel_role": "reception_thread_launcher_only",
     "project_intake_location": "manager_attendance_thread",
     "project_questions_location": "same_manager_attendance_thread",
@@ -22,15 +28,17 @@
   "adapter_patch": {
     "public_automation": "factory_concierge_discord_automation now scans GERENTE attendance threads and ignores loose project-like reception messages.",
     "live_profile": "GERENTE SOUL now documents the reception/thread contract.",
-    "live_config": "Discord require_mention, auto_thread and thread_require_mention were read back as the expected values."
+    "live_config": "Discord env overrides were corrected so YAML and runtime agree: mention required in the reception channel, auto-thread enabled, no free-response/no-thread exception for the GERENTE channel, and no mention required inside the thread."
   },
   "checks": {
     "backup_created_before_live_soul_update": true,
+    "backup_created_before_live_env_update": true,
     "public_docs_updated": true,
     "public_schema_updated": true,
     "unit_tests_updated": true,
     "live_readback_passed": true,
     "live_discord_automation_smoke_passed": true,
+    "live_discord_thread_permission_probe_passed": true,
     "public_safe": true
   },
   "decision": {


### PR DESCRIPTION
## Summary
- Documents that Hermes Discord env vars override config.yaml for the GERENTE profile.
- Records the real cause of the failed thread opening: DISCORD_NO_THREAD_CHANNELS / free-response overrides were blocking auto-thread.
- Updates the public-safe receipt and UX audit with the live env correction and thread permission probe.

## Validation
- python -m unittest discover -s tests -p "test*.py" -q
- python scripts/validate_public_json_artifacts.py
- python scripts/secret_safety_scan.py
- python scripts/public_safety_scan.py
- live Hermes readback: require mention true, auto-thread true, thread mention false, no-thread/free-response empty
- live Discord VM probe: bot can create, archive, delete a disposable manager thread and delete the seed message