### PR TITLE
Fix GitHub overview README rendering

### DIFF
--- a/.github/PROJECT_SURFACE.md
+++ b/.github/PROJECT_SURFACE.md
@@ -4,6 +4,8 @@
 > Current authority: README.md, pyproject.toml, .github/workflows/, tests/
 > Runtime boundary: GitHub automation protects the public repository. Hermes
 > remains the runtime source of truth for real factory cards.
+> Naming note: this guide is intentionally not named README.md so GitHub keeps
+> the repository overview anchored to the product README at the repository root.
 
 ## What Belongs Here
 

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -100,7 +100,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "CONTRIBUTING.md",
             "SECURITY.md",
             ".github/dependabot.yml",
-            ".github/README.md",
+            ".github/PROJECT_SURFACE.md",
             ".github/workflows/codeql.yml",
             ".github/workflows/dependency-review.yml",
             ".github/workflows/security.yml",
@@ -150,10 +150,10 @@ class OpenSourceDocsTest(unittest.TestCase):
 
         self.assertIn("Generated worker packets and gate reports belong in `.tmp/`", readme)
 
-    def test_high_noise_public_directories_have_entrypoint_readmes(self) -> None:
-        required_readmes = {
+    def test_high_noise_public_directories_have_entrypoint_guides(self) -> None:
+        required_entrypoints = {
             "adapters/README.md": ["runtime integrations", "Hermes"],
-            ".github/README.md": ["GitHub project surface", "Dependabot"],
+            ".github/PROJECT_SURFACE.md": ["GitHub project surface", "Dependabot"],
             "agents/README.md": ["worker registry", "Hermes bindings"],
             "docs/README.md": ["human guides", "public onboarding"],
             "examples/README.md": ["source examples", ".tmp/"],
@@ -165,7 +165,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "tests/README.md": ["regression", "public path"],
         }
 
-        for rel, expected_phrases in required_readmes.items():
+        for rel, expected_phrases in required_entrypoints.items():
             with self.subTest(path=rel):
                 path = ROOT / rel
                 self.assertTrue(path.is_file())


### PR DESCRIPTION
## Summary
- rename the .github folder guide from README.md to PROJECT_SURFACE.md so GitHub keeps the repository overview anchored to the root product README
- update public docs tests to validate the renamed guide

## Validation
- python -m unittest tests.test_open_source_docs -q
- git diff --check