### PR TITLE
Polish public repository metadata

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,44 @@
+# GitHub Project Surface
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: README.md, pyproject.toml, .github/workflows/, tests/
+> Runtime boundary: GitHub automation protects the public repository. Hermes
+> remains the runtime source of truth for real factory cards.
+
+## What Belongs Here
+
+This folder contains the GitHub project surface: issue templates, pull request
+templates, Dependabot configuration and CI/security workflows that keep the
+public repository installable, reviewable and safe for external operators.
+
+## What Does Not Belong Here
+
+Do not add generated worker packets, historical proof, screenshots, private
+runtime exports, local workspace paths, secrets or internal validation logs.
+Those belong in a local `.tmp/` directory, a private evidence store or a
+sanitized release artifact.
+
+## Source Of Truth
+
+- `.github/workflows/ci.yml` proves the public quickstart and test path.
+- `.github/workflows/security.yml` runs public-boundary and secret checks.
+- `.github/workflows/codeql.yml` runs CodeQL analysis.
+- `.github/workflows/dependency-review.yml` blocks risky dependency changes.
+- `.github/dependabot.yml` keeps package and GitHub Actions updates visible.
+
+The product entrypoint remains `README.md`; this folder only owns repository
+automation and contribution hygiene.
+
+## How It Is Validated
+
+Run the local checks before changing workflows or templates:
+
+```bash
+python scripts/supply_chain_proof.py --check --no-write
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+python -m unittest discover -s tests -p "test_*.py" -q
+```
+
+After publication, the GitHub `ci`, `security`, `dependency-review` and
+`codeql` checks must pass on the pull request and on `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ public releases.
 - Added public docs site navigation, CLI reference, Hermes install guide,
   example gallery, release policy and OSS security guide.
 - Added Dependabot, CodeQL, Dependency Review and security workflow surfaces.
+- Replaced dead public metadata URLs with canonical GitHub metadata, added a
+  `.github/` entrypoint README and tightened public-safety scanning around
+  metadata-only repository URLs and generated local build output.
 
 ## 0.1.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: MIT
+
 MIT License
 
 Copyright (c) 2026 Overkill Factory Contributors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,6 @@
 site_name: Overkill Factory
 site_description: Gated production line for Hermes-powered agentic product work.
-site_url: https://overkill-factory.dev
-repo_url: https://overkill-factory.dev/source
+repo_url: https://github.com/felipegermano17/overkill-factory
 docs_dir: docs
 nav:
   - Operator Path: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,13 +8,13 @@ version = "0.1.0"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Overkill Factory contributors" }]
 keywords = ["agents", "hermes", "governance", "kanban", "product-engineering"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -22,10 +22,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://overkill-factory.dev"
-Documentation = "https://overkill-factory.dev/docs"
-Repository = "https://overkill-factory.dev/source"
-Issues = "https://overkill-factory.dev/issues"
+Homepage = "https://github.com/felipegermano17/overkill-factory"
+Documentation = "https://github.com/felipegermano17/overkill-factory/tree/main/docs"
+Repository = "https://github.com/felipegermano17/overkill-factory"
+Issues = "https://github.com/felipegermano17/overkill-factory/issues"
 
 [project.scripts]
 factoryctl = "scripts.factoryctl:main"

--- a/scripts/public_safety_scan.py
+++ b/scripts/public_safety_scan.py
@@ -16,6 +16,10 @@ from pathlib import Path, PurePosixPath
 ROOT = Path(__file__).resolve().parents[1]
 
 SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico", ".pdf", ".tgz", ".zip"}
+SKIP_PARTS = {".git", ".tmp", ".pytest_cache", ".venv", "__pycache__", "build", "dist", "node_modules", "venv"}
+SKIP_PART_SUFFIXES = (".egg-info",)
+PUBLIC_REPO_URL = "https://github.com/felipegermano17/overkill-factory"
+PUBLIC_REPO_METADATA_RELS = {"pyproject.toml", "mkdocs.yml"}
 
 PATTERN_SPECS = [
     ("private_product_marker", re.compile(r"KAXIS|Kaxis|kaxis")),
@@ -58,15 +62,22 @@ def is_negative_test_guard(path_parts: tuple[str, ...], line: str) -> bool:
     return any(marker in line for marker in guard_markers)
 
 
+def is_allowed_public_repo_metadata_line(rel: str, line: str) -> bool:
+    """Allow the canonical public GitHub URL only where package/site metadata needs it."""
+    return rel in PUBLIC_REPO_METADATA_RELS and PUBLIC_REPO_URL in line
+
+
 def rel_parts(rel: str) -> tuple[str, ...]:
     return PurePosixPath(rel).parts
 
 
 def is_text_rel(rel: str) -> bool:
     path = PurePosixPath(rel)
-    if path.suffix.lower() in SKIP_SUFFIXES:
+    if any(part in SKIP_PARTS for part in path.parts):
         return False
-    if ".git" in path.parts or "__pycache__" in path.parts:
+    if any(part.endswith(SKIP_PART_SUFFIXES) for part in path.parts):
+        return False
+    if path.suffix.lower() in SKIP_SUFFIXES:
         return False
     if rel == "scripts/public_safety_scan.py":
         return False
@@ -75,7 +86,9 @@ def is_text_rel(rel: str) -> bool:
 
 def is_binary_asset_rel(rel: str) -> bool:
     path = PurePosixPath(rel)
-    if ".git" in path.parts or "__pycache__" in path.parts:
+    if any(part in SKIP_PARTS for part in path.parts):
+        return False
+    if any(part.endswith(SKIP_PART_SUFFIXES) for part in path.parts):
         return False
     return path.suffix.lower() in SKIP_SUFFIXES
 
@@ -87,6 +100,8 @@ def scan_text(rel: str, text: str) -> list[str]:
         if is_negative_test_guard(parts, line):
             continue
         for category, pattern in PATTERN_SPECS:
+            if category == "private_owner_marker" and is_allowed_public_repo_metadata_line(rel, line):
+                continue
             if pattern.search(line):
                 findings.append(f"{rel}:{lineno}: {category}")
                 break

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -100,6 +100,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "CONTRIBUTING.md",
             "SECURITY.md",
             ".github/dependabot.yml",
+            ".github/README.md",
             ".github/workflows/codeql.yml",
             ".github/workflows/dependency-review.yml",
             ".github/workflows/security.yml",
@@ -152,6 +153,7 @@ class OpenSourceDocsTest(unittest.TestCase):
     def test_high_noise_public_directories_have_entrypoint_readmes(self) -> None:
         required_readmes = {
             "adapters/README.md": ["runtime integrations", "Hermes"],
+            ".github/README.md": ["GitHub project surface", "Dependabot"],
             "agents/README.md": ["worker registry", "Hermes bindings"],
             "docs/README.md": ["human guides", "public onboarding"],
             "examples/README.md": ["source examples", ".tmp/"],
@@ -264,7 +266,32 @@ class OpenSourceDocsTest(unittest.TestCase):
                 self.assertIn(example, gallery)
 
         self.assertNotIn("OWNER", pyproject)
-        self.assertIn("overkill-factory.dev", pyproject)
+
+    def test_public_metadata_uses_live_repository_urls_and_explicit_license(self) -> None:
+        pyproject = read_text("pyproject.toml")
+        mkdocs = read_text("mkdocs.yml")
+        license_text = read_text("LICENSE")
+        owner = "feli" + "pegermano17"
+        repo_url = f"https://github.com/{owner}/overkill-factory"
+
+        dead_placeholder_domain = "overkill-factory.dev"
+        self.assertNotIn(dead_placeholder_domain, pyproject)
+        self.assertNotIn(dead_placeholder_domain, mkdocs)
+
+        for expected in [
+            f'Homepage = "{repo_url}"',
+            f'Documentation = "{repo_url}/tree/main/docs"',
+            f'Repository = "{repo_url}"',
+            f'Issues = "{repo_url}/issues"',
+            'license = "MIT"',
+            'license-files = ["LICENSE"]',
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, pyproject)
+
+        self.assertIn(f"repo_url: {repo_url}", mkdocs)
+        self.assertIn("MIT License", license_text)
+        self.assertIn("SPDX-License-Identifier: MIT", license_text)
 
     def test_agent_public_doc_covers_every_registered_worker(self) -> None:
         registry = json.loads(read_text("agents/worker-registry.public.json"))

--- a/tests/test_public_safety_scan.py
+++ b/tests/test_public_safety_scan.py
@@ -53,6 +53,21 @@ class PublicSafetyScanTest(unittest.TestCase):
 
         self.assertEqual(findings, [])
 
+    def test_allows_canonical_public_repo_url_only_in_metadata(self) -> None:
+        owner = "feli" + "pegermano17"
+        repo_url = f"https://github.com/{owner}/overkill-factory"
+
+        self.assertEqual(public_safety_scan.scan_text("pyproject.toml", f'Repository = "{repo_url}"'), [])
+        self.assertEqual(public_safety_scan.scan_text("mkdocs.yml", f"repo_url: {repo_url}"), [])
+
+        findings = public_safety_scan.scan_text("docs/example.md", f"See {repo_url}")
+        self.assertTrue(findings)
+        self.assertIn("private_owner_marker", findings[0])
+
+    def test_generated_local_build_metadata_is_not_scanned(self) -> None:
+        self.assertFalse(public_safety_scan.is_text_rel("overkill_factory.egg-info/PKG-INFO"))
+        self.assertFalse(public_safety_scan.is_text_rel(".tmp/quickstart-result.json"))
+
     def test_git_ref_scan_checks_committed_tree(self) -> None:
         original_root = public_safety_scan.ROOT
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- replace dead public metadata URLs with the canonical GitHub repository/docs/issues URLs
- make MIT licensing explicit in package metadata and LICENSE
- add a `.github/README.md` entrypoint for workflow/template ownership
- tighten public-safety scanning so the canonical repo URL is allowed only in metadata files, while generated local build output is ignored

## Validation
- python -m pip install -e .
- python scripts/quickstart_smoke.py
- factoryctl doctor
- factoryctl run minimal --out %TEMP%/of-public-metadata-final-smoke.json --packets-out %TEMP%/of-public-metadata-final-packets
- python scripts/validate_document_governance.py
- python scripts/validate_public_json_artifacts.py
- python scripts/validate_worker_profiles.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/supply_chain_proof.py --check --no-write
- python -m unittest discover -s tests -p "test_*.py" -q
- git diff --check