### PR TITLE
Fix Discord approval fallback UX

### DIFF
--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -162,8 +162,11 @@ Formal approvals are the exception to "keep the project conversation in the
 project thread". The project thread may explain that a decision is needed and
 link to it, but the formal approval request itself must be rendered by the
 bridge in `#aprovacoes-formais` with structured scope, risk, buttons and a
-runtime-registration path. A free-form approval message in a project thread is
-only context; it is not a valid factory approval.
+runtime-registration path. If a Discord interaction expires, a short fallback
+reply in the approval thread can be accepted only when it maps to the same
+pending approval and passes the same owner, scope and deadline validation. A
+free-form approval message in a project thread is only context; it is not a
+valid factory approval.
 
 ## Multi-Project Kanban Rule
 
@@ -336,7 +339,8 @@ It composes the projector with the remaining Control Tower behavior:
 - create or reuse the project forum topic and cockpit;
 - project runtime events into the correct operational lane;
 - create threads for active events such as access, blockers and approvals;
-- render Portuguese approval buttons with scoped `custom_id` values;
+- render Portuguese approval buttons with scoped `custom_id` values and a short
+  text fallback for expired interactions;
 - validate a decision payload before producing an `approval_recorded` event;
 - update bridge health in `#saude-do-bot`;
 - read projections, events and approvals from private inbox directories for

--- a/docs/control-tower/discord-control-tower-setup-pt-br.md
+++ b/docs/control-tower/discord-control-tower-setup-pt-br.md
@@ -172,7 +172,7 @@ O repo publico nao pode conter:
 | `#torre-de-controle` | status resumido, fase atual, previsao e proximos passos | ponte |
 | `#falar-com-gerente` | conversa direta com o GERENTE | dono e GERENTE |
 | `#projetos-recebidos` | registro operacional de projetos recebidos | ponte |
-| `#aprovacoes-formais` | aprovacoes estruturadas | dono por botao/evento e ponte |
+| `#aprovacoes-formais` | aprovacoes estruturadas | dono por botao/fallback/evento e ponte |
 | `#acessos-pendentes` | pedidos de acesso, contas, cloud, GitHub e chaves | ponte |
 | `#bloqueios-reais` | bloqueios que impedem progresso | ponte |
 | `#provas-e-evidencias` | links de evidencia e recibos | ponte |
@@ -332,10 +332,12 @@ nativos em ingles, eles ficam como camada tecnica por baixo. A interface humana
 deve ser em portugues, conduzida pelo GERENTE e por botoes, menus ou formularios
 em portugues.
 
-Para botoes operacionais, formularios e aprovacoes clicaveis, a fabrica precisa
-da `Factory Concierge Discord Bridge`. O Hermes ja suporta perguntas com botoes
-via `clarify`, mas aprovacoes de fabrica precisam ser validadas e registradas no
-Hermes antes de valerem.
+Para atalhos operacionais e formularios, a fabrica precisa da
+`Factory Concierge Discord Bridge`. O Hermes ja suporta perguntas com botoes via
+`clarify`. Aprovacao formal no Discord usa botoes claros: `Aprovar`,
+`Rejeitar` e `Pedir ajuste`. Se a interacao expirar, o fallback e responder
+`aprovado`, `rejeitado` ou `pedir ajuste` na thread daquele pedido. A ponte
+valida usuario, escopo, prazo e registra o evento no Hermes antes de valer.
 
 Especialistas nao devem ficar interrompendo o dono diretamente. Eles falam com
 o runtime; o Concierge consolida o que importa.
@@ -394,7 +396,7 @@ Ela cobre:
 - eventos de acesso, bloqueio, prova, release e health vao para os canais
   certos;
 - mensagem ativa cria thread ou aponta para thread existente;
-- aprovacao formal aparece com botoes em portugues;
+- aprovacao formal aparece com reacoes simples em portugues;
 - aprovacao formal nasce em `#aprovacoes-formais`, nao como texto solto na
   thread do projeto;
 - decisao de aprovacao so vira evento depois de validar id, papel, escopo e
