### PR TITLE
[codex] Finalize public repository shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,19 +133,23 @@ outputs locally.
 
 ## Repository Shape
 
+Every public directory below has a local README with its purpose, boundary,
+source of truth and validation path. Open that README before treating a folder
+as a place to add files.
+
 | Path | Public Purpose |
 | --- | --- |
 | `.github/` | CI, issue templates and pull request hygiene. |
-| `adapters/` | Runtime integrations, currently Hermes transition hooks and patches. |
-| `agents/` | Public worker registry, profiles, permissions and Hermes bindings. |
-| `docs/` | Human guides for getting started, concepts, operations, agents and integrations. |
-| `examples/` | Small source examples and fixtures that teach or test the factory path. |
-| `products/` | Public validation products used by product-like and production-lane checks. |
-| `schemas/` | Machine contracts for cards, receipts, worker outputs and gates. |
-| `scripts/` | CLI entrypoints, validation tools, proof helpers and maintainer checks. |
-| `skills/` | Installable Codex skill material for operating the factory. |
-| `templates/` | Contract templates paired with schemas and tests. |
-| `tests/` | Regression coverage for the public contracts and quickstart path. |
+| `adapters/` | Runtime integrations, currently Hermes transition hooks and patches. See `adapters/README.md`. |
+| `agents/` | Public worker registry, profiles, permissions and Hermes bindings. See `agents/README.md`. |
+| `docs/` | Human guides for getting started, concepts, operations, agents and integrations. See `docs/README.md`. |
+| `examples/` | Small source examples and fixtures that teach or test the factory path. See `examples/README.md`. |
+| `products/` | Public validation products used by product-like and production-lane checks. See `products/README.md`. |
+| `schemas/` | Machine contracts for cards, receipts, worker outputs and gates. See `schemas/README.md`. |
+| `scripts/` | CLI entrypoints, validation tools, proof helpers and maintainer checks. See `scripts/README.md`. |
+| `skills/` | Installable Codex skill material for operating the factory. See `skills/README.md`. |
+| `templates/` | Contract templates paired with schemas and tests. See `templates/README.md`. |
+| `tests/` | Regression coverage for the public contracts and quickstart path. See `tests/README.md`. |
 
 ## Current Status
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,0 +1,36 @@
+# Adapters
+
+Adapters connect Overkill Factory contracts to a runtime. Hermes is the first
+supported adapter.
+
+## What Belongs Here
+
+- Runtime integrations that translate factory cards, gates, worker packets and
+  receipts into a real execution floor.
+- Hermes adapter code, transition hooks and runtime patch notes.
+- Small adapter fixtures that are required by tests.
+
+## What Does Not Belong Here
+
+- Private runtime patches from a local workspace.
+- Historical proof, raw logs, screenshots or past pilot evidence.
+- Runtime-specific secrets, local paths, board URLs or operator credentials.
+
+## Source Of Truth
+
+The factory contract remains in schemas, templates, tests and `factoryctl.py`.
+The adapter is the runtime bridge, not a second methodology.
+
+## How It Is Validated
+
+Run adapter and public-path checks after changes:
+
+```bash
+python scripts/quickstart_smoke.py
+python -m unittest discover -s tests -p "test_*.py" -q
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+```
+
+For Hermes-specific behavior, inspect `adapters/hermes/README.md` and validate
+the transition-hook tests before publishing.

--- a/agents/README.md
+++ b/agents/README.md
@@ -20,6 +20,39 @@ The factory does not treat agents as loose personalities. A worker becomes
 operable only when its process role, profile, permission class, Hermes binding
 and packet route all exist.
 
