### PR TITLE
Harden Discord Control Tower audit

### DIFF
--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -169,16 +169,16 @@ O repo publico nao pode conter:
 
 | Canal | Para que serve | Quem fala ali |
 | --- | --- | --- |
-| `#torre-de-controle` | status resumido, fase atual, previsao e proximos passos | Concierge |
-| `#falar-com-gerente` | conversa direta com o GERENTE | dono e Concierge |
-| `#projetos-recebidos` | registro operacional de projetos recebidos | Concierge |
-| `#aprovacoes-formais` | aprovacoes estruturadas | dono e ponte |
-| `#acessos-pendentes` | pedidos de acesso, contas, cloud, GitHub e chaves | Concierge |
-| `#bloqueios-reais` | bloqueios que impedem progresso | Concierge |
+| `#torre-de-controle` | status resumido, fase atual, previsao e proximos passos | ponte |
+| `#falar-com-gerente` | conversa direta com o GERENTE | dono e GERENTE |
+| `#projetos-recebidos` | registro operacional de projetos recebidos | ponte |
+| `#aprovacoes-formais` | aprovacoes estruturadas | dono por botao/evento e ponte |
+| `#acessos-pendentes` | pedidos de acesso, contas, cloud, GitHub e chaves | ponte |
+| `#bloqueios-reais` | bloqueios que impedem progresso | ponte |
 | `#provas-e-evidencias` | links de evidencia e recibos | ponte |
-| `#producao-e-releases` | decisao de release e producao | dono e Concierge |
+| `#producao-e-releases` | decisao de release e producao | ponte |
 | `#saude-do-bot` | health do bot, ponte e Hermes | ponte |
-| `kanban-da-fabrica` | um topico por projeto | Concierge e dono |
+| `kanban-da-fabrica` | um topico por projeto | ponte |
 | `#arquivo-projetos-antigo` | arquivo, nao uso diario | ponte |
 
 O canal `#falar-com-gerente` e a portaria humana principal. O dono menciona o
@@ -198,6 +198,11 @@ paper/projeto/piloto -> mesma thread vira intake + cartao no forum
 `#projetos-recebidos` nao deve ser uma segunda porta humana para mandar paper.
 Ele existe para registrar que um projeto entrou e apontar para o topico/card
 correto. Se o dono estiver em duvida, deve falar com o GERENTE.
+
+Pedido operacional sobre Discord, canal, thread, botao, mensagem, limpeza,
+recriacao ou correcao visual nao e intake de projeto. Mesmo que a frase tenha
+as palavras "projeto" ou "produto", ela deve ser tratada como manutencao da
+torre de controle, nao como novo produto.
 
 Importante: a thread do projeto nao e o lugar da aprovacao formal. A thread
 pode explicar que existe uma decisao pendente e apontar para ela, mas o pedido
@@ -220,6 +225,20 @@ O GERENTE deve usar `discord.require_mention=true`,
 `discord.auto_thread=true` e `discord.thread_require_mention=false`: o dono
 menciona uma vez na portaria, o Hermes abre a thread, e dentro dela o dono nao
 precisa ficar mencionando o bot a cada resposta.
+
+Os canais de cockpit precisam ser protegidos por politica de canal. O runtime
+deve deixar `DISCORD_FREE_RESPONSE_CHANNELS` e `DISCORD_NO_THREAD_CHANNELS`
+vazios, permitir conversa apenas na portaria e na lane de aprovacao formal, e
+colocar as superficies de painel/registro em `DISCORD_IGNORED_CHANNELS`. Isso
+impede que o GERENTE responda em `#torre-de-controle`,
+`#projetos-recebidos`, `kanban-da-fabrica`, evidencias, bloqueios, acessos,
+producao e health.
+
+O perfil GERENTE tambem deve desligar progresso interno no Discord:
+`display.platforms.discord.tool_progress=off`,
+`interim_assistant_messages=false`, `long_running_notifications=false` e
+`busy_ack_detail=false`. O dono precisa ver resposta final limpa; leitura de
+arquivo, patch, terminal e rascunho do agente nao sao UI da fabrica.
 
 Detalhe critico do runtime: no Hermes, variaveis do `.env` ganham do
 `config.yaml`. Entao o perfil de producao do GERENTE nao pode deixar o canal do

