### PR TITLE
Enforce Discord formal approval lane

### DIFF
--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -158,6 +158,13 @@ unsearchable transcript. Raw project-like messages left directly in the
 reception channel are ignored by the automation until the owner starts or uses
 an attendance thread.
 
+Formal approvals are the exception to "keep the project conversation in the
+project thread". The project thread may explain that a decision is needed and
+link to it, but the formal approval request itself must be rendered by the
+bridge in `#aprovacoes-formais` with structured scope, risk, buttons and a
+runtime-registration path. A free-form approval message in a project thread is
+only context; it is not a valid factory approval.
+
 ## Multi-Project Kanban Rule
 
 The Discord Kanban can support multiple projects if the bridge treats the forum

--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -199,6 +199,12 @@ paper/projeto/piloto -> mesma thread vira intake + cartao no forum
 Ele existe para registrar que um projeto entrou e apontar para o topico/card
 correto. Se o dono estiver em duvida, deve falar com o GERENTE.
 
+Importante: a thread do projeto nao e o lugar da aprovacao formal. A thread
+pode explicar que existe uma decisao pendente e apontar para ela, mas o pedido
+formal precisa aparecer em `#aprovacoes-formais`, criado pela bridge a partir
+de um `approval-request` estruturado. Mensagem solta na thread, mesmo escrita
+pelo GERENTE, nao aprova gate.
+
 Mensagens ativas tambem precisam seguir uma regra simples:
 
 ```text
@@ -370,6 +376,8 @@ Ela cobre:
   certos;
 - mensagem ativa cria thread ou aponta para thread existente;
 - aprovacao formal aparece com botoes em portugues;
+- aprovacao formal nasce em `#aprovacoes-formais`, nao como texto solto na
+  thread do projeto;
 - decisao de aprovacao so vira evento depois de validar id, papel, escopo e
   prazo;
 - health da ponte e atualizado em `#saude-do-bot`;

--- a/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
+++ b/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
@@ -399,6 +399,11 @@ No Discord isso pode aparecer como botao, menu ou formulario. Mas o clique so
 vale depois que a ponte valida usuario, canal, prazo, escopo e registra o evento
 no Hermes.
 
+A thread do projeto pode avisar "ha uma aprovacao pendente" e apontar para o
+canal certo. Ela nao deve conter o pedido formal como texto solto. Pedido
+formal fica em `#aprovacoes-formais`, com escopo, risco, botoes e caminho de
+registro no Hermes.
+
 ## O que ja esta pronto no Discord real
 
 A estrutura real foi ajustada para:

--- a/schemas/discord-control-tower-ux-audit.schema.json
+++ b/schemas/discord-control-tower-ux-audit.schema.json
@@ -86,6 +86,7 @@
         "manager_reception_thread_launcher_only",
         "project_conversation_stays_in_single_thread",
         "thread_first_project_intake_automated",
+        "formal_approvals_lane_bound",
         "structured_approval_interactions_automated",
         "live_runtime_projection_automated"
       ],
@@ -123,6 +124,7 @@
         "manager_reception_thread_launcher_only": { "type": "boolean" },
         "project_conversation_stays_in_single_thread": { "type": "boolean" },
         "thread_first_project_intake_automated": { "type": "boolean" },
+        "formal_approvals_lane_bound": { "type": "boolean" },
         "structured_approval_interactions_automated": { "type": "boolean" },
         "live_runtime_projection_automated": { "type": "boolean" }
       },

--- a/templates/discord-control-tower-ux-audit.json
+++ b/templates/discord-control-tower-ux-audit.json
@@ -44,6 +44,7 @@
     "manager_reception_thread_launcher_only": false,
     "project_conversation_stays_in_single_thread": false,
     "thread_first_project_intake_automated": false,
+    "formal_approvals_lane_bound": false,
     "structured_approval_interactions_automated": false,
     "live_runtime_projection_automated": false
   },

--- a/tests/test_discord_control_tower_ux_audit.py
+++ b/tests/test_discord_control_tower_ux_audit.py
@@ -26,6 +26,8 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertIn("raw project-like messages left directly in the", os_doc)
         self.assertIn("env vars override `config.yaml`", os_doc)
         self.assertIn("variaveis do `.env` ganham do", setup_guide)
+        self.assertIn("the formal approval request itself must be rendered", os_doc)
+        self.assertIn("aprovacao formal nasce em `#aprovacoes-formais`", setup_guide)
         self.assertIn("#projetos-recebidos", combined)
         self.assertIn("not a second owner intake", os_doc)
         self.assertIn("project cockpit", os_doc)
@@ -61,11 +63,13 @@ class DiscordControlTowerUxAuditTest(unittest.TestCase):
         self.assertTrue(audit["checks"]["manager_reception_thread_launcher_only"])
         self.assertTrue(audit["checks"]["project_conversation_stays_in_single_thread"])
         self.assertTrue(audit["checks"]["thread_first_project_intake_automated"])
