### PR TITLE
Use standard MIT license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-SPDX-License-Identifier: MIT
-
 MIT License
 
 Copyright (c) 2026 Overkill Factory Contributors

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -290,8 +290,8 @@ class OpenSourceDocsTest(unittest.TestCase):
                 self.assertIn(expected, pyproject)
 
         self.assertIn(f"repo_url: {repo_url}", mkdocs)
-        self.assertIn("MIT License", license_text)
-        self.assertIn("SPDX-License-Identifier: MIT", license_text)
+        self.assertTrue(license_text.startswith("MIT License"))
+        self.assertIn("Permission is hereby granted", license_text)
 
     def test_agent_public_doc_covers_every_registered_worker(self) -> None:
         registry = json.loads(read_text("agents/worker-registry.public.json"))


### PR DESCRIPTION
## Summary
- restore the LICENSE file to standard MIT text so GitHub can classify it as MIT
- keep package metadata explicit through `license = "MIT"` and `license-files = ["LICENSE"]`
- update the open-source metadata test to assert standard MIT file shape

## Validation
- python -m pip install -e .
- python scripts/validate_document_governance.py
- python scripts/validate_public_json_artifacts.py
- python scripts/validate_worker_profiles.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/supply_chain_proof.py --check --no-write
- python -m unittest discover -s tests -p "test_*.py" -q