@@ -408,10 +410,10 @@ O recibo live da automacao completa esta em:
 validation/control-tower/discord-control-tower-automation-live-2026-06-11.json
 ```
 
-Observacao importante: botao de aprovacao nao significa aprovacao magica. Em
-producao, a aprovacao so vale se vier de interacao real do dono ou evento
-duravel do Hermes. Smoke, teste ou silencio nunca aprovam execucao, gasto,
-release ou producao.
+Observacao importante: botao ou texto curto nao significa aprovacao magica. Em
+producao, so vale depois que a ponte confirma dono autorizado, escopo, prazo e
+evento duravel no Hermes. Smoke, teste ou silencio nunca aprovam execucao,
+gasto, release ou producao.
 
 ## Rollback seguro
 

--- a/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
+++ b/docs/control-tower/discord-control-tower-ux-audit-pt-br.md
@@ -27,7 +27,7 @@ O que esta corrigido:
   sao atualizados por `project-projection.json`.
 - intake do GERENTE cria ou reutiliza thread;
 - eventos ativos caem na lane correta e abrem thread;
-- aprovacao formal tem botoes em portugues e validacao de decisao;
+- aprovacao formal tem reacoes simples em portugues e validacao de decisao;
 - health da ponte e atualizado em `#saude-do-bot`;
 - a automacao completa foi aplicada duas vezes e o read-back confirmou que nao
   houve duplicata.
@@ -172,14 +172,26 @@ O recibo publico-safe esta em:
 validation/control-tower/discord-bridge-projector-live-2026-06-11.json
 ```
 
-### P1: aprovacoes ainda precisam de interacao estruturada
+### Resolvido: aprovacao simples por botao com fallback
 
-Resolvido para a camada de ponte: a aprovacao aparece com botoes em portugues e
-a decisao precisa bater `approval_id`, papel, escopo e prazo antes de gerar um
-evento `approval_recorded`.
+Quando o botao expira, o Discord responde "Esta interacao falhou". Isso nao
+pode virar uma explicacao burocratica. A camada de ponte deve manter botoes
+claros e aceitar um fallback curto na thread do pedido:
+
+```text
+Aprovar
+Rejeitar
+Pedir ajuste
+fallback: aprovado / rejeitado / pedir ajuste
+```
+
+A decisao so vale quando a ponte valida dono autorizado, `approval_id`, papel,
+escopo e prazo antes de gerar um evento
+`approval_recorded`.
 
 Limite importante: em producao, isso so pode liberar algo quando vier de clique
-real do dono ou evento duravel do Hermes. Smoke ou teste nao e aprovacao.
+real, fallback textual claro do dono na thread correta ou evento duravel do
+Hermes. Smoke ou teste nao e aprovacao.
 
 ### Resolvido: canais operacionais vivos
 

--- a/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
+++ b/docs/control-tower/discord-dynamic-control-tower-study-pt-br.md
@@ -401,9 +401,12 @@ Quem aprovou: dono autorizado
 Registro: evento real no Hermes
 ```
 
-No Discord isso pode aparecer como botao, menu ou formulario. Mas o clique so
-vale depois que a ponte valida usuario, canal, prazo, escopo e registra o evento
-no Hermes.
+No Discord, a versao correta para aprovacao formal e um pedido estruturado com
+botoes claros: `Aprovar`, `Rejeitar` e `Pedir ajuste`. Se o Discord responder
+que a interacao falhou ou o botao expirar, o fallback humano e responder
+`aprovado`, `rejeitado` ou `pedir ajuste` na thread daquele pedido. A decisao
+so vale depois que a ponte valida usuario, canal, prazo, escopo e registra o
+evento no Hermes.
 
 A thread do projeto pode avisar "ha uma aprovacao pendente" e apontar para o
 canal certo. Ela nao deve conter o pedido formal como texto solto. Pedido
@@ -463,12 +466,21 @@ de conversa perdido no chat. O dono menciona o GERENTE no `#falar-com-gerente`,
 o Hermes abre a thread de atendimento, e a ponte cria o topico e o cartao a
 partir do conteudo dessa thread.
 
-### 3. Aprovacao com botao e formulario
+### 3. Aprovacao com botao e fallback curto
 
-O dono deve conseguir aprovar pelo Discord, mas a ponte precisa registrar isso
-no Hermes como evento estruturado.
+O dono deve conseguir aprovar pelo Discord sem burocracia. O caminho atual e
+clicar no botao da mensagem de aprovacao:
 