+        self.assertTrue(audit["checks"]["formal_approvals_lane_bound"])
         self.assertTrue(audit["checks"]["structured_approval_interactions_automated"])
         self.assertTrue(audit["checks"]["live_runtime_projection_automated"])
         self.assertIn("created and reused a project conversation thread", "\n".join(audit["live_corrections"]))
         self.assertIn("raw reception message ignore behavior", "\n".join(audit["live_corrections"]))
         self.assertIn("env overrides", "\n".join(audit["live_corrections"]))
+        self.assertIn("formal approval requests must live in the approvals lane", "\n".join(audit["live_corrections"]))
         self.assertIn("retry-safe project mapping", "\n".join(audit["live_corrections"]))
         self.assertIn(
             "validation/control-tower/discord-bridge-projector-live-2026-06-11.json",

--- a/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
@@ -44,6 +44,7 @@
     "manager_reception_thread_launcher_only": true,
     "project_conversation_stays_in_single_thread": true,
     "thread_first_project_intake_automated": true,
+    "formal_approvals_lane_bound": true,
     "structured_approval_interactions_automated": true,
     "live_runtime_projection_automated": true
   },
@@ -69,6 +70,7 @@
     "implemented thread-first GERENTE intake scan over manager attendance threads",
     "implemented raw reception message ignore behavior so loose project-like messages do not create duplicate projects",
     "corrected live GERENTE Discord env overrides that were disabling auto-thread in the manager channel",
+    "formalized that project threads can point to approvals but formal approval requests must live in the approvals lane",
     "implemented active event lane projection with thread creation",
     "implemented Portuguese structured approval buttons and decision validation",
     "implemented bridge health projection",

--- a/validation/control-tower/discord-formal-approval-lane-contract-2026-06-11.json
+++ b/validation/control-tower/discord-formal-approval-lane-contract-2026-06-11.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/hermes-update-receipt.schema.json",
+  "record_type": "hermes_update_receipt",
+  "created_at": "2026-06-11T10:45:00Z",
+  "scope": "Public-safe receipt for the Discord formal approval lane contract.",
+  "before": {
+    "gerente_could_write_approval_context_in_project_thread": true,
+    "approval_lane_contract_was_not_explicit_enough": true,
+    "free_form_thread_text_was_not_valid_approval": true
+  },
+  "after": {
+    "project_thread_role": "context_and_pointer_only",
+    "formal_approval_surface": "approvals_lane",
+    "formal_approval_requires_structured_request": true,
+    "formal_approval_requires_runtime_registration_path": true,
+    "planning_gate_scope_limited": true,
+    "live_gerente_soul_updated": true,
+    "gateway_reloaded": true
+  },
+  "adapter_patch": {
+    "live_profile": "GERENTE SOUL now requires formal approval requests to be created through a structured approval-request and rendered in the approvals lane.",
+    "public_docs": "Control Tower docs now state that project threads may point to formal approvals but cannot host free-form approval requests.",
+    "live_bridge_smoke": "A pending G0 planning-boundary approval request was posted through the bridge with structured buttons and public-safe limits."
+  },
+  "checks": {
+    "backup_created_before_live_soul_update": true,
+    "public_docs_updated": true,
+    "public_schema_updated": true,
+    "unit_tests_updated": true,
+    "live_discord_approval_lane_smoke_passed": true,
+    "public_safe": true
+  },
+  "decision": {
+    "result": "PASS",
+    "operator_effect": "The project thread should no longer be used as the formal approval surface; approval requests belong in the approvals lane with explicit scope and buttons."
+  },
+  "evidence_refs": [
+    "docs/control-tower/discord-control-tower-os.md",
+    "docs/control-tower/discord-control-tower-setup-pt-br.md",
+    "docs/control-tower/discord-dynamic-control-tower-study-pt-br.md",
+    "tests/test_discord_control_tower_ux_audit.py",
+    "validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json",
+    "external:live-discord-g0-approval-lane-smoke"
+  ]
+}


### PR DESCRIPTION
## Summary
- Makes the Discord Control Tower contract explicit: project threads may point to approvals, but formal approval requests must live in #aprovacoes-formais.
- Adds a UX audit check for lane-bound formal approvals.
- Updates public-safe receipt after the live GERENTE SOUL was corrected and a G0 planning-boundary approval was posted through the bridge.

## Validation
- python -m unittest discover -s tests -p "test*.py" -q
- python scripts/validate_public_json_artifacts.py
- python scripts/secret_safety_scan.py
- python scripts/public_safety_scan.py
- live GERENTE SOUL readback: Formal Approval UX present
- live Discord bridge smoke: pending G0 approval rendered in approvals lane with structured buttons; bridge health PASS