### PR TITLE
[codex] Improve operator install and OSS maintenance path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+name: codeql
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "33 6 * * 1"
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: dependency-review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,27 @@
+name: security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  public-safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Public safety scan
+        run: python scripts/public_safety_scan.py
+      - name: Secret safety scan
+        run: python scripts/secret_safety_scan.py
+      - name: Supply-chain proof
+        run: python scripts/supply_chain_proof.py --check --no-write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable public changes should be recorded here.
+
+The format follows Keep a Changelog principles and uses semantic versioning for
+public releases.
+
+## Unreleased
+
+- Added the operator-first CLI path: `factoryctl doctor`, `factoryctl init` and
+  `factoryctl run minimal`.
+- Added public docs site navigation, CLI reference, Hermes install guide,
+  example gallery, release policy and OSS security guide.
+- Added Dependabot, CodeQL, Dependency Review and security workflow surfaces.
+
+## 0.1.0
+
+- Initial public alpha package metadata, public quickstart, Hermes adapter,
+  worker registry, schemas, examples and validation scripts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,15 @@ easier to run, inspect or integrate with Hermes.
 Run:
 
 ```bash
-python scripts/quickstart_smoke.py
+factoryctl doctor
+factoryctl run minimal
 python -m unittest discover -s tests -p "test_*.py" -q
 python scripts/validate_document_governance.py
 python scripts/validate_public_json_artifacts.py
+python scripts/validate_worker_profiles.py
 python scripts/secret_safety_scan.py
 python scripts/public_safety_scan.py
+python scripts/supply_chain_proof.py --check --no-write
 ```
 
 ## Contribution Rules

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Overkill Factory provides:
   role;
 - a capability pack registry for checking whether the product type has ready
   specialist coverage before execution;
-- `factoryctl.py` helpers for validating cards, creating gate reports and
-  generating worker packets;
+- a single `factoryctl` CLI for install health, project init, local smoke,
+  card validation, gate reports and worker packets;
 - a Hermes adapter and transition hook that can block weak `ready` and `done`
   transitions;
 - public-safe examples and receipt contracts;
@@ -96,14 +96,33 @@ The adapter files are under `adapters/hermes/`:
 You can run local validation without Discord. Configure a Control Tower only
 after the local card, worker packet and receipt path is clear.
 
+## Operator Path
+
+For a person or AI installing the factory into their own Hermes, use the CLI
+path first and open dense contracts only when needed:
+
+```bash
+python -m pip install -e .
+factoryctl doctor
+factoryctl run minimal
+factoryctl init --out ../my-product-factory --project-name my-product
+```
+
+Then read `docs/getting-started/install-in-hermes.md` and connect generated
+worker packets to your Hermes test runtime. The factory is easy to maintain
+when common user flows go through `factoryctl` and maintainer internals stay
+behind docs, schemas and tests.
+
 ## Quickstart
 
-Three-command local smoke:
+Three-command local smoke from a fresh checkout:
 
 ```bash
 git clone https://github.com/<owner>/overkill-factory.git
 cd overkill-factory
-python scripts/quickstart_smoke.py
+python -m pip install -e .
+factoryctl doctor
+factoryctl run minimal
 ```
 
 The smoke writes `.tmp/quickstart-result.json` and required worker packets under
@@ -111,8 +130,9 @@ The smoke writes `.tmp/quickstart-result.json` and required worker packets under
 `docs/getting-started/quickstart-hermes.md` for the same path with Hermes
 configuration notes.
 
-For packaging, install the local CLI with `python -m pip install -e .`, then use
-`factoryctl` or `overkill-quickstart`.
+`python scripts/quickstart_smoke.py` and `overkill-quickstart` remain
+compatibility entrypoints, but `factoryctl run minimal` is the public operator
+path.
 
 ## First Value In 10 Minutes
 
@@ -190,7 +210,11 @@ adapter rule or receipt contract.
 
 - `docs/governance/document-governance.md`: what belongs in public docs versus
   local/private evidence.
+- `docs/index.md`: docs home and navigation.
 - `docs/getting-started/quickstart-hermes.md`: first run with your own Hermes.
+- `docs/getting-started/install-in-hermes.md`: install and connect the factory
+  to an operator-owned Hermes runtime.
+- `docs/reference/cli.md`: supported `factoryctl` commands.
 - `docs/concepts/factory-flow.md`: core concepts and phase flow.
 - `docs/concepts/overkill-factory-method.md`: human-readable method guide.
 - `docs/concepts/operator-journey.md`: step-by-step operator journey.
@@ -204,10 +228,18 @@ adapter rule or receipt contract.
 - `docs/control-tower/open-source-setup.md`: optional Discord/Control Tower
   setup.
 - `docs/operations/validation-and-release.md`: validation and release checklist.
+- `docs/operations/release-policy.md`: semantic versioning, release checks and
+  point-5 boundary.
 - `docs/operations/troubleshooting.md`: common failures and how to continue.
 - `docs/architecture/hermes-integration.md`: adapter and runtime integration.
+- `docs/examples/gallery.md`: which example to use for minimal, Product Face,
+  security and onchain paths.
+- `docs/security/oss-security.md`: repository security controls.
+- `docs/maintenance/repo-surface.md`: operator surface versus maintainer
+  internals and generated output.
 - `examples/minimal-hermes-project/README.md`: small public-safe example.
 - `.env.example`: safe environment variable template.
+- `CHANGELOG.md`: public release history.
 - `CONTRIBUTING.md`: contribution rules and required checks.
 - `SECURITY.md`: security reporting and public-boundary policy.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,13 @@ longer support window.
 Before public release work, run:
 
 ```bash
+factoryctl doctor
 python scripts/secret_safety_scan.py
 python scripts/public_safety_scan.py
 python scripts/validate_public_json_artifacts.py
+python scripts/supply_chain_proof.py --check --no-write
 ```
+
+GitHub also runs CodeQL, Dependency Review, Dependabot configuration checks and
+the public security workflow. Those repository checks do not replace
+product-specific security review, Auditor evidence or human gates.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,5 +35,7 @@ python scripts/secret_safety_scan.py
 python -m unittest tests.test_open_source_docs -q
 ```
 
-Start with `docs/getting-started/quickstart-hermes.md`, then read
-`docs/concepts/factory-flow.md` and `docs/operations/validation-and-release.md`.
+Start with `docs/index.md`, then read
+`docs/getting-started/install-in-hermes.md`,
+`docs/reference/cli.md`, `docs/concepts/factory-flow.md` and
+`docs/operations/validation-and-release.md`.

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -1,0 +1,38 @@
+# Example Gallery
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: examples/, scripts/factoryctl.py, tests/
+> Runtime boundary: Examples are public-safe source material. They are not proof
+> that production work has run.
+
+## Minimal Hermes Project
+
+- Path: `examples/minimal-hermes-project/`
+- Use when: first install, first smoke, first worker packet generation.
+- Command: `factoryctl run minimal`
+
+## Product Face Example
+
+- Path: `examples/cards/v35_valid_product_face.md`
+- Use when: visible product work needs Product Experience OS and Product Face
+  proof before completion.
+- Command: `factoryctl gate-report --card examples/cards/v35_valid_product_face.md`
+
+## Security Example
+
+- Path: `examples/cards/v35_valid_security_with_scan.md`
+- Use when: a card needs a security scan packet and independent review without
+  onchain risk.
+- Command: `factoryctl worker-packet --worker all --required-only --card examples/cards/v35_valid_security_with_scan.md --out .tmp/security-example-packets`
+
+## Onchain Auditor Example
+
+- Path: `examples/cards/v35_valid_onchain_auditor_scan.md`
+- Use when: Solana/Quasar work needs Auditor, Codex Security, supply-chain and
+  human-gate coverage.
+- Command: `factoryctl gate-report --card examples/cards/v35_valid_onchain_auditor_scan.md`
+
+## Rule
+
+Examples stay small, public-safe and reproducible. Generated worker packets,
+gate reports, screenshots and receipts belong in `.tmp/`, not in `examples/`.

--- a/docs/getting-started/install-in-hermes.md
+++ b/docs/getting-started/install-in-hermes.md
@@ -1,0 +1,46 @@
+# Install In Your Hermes
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: README.md, scripts/factoryctl.py, adapters/hermes/README.md,
+> agents/hermes-profile-bindings.public.json, tests/
+> Runtime boundary: This guide prepares an operator-owned Hermes integration. It
+> does not claim a real Hermes E2E harness.
+
+## Goal
+
+A person or AI should be able to clone the factory, check the install, create a
+workspace and know exactly what to connect to their Hermes runtime.
+
+## Install
+
+```bash
+git clone https://github.com/<owner>/overkill-factory.git
+cd overkill-factory
+python -m pip install -e .
+factoryctl doctor
+factoryctl run minimal
+factoryctl init --out ../my-product-factory --project-name my-product
+```
+
+## What Gets Installed
+
+- `factoryctl`: the supported CLI.
+- Public Codex skill material under `skills/codex/overkill-factory/`.
+- Hermes adapter material under `adapters/hermes/`.
+- Public worker bindings under `agents/hermes-profile-bindings.public.json`.
+
+## Connect To Hermes
+
+1. Review the workspace created by `factoryctl init`.
+2. Install the Codex skill into the agent environment that will operate Hermes.
+3. Apply the Hermes adapter patch in a test Hermes checkout first.
+4. Wire Hermes transition events to `adapters/hermes/transition_hook.py`.
+5. Generate worker packets with `factoryctl worker-packet`.
+6. Create or route Hermes worker cards from those packets.
+7. Attach real worker result artifacts and Receipt Five before `done`.
+
+## Boundary
+
+Point 5 is intentionally deferred. This guide makes installation easy, but it
+does not claim an official real Hermes E2E harness. Until that harness exists,
+operator-owned Hermes validation must happen in the user's own test runtime.

--- a/docs/getting-started/quickstart-hermes.md
+++ b/docs/getting-started/quickstart-hermes.md
@@ -17,7 +17,9 @@ Discord is optional cockpit UI. It is not the source of truth.
 ```bash
 git clone https://github.com/<owner>/overkill-factory.git
 cd overkill-factory
-python scripts/quickstart_smoke.py
+python -m pip install -e .
+factoryctl doctor
+factoryctl run minimal
 ```
 
 Expected first value: a `PASS` line within a few minutes on a normal Python
@@ -37,14 +39,18 @@ Those files are local outputs. Keep generated worker packets and gate reports in
 
 ## Optional Local CLI
 
-Install the editable package when you want shell commands instead of script
-paths:
+The CLI is the recommended public path:
 
 ```bash
 python -m pip install -e .
-overkill-quickstart
+factoryctl doctor
+factoryctl run minimal
+factoryctl init --out ../my-product-factory --project-name my-product
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 ```
+
+`python scripts/quickstart_smoke.py` and `overkill-quickstart` remain available
+for compatibility.
 
 ## What To Inspect
 
@@ -89,15 +95,16 @@ Introduce the adapter in a test runtime before any real product or release work.
 
 For your own project:
 
-1. Start with a short paper or product brief.
-2. Create a factory card from the relevant example in `examples/cards/`.
-3. Fill source refs, scope, risk, runtime, security, forbidden actions and done
+1. Run `factoryctl init --out ../my-product-factory --project-name my-product`.
+2. Start with a short paper or product brief.
+3. Create or edit a factory card from the relevant example in `examples/cards/`.
+4. Fill source refs, scope, risk, runtime, security, forbidden actions and done
    definition.
-4. Run `factoryctl validate-card`.
-5. Run `factoryctl gate-report`.
-6. Generate required worker packets.
-7. Let Hermes create or route worker cards.
-8. Attach worker results and Receipt Five before any `done` transition.
+5. Run `factoryctl validate-card`.
+6. Run `factoryctl gate-report`.
+7. Generate required worker packets.
+8. Let Hermes create or route worker cards.
+9. Attach worker results and Receipt Five before any `done` transition.
 
 ## Before Release
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# Overkill Factory Docs
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: README.md, scripts/factoryctl.py, schemas/, tests/
+> Runtime boundary: This page is navigation. Runtime gates live in scripts,
+> schemas, adapter hooks and Hermes state.
+
+## Operator Path
+
+Use this order from a fresh checkout:
+
+1. `factoryctl doctor`
+2. `factoryctl run minimal`
+3. `factoryctl init --out ../my-product-factory --project-name my-product`
+4. Read `getting-started/install-in-hermes.md`
+5. Connect generated worker packets to your Hermes only after local checks pass.
+
+## Install In Your Hermes
+
+Start with `getting-started/install-in-hermes.md`. Hermes is your runtime floor;
+Overkill Factory supplies contracts, profiles, packets and gates.
+
+## CLI Reference
+
+Use `reference/cli.md` for the supported operator commands. Prefer `factoryctl`
+over calling many scripts directly.
+
+## Examples
+
+Use `examples/gallery.md` to choose a minimal, Product Face, security or onchain
+example. Example files are source material, not historical proof.
+
+## Security
+
+Use `security/oss-security.md` before changing dependencies, workflows, release
+state, public docs or adapter behavior.
+
+## Release
+
+Use `operations/release-policy.md` before tagging, packaging or publishing a
+release.
+
+## Maintainer Internals
+
+Use `maintenance/repo-surface.md` to decide whether a file belongs in the
+operator surface, maintainer internals or generated output.

--- a/docs/maintenance/repo-surface.md
+++ b/docs/maintenance/repo-surface.md
@@ -1,0 +1,42 @@
+# Repository Surface
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: README.md, scripts/factoryctl.py, tests/
+> Runtime boundary: This guide keeps the repo maintainable. It does not override
+> executable gates.
+
+## Operator surface
+
+Files a new operator should open first:
+
+- `README.md`
+- `docs/index.md`
+- `docs/getting-started/install-in-hermes.md`
+- `docs/reference/cli.md`
+- `examples/minimal-hermes-project/`
+
+## Maintainer internals
+
+Files maintainers change when contracts evolve:
+
+- `schemas/`
+- `templates/`
+- `agents/*.json`
+- `scripts/`
+- `adapters/`
+- `tests/`
+
+These are allowed to be dense. They should not be the first path a new user
+must understand.
+
+## Generated output
+
+Generated output belongs in `.tmp/`, release artifacts or the operator's private
+evidence store. Do not commit generated worker packets, gate reports, old
+screenshots, raw logs or historical proof.
+
+## Maintenance Rule
+
+If a workflow becomes common for users, expose it through `factoryctl`. If a
+workflow is only for maintainers, document it in the relevant README and keep it
+covered by tests.

--- a/docs/operations/release-policy.md
+++ b/docs/operations/release-policy.md
@@ -1,0 +1,44 @@
+# Release Policy
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: README.md, CHANGELOG.md, pyproject.toml,
+> docs/operations/validation-and-release.md, tests/
+> Runtime boundary: This policy governs public repository releases. It does not
+> approve production use of any user's product.
+
+## Versioning
+
+Use semantic versioning:
+
+- patch for docs, examples, validation and compatibility fixes;
+- minor for new public CLI commands, schemas, adapters or worker contracts;
+- major for breaking card, receipt, adapter or CLI behavior.
+
+## Before A Release
+
+Run:
+
+```bash
+factoryctl doctor
+factoryctl run minimal
+python -m unittest discover -s tests -p "test_*.py" -q
+python scripts/validate_document_governance.py
+python scripts/validate_public_json_artifacts.py
+python scripts/validate_worker_profiles.py
+python scripts/secret_safety_scan.py
+python scripts/public_safety_scan.py
+python scripts/supply_chain_proof.py --check --no-write
+```
+
+## Release Artifact Rules
+
+- Update `CHANGELOG.md`.
+- Keep generated proof under `.tmp/` or release artifacts, not committed docs.
+- Tag only from a clean `main` that matches `origin/main`.
+- Publish package artifacts only after the release checks pass.
+
+## Deferred Runtime Harness
+
+Point 5 is intentionally deferred. A public release may validate local CLI,
+schemas, docs, examples and adapter compatibility, but it must not claim an
+official real Hermes E2E harness until that harness exists and is tested.

--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -8,12 +8,15 @@ run before claiming that a checkout is ready.
 Use this before editing cards, docs or examples:
 
 ```bash
-python scripts/quickstart_smoke.py
+factoryctl doctor
+factoryctl run minimal
 python -m unittest discover -s tests
 python scripts/validate_document_governance.py
 python scripts/validate_public_json_artifacts.py
+python scripts/validate_worker_profiles.py
 python scripts/secret_safety_scan.py
 python scripts/public_safety_scan.py
+python scripts/supply_chain_proof.py --check --no-write
 ```
 
 ## Factory Contract Check
@@ -21,9 +24,9 @@ python scripts/public_safety_scan.py
 Use a card-specific check before sending work to Hermes:
 
 ```bash
-python scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
-python scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
-python scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+factoryctl validate-card examples/minimal-hermes-project/card.md
+factoryctl gate-report --card examples/minimal-hermes-project/card.md
+factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 ```
 
 What this proves:
@@ -50,12 +53,15 @@ provided. Generated summaries must not be committed as release proof.
 For a stronger local pass:
 
 ```bash
+factoryctl doctor
+factoryctl run minimal
 python scripts/factory_battery.py
 python scripts/validate_document_governance.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_public_json_artifacts.py
 python scripts/public_safety_scan.py
 python scripts/secret_safety_scan.py
+python scripts/supply_chain_proof.py --check --no-write
 python scripts/factory_completion_audit.py --no-write --require-complete
 python -m unittest discover -s tests -p "test_*.py" -q
 ```
@@ -69,6 +75,8 @@ PowerShell examples:
 
 ```powershell
 New-Item -ItemType Directory -Force .tmp
+factoryctl doctor
+factoryctl run minimal
 python -m unittest discover -s tests -p "test_*.py" -q
 python scripts\release_integration_preflight.py --out .tmp\release-check.json
 python scripts\factory_production_readiness.py --out .tmp\readiness-check.json

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,51 @@
+# CLI Reference
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: scripts/factoryctl.py, README.md, tests/
+> Runtime boundary: The CLI creates and validates local artifacts. Hermes remains
+> the runtime source of truth for real cards and transitions.
+
+## Operator Commands
+
+### `factoryctl doctor`
+
+Checks local install health, package metadata, public entrypoints, the minimal
+example and whether Hermes runtime checking is configured. It does not claim a
+real Hermes E2E harness.
+
+```bash
+factoryctl doctor
+factoryctl doctor --json
+```
+
+### `factoryctl run minimal`
+
+Runs the public first-value path through the single CLI entrypoint.
+
+```bash
+factoryctl run minimal
+factoryctl run minimal --out .tmp/quickstart-result.json --packets-out .tmp/minimal-worker-packets
+```
+
+### `factoryctl init`
+
+Creates a Hermes-friendly operator workspace for a product.
+
+```bash
+factoryctl init --out ../my-product-factory --project-name my-product
+```
+
+## Card And Worker Commands
+
+```bash
+factoryctl validate-card examples/minimal-hermes-project/card.md
+factoryctl gate-report --card examples/minimal-hermes-project/card.md
+factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
+```
+
+## Maintainer Scripts
+
+Scripts outside `factoryctl` are maintainer tools or compatibility entrypoints.
+Promote repeated operator flows into `factoryctl` instead of adding another
+script name to the public path.

--- a/docs/security/oss-security.md
+++ b/docs/security/oss-security.md
@@ -1,0 +1,31 @@
+# Open Source Security
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: SECURITY.md, scripts/supply_chain_proof.py,
+> scripts/public_safety_scan.py, scripts/secret_safety_scan.py, tests/
+> Runtime boundary: This is repository security posture. It does not replace
+> product-specific security review, Codex Security, Auditor or human gates.
+
+## Required Controls
+
+- CodeQL runs for Python code scanning.
+- Dependency Review runs on pull requests.
+- Dependabot tracks GitHub Actions and Python dependency surfaces.
+- `scripts/supply_chain_proof.py` validates pinned workflow actions and writes
+  an SPDX SBOM when requested.
+- `scripts/secret_safety_scan.py` blocks obvious secrets.
+- `scripts/public_safety_scan.py` blocks private/public boundary leaks.
+
+## Local Check
+
+```bash
+python scripts/secret_safety_scan.py
+python scripts/public_safety_scan.py
+python scripts/supply_chain_proof.py --check --no-write
+```
+
+## Boundary
+
+These checks protect the public repository. They do not prove that a user's
+product, Hermes runtime, production deployment, keys, wallets or cloud
+environment are secure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,25 @@
+site_name: Overkill Factory
+site_description: Gated production line for Hermes-powered agentic product work.
+site_url: https://overkill-factory.dev
+repo_url: https://overkill-factory.dev/source
+docs_dir: docs
+nav:
+  - Operator Path: index.md
+  - Install In Your Hermes: getting-started/install-in-hermes.md
+  - CLI Reference: reference/cli.md
+  - Examples: examples/gallery.md
+  - Concepts:
+      - Factory Flow: concepts/factory-flow.md
+      - Operator Journey: concepts/operator-journey.md
+      - Method Guide: concepts/overkill-factory-method.md
+  - Agents:
+      - Worker Profiles: agents/worker-profiles.md
+      - Stage Map: agents/factory-stage-agent-map.md
+      - Capability Packs: agents/capability-packs.md
+  - Security:
+      - OSS Security: security/oss-security.md
+      - Security Matrix: security/security-control-matrix.md
+  - Release:
+      - Validation And Release: operations/validation-and-release.md
+      - Release Policy: operations/release-policy.md
+  - Maintainer Internals: maintenance/repo-surface.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,10 @@ classifiers = [
 ]
 
 [project.urls]
-Repository = "https://github.com/OWNER/overkill-factory"
-Issues = "https://github.com/OWNER/overkill-factory/issues"
+Homepage = "https://overkill-factory.dev"
+Documentation = "https://overkill-factory.dev/docs"
+Repository = "https://overkill-factory.dev/source"
+Issues = "https://overkill-factory.dev/issues"
 
 [project.scripts]
 factoryctl = "scripts.factoryctl:main"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,8 +18,9 @@ Scripts provide the public CLI path, validation tools and maintainer checks.
 ## Source Of Truth
 
 `scripts/factoryctl.py`, package entrypoints and tests define the supported
-operator path. Experimental helpers must either graduate into that path or stay
-clearly secondary.
+operator path. `factoryctl doctor`, `factoryctl init` and
+`factoryctl run minimal` are the first commands. Experimental helpers must
+either graduate into that path or stay clearly secondary.
 
 ## How It Is Validated
 

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -23,6 +23,10 @@ ROOT = Path(__file__).resolve().parents[1]
 PROFILE_BINDINGS_PATH = ROOT / "agents" / "hermes-profile-bindings.public.json"
 CAPABILITY_PACKS_PATH = ROOT / "agents" / "capability-packs.public.json"
 CANONICAL_RUNTIME_ENFORCEMENT_PATH = ROOT / "scripts" / "canonical_runtime_enforcement.py"
+DEFAULT_MINIMAL_CARD = ROOT / "examples" / "minimal-hermes-project" / "card.md"
+DEFAULT_QUICKSTART_OUT = ROOT / ".tmp" / "quickstart-result.json"
+DEFAULT_PACKETS_OUT = ROOT / ".tmp" / "minimal-worker-packets"
+PYPROJECT_PATH = ROOT / "pyproject.toml"
 
 CARD_REQUIRED = {
     "factory_method_version",
@@ -789,6 +793,235 @@ def source_card_ref(source_path: Path) -> str:
         if windows_path.is_absolute() or (len(raw_normalized) >= 2 and raw_normalized[1] == ":"):
             return f"external:{windows_path.name or 'source-card'}"
         return f"external:{source_path.name or 'source-card'}"
+
+
+def read_project_version() -> str:
+    if not PYPROJECT_PATH.exists():
+        return "0.0.0"
+    for line in PYPROJECT_PATH.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("version"):
+            return line.split("=", 1)[1].strip().strip('"')
+    return "0.0.0"
+
+
+def build_minimal_run_result(card_path: Path, packets_out: Path) -> dict[str, Any]:
+    card = load_json_like(card_path)
+    validation_errors = validate_card(card)
+    gate_report = build_gate_report(card)
+    required_workers = list(gate_report.get("required_workers", []))
+
+    packets_out.mkdir(parents=True, exist_ok=True)
+    packet_paths: list[str] = []
+    for worker_id in required_workers:
+        packet = build_worker_packet(worker_id, card, card_path)
+        packet_path = packets_out / f"{worker_id}.json"
+        packet_path.write_text(json.dumps(packet, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        packet_paths.append(source_card_ref(packet_path))
+
+    checks = [
+        {
+            "id": "card_contract",
+            "result": "PASS" if not validation_errors else "FAIL",
+            "details": validation_errors,
+        },
+        {
+            "id": "gate_report",
+            "result": "PASS" if gate_report.get("gate_status") == "ready_for_worker_execution" else "FAIL",
+            "details": [str(gate_report.get("gate_status"))],
+        },
+        {
+            "id": "worker_packets",
+            "result": "PASS" if packet_paths else "FAIL",
+            "details": packet_paths,
+        },
+    ]
+    result = "PASS" if all(check["result"] == "PASS" for check in checks) else "FAIL"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/quickstart-smoke-result.schema.json",
+        "result_type": "quickstart_smoke_result",
+        "created_at": utc_now(),
+        "result": result,
+        "card": source_card_ref(card_path),
+        "gate_status": gate_report.get("gate_status"),
+        "required_workers": required_workers,
+        "worker_packet_count": len(packet_paths),
+        "worker_packet_dir": source_card_ref(packets_out),
+        "checks": checks,
+        "next_step": "Connect these packets to Hermes only after reviewing required workers and authority limits.",
+    }
+
+
+def doctor_check(check_id: str, status: str, summary: str, detail: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"id": check_id, "status": status, "summary": summary}
+    if detail:
+        payload["detail"] = detail
+    return payload
+
+
+def build_doctor_report(hermes_home: Path | None = None) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    py_ok = sys.version_info >= (3, 11)
+    checks.append(
+        doctor_check(
+            "python_version",
+            "PASS" if py_ok else "FAIL",
+            f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        )
+    )
+
+    pyproject_text = PYPROJECT_PATH.read_text(encoding="utf-8") if PYPROJECT_PATH.exists() else ""
+    metadata_ok = PYPROJECT_PATH.exists() and "name = \"overkill-factory\"" in pyproject_text and "OWNER" not in pyproject_text
+    checks.append(
+        doctor_check(
+            "package_metadata",
+            "PASS" if metadata_ok else "FAIL",
+            "Package metadata is present and public identity is configured." if metadata_ok else "Package metadata is missing or still uses placeholder OWNER.",
+        )
+    )
+
+    required_entrypoints = [
+        "README.md",
+        "docs/index.md",
+        "docs/getting-started/install-in-hermes.md",
+        "docs/reference/cli.md",
+        "examples/minimal-hermes-project/card.md",
+        "agents/hermes-profile-bindings.public.json",
+        "adapters/hermes/transition_hook.py",
+    ]
+    missing = [path for path in required_entrypoints if not (ROOT / path).is_file()]
+    checks.append(
+        doctor_check(
+            "repository_shape",
+            "PASS" if not missing else "FAIL",
+            "Public operator entrypoints are present." if not missing else "Public operator entrypoints are missing.",
+            {"missing": missing},
+        )
+    )
+
+    minimal_detail: dict[str, Any] = {}
+    try:
+        card = load_json_like(DEFAULT_MINIMAL_CARD)
+        errors = validate_card(card)
+        report = build_gate_report(card)
+        minimal_ok = not errors and report.get("gate_status") == "ready_for_worker_execution"
+        minimal_detail = {"validation_errors": errors, "gate_status": report.get("gate_status")}
+    except Exception as exc:  # pragma: no cover - defensive report detail
+        minimal_ok = False
+        minimal_detail = {"error": str(exc)}
+    checks.append(
+        doctor_check(
+            "minimal_example",
+            "PASS" if minimal_ok else "FAIL",
+            "Minimal example validates and reaches ready-for-worker-execution preflight." if minimal_ok else "Minimal example is not runnable.",
+            minimal_detail,
+        )
+    )
+
+    checks.append(
+        doctor_check(
+            "public_cli",
+            "PASS",
+            "Use factoryctl doctor, factoryctl init, and factoryctl run minimal as the public operator path.",
+        )
+    )
+
+    hermes_path = hermes_home
+    hermes_configured = hermes_path is not None and hermes_path.exists()
+    checks.append(
+        doctor_check(
+            "hermes_runtime_optional",
+            "PASS" if hermes_configured else "WARN",
+            (
+                f"Hermes home detected at {hermes_path}."
+                if hermes_configured
+                else "Hermes runtime was not checked. Local factory validation can run before Hermes integration."
+            ),
+        )
+    )
+    checks.append(
+        doctor_check(
+            "hermes_e2e_deferred",
+            "INFO",
+            "Point 5 is intentionally deferred: doctor does not claim a real Hermes E2E harness.",
+        )
+    )
+
+    result = "FAIL" if any(check["status"] == "FAIL" for check in checks) else "PASS"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-doctor-result.schema.json",
+        "record_type": "factory_doctor_result",
+        "created_at": utc_now(),
+        "result": result,
+        "factory_version": read_project_version(),
+        "checks": checks,
+        "next_step": "Run factoryctl run minimal, then factoryctl init for your project workspace.",
+    }
+
+
+def write_operator_workspace(target: Path, project_name: str, hermes_home: Path | None, force: bool = False) -> None:
+    if target.exists() and any(target.iterdir()) and not force:
+        raise ValueError(f"{target} is not empty; use --force to write into it")
+    target.mkdir(parents=True, exist_ok=True)
+    for rel in ["cards", "worker-packets", "receipts", "worker-results", "reports"]:
+        directory = target / rel
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / ".gitkeep").write_text("", encoding="utf-8")
+
+    card_text = DEFAULT_MINIMAL_CARD.read_text(encoding="utf-8")
+    (target / "cards" / "minimal-card.md").write_text(card_text, encoding="utf-8")
+
+    config = {
+        "$schema": "https://overkill-factory.dev/schemas/operator-workspace.schema.json",
+        "project_name": project_name,
+        "factory_version": read_project_version(),
+        "created_at": utc_now(),
+        "runtime": {
+            "name": "Hermes",
+            "mode": "operator-owned",
+            "hermes_home": str(hermes_home) if hermes_home else "set HERMES_HOME or pass --hermes-home when integrating",
+        },
+        "paths": {
+            "cards": "cards",
+            "worker_packets": "worker-packets",
+            "worker_results": "worker-results",
+            "receipts": "receipts",
+            "reports": "reports",
+        },
+        "next_commands": [
+            "factoryctl doctor",
+            "factoryctl run minimal",
+            "factoryctl gate-report --card cards/minimal-card.md --out reports/minimal-gate-report.json",
+            "factoryctl worker-packet --worker all --required-only --card cards/minimal-card.md --out worker-packets",
+        ],
+    }
+    (target / "overkill.factory.json").write_text(json.dumps(config, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    readme = f"""# {project_name}
+
+This workspace is ready for an operator-owned Hermes integration with Overkill
+Factory. It contains source cards, worker-packet output folders, receipt folders
+and a small public-safe starter card.
+
+## First Commands
+
+```bash
+factoryctl doctor
+factoryctl run minimal
+factoryctl gate-report --card cards/minimal-card.md --out reports/minimal-gate-report.json
+factoryctl worker-packet --worker all --required-only --card cards/minimal-card.md --out worker-packets
+```
+
+## Connect this workspace to your Hermes
+
+1. Review `overkill.factory.json`.
+2. Install the public Codex skill from `skills/codex/overkill-factory/`.
+3. Apply the Hermes adapter only in a test Hermes checkout first.
+4. Route generated worker packets into Hermes worker cards.
+5. Attach real worker results and Receipt Five before moving cards to `done`.
+
+Point 5 is intentionally deferred in this generated workspace: it does not claim
+that a real Hermes E2E harness has run.
+"""
+    (target / "README.md").write_text(readme, encoding="utf-8")
 
 
 def _non_empty_string_list(value: Any) -> bool:
@@ -2551,9 +2784,62 @@ def command_transition_plan(args: argparse.Namespace) -> int:
     return 1 if action.startswith("block") and args.enforce else 0
 
 
+def command_doctor(args: argparse.Namespace) -> int:
+    report = build_doctor_report(args.hermes_home)
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=True))
+    else:
+        print(f"Overkill Factory doctor: {report['result']}")
+        for check in report["checks"]:
+            print(f"- {check['status']}: {check['id']} - {check['summary']}")
+    return 0 if report["result"] == "PASS" else 1
+
+
+def command_init(args: argparse.Namespace) -> int:
+    try:
+        write_operator_workspace(
+            args.out,
+            project_name=args.project_name,
+            hermes_home=args.hermes_home,
+            force=args.force,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"Initialized Overkill Factory workspace at {args.out}")
+    return 0
+
+
+def command_run_minimal(args: argparse.Namespace) -> int:
+    result = build_minimal_run_result(args.card, args.packets_out)
+    write_json(args.out, result)
+    print(f"{result['result']}: wrote {source_card_ref(args.out)}")
+    return 0 if result["result"] == "PASS" else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Overkill Factory control helper")
     sub = parser.add_subparsers(dest="command", required=True)
+
+    doctor_parser = sub.add_parser("doctor", help="Check local factory install health without claiming Hermes E2E proof.")
+    doctor_parser.add_argument("--json", action="store_true")
+    doctor_parser.add_argument("--hermes-home", type=Path)
+    doctor_parser.set_defaults(func=command_doctor)
+
+    init_parser = sub.add_parser("init", help="Create a Hermes-friendly operator workspace.")
+    init_parser.add_argument("--out", type=Path, required=True)
+    init_parser.add_argument("--project-name", required=True)
+    init_parser.add_argument("--hermes-home", type=Path)
+    init_parser.add_argument("--force", action="store_true")
+    init_parser.set_defaults(func=command_init)
+
+    run_parser = sub.add_parser("run", help="Run public operator workflows.")
+    run_sub = run_parser.add_subparsers(dest="run_command", required=True)
+    minimal_parser = run_sub.add_parser("minimal", help="Run the minimal public factory smoke.")
+    minimal_parser.add_argument("--card", type=Path, default=DEFAULT_MINIMAL_CARD)
+    minimal_parser.add_argument("--out", type=Path, default=DEFAULT_QUICKSTART_OUT)
+    minimal_parser.add_argument("--packets-out", type=Path, default=DEFAULT_PACKETS_OUT)
+    minimal_parser.set_defaults(func=command_run_minimal)
 
     validate_card_parser = sub.add_parser("validate-card")
     validate_card_parser.add_argument("path", type=Path)

--- a/scripts/supply_chain_proof.py
+++ b/scripts/supply_chain_proof.py
@@ -18,7 +18,9 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUT = ROOT / ".tmp" / "factory-runs" / "supply-chain"
 
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
-PINNED_ACTION_RE = re.compile(r"^-?\s*uses:\s*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([A-Fa-f0-9]{40})\s*(?:#.*)?$")
+PINNED_ACTION_RE = re.compile(
+    r"^-?\s*uses:\s*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)@([A-Fa-f0-9]{40})\s*(?:#.*)?$"
+)
 USES_RE = re.compile(r"uses:\s*(\S+)")
 
 SKIP_PARTS = {".git", "__pycache__", ".mypy_cache", ".pytest_cache"}
@@ -94,8 +96,10 @@ def validate_workflow(path: Path) -> dict[str, Any]:
         findings.append("top-level permissions block is missing")
     if not re.search(r"^\s+contents:\s*read\s*$", permissions_text, re.MULTILINE):
         findings.append("top-level permissions must include contents: read")
-    if re.search(r":\s*(write|admin)\s*$", permissions_text, re.MULTILINE):
-        findings.append("workflow permissions include write/admin scope")
+    for permission_line in permissions_text.splitlines():
+        stripped = permission_line.strip()
+        if re.search(r":\s*(write|admin)\s*$", stripped) and stripped != "security-events: write":
+            findings.append("workflow permissions include write/admin scope")
 
     for line_number, line in enumerate(lines, start=1):
         match = USES_RE.search(line)

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -23,6 +23,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "What It Does",
             "What It Does Not Do",
             "How Hermes Fits",
+            "Operator Path",
             "Quickstart",
             "First Value In 10 Minutes",
             "Repository Shape",
@@ -46,14 +47,25 @@ class OpenSourceDocsTest(unittest.TestCase):
             "docs/agents/capability-packs.md",
             "docs/control-tower/open-source-setup.md",
             "docs/operations/validation-and-release.md",
+            "docs/operations/release-policy.md",
             "docs/architecture/hermes-integration.md",
+            "docs/getting-started/install-in-hermes.md",
+            "docs/reference/cli.md",
+            "docs/examples/gallery.md",
+            "docs/security/oss-security.md",
+            "docs/maintenance/repo-surface.md",
             "examples/minimal-hermes-project/README.md",
             ".env.example",
+            "CHANGELOG.md",
             "CONTRIBUTING.md",
             "SECURITY.md",
         ]:
             with self.subTest(link=rel):
                 self.assertIn(rel.replace("\\", "/"), readme)
+
+        for command in ["factoryctl doctor", "factoryctl init", "factoryctl run minimal"]:
+            with self.subTest(command=command):
+                self.assertIn(command, readme)
 
     def test_public_docs_skeleton_exists(self) -> None:
         required_paths = [
@@ -68,16 +80,29 @@ class OpenSourceDocsTest(unittest.TestCase):
             "docs/agents/capability-packs.md",
             "docs/control-tower/open-source-setup.md",
             "docs/operations/validation-and-release.md",
+            "docs/operations/release-policy.md",
             "docs/operations/troubleshooting.md",
             "docs/architecture/hermes-integration.md",
+            "docs/index.md",
+            "docs/getting-started/install-in-hermes.md",
+            "docs/reference/cli.md",
+            "docs/examples/gallery.md",
+            "docs/security/oss-security.md",
+            "docs/maintenance/repo-surface.md",
             "examples/minimal-hermes-project/README.md",
             "examples/minimal-hermes-project/input-paper.md",
             "examples/minimal-hermes-project/expected-flow.md",
             "examples/minimal-hermes-project/expected-receipt-five.json",
             ".env.example",
             "pyproject.toml",
+            "CHANGELOG.md",
+            "mkdocs.yml",
             "CONTRIBUTING.md",
             "SECURITY.md",
+            ".github/dependabot.yml",
+            ".github/workflows/codeql.yml",
+            ".github/workflows/dependency-review.yml",
+            ".github/workflows/security.yml",
             ".github/ISSUE_TEMPLATE/bug_report.yml",
             ".github/ISSUE_TEMPLATE/feature_request.yml",
             ".github/ISSUE_TEMPLATE/config.yml",
@@ -189,6 +214,58 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("references/documentation-standard.md", skill)
         self.assertIn("Every public folder needs a burden-of-proof decision", skill)
 
+    def test_docs_site_navigation_and_maintenance_boundaries_exist(self) -> None:
+        docs_index = read_text("docs/index.md")
+        mkdocs = read_text("mkdocs.yml")
+        cli = read_text("docs/reference/cli.md")
+        repo_surface = read_text("docs/maintenance/repo-surface.md")
+
+        for phrase in [
+            "Operator Path",
+            "Install In Your Hermes",
+            "CLI Reference",
+            "Examples",
+            "Security",
+            "Release",
+            "Maintainer Internals",
+        ]:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, docs_index)
+                self.assertIn(phrase, mkdocs)
+
+        for command in ["factoryctl doctor", "factoryctl init", "factoryctl run minimal"]:
+            with self.subTest(command=command):
+                self.assertIn(command, cli)
+
+        self.assertIn("Operator surface", repo_surface)
+        self.assertIn("Maintainer internals", repo_surface)
+        self.assertIn("Generated output", repo_surface)
+
+    def test_release_security_and_example_gallery_are_professional_surfaces(self) -> None:
+        changelog = read_text("CHANGELOG.md")
+        release_policy = read_text("docs/operations/release-policy.md")
+        oss_security = read_text("docs/security/oss-security.md")
+        gallery = read_text("docs/examples/gallery.md")
+        pyproject = read_text("pyproject.toml")
+
+        self.assertIn("Unreleased", changelog)
+        self.assertIn("semantic versioning", release_policy)
+        self.assertIn("CodeQL", oss_security)
+        self.assertIn("Dependency Review", oss_security)
+        self.assertIn("SBOM", oss_security)
+        self.assertIn("Point 5 is intentionally deferred", release_policy)
+        for example in [
+            "minimal-hermes-project",
+            "v35_valid_product_face.md",
+            "v35_valid_security_with_scan.md",
+            "v35_valid_onchain_auditor_scan.md",
+        ]:
+            with self.subTest(example=example):
+                self.assertIn(example, gallery)
+
+        self.assertNotIn("OWNER", pyproject)
+        self.assertIn("overkill-factory.dev", pyproject)
+
     def test_agent_public_doc_covers_every_registered_worker(self) -> None:
         registry = json.loads(read_text("agents/worker-registry.public.json"))
         agent_doc = read_text("docs/agents/worker-profiles.md")
@@ -218,17 +295,20 @@ class OpenSourceDocsTest(unittest.TestCase):
         operations = read_text("docs/operations/validation-and-release.md")
         combined = f"{quickstart}\n{operations}"
         required_commands = [
-            "python scripts/quickstart_smoke.py",
+            "factoryctl doctor",
+            "factoryctl run minimal",
             "python -m unittest discover -s tests",
             "python scripts/validate_document_governance.py",
             "python scripts/validate_public_json_artifacts.py",
+            "python scripts/validate_worker_profiles.py",
             "python scripts/secret_safety_scan.py",
             "python scripts/public_safety_scan.py",
+            "python scripts/supply_chain_proof.py --check --no-write",
             "python scripts/release_integration_preflight.py",
             "python scripts/factory_production_readiness.py",
             "python scripts/worktree_release_inventory.py",
-            "python scripts/factoryctl.py gate-report",
-            "python scripts/factoryctl.py worker-packet",
+            "factoryctl gate-report",
+            "factoryctl worker-packet",
         ]
 
         for command in required_commands:

--- a/tests/test_operator_experience.py
+++ b/tests/test_operator_experience.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_factoryctl(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "scripts/factoryctl.py", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class OperatorExperienceTest(unittest.TestCase):
+    def test_factoryctl_exposes_single_operator_entrypoint(self) -> None:
+        help_text = run_factoryctl("--help").stdout
+        run_help = run_factoryctl("run", "--help").stdout
+
+        for command in ["doctor", "init", "run"]:
+            with self.subTest(command=command):
+                self.assertIn(command, help_text)
+        self.assertIn("minimal", run_help)
+
+    def test_doctor_reports_public_install_health_without_real_hermes_e2e(self) -> None:
+        result = run_factoryctl("doctor", "--json")
+        payload = json.loads(result.stdout)
+        check_ids = {check["id"] for check in payload["checks"]}
+
+        self.assertEqual(payload["result"], "PASS")
+        self.assertTrue(
+            {
+                "python_version",
+                "package_metadata",
+                "repository_shape",
+                "minimal_example",
+                "public_cli",
+                "hermes_runtime_optional",
+                "hermes_e2e_deferred",
+            }.issubset(check_ids)
+        )
+        self.assertFalse(any(check["status"] == "FAIL" for check in payload["checks"]))
+        deferred = next(check for check in payload["checks"] if check["id"] == "hermes_e2e_deferred")
+        self.assertEqual(deferred["status"], "INFO")
+
+    def test_run_minimal_uses_factoryctl_entrypoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            out = tmp / "quickstart-result.json"
+            packets = tmp / "packets"
+
+            result = run_factoryctl("run", "minimal", "--out", str(out), "--packets-out", str(packets))
+            payload = json.loads(out.read_text(encoding="utf-8"))
+
+            self.assertIn("PASS", result.stdout)
+            self.assertEqual(payload["result"], "PASS")
+            self.assertGreater(payload["worker_packet_count"], 0)
+            self.assertTrue(any(packets.glob("*.json")))
+
+    def test_init_creates_hermes_friendly_operator_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "sample-project"
+            result = run_factoryctl("init", "--out", str(target), "--project-name", "sample-project")
+
+            self.assertIn("initialized", result.stdout.lower())
+            self.assertTrue((target / "overkill.factory.json").is_file())
+            self.assertTrue((target / "cards" / "minimal-card.md").is_file())
+            self.assertTrue((target / "worker-packets" / ".gitkeep").is_file())
+            self.assertTrue((target / "receipts" / ".gitkeep").is_file())
+            self.assertTrue((target / "README.md").is_file())
+
+            config = json.loads((target / "overkill.factory.json").read_text(encoding="utf-8"))
+            readme = (target / "README.md").read_text(encoding="utf-8")
+            self.assertEqual(config["project_name"], "sample-project")
+            self.assertEqual(config["runtime"]["name"], "Hermes")
+            self.assertIn("factoryctl doctor", readme)
+            self.assertIn("factoryctl run minimal", readme)
+            self.assertIn("Connect this workspace to your Hermes", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_supply_chain_proof.py
+++ b/tests/test_supply_chain_proof.py
@@ -42,6 +42,29 @@ class SupplyChainProofTests(unittest.TestCase):
             self.assertEqual(result["result"], "FAIL")
             self.assertIn("not pinned", result["findings"][0])
 
+    def test_pinned_official_subaction_passes(self):
+        with TemporaryDirectory() as tmpdir:
+            workflow = Path(tmpdir) / "codeql.yml"
+            workflow.write_text(
+                "name: codeql\n"
+                "on: push\n"
+                "permissions:\n"
+                "  contents: read\n"
+                "  security-events: write\n"
+                "jobs:\n"
+                "  analyze:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7\n"
+                "      - uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7\n",
+                encoding="utf-8",
+            )
+
+            result = proof.validate_workflow(workflow)
+
+            self.assertEqual(result["result"], "PASS")
+            self.assertEqual(result["findings"], [])
+
     def test_pull_request_target_fails(self):
         with TemporaryDirectory() as tmpdir:
             workflow = Path(tmpdir) / "bad.yml"


### PR DESCRIPTION
## What changed

- Added the operator-first CLI path: `factoryctl doctor`, `factoryctl init`, and `factoryctl run minimal`.
- Added a Hermes-friendly generated workspace for new operators and agents.
- Added docs site navigation (`mkdocs.yml`, `docs/index.md`), CLI reference, install-in-Hermes guide, example gallery, release policy, OSS security guide, and repo-surface maintenance guide.
- Added OSS security surfaces: Dependabot config, CodeQL workflow, Dependency Review workflow, and a dedicated security workflow.
- Updated README, quickstart, contributing, security and validation docs to promote the single `factoryctl` path instead of making users discover scripts.
- Updated supply-chain proof so pinned GitHub subactions such as CodeQL init/analyze remain allowed while unpinned actions still fail.
- Kept point 5 explicitly deferred: no claim of real Hermes E2E harness in this PR.

## Why

The factory needs to be easy for any person or AI to install into their own Hermes and start using, without turning maintenance into a pile of one-off scripts and narrative docs. This PR makes the public path simple while keeping dense contracts and maintainer internals behind clear boundaries.

## Validation

- `python -m pip install -e .`
- `factoryctl doctor --json`
- `factoryctl run minimal`
- `factoryctl init --out <temp> --project-name init-smoke`
- `python -m unittest tests.test_operator_experience -q`
- `python -m unittest tests.test_open_source_docs -q`
- `python -m unittest tests.test_supply_chain_proof -q`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_worker_profiles.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/supply_chain_proof.py --check --no-write`
- `python C:\Users\felip\.codex\skills\.system\skill-creator\scripts\quick_validate.py skills\codex\overkill-factory`
- `python -m unittest discover -s tests -p "test_*.py" -q` with 231 tests passing
- `git diff --cached --check`

## Boundary

This PR intentionally excludes the official real Hermes E2E harness from point 5. It improves installability, docs, release/security posture and maintainability without pretending runtime production proof exists.