--- a/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
+++ b/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
@@ -100,6 +100,36 @@ dono fala com o GERENTE
 
 ## Achados principais
 
+### Resolvido: superficies bridge-owned nao sao conversa
+
+`#torre-de-controle`, `#projetos-recebidos`, `kanban-da-fabrica`,
+`#acessos-pendentes`, `#bloqueios-reais`, `#provas-e-evidencias`,
+`#producao-e-releases` e `#saude-do-bot` sao superficies de exibicao,
+registro ou health. O GERENTE nao deve conversar ali.
+
+A conversa humana fica em `#falar-com-gerente` e nas threads abertas a partir
+dele. A excecao operacional e `#aprovacoes-formais`, que pode receber clique
+ou evento de decisao, mas ainda nao deve virar sala de conversa.
+
+### Resolvido: pedido operacional nao vira projeto
+
+A automacao de intake agora rejeita pedidos sobre Discord, canal, thread,
+botao, mensagem, limpeza, recriacao ou correcao visual. Uma frase como
+"recrie o projeto/produto nesses dois canais" e manutencao do cockpit, nao
+briefing de produto.
+
+Um projeto novo precisa ter intencao clara: paper, briefing, novo produto,
+pedido explicito de criar/construir produto, texto longo de demanda ou anexo
+de entrada. Palavras soltas como "projeto" e "produto" nao bastam.
+
+### Resolvido: GERENTE sem bastidor tecnico no Discord
+
+O GERENTE nao deve exibir progresso interno de ferramenta no Discord. Mensagens
+como leitura de arquivo, patch, terminal, busca ou rascunho intermediario
+poluem a experiencia e confundem o dono. O perfil de producao deve manter o
+progresso de ferramentas e mensagens intermediarias desligados no Discord,
+entregando resposta final limpa ou evento estruturado da ponte.
+
 ### Resolvido: intake thread-first pelo GERENTE
 
 A automacao `factory_concierge_discord_automation.py` escaneia

--- a/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
+++ b/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
@@ -246,6 +246,12 @@ Mensagem de projeto deixada solta no `#falar-com-gerente` nao deve ser
 processada como novo projeto. O dono precisa iniciar ou usar a thread de
 atendimento; isso evita que uma resposta de pergunta vire um segundo projeto.
 