+## What Belongs Here
+
+- Public worker registry files, public worker profiles, permission classes and
+  Hermes bindings.
+- Human entrypoint docs that explain how to read the full worker contract.
+- Schemas required to validate public worker contracts.
+
+## What Does Not Belong Here
+
+- Generated worker packets, run logs, Receipt Five evidence or old execution
+  output.
+- Private agent prompts, private Hermes profile material, local paths or board
+  links.
+- Hand-written partial mirrors of the worker registry.
+
+## Source Of Truth
+
+The machine-readable JSON files define worker operability. Human docs explain
+the contract, but the worker registry, profiles, permission classes and Hermes
+bindings are the source of truth.
+
+## How It Is Validated
+
+Run these checks after changing agent contracts or guides:
+
+```bash
+python scripts/validate_worker_profiles.py
+python scripts/validate_public_json_artifacts.py
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+python -m unittest tests.test_worker_profiles tests.test_worker_permission_classes tests.test_agent_directory_docs -q
+```
+
 ## Read Order
 
 | Read | File | Purpose |
@@ -104,7 +137,7 @@ as an executable factory role.
 - A Control Tower view cannot become the source of truth.
 - A generated evidence archive does not belong in this public directory.
 
-## Validation
+## Validation Bundle
 
 Run these checks after changing agent contracts or guides:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Docs
+
+This directory contains human guides for public onboarding, operation and
+maintenance of Overkill Factory.
+
+## What Belongs Here
+
+- Public human guides that help an external operator understand, run and extend
+  the factory.
+- Concept guides, quickstart material, operations checks, architecture notes and
+  public governance rules.
+- Area manuals that explain a real factory area deeply enough for another agent
+  to continue the work.
+
+## What Does Not Belong Here
+
+- Evidence from past runs, screenshots, raw source extraction or chat history.
+- Private product context, private board links, local absolute paths or secrets.
+- Roadmap doubts inside final/canonical documents.
+
+## Source Of Truth
+
+Executable contracts come first: schemas, scripts, adapter hooks and tests.
+Docs explain how to use them. When a doc conflicts with executable behavior,
+fix the mismatch and keep the runnable path authoritative.
+
+## How It Is Validated
+
+Run the document and public safety checks:
+
+```bash
+python scripts/validate_document_governance.py
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+python -m unittest tests.test_open_source_docs -q
+```
+
+Start with `docs/getting-started/quickstart-hermes.md`, then read
+`docs/concepts/factory-flow.md` and `docs/operations/validation-and-release.md`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,34 @@
+# Examples
+
+Examples are small source examples and fixtures that teach or test the public
+factory path.
+
+## What Belongs Here
+
+- Source examples that can be read, validated and rerun by a new operator.
+- Minimal cards, papers, expected flows and public-safe receipt examples.
+- Fixtures that support tests without storing generated proof archives.
+
+## What Does Not Belong Here
+
+- Do not commit generated run output.
+- Generated worker packets and gate reports belong in `.tmp/`, not in this
+  directory.
+- Do not store old pilot evidence, private product material, screenshots,
+  raw logs or local workspace paths here.
+
+## Source Of Truth
+
+`examples/minimal-hermes-project/` is the first public example. It is source
+material for quickstart validation, not a record of a past run.
+
+## How It Is Validated
+
+Run the quickstart and public example checks:
+
+```bash
+python scripts/quickstart_smoke.py
+python scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
+python scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+python -m unittest tests.test_open_source_docs -q
+```