-O Discord pode coletar a decisao. Hermes decide se a decisao e valida.
+```text
+Aprovar
+Rejeitar
+Pedir ajuste
+```
+
+Se o botao expirar ou o Discord falhar, a resposta curta na thread do pedido
+resolve: `aprovado`, `rejeitado` ou `pedir ajuste`.
+
+O Discord coleta a decisao. Hermes decide se a decisao e valida.
 
 ### 4. Pedidos de acesso como checklist
 

--- a/scripts/factory_concierge_discord_automation.py
+++ b/scripts/factory_concierge_discord_automation.py
@@ -8,8 +8,8 @@ UX automation:
   project surfaces.
 - Active-message threading: events and approvals that invite action get a
   thread or a clear existing thread.
-- Structured approvals: approval requests render as Portuguese buttons and a
-  decision payload is validated before producing a runtime-registerable event.
+- Structured approvals: approval requests render as Portuguese buttons, with a
+  short text fallback in the approval thread when Discord interactions expire.
 - Operational lanes: access, blockers, evidence, release and health events are
   projected into their channels without making Discord the source of truth.
 """
@@ -40,6 +40,23 @@ INTAKE_MARKER_PREFIX = "of-intake:"
 EVENT_MARKER_PREFIX = "of-event:"
 APPROVAL_MARKER_PREFIX = "of-approval:"
 HEALTH_MARKER = "of-health:bridge"
+APPROVAL_DECISION_LABELS = {
+    "approved": "Aprovar",
+    "rejected": "Rejeitar",
+    "needs_changes": "Pedir ajuste",
+}
+APPROVAL_TEXT_DECISIONS = {
+    "aprovado": "approved",
+    "aprovar": "approved",
+    "sim aprovado": "approved",
+    "rejeitado": "rejected",
+    "rejeitar": "rejected",
+    "nao aprovado": "rejected",
+    "não aprovado": "rejected",
+    "pedir ajuste": "needs_changes",
+    "ajuste": "needs_changes",
+    "precisa ajuste": "needs_changes",
+}
 
 ACTIVE_EVENT_TYPES = {
     "intake_received",
@@ -566,8 +583,13 @@ def approval_payload(approval: dict[str, Any]) -> dict[str, Any]:
                         "inline": False,
                     },
                     {
-                        "name": "Nao autorizado por este botao",
+                        "name": "Nao autorizado por este pedido",
                         "value": bridge.truncate(bridge.bullet_list(bridge.non_empty_list(approval.get("not_authorized"))), 1024),
+                        "inline": False,
+                    },
+                    {
+                        "name": "Se o botao falhar",
+                        "value": "Responda `aprovado`, `rejeitado` ou `pedir ajuste` na thread deste pedido. A ponte valida escopo, dono e prazo antes de registrar.",
                         "inline": False,
                     },
                 ],
@@ -643,6 +665,88 @@ def post_approval_request(
         "message_resolved": bool(message_result.get("message_id")) or not apply,
         "thread_resolved": bool(thread_result.get("thread_id")) or not apply,
         "components_rendered": True,
+        "decision_controls_rendered": bool(message_result.get("message_id")) or not apply,
+    }
+
+
+def allowed_discord_user_ids() -> set[str]:
+    raw = os.environ.get("DISCORD_ALLOWED_USERS", "")
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def text_decision_from_message(message: dict[str, Any]) -> str | None:
+    content = normalize_intake_text(str(message.get("content") or ""))
+    content = re.sub(r"\s+", " ", content).strip(" .!?,;:")
+    return APPROVAL_TEXT_DECISIONS.get(content)
+
+
+def text_decision_for_approval(
+    client: bridge.DiscordClient,
+    thread_id: str,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    allowed = allowed_discord_user_ids()
+    found: list[tuple[str, dict[str, Any]]] = []
+    for message in client.list_messages(thread_id, limit=50):
+        author = message.get("author") or {}
+        if author.get("bot"):
+            continue
+        user_id = str(author.get("id") or "")
+        if allowed and user_id not in allowed:
+            continue
+        decision = text_decision_from_message(message)
+        if decision:
+            found.append((decision, message))
+    if not found:
+        return None, []
+    decisions = sorted({decision for decision, _ in found})
+    if len(decisions) > 1:
+        return None, [f"multiple text decisions found: {', '.join(decisions)}"]
+    decision, _ = found[0]
+    return {"actor_role": "Factory Owner", "decision": decision}, []
+
+
+def sync_approval_text_decision(
+    approval: dict[str, Any],
+    client: bridge.DiscordClient,
+    config: bridge.BridgeConfig,
+    state: dict[str, Any],
+    *,
+    apply: bool,
+) -> dict[str, Any]:
+    validate_artifact(approval)
+    approval_state = state.setdefault("approvals", {}).setdefault(str(approval["approval_id"]), {})
+    thread_id = approval_state.get("thread_id")
+    if not thread_id:
+        return {"approval_id": str(approval["approval_id"]), "decision_found": False, "accepted": False}
+    decision, reasons = text_decision_for_approval(client, str(thread_id))
+    if reasons:
+        return {"approval_id": str(approval["approval_id"]), "decision_found": True, "accepted": False, "reasons": reasons}
+    if not decision:
+        return {"approval_id": str(approval["approval_id"]), "decision_found": False, "accepted": False}
+    decision.update({"approval_id": approval["approval_id"], "scope": approval["scope"]})
+    registered, event = register_approval_decision(approval, decision)
+    if not event.get("accepted", True):
+        return {
+            "approval_id": str(approval["approval_id"]),
+            "decision_found": True,
+            "accepted": False,
+            "reasons": list(event.get("reasons", [])),
+        }
+    if apply:
+        post_approval_request(registered, client, config, state, apply=apply)
+        sync_event(event, client, config, state, apply=apply)
+        state.setdefault("approval_events", {})[str(approval["approval_id"])] = {
+            "status": registered.get("status"),
+            "event_id": event.get("event_id"),
+            "synced_at": utc_now(),
+            "source": "discord_text_fallback",
+        }
+    return {
+        "approval_id": str(approval["approval_id"]),
+        "decision_found": True,
+        "accepted": True,
+        "decision": registered.get("status"),
+        "event_id": event.get("event_id"),
     }
 
 
@@ -886,23 +990,44 @@ def run_automation(args: argparse.Namespace) -> dict[str, Any]:
         approval_result = post_approval_request(approval_item, client, config, state, apply=bool(args.apply))
         results["approval"] = approval_result
         results["structured_approval_interactions_automated"] = (
-            approval_result["message_resolved"] and approval_result["thread_resolved"] and approval_result["components_rendered"]
+            approval_result["message_resolved"]
+            and approval_result["thread_resolved"]
+            and approval_result["decision_controls_rendered"]
         )
         results["active_bot_messages_threaded_or_linked"] = (
             results["active_bot_messages_threaded_or_linked"] or approval_result["thread_resolved"]
         )
 
+    if approvals and args.scan_approval_text:
+        text_results = []
+        for approval_item in approvals:
+            text_result = sync_approval_text_decision(approval_item, client, config, state, apply=bool(args.apply))
+            text_results.append(text_result)
+            if text_result.get("accepted"):
+                results["approval_registration_path_reachable"] = True
+                results["structured_approval_interactions_automated"] = True
+        results["approval_text_fallback"] = text_results
+
     decision = load_json(args.decision)
     if approval and decision:
         registered, approval_event = register_approval_decision(approval, decision, now=args.decision_time)
+        if approval_event.get("accepted") is False:
+            results["approval_decision"] = {
+                "accepted": False,
+                "reasons": list(approval_event.get("reasons", [])),
+            }
+        else:
+            if args.apply:
+                post_approval_request(registered, client, config, state, apply=bool(args.apply))
+            sync_result = sync_event(approval_event, client, config, state, apply=bool(args.apply))
+            results["approval_decision"] = {"accepted": True, "event_synced": sync_result["message_resolved"]}
+            results["approval_registration_path_reachable"] = True
         state.setdefault("approval_events", {})[str(approval["approval_id"])] = {
             "status": registered.get("status"),
-            "event_id": approval_event.get("event_id"),
+            "event_id": approval_event.get("event_id") if approval_event.get("accepted") is not False else None,
             "synced_at": utc_now(),
+            "source": "explicit_decision_file",
         }
-        sync_result = sync_event(approval_event, client, config, state, apply=bool(args.apply))
-        results["approval_decision"] = {"accepted": True, "event_synced": sync_result["message_resolved"]}
-        results["approval_registration_path_reachable"] = True
 
     if args.post_health:
         health_result = post_health(
@@ -937,6 +1062,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--approval-dir", type=Path)
     parser.add_argument("--decision", type=Path)
     parser.add_argument("--decision-time")
+    parser.add_argument("--scan-approval-text", action="store_true")
     parser.add_argument("--scan-intake", action="store_true")
     parser.add_argument("--post-health", action="store_true")
     parser.add_argument("--max-messages", type=int, default=50)

--- a/tests/test_factory_concierge_discord_automation.py
+++ b/tests/test_factory_concierge_discord_automation.py
@@ -278,8 +278,32 @@ class FactoryConciergeDiscordAutomationTest(unittest.TestCase):
         self.assertTrue(result["thread_resolved"])
         components = client.messages["chan-approvals"][0]["components"][0]["components"]
         self.assertEqual([button["label"] for button in components], ["Aprovar", "Rejeitar", "Pedir ajuste"])
+        fallback_field = client.messages["chan-approvals"][0]["embeds"][0]["fields"][5]
+        self.assertEqual(fallback_field["name"], "Se o botao falhar")
         self.assertEqual(registered["status"], "needs_changes")
         self.assertEqual(event["event_type"], "approval_recorded")
+
+    def test_approval_text_fallback_registers_owner_decision(self) -> None:
+        client = FakeDiscordClient()
+        state: dict[str, Any] = {"version": 1, "dashboard": {}, "projects": {}}
+        config = bridge.BridgeConfig(apply=True, guild_id=None, state_path=Path("private.json"))
+        approval = approval_request()
+        automation.post_approval_request(approval, client, config, state, apply=True)
+        thread_id = state["approvals"][approval["approval_id"]]["thread_id"]
+        client.messages[thread_id].append(
+            {
+                "id": "owner-decision",
+                "content": "aprovado",
+                "author": {"id": "owner", "bot": False},
+            }
+        )
+
+        result = automation.sync_approval_text_decision(approval, client, config, state, apply=True)
+
+        self.assertTrue(result["accepted"])
+        self.assertEqual(result["decision"], "approved")
+        self.assertEqual(state["approval_events"][approval["approval_id"]]["status"], "approved")
+        self.assertEqual(client.messages["chan-approvals"][0]["embeds"][0]["fields"][2]["value"], "approved")
 
     def test_health_and_public_receipt_cover_remaining_discord_fronts(self) -> None:
         client = FakeDiscordClient()

--- a/validation/control-tower/discord-approval-ux-fallback-fix-2026-06-11.json
+++ b/validation/control-tower/discord-approval-ux-fallback-fix-2026-06-11.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operator-control-tower-bridge-health.schema.json",
+  "record_type": "operator_control_tower_bridge_health",
+  "created_at": "2026-06-11T11:36:50Z",
+  "result": "PASS",
+  "applied_to_discord": true,
+  "audit_scope": "Public-safe receipt for the Discord formal approval UX fallback fix after an expired or failed interaction.",
+  "checks": {
+    "bot_reachable": true,
+    "bridge_reachable": true,
+    "runtime_readback_reachable": true,
+    "approval_registration_path_reachable": true,
+    "approval_buttons_remain_primary": true,
+    "approval_text_fallback_documented": true,
+    "approval_text_fallback_validated_by_tests": true,
+    "g0_owner_decision_registered": true,
+    "pilot_projection_advanced_to_planning": true,
+    "material_execution_still_blocked": true,
+    "bridge_health_passed": true,
+    "no_discord_source_of_truth": true,
+    "no_private_material_in_public_receipt": true
+  },
+  "corrections": [
+    "restored Portuguese approval buttons as the primary operator action",
+    "added a short text fallback in the approval thread for expired or failed Discord interactions",
+    "updated the pilot G0 approval state to approved for planning only",
+    "updated the pilot cockpit projection from waiting owner to planning"
+  ],
+  "evidence_refs": [
+    "scripts/factory_concierge_discord_automation.py",
+    "tests/test_factory_concierge_discord_automation.py",
+    "docs/control-tower/discord-control-tower-os.md",
+    "docs/control-tower/discord-control-tower-setup-pt-br.md",
+    "docs/control-tower/discord-control-tower-ux-audit-pt-br.md",
+    "external:private-discord-g0-approval-readback"
+  ],
+  "limits": [
+    "This approves only planning and initial architecture for the pilot.",
+    "It does not approve material execution, deploy, spend, secrets, production changes, worker packet changes, release or production.",
+    "Discord remains the cockpit; Hermes remains the durable source of truth."
+  ]
+}

--- a/validation/control-tower/discord-bridge-projector-live-2026-06-11.json
+++ b/validation/control-tower/discord-bridge-projector-live-2026-06-11.json
@@ -29,7 +29,7 @@
   "limits": [
     "Discord is the owner cockpit only; Hermes remains the source of truth.",
     "The public receipt redacts Discord ids and private file paths.",
-    "Structured approval buttons and inbound approval registration are separate contracts."
+    "Structured approval buttons, text fallback and inbound approval registration are separate contracts."
   ],
   "project_id": "pilot-front-jogo-fabrica",
   "projection_freshness": "runtime_fresh",

--- a/validation/control-tower/discord-control-tower-full-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-full-audit-2026-06-11.json
@@ -29,7 +29,8 @@
     "single_current_project_cockpit_readback": true,
     "dashboard_single_panel_readback": true,
     "registry_current_project_readback": true,
-    "formal_approval_buttons_readback": true
+    "formal_approval_buttons_readback": true,
+    "formal_approval_text_fallback_readback": true
   },
   "public_safe_cleanup_summary": {
     "cleanup_actions_count": 25,

--- a/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
+++ b/validation/control-tower/discord-control-tower-ux-audit-2026-06-11.json
@@ -51,7 +51,7 @@
   "findings": [
     {
       "severity": "P3",
-      "finding": "Structured approval buttons and decision validation are implemented, but a production approval still requires a real owner interaction or signed runtime event.",
+      "finding": "Structured approval buttons, short text fallback and decision validation are implemented, but a production approval still requires a real owner interaction or signed runtime event.",
       "impact": "The bridge can render and validate approval decisions, but it must never treat a smoke decision or silence as owner approval.",
       "required_fix": "Keep owner approvals tied to real Discord interactions or durable Hermes events before using them for execution, release, spend or production gates."
     }
@@ -72,7 +72,7 @@
     "corrected live GERENTE Discord env overrides that were disabling auto-thread in the manager channel",
     "formalized that project threads can point to approvals but formal approval requests must live in the approvals lane",
     "implemented active event lane projection with thread creation",
-    "implemented Portuguese structured approval buttons and decision validation",
+    "implemented Portuguese structured approval buttons, short text fallback and decision validation",
     "implemented bridge health projection",
     "proved live Discord automation after the GERENTE thread contract update with thread-first and health checks passing",
     "proved live Discord automation twice: one manager thread, one forum topic, one dashboard marker, one registry marker, one event marker, one approval marker and one health marker"

--- a/validation/control-tower/discord-formal-approval-lane-contract-2026-06-11.json
+++ b/validation/control-tower/discord-formal-approval-lane-contract-2026-06-11.json
@@ -20,7 +20,7 @@
   "adapter_patch": {
     "live_profile": "GERENTE SOUL now requires formal approval requests to be created through a structured approval-request and rendered in the approvals lane.",
     "public_docs": "Control Tower docs now state that project threads may point to formal approvals but cannot host free-form approval requests.",
-    "live_bridge_smoke": "A pending G0 planning-boundary approval request was posted through the bridge with structured buttons and public-safe limits."
+    "live_bridge_smoke": "A pending G0 planning-boundary approval request was posted through the bridge with structured buttons, a short text fallback for expired interactions and public-safe limits."
   },
   "checks": {
     "backup_created_before_live_soul_update": true,
@@ -32,7 +32,7 @@
   },
   "decision": {
     "result": "PASS",
-    "operator_effect": "The project thread should no longer be used as the formal approval surface; approval requests belong in the approvals lane with explicit scope and buttons."
+    "operator_effect": "The project thread should no longer be used as the formal approval surface; approval requests belong in the approvals lane with explicit scope, buttons and a short fallback in the approval thread."
   },
   "evidence_refs": [
     "docs/control-tower/discord-control-tower-os.md",


### PR DESCRIPTION
## Summary
- Keeps Portuguese approval buttons as the primary Discord UX.
- Adds a short text fallback for expired or failed Discord interactions in the approval thread.
- Records the G0 pilot approval as planning-only and updates public-safe receipts, docs and tests.

## Validation
- `python -m unittest discover -s tests -p "test*.py" -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/public_safety_scan.py`
- `python scripts/factory_production_readiness.py --out .tmp/readiness-discord-approval-ux-fallback.json`
- Live Discord readback: approval status approved, buttons present, fallback present, pilot status planning.