+Pedido de manutencao da propria Control Tower nao e intake. Se o dono pedir
+para recriar, corrigir, limpar ou mover mensagem, canal, thread, botao,
+Kanban, aprovacao ou painel, a fabrica deve tratar isso como ajuste do
+Discord/cockpit. A palavra "projeto" dentro dessa frase nao autoriza criar
+produto novo.
+
 O nome do topico deve ser humano e curto, por exemplo:
 
 ```text

--- a/scripts/factory_concierge_discord_automation.py
+++ b/scripts/factory_concierge_discord_automation.py
@@ -21,6 +21,7 @@ import json
 import os
 import re
 import sys
+import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -82,6 +83,69 @@ PIPELINE = [
     "Operacao/aprendizado",
 ]
 
+PROJECT_INTAKE_KEYWORDS = [
+    "paper",
+    "briefing",
+    "projeto",
+    "produto",
+    "piloto",
+    "construir",
+    "criar",
+    "fabrica",
+    "factory",
+    "front",
+    "jogo",
+    "sot",
+]
+
+PROJECT_INTAKE_STRONG_PHRASES = [
+    "paper do projeto",
+    "paper:",
+    "briefing do projeto",
+    "briefing:",
+    "novo projeto",
+    "novo produto",
+    "criar um produto",
+    "construir um produto",
+    "quero criar",
+    "quero construir",
+    "vamos criar",
+    "vamos construir",
+    "produto sera",
+    "produto será",
+    "demanda do projeto",
+]
+
+OPERATIONAL_DISCORD_PHRASES = [
+    "recrie",
+    "recriar",
+    "corrija",
+    "arrume",
+    "apague",
+    "delete",
+    "limpe",
+    "atualize",
+    "mova",
+    "mande",
+    "envie",
+    "poste",
+    "canal",
+    "canais",
+    "thread",
+    "tread",
+    "mensagem",
+    "discord",
+    "torre de controle",
+    "aprovacao",
+    "aprovação",
+    "botao",
+    "botão",
+    "kanban",
+    "projetos-recebidos",
+    "nao funcionou",
+    "não funcionou",
+]
+
 
 def utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -125,28 +189,43 @@ def stable_project_id(title: str) -> str:
     return bridge.normalize_name(title)
 
 
+def normalize_intake_text(value: str) -> str:
+    without_marks = "".join(
+        char
+        for char in unicodedata.normalize("NFKD", value.lower())
+        if not unicodedata.combining(char)
+    )
+    return re.sub(r"\s+", " ", without_marks).strip()
+
+
+def has_phrase(text: str, phrases: list[str]) -> bool:
+    normalized_phrases = [normalize_intake_text(phrase) for phrase in phrases]
+    return any(phrase in text for phrase in normalized_phrases)
+
+
 def looks_like_project_intake(message: dict[str, Any]) -> bool:
     author = message.get("author") or {}
     if author.get("bot"):
         return False
-    content = str(message.get("content") or "")
+    content = str(message.get("content") or "").strip()
     attachments = message.get("attachments") or []
-    low = content.lower()
-    keywords = [
-        "paper",
-        "projeto",
-        "produto",
-        "piloto",
-        "construir",
-        "criar",
-        "fabrica",
-        "factory",
-        "front",
-        "jogo",
-        "sot",
-    ]
-    hits = sum(1 for word in keywords if word in low)
-    return bool(attachments) or len(content) >= 240 or hits >= 2
+    low = normalize_intake_text(content)
+    if not content and not attachments:
+        return False
+
+    has_strong_project_intent = has_phrase(low, PROJECT_INTAKE_STRONG_PHRASES)
+    has_operational_discord_intent = has_phrase(low, OPERATIONAL_DISCORD_PHRASES)
+    if has_operational_discord_intent and not has_strong_project_intent:
+        return False
+
+    hits = sum(1 for word in PROJECT_INTAKE_KEYWORDS if normalize_intake_text(word) in low)
+    if has_strong_project_intent:
+        return True
+    if attachments:
+        return True
+    if "paper" in low and hits >= 1 and len(content) >= 80:
+        return True
+    return len(content) >= 700 and hits >= 2
 
 
 def default_projection_from_intake(message: dict[str, Any], now: str | None = None) -> dict[str, Any]:

--- a/tests/test_factory_concierge_discord_automation.py
+++ b/tests/test_factory_concierge_discord_automation.py
@@ -204,6 +204,33 @@ class FactoryConciergeDiscordAutomationTest(unittest.TestCase):
         self.assertEqual(len([t for t in client.threads if t["parent_id"] == "chan-manager"]), 0)
         self.assertEqual(state["projects"], {})
 
+    def test_intake_scan_rejects_operational_discord_repair_request(self) -> None:
+        client = FakeDiscordClient()
+        client.seed_manager_thread_message(
+            "preciso que voce recrie o projeto/produto nesses dois canais",
+            thread_name="ajuste-discord",
+        )
+        state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {}}
+        config = bridge.BridgeConfig(apply=True, guild_id=None, state_path=Path("private.json"))
+
+        result = automation.process_intake_messages(client, config, state, apply=True)
+
+        self.assertEqual(result["processed"], 0)
+        self.assertEqual(state["projects"], {})
+        self.assertEqual(len([t for t in client.threads if t["parent_id"] == "forum-kanban"]), 0)
+
+    def test_project_intake_accepts_explicit_product_briefing(self) -> None:
+        message = {
+            "author": {"id": "owner", "bot": False},
+            "attachments": [],
+            "content": (
+                "Briefing do projeto: quero construir um produto local para acompanhar "
+                "a fabrica, com etapas, aprovacoes e progresso visual."
+            ),
+        }
+
+        self.assertTrue(automation.looks_like_project_intake(message))
+
     def test_active_event_sync_posts_lane_message_and_thread(self) -> None:
         client = FakeDiscordClient()
         state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {"p1": {}}}

--- a/validation/control-tower/discord-control-tower-full-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-full-audit-2026-06-11.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operator-control-tower-bridge-health.schema.json",
+  "record_type": "operator_control_tower_bridge_health",
+  "created_at": "2026-06-11T11:07:17Z",
+  "result": "PASS",
+  "applied_to_discord": true,
+  "audit_scope": "Full Discord Control Tower UX/runtime audit after live pilot regressions.",
+  "checks": {
+    "active_bot_messages_threaded_or_linked": true,
+    "approval_registration_path_reachable": true,
+    "bot_reachable": true,
+    "bridge_reachable": true,
+    "health_anti_stale_posted": true,
+    "live_runtime_projection_automated": true,
+    "multi_project_safe": true,
+    "no_discord_source_of_truth": true,
+    "no_private_material_in_public_receipt": true,
+    "operational_channels_projected": true,
+    "runtime_readback_reachable": true,
+    "structured_approval_interactions_automated": true,
+    "thread_first_project_intake_automated": true,
+    "runtime_env_channel_policy_applied": true,
+    "gerente_discord_tool_progress_disabled": true,
+    "false_project_from_operational_request_blocked_by_test": true,
+    "false_project_from_operational_request_cleaned_live": true,
+    "bridge_owned_surfaces_isolated_from_chat": true,
+    "stale_smoke_messages_removed": true,
+    "duplicate_kanban_project_removed": true,
+    "single_current_project_cockpit_readback": true,
+    "dashboard_single_panel_readback": true,
+    "registry_current_project_readback": true,
+    "formal_approval_buttons_readback": true
+  },
+  "public_safe_cleanup_summary": {
+    "cleanup_actions_count": 25,
+    "normalization_actions_count": 15,
+    "dedup_actions_count": 1,
+    "removed_false_project": true,
+    "removed_stale_front_game_pilot_surface": true,
+    "removed_old_smoke_surfaces": true,
+    "removed_dashboard_freeform_pollution": true,
+    "removed_registry_freeform_pollution": true,
+    "removed_health_freeform_noise": true
+  },
+  "post_audit_readback": {
+    "current_project_count": 1,
+    "current_project": "Piloto 01 - Reasoning Control System da Overkill Factory",
+    "dashboard_shape": "single bridge-owned dashboard panel",
+    "registry_shape": "current project plus onboarding",
+    "kanban_shape": "one active project cockpit plus guide topic",
+    "manager_shape": "one active project conversation thread",
+    "health_result": "PASS"
+  },
+  "corrections": [
+    "hardened intake classification so operational Discord repair requests cannot become projects",
+    "configured live Hermes Discord policy with ignored bridge-owned surfaces and empty free/no-thread overrides",
+    "disabled Discord tool progress and interim assistant messages for the GERENTE profile",
+    "removed false project registry, false cockpit, stale pilot surfaces, smoke leftovers and freeform dashboard pollution",
+    "re-projected the current pilot as waiting for formal G0 evidence instead of pretending execution is approved"
+  ],
+  "evidence_refs": [
+    "scripts/factory_concierge_discord_automation.py",
+    "docs/control-tower/discord-control-tower-setup-pt-br.md",
+    "docs/control-tower/discord-control-tower-ux-audit-pt-br.md",
+    "docs/control-tower/discord-dynamic-control-tower-study-pt-br.md",
+    "tests/test_factory_concierge_discord_automation.py",
+    "external:private-discord-full-audit-cleanup-receipt",
+    "external:live-discord-readback-after-cleanup"
+  ],
+  "limits": [
+    "Discord remains the cockpit; Hermes remains the durable source of truth.",
+    "This receipt omits raw Discord ids, private paths, credentials and logs.",
+    "The current pilot is visible but material execution remains blocked until the required factory gates are recorded."
+  ]
+}


### PR DESCRIPTION
## Summary
- hardened Discord intake so operational Control Tower repair requests cannot become projects
- documented bridge-owned surfaces, channel isolation, and GERENTE display policy
- added a public-safe full Discord audit receipt after live cleanup/readback

## Validation
- `python -m unittest tests.test_factory_concierge_discord_automation tests.test_discord_control_tower_ux_audit -q`
- `python -m unittest discover -s tests -p "test*.py" -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/public_safety_scan.py`
- `python scripts/factory_production_readiness.py --out .tmp\readiness-discord-full-audit.json`
- `git diff --check`

## Live Discord Readback
- current project: one active project cockpit plus one GERENTE project conversation thread
- Control Tower dashboard: single bridge-owned panel
- registry: current project plus onboarding
- health receipt: PASS with no failed checks