--- a/products/README.md
+++ b/products/README.md
@@ -1,0 +1,37 @@
+# Products
+
+This directory contains public validation products used to exercise product-like
+and production-lane factory checks.
+
+## What Belongs Here
+
+- Public validation products that are safe to inspect, rerun and reference in
+  tests.
+- Product-shaped fixtures that help validate Receipt Five, release readiness,
+  Product Face proof or security gates.
+- Minimal product material that is intentionally public and reproducible.
+
+## What Does Not Belong Here
+
+- No private product material.
+- No customer, workspace, board, key, deployment or internal project evidence.
+- A validation product is not production approval and must not be presented as
+  a live release.
+
+## Source Of Truth
+
+The public validation product is only a fixture when it is covered by schemas,
+tests, scripts or a documented release-readiness command. Production approval
+must still come from the real runtime, receipt and human gate records.
+
+## How It Is Validated
+
+Run product and release checks before relying on these fixtures:
+
+```bash
+python scripts/validate_public_json_artifacts.py
+python scripts/factory_production_readiness.py
+python scripts/worktree_release_inventory.py
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+```

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,33 @@
+# Schemas
+
+Schemas are the machine contracts for public factory cards, packets, receipts,
+gates and worker outputs.
+
+## What Belongs Here
+
+- JSON Schema files for canonical factory contracts.
+- Public-safe schema versions paired with templates, tests or validation
+  scripts.
+- Contracts that scripts and adapters can enforce without relying on chat
+  memory.
+
+## What Does Not Belong Here
+
+- Narrative explanations that should live in `docs/`.
+- Generated examples, one-off outputs or partial mirrors of private schemas.
+- Unused contract drafts without tests, templates or a clear owner.
+
+## Source Of Truth
+
+For machine validation, JSON Schema files are authoritative. Templates and docs
+must follow the schema, not the other way around.
+
+## How It Is Validated
+
+Run schema and public artifact checks:
+
+```bash
+python scripts/validate_public_json_artifacts.py
+python -m unittest discover -s tests -p "test_*.py" -q
+python scripts/public_safety_scan.py
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+# Scripts
+
+Scripts provide the public CLI path, validation tools and maintainer checks.
+
+## What Belongs Here
+
+- CLI entrypoints such as `factoryctl.py`.
+- Validation scripts for cards, schemas, worker profiles, public safety and
+  release readiness.
+- Small maintainer utilities that are documented and covered by tests.
+
+## What Does Not Belong Here
+
+- One-off local automation from a private workspace.
+- Scripts that depend on private paths, private boards or local credentials.
+- Generated outputs. Write those to `.tmp/`.
+
+## Source Of Truth
+
+`scripts/factoryctl.py`, package entrypoints and tests define the supported
+operator path. Experimental helpers must either graduate into that path or stay
+clearly secondary.
+
+## How It Is Validated
+
+Run the script-facing bundle:
+
+```bash
+python scripts/quickstart_smoke.py
+python scripts/validate_worker_profiles.py
+python scripts/validate_public_json_artifacts.py
+python -m unittest discover -s tests -p "test_*.py" -q
+```

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,34 @@
+# Skills
+
+This directory contains installable Codex skill material for operating Overkill
+Factory from a public clone.
+
+## What Belongs Here
+
+- Codex skill instructions that are public-safe and aligned with the current
+  factory contracts.
+- Skill references and helper scripts that can be installed without private
+  workspace context.
+- Open-source stewardship rules for maintaining the public repository surface.
+
+## What Does Not Belong Here
+
+- Local-only memories, private paths, private project names or internal board
+  references.
+- Partial mirrors of generated contracts that can drift from schemas or tests.
+- Evidence from past validation runs.
+
+## Source Of Truth
+
+The public skill should match the public repository contracts and the current
+factory operating rules. When the local operator skill evolves, this copy must
+be reviewed before publishing so GitHub users do not receive stale behavior.
+
+## How It Is Validated
+
+Validate the skill and the public docs together:
+
+```bash
+python -m unittest tests.test_open_source_docs -q
+python scripts/public_safety_scan.py
+```

--- a/skills/codex/overkill-factory/SKILL.md
+++ b/skills/codex/overkill-factory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: overkill-factory
-description: Operate the Overkill Factory product-production line. Use when turning raw product papers into Product SOT, architecture, Product Face, security/onchain review, Hermes Kanban cards, agent execution, Receipt Five evidence, human gates, pilots, Factory VNext methodology updates, or professional open-source GitHub stewardship for the public factory repository.
+description: Operate the Overkill Factory product-production line. Use when turning raw product papers into Product SOT, Product Experience OS/Product Face, security architecture, access readiness, Hermes Kanban cards, agent execution, Receipt Five evidence, human gates, pilots, Factory VNext methodology updates, or professional open-source GitHub stewardship for the public factory repository.
 ---
 
 # Overkill Factory
@@ -11,10 +11,11 @@ different runtime.
 
 ## First Move
 
-1. Identify the current factory phase: source, SOT, architecture, Product Face,
-   review, decomposition, execution, verification, promotion, pilot, or VNext.
+1. Identify the current factory phase: source, SOT, architecture, Product
+   Experience OS/Product Face, review, decomposition, execution, verification,
+   promotion, pilot, VNext or public GitHub stewardship.
 2. Separate source facts from inference and decisions.
-3. If Hermes/Overkill state matters, use the `hermes-kanban` skill and inspect
+3. If Hermes runtime state matters, use the `hermes-kanban` skill and inspect
    the real Hermes runtime/board before mutating anything.
 4. Do not promote work from planning to execution without the matching gate.
 5. For external research, check existing local artifacts/source ledgers before
@@ -27,11 +28,26 @@ different runtime.
 
 ## Factory Spine
 
-Use this sequence:
+Use this vFinal sequence when the work is Factory VNext/vFinal:
+
+```text
+source intake -> source resolution -> outcome/discovery -> Product SOT
+-> Agentic Method Router -> method contract -> Product/Surface Pack selection
+-> risk, dependency, compliance, access and budget gates
+-> security architecture when material risk exists
+-> software/product-experience/data/agent-eval plans -> spec graph -> loop plan
+-> autonomy readiness -> Ready Gate -> execution -> worker results
+-> verification -> independent review -> human gate when needed
+-> closure summary -> Receipt Five -> completion audit
+-> production operations -> release or block -> monitoring/support
+-> learnback -> factory maturity audit
+```
+
+Use this legacy sequence only when handling existing Factory 10/11 cards:
 
 ```text
 source intake -> source resolution -> Product SOT -> alignment questions
--> architecture -> Product Face -> specialist reviews -> onchain package
+-> architecture -> Product Experience OS/Product Face -> specialist reviews -> onchain package
 -> security scan plan -> human architecture gate -> documentation OS
 -> decomposition -> Hermes cards -> execution -> verification
 -> independent review -> human R3/R4 gate -> promotion -> monitoring
@@ -57,17 +73,17 @@ For Factory 10 / Overkill V3.5 cards, require:
 - `done_definition`
 - `kanban_transition_event_ref`
 
-## Validation Standard
-
-A factory test only counts as a real test when Hermes runs the production line
-through durable Kanban state: board, card, assigned profile, run log, worker
-result, Receipt Five evidence and gate transition. Local scripts, chat
-simulation and dry runs are preflight support only; they can prepare or debug the
-factory, but they cannot be reported as end-to-end production-line validation.
-
 Block or revise cards when:
 
-- Product Face surfaces lack a Product Face Packet.
+- `OVERKILL_VFINAL` cards lack `outcome_contract`, `method_contract`, or
+  `loop_plan`.
+- Product-facing vFinal cards lack Product Experience routing, Product Face
+  Packet, or Product Face Result proof.
+- Material vFinal execution lacks ready `access_capability` or
+  `autonomy_readiness_packet`.
+- R3/R4 or security-sensitive vFinal work lacks `security_architecture_plan`.
+- Product-facing surfaces lack Product Experience routing, Product Face Packet,
+  or Product Face Result proof.
 - Onchain/Solana/Quasar work lacks an Onchain Work Package.
 - R3/R4 onchain work lacks Auditor or human waiver.
 - R3/R4/security/onchain work lacks a Codex Security/Cybersecurity scan packet.
@@ -78,9 +94,12 @@ Block or revise cards when:
   or private workspace links.
 - The public repository contains partial manual mirrors of generated contracts,
   historical evidence dumps, or folders that cannot justify their public
-  purpose, first-use path, source of truth and validation coverage.
+  purpose, first-use path, source of truth, and validation coverage.
 - Hermes updates have not passed compatibility manifest, update runbook,
   disposable smoke and rollback planning.
+- Hermes `dispatch --dry-run` and `--initial-status blocked` are not enough to
+  prove no-spawn safety. No-spawn Hermes smoke cards need a verified `blocked`
+  event in `show --json`, and dry-run should be used only on disposable boards.
 
 ## References
 
@@ -90,12 +109,18 @@ Load only what is needed:
 - `references/hermes-adapter.md` for Hermes/Kanban coupling and patch status.
 - `references/card-contract.md` for card and Receipt Five field rules.
 - `references/automation.md` for critical worker packets and `factoryctl.py`.
+- `references/documentation-standard.md` for Area Manual quality, document
+  types, and the "another agent can continue from this" documentation rule.
 - `references/open-source-github.md` when assessing or changing the public
   GitHub repository, README, folder architecture, onboarding, examples, CI,
   release hygiene, public safety, or comparisons with other open-source repos.
-- `agents/worker-profiles.public.json` and
-  `agents/hermes-profile-bindings.public.json` before changing worker profiles
-  or dispatch behavior.
+- `agents/worker-registry.public.json`, `agents/worker-profiles.public.json`
+  and `agents/hermes-profile-bindings.public.json` before changing worker
+  profiles or dispatch behavior.
+- `docs/concepts/overkill-factory-method.md`,
+  `docs/concepts/factory-flow.md`, `docs/concepts/operator-journey.md` and
+  `docs/operations/validation-and-release.md` when aligning public docs with
+  the executable repo.
 
 ## Scripts
 
@@ -122,8 +147,21 @@ running on the Hermes adapter.
 ## Operating Rules
 
 - Prefer one operational artifact over scattered notes.
+- Every important factory area needs a simple, deep Area Manual. If another
+  agent cannot continue the area from the document, the document is not done.
 - Explain why a proposed gate or worker is better than the alternative.
 - Treat older methodology notes as evidence, not as truth by default.
+- Planning may continue with missing access. Material execution must not start
+  until indispensable access/capabilities are ready or explicitly blocked.
+- Security Review does not replace Security Architecture. Material security
+  risk needs security architecture before implementation.
+- Keep final canonical documents free of doubts, backlog, raw study, and
+  behind-the-scenes comparison. Put those in study, proposal, roadmap, or
+  context-lock documents instead.
+- When the factory methodology is still under blind-spot exploration, do not
+  suggest pilots or live validation as the next step. First run or update the
+  Blind Spot Audit and decide whether gaps become core, pack, gate, worker,
+  template, checklist, or out of scope.
 - For Solana/Quasar program work, prefer Quasar and require the Auditor path.
 - For security-sensitive work, make Codex Security/Cybersecurity timing explicit.
 - Security is a specialist matrix: AppSec/OWASP, agentic AI, cloud/IaC,
@@ -149,9 +187,13 @@ running on the Hermes adapter.
   profile with skill refs, result schema and evidence policy.
 - Do not treat a worker name as an agent configuration. Agent configuration
   lives in the worker profile and Hermes binding.
-- Product Face Packet is planning; `product_face_result` is proof. Product-facing
-  completion needs screenshots, viewports, checked states, journeys,
-  accessibility, overlap, performance note and evidence refs.
+- Product Face Packet is planning; `product_face_result` is proof.
+  Product-facing completion needs screenshots, viewports, checked states,
+  journeys, accessibility, overlap, performance note and evidence refs.
+- Product Experience OS is the official layer for product experience across
+  websites, web apps, mobile, desktop, CLI/TUI, extensions, agentic interfaces,
+  design systems, docs and onboarding. Product Face is the packet/result inside
+  that layer, not the whole layer.
 - Auditor preflight is not a real Quasar code audit. Preflight must be marked as
   bounded evidence, not code-audit PASS.
 - Keep R3/R4 human authority explicit; never fake approval records.

--- a/skills/codex/overkill-factory/references/documentation-standard.md
+++ b/skills/codex/overkill-factory/references/documentation-standard.md
@@ -1,0 +1,50 @@
+# Documentation Standard
+
+Use this reference when creating or updating Overkill Factory methodology,
+area manuals, submanuals, context locks, handoffs, or final factory documents.
+
+## Core Rule
+
+Every important factory area needs a readable Area Manual.
+
+The manual must be simple enough for a smart newcomer to understand and deep
+enough for another agent to operate from it without relying on chat memory.
+
+## Document Types
+
+- Canonical document: final decisions only. No doubts, backlog, or raw study.
+- Study document: sources, critique, alternatives, uncertainty, recommendation.
+- Proposal document: candidate decision and what changes if accepted.
+- Area Manual: operational explanation of one factory area.
+- Context lock: continuity map, valid files, replaced files, open pending work.
+
+## Area Manual Checklist
+
+An Area Manual should explain:
+
+- what the area is;
+- why it exists;
+- when it enters the factory journey;
+- accepted inputs;
+- produced outputs;
+- internal step-by-step flow;
+- workers involved;
+- gates and blocking conditions;
+- evidence required;
+- examples;
+- anti-patterns;
+- final done checklist.
+
+## Writing Style
+
+- Use plain language.
+- Explain necessary technical terms the first time they appear.
+- Prefer concrete examples over abstract claims.
+- Separate source, inference, and decision.
+- Keep roadmap and pending work out of final canonical documents.
+- Do not write a document that only the author can understand.
+
+## Done Rule
+
+If another agent cannot continue the area from the document, the document is
+not done.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,30 @@
+# Templates
+
+Templates are starter contract files paired with schemas and tests.
+
+## What Belongs Here
+
+- Public card, gate, receipt, plan and result templates.
+- Minimal JSON or Markdown starting points that match schemas.
+- Templates that help an operator create a valid factory artifact faster.
+
+## What Does Not Belong Here
+
+- Finished decisions, approval records or evidence from real work.
+- Generated run output or private product material.
+- Templates without matching schemas, tests or documentation.
+
+## Source Of Truth
+
+Templates are examples of valid shape. Schemas and validation scripts decide
+whether an artifact is acceptable.
+
+## How It Is Validated
+
+Run template and schema checks:
+
+```bash
+python scripts/validate_public_json_artifacts.py
+python -m unittest discover -s tests -p "test_*.py" -q
+python scripts/public_safety_scan.py
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# Tests
+
+Tests are the regression suite for the public path and contract behavior.
+
+## What Belongs Here
+
+- Automated regression tests for schemas, scripts, adapters, docs and the public
+  quickstart.
+- Tests that make public onboarding, worker routing and safety rules durable.
+- Small fixtures required to reproduce contract behavior.
+
+## What Does Not Belong Here
+
+- Manual evidence archives, screenshots or generated proof outputs.
+- Tests that rely on private local paths, private boards or operator secrets.
+- Narrative validation history.
+
+## Source Of Truth
+
+Tests encode the public behavior the repository promises. Passing tests are not
+production approval, but failing tests block publication.
+
+## How It Is Validated
+
+Run the full public test suite:
+
+```bash
+python -m unittest discover -s tests -p "test_*.py" -q
+python scripts/quickstart_smoke.py
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+```

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -124,13 +124,70 @@ class OpenSourceDocsTest(unittest.TestCase):
 
         self.assertIn("Generated worker packets and gate reports belong in `.tmp/`", readme)
 
+    def test_high_noise_public_directories_have_entrypoint_readmes(self) -> None:
+        required_readmes = {
+            "adapters/README.md": ["runtime integrations", "Hermes"],
+            "agents/README.md": ["worker registry", "Hermes bindings"],
+            "docs/README.md": ["human guides", "public onboarding"],
+            "examples/README.md": ["source examples", ".tmp/"],
+            "products/README.md": ["public validation products", "not production approval"],
+            "schemas/README.md": ["machine contracts", "JSON Schema"],
+            "scripts/README.md": ["CLI", "validation"],
+            "skills/README.md": ["Codex skill", "public-safe"],
+            "templates/README.md": ["templates", "schemas"],
+            "tests/README.md": ["regression", "public path"],
+        }
+
+        for rel, expected_phrases in required_readmes.items():
+            with self.subTest(path=rel):
+                path = ROOT / rel
+                self.assertTrue(path.is_file())
+                text = read_text(rel)
+                for heading in [
+                    "## What Belongs Here",
+                    "## What Does Not Belong Here",
+                    "## Source Of Truth",
+                    "## How It Is Validated",
+                ]:
+                    self.assertIn(heading, text)
+                normalized = text.lower()
+                for phrase in expected_phrases:
+                    self.assertIn(phrase.lower(), normalized)
+
+    def test_examples_readme_keeps_generated_outputs_out_of_repo(self) -> None:
+        examples = read_text("examples/README.md")
+
+        self.assertIn("Generated worker packets and gate reports belong in `.tmp/`", examples)
+        self.assertIn("Do not commit generated run output", examples)
+        self.assertIn("examples/minimal-hermes-project/", examples)
+
+    def test_products_readme_sets_public_validation_boundary(self) -> None:
+        products = read_text("products/README.md")
+
+        self.assertIn("public validation products", products)
+        self.assertIn("not production approval", products)
+        self.assertIn("No private product material", products)
+
     def test_public_codex_skill_covers_open_source_stewardship(self) -> None:
         skill = read_text("skills/codex/overkill-factory/SKILL.md")
         open_source_ref = ROOT / "skills" / "codex" / "overkill-factory" / "references" / "open-source-github.md"
+        documentation_ref = (
+            ROOT
+            / "skills"
+            / "codex"
+            / "overkill-factory"
+            / "references"
+            / "documentation-standard.md"
+        )
 
         self.assertTrue(open_source_ref.is_file())
+        self.assertTrue(documentation_ref.is_file())
         self.assertIn("professional open-source GitHub stewardship", skill)
+        self.assertIn("Product Experience OS/Product Face", skill)
+        self.assertIn("Use this vFinal sequence", skill)
         self.assertIn("references/open-source-github.md", skill)
+        self.assertIn("references/documentation-standard.md", skill)
+        self.assertIn("Every public folder needs a burden-of-proof decision", skill)
 
     def test_agent_public_doc_covers_every_registered_worker(self) -> None:
         registry = json.loads(read_text("agents/worker-registry.public.json"))


### PR DESCRIPTION
## What changed

- Added top-level boundary READMEs for public folders that previously looked like raw contract mass instead of a navigable open-source project.
- Updated the repository shape section so every kept folder points to its local purpose, source-of-truth and validation rules.
- Synchronized the public Codex skill with the current vFinal/Product Experience OS behavior and added the documentation standard reference.
- Added tests that block future drift: public folders must keep entrypoint READMEs, generated example outputs stay out of the repo, product fixtures cannot be treated as production approval, and the public skill cannot fall behind the current factory mode.

## Why

The repo already had real factory machinery, but GitHub still needed to behave like a professional product surface: clone, understand, run, extend. This PR makes folder existence explicit and test-backed instead of relying on memory from prior cleanup work.

## Validation

- `python -m unittest tests.test_open_source_docs -q`
- `python C:\Users\felip\.codex\skills\.system\skill-creator\scripts\quick_validate.py skills\codex\overkill-factory`
- `python scripts\quickstart_smoke.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` with 224 tests passing
- `git diff --cached --check`

## Production gate note

`release_integration_preflight.py`, `factory_production_readiness.py` and `worktree_release_inventory.py` still report `BLOCKED` outside this PR scope because they require real runtime, Control Tower and release-ref receipts. This PR does not invent historical evidence or production approval inside the repository.