### PR TITLE
Fix Factory Mechanic gate enforcement

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -68,6 +68,74 @@ def hermes_kanban(hermes_bin: str, board: str, *args: str) -> list[str]:
     return [hermes_bin, "kanban", "--board", board, *args]
 
 
+def route_readiness_blockers(path: Path | None, required_worker_ids: list[str]) -> list[str]:
+    if path is None:
+        return ["route readiness manifest is required before live Hermes dispatch"]
+    data = load_json(path)
+    raw_routes = data.get("routes") or data.get("workers") or {}
+    if isinstance(raw_routes, list):
+        routes = {
+            str(route.get("worker_id") or route.get("worker") or ""): route
+            for route in raw_routes
+            if isinstance(route, dict)
+        }
+    elif isinstance(raw_routes, dict):
+        routes = {str(worker_id): route for worker_id, route in raw_routes.items() if isinstance(route, dict)}
+    else:
+        routes = {}
+    blockers: list[str] = []
+    for worker_id in sorted(set(required_worker_ids)):
+        route = routes.get(worker_id)
+        if not route:
+            blockers.append(f"{worker_id}: missing route readiness record")
+            continue
+        checks = {
+            "profile_exists": route.get("profile_exists") is True,
+            "provider_configured": route.get("provider_configured", route.get("provider_status")) in {True, "pass", "PASS"},
+            "model_configured": route.get("model_configured", route.get("model_status")) in {True, "pass", "PASS"},
+            "credential_status": str(route.get("credential_status") or "").strip().lower() == "pass",
+            "capability_manifest": route.get("capability_manifest_ok", route.get("capability_status")) in {True, "pass", "PASS"},
+        }
+        failed = [name for name, ok in checks.items() if not ok]
+        if failed:
+            blockers.append(f"{worker_id}: route readiness failed ({', '.join(failed)})")
+    return blockers
+
+
+def ensure_non_empty_body(body: str) -> None:
+    if not str(body or "").strip():
+        raise RuntimeError("Hermes task body must be non-empty before dispatch")
+
+
+def task_has_blocked_event(payload: dict[str, Any]) -> bool:
+    if str(payload.get("status") or "").strip().lower() == "blocked":
+        events = payload.get("events") or payload.get("history") or payload.get("timeline") or []
+        if isinstance(events, list):
+            return any("block" in str(event).lower() for event in events)
+    return False
+
+
+def ensure_blocked_event(
+    *,
+    hermes_bin: str,
+    board: str,
+    task_id: str,
+    reason: str,
+    runner: Runner = default_runner,
+) -> None:
+    run_checked(
+        hermes_kanban(hermes_bin, board, "block", task_id, "--reason", reason, "--json"),
+        runner,
+    )
+    shown = run_checked(hermes_kanban(hermes_bin, board, "show", task_id, "--json"), runner)
+    try:
+        payload = json.loads(shown.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Hermes show --json did not return JSON while verifying blocked event") from exc
+    if not isinstance(payload, dict) or not task_has_blocked_event(payload):
+        raise RuntimeError(f"Hermes task {task_id} is not durably blocked after block command")
+
+
 def record_live_binding(
     *,
     ledger_path: Path,
@@ -140,6 +208,7 @@ def create_task(
     blocked: bool,
     runner: Runner = default_runner,
 ) -> str:
+    ensure_non_empty_body(body)
     args = hermes_kanban(
         hermes_bin,
         board,
@@ -159,7 +228,16 @@ def create_task(
     )
     if blocked:
         args.extend(["--initial-status", "blocked"])
-    return parse_task_id(run_checked(args, runner).stdout)
+    task_id = parse_task_id(run_checked(args, runner).stdout)
+    if blocked:
+        ensure_blocked_event(
+            hermes_bin=hermes_bin,
+            board=board,
+            task_id=task_id,
+            reason="Overkill Factory gate starts blocked until required authority evidence passes.",
+            runner=runner,
+        )
+    return task_id
 
 
 def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
@@ -198,6 +276,17 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         if args.out:
             write_json(args.out, envelope)
         return envelope
+
+    readiness_blockers = route_readiness_blockers(
+        args.route_readiness,
+        [
+            str(task.get("worker_id"))
+            for task in plan.get("worker_tasks", [])
+            if str(task.get("worker_id") or "").strip() and task.get("status") != "not_required_by_current_card"
+        ],
+    )
+    if readiness_blockers:
+        raise RuntimeError("pre-dispatch route readiness blocked live materialization: " + "; ".join(readiness_blockers))
 
     main_task_id = create_task(
         hermes_bin=args.hermes_bin,
@@ -277,6 +366,9 @@ def enforce_done(args: argparse.Namespace, runner: Runner = default_runner) -> d
         write_json(args.out, envelope)
     if blocked:
         return envelope
+    readiness_blockers = route_readiness_blockers(args.route_readiness, ["evidence-reconciler"])
+    if readiness_blockers:
+        raise RuntimeError("pre-completion route readiness blocked live completion: " + "; ".join(readiness_blockers))
     if args.complete_main:
         card_id = str(result.get("plan", {}).get("event", {}).get("card_id") or args.card.stem)
         validate_live_binding(
@@ -320,6 +412,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_mat.add_argument("--worker-ready", action="store_true")
     p_mat.add_argument("--ensure-board", action="store_true")
     p_mat.add_argument("--dry-run", action="store_true")
+    p_mat.add_argument("--route-readiness", type=Path)
     p_mat.add_argument("--out", type=Path)
 
     p_done = sub.add_parser("enforce-done", help="Validate worker results before completing the main card.")
@@ -333,6 +426,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_done.add_argument("--to-status", default="done")
     p_done.add_argument("--hermes-bin", default="hermes")
     p_done.add_argument("--complete-main", action="store_true")
+    p_done.add_argument("--route-readiness", type=Path)
     p_done.add_argument("--result", default="Overkill Factory gate satisfied.")
     p_done.add_argument("--summary", default="Worker evidence reconciled by Overkill Factory.")
     p_done.add_argument("--out", type=Path)

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -62,6 +62,20 @@ Rotate any real credential that was committed. Replace public examples with
 short placeholders such as `example`, and keep real values in your private
 runtime environment.
 
+## Test Runner Or Sandbox Launch Fails
+
+Keep the worker result blocked until the same command is proven. Record the
+command as an argv list and rerun through the safest available local runner:
+
+```bash
+python -m unittest tests.test_factoryctl -q
+```
+
+Do not turn a shell launcher failure into a PASS. If the environment reports a
+runner error such as `CreateProcessAsUserW failed: 5`, use the pattern in
+`scripts/safe_shell.py` and record the result as `BLOCKED` with remediation.
+Only a later successful run of the same argv can supersede that blocker.
+
 ## Hermes Patch Does Not Apply
 
 Read `adapters/hermes/README.md` and rerun the patch check from a clean Hermes

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,9 +40,18 @@ factoryctl init --out ../my-product-factory --project-name my-product
 ```bash
 factoryctl validate-card examples/minimal-hermes-project/card.md
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
+factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
 ```
+
+### Test Runner Fallback
+
+Worker packets should run commands as argv lists, not shell strings. Use
+`scripts/safe_shell.py` as the local pattern when a packet needs a fallback for
+runner failures, timeouts, or Windows sandbox launch errors. A fallback result
+is `BLOCKED` until the same argv is rerun successfully or replaced by a
+traceable worker result.
 
 ## Maintainer Scripts
 

--- a/examples/minimal-hermes-project/expected-receipt-five.json
+++ b/examples/minimal-hermes-project/expected-receipt-five.json
@@ -15,14 +15,14 @@
       "python scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md",
       "python scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets"
     ],
-    "verification_result": "PASS for local contract generation when commands complete without errors.",
+    "verification_result": "BLOCKED",
     "reviewer_required": true,
     "reviewer_result": "Required before real done transition.",
     "next_action": "Connect to a local Hermes test runtime and attach current worker results."
   },
   "kanban_transition_event": {
     "from_status": "ready",
-    "to_status": "done",
+    "to_status": "blocked",
     "actor": "example-operator",
     "worker": "evidence-reconciler",
     "receipt_refs": [

--- a/schemas/hermes-transition-hook.schema.json
+++ b/schemas/hermes-transition-hook.schema.json
@@ -19,6 +19,7 @@
         "allow",
         "allow_and_create_worker_tasks",
         "allow_done",
+        "allow_review_ready",
         "block_and_create_before_ready_tasks",
         "block_transition"
       ]

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -22,6 +22,7 @@
         "allow",
         "allow_and_create_worker_tasks",
         "allow_done",
+        "allow_review_ready",
         "block_and_create_before_ready_tasks",
         "block_transition"
       ]

--- a/schemas/hermes-worker-ledger.schema.json
+++ b/schemas/hermes-worker-ledger.schema.json
@@ -32,6 +32,7 @@
         "allow",
         "allow_and_create_worker_tasks",
         "allow_done",
+        "allow_review_ready",
         "block_and_create_before_ready_tasks",
         "block_transition"
       ]

--- a/schemas/public-safety-scan-summary.schema.json
+++ b/schemas/public-safety-scan-summary.schema.json
@@ -10,6 +10,8 @@
     "target",
     "result",
     "finding_count",
+    "artifact_classes_checked",
+    "publication_policy",
     "forbidden_hits",
     "categories",
     "limits"
@@ -33,6 +35,27 @@
     },
     "result": { "enum": ["PASS", "FAIL"] },
     "finding_count": { "type": "integer" },
+    "artifact_classes_checked": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "public_repository_tree",
+          "private_run_evidence",
+          "sanitized_report",
+          "publication_candidate"
+        ]
+      }
+    },
+    "publication_policy": {
+      "type": "object",
+      "required": [
+        "private_run_evidence",
+        "sanitized_report",
+        "publication_candidate"
+      ],
+      "additionalProperties": { "type": "string" }
+    },
     "forbidden_hits": {
       "type": "array",
       "items": {

--- a/schemas/receipt-five.schema.json
+++ b/schemas/receipt-five.schema.json
@@ -27,7 +27,7 @@
           "minItems": 1,
           "items": { "type": "string" }
         },
-        "verification_result": { "type": "string" },
+        "verification_result": { "enum": ["PASS", "BLOCKED", "WAIVED"] },
         "reviewer_required": { "type": "boolean" },
         "reviewer_result": { "type": "string" },
         "next_action": { "type": "string" }

--- a/schemas/secret-safety-scan-summary.schema.json
+++ b/schemas/secret-safety-scan-summary.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/secret-safety-scan-summary.schema.json",
+  "title": "Overkill Factory Secret Safety Scan Summary",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "result",
+    "finding_count",
+    "artifact_classes_checked",
+    "limits"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/secret-safety-scan-summary.schema.json"
+    },
+    "record_type": {
+      "const": "secret_safety_scan_summary"
+    },
+    "created_at": { "type": "string", "minLength": 10 },
+    "result": { "enum": ["PASS", "FAIL"] },
+    "finding_count": { "type": "integer" },
+    "artifact_classes_checked": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "public_repository_tree",
+          "publication_candidate"
+        ]
+      }
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/evidence_reconciler.py
+++ b/scripts/evidence_reconciler.py
@@ -42,6 +42,11 @@ def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict
         card=card,
         evidence_root=ROOT,
     )
+    authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
+    active = authority.get("active")
+    if active is None:
+        active = data.get("active", True)
+    superseded_by = data.get("superseded_by") or authority.get("superseded_by")
     return {
         "record_type": record_type,
         "worker_id": worker_ref.get("id"),
@@ -49,6 +54,11 @@ def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict
         "blocking_findings": data.get("blocking_findings"),
         "created_at": data.get("created_at") or data.get("decision_at"),
         "evidence_ref": factoryctl.source_card_ref(path),
+        "active": bool(active) and not bool(superseded_by),
+        "supersession_key": data.get("supersession_key") or record_type,
+        "supersedes": data.get("supersedes") or authority.get("supersedes"),
+        "superseded_by": superseded_by,
+        "supersession_reason": data.get("supersession_reason") or authority.get("supersession_reason"),
         "valid_for_closure": not validation_errors,
         "validation_errors": validation_errors,
     }
@@ -117,16 +127,27 @@ def reconcile(
     superseded_results: list[dict[str, Any]] = []
 
     for record_type, entries in grouped.items():
-        ordered = sort_result_entries(entries)
+        explicit_inactive = [entry for entry in entries if not entry.get("active")]
+        ordered = sort_result_entries([entry for entry in entries if entry.get("active")])
         if not ordered:
+            superseded_results.extend(
+                {
+                    **entry,
+                    "effective_result": False,
+                    "supersession_reason": entry.get("supersession_reason") or "explicitly inactive result",
+                }
+                for entry in explicit_inactive
+            )
             continue
-        effective_results[record_type] = ordered[0]
-        for superseded in ordered[1:]:
+        effective_results[record_type] = {**ordered[0], "effective_result": True}
+        for superseded in [*explicit_inactive, *ordered[1:]]:
             superseded_results.append(
                 {
                     **superseded,
+                    "active": False,
+                    "effective_result": False,
                     "superseded_by": ordered[0]["evidence_ref"],
-                    "supersession_reason": "newer result for same receipt field",
+                    "supersession_reason": superseded.get("supersession_reason") or "newer active result for same receipt field",
                 }
             )
 
@@ -185,7 +206,7 @@ def build_reconciler_result(card: dict[str, Any], index_ref: str, index: dict[st
     payload = factoryctl.build_worker_result(
         "evidence-reconciler",
         card,
-        result="PASS" if ready else "FAIL",
+        result="PASS" if ready else "BLOCKED",
         tool_or_profile="scripts/evidence_reconciler.py",
         executed_by="evidence-reconciler",
         evidence_refs=[index_ref],
@@ -220,7 +241,7 @@ def build_receipt_draft(card: dict[str, Any], index_ref: str, result_ref: str, i
             ],
         }
     )
-    return {
+    receipt = {
         "receipt_five": {
             "changed": card.get("done_definition") or "Reconciled worker evidence for done promotion.",
             "artifact_paths": artifact_paths,
@@ -240,8 +261,14 @@ def build_receipt_draft(card: dict[str, Any], index_ref: str, result_ref: str, i
         },
         "receipt_five_reconciliation_result": {
             "evidence_ref": result_ref,
-            "result": "PASS" if index["receipt_five_ready"] else "FAIL",
+            "result": "PASS" if index["receipt_five_ready"] else "BLOCKED",
             "valid": bool(index["receipt_five_ready"]),
+            "promotion_authority": {
+                "result": "PASS" if index["receipt_five_ready"] else "BLOCK",
+                "predicate": "all required worker results are active, valid, non-blocking, and reconciled",
+                "allowed_transition_scopes": ["done"] if index["receipt_five_ready"] else [],
+                "active": True,
+            },
         },
         "worker_result_index": index_ref,
         "kanban_transition_event": {
@@ -259,6 +286,10 @@ def build_receipt_draft(card: dict[str, Any], index_ref: str, result_ref: str, i
             "reason": "Receipt Five ready" if index["receipt_five_ready"] else "Receipt Five blocked by evidence reconciliation",
         },
     }
+    errors = factoryctl.validate_receipt(receipt)
+    if index["receipt_five_ready"] and errors:
+        raise ValueError("generated receipt draft is invalid: " + "; ".join(errors))
+    return receipt
 
 
 def command_reconcile(args: argparse.Namespace) -> int:

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -81,6 +81,11 @@ RECEIPT_REQUIRED = {
     "reviewer_required",
     "next_action",
 }
+
+PROMOTION_PASS_RESULTS = {"PASS", "WAIVED"}
+ARTIFACT_PUBLIC_CLASSES = {"public_safe", "sanitized_report", "publication_candidate"}
+ARTIFACT_PRIVATE_CLASSES = {"private_run_evidence", "transient_cache"}
+PUBLICATION_SCANNER_FIELDS = ("public_safety_scan", "secret_safety_scan")
 V2_APPROVAL_KEYS = [
     "qa",
     "independent_review",
@@ -795,6 +800,61 @@ def source_card_ref(source_path: Path) -> str:
         return f"external:{source_path.name or 'source-card'}"
 
 
+def classify_artifact_ref(ref: Any) -> dict[str, Any]:
+    value = str(ref or "").strip()
+    normalized = value.replace("\\", "/")
+    if not value:
+        return {"ref": value, "artifact_class": "invalid", "public_safe": False, "reason": "empty artifact ref"}
+    if value.startswith("external:"):
+        return {"ref": value, "artifact_class": "sanitized_report", "public_safe": True, "reason": "explicit external/sanitized ref"}
+    if value.startswith(("http://", "https://", "file://")) or Path(value).is_absolute() or ":" in normalized.split("/", 1)[0]:
+        return {"ref": value, "artifact_class": "private_run_evidence", "public_safe": False, "reason": "absolute, URL, or private runtime ref"}
+    if normalized.startswith((".tmp/", "tmp/", "reports/private/", "private/", "run-evidence/")) or "/.tmp/" in normalized:
+        return {"ref": value, "artifact_class": "private_run_evidence", "public_safe": False, "reason": "private or transient evidence location"}
+    if normalized.startswith(("dist/", "site/", "public/", "release/", "publication-candidates/")):
+        return {"ref": value, "artifact_class": "publication_candidate", "public_safe": True, "reason": "repo publication surface"}
+    return {"ref": value, "artifact_class": "public_safe", "public_safe": True, "reason": "repo-relative artifact ref"}
+
+
+def artifact_contract_for_refs(refs: list[str]) -> dict[str, Any]:
+    classifications = [classify_artifact_ref(ref) for ref in refs]
+    return {
+        "artifact_classes_checked": sorted({item["artifact_class"] for item in classifications}),
+        "classifications": classifications,
+        "publication_candidates": [
+            item["ref"] for item in classifications if item["artifact_class"] == "publication_candidate"
+        ],
+        "private_run_evidence": [
+            item["ref"] for item in classifications if item["artifact_class"] in ARTIFACT_PRIVATE_CLASSES
+        ],
+        "public_safe": all(bool(item.get("public_safe")) for item in classifications),
+    }
+
+
+def scan_result_passed(value: Any) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, dict):
+        return str(value.get("result") or value.get("status") or "").strip().upper() == "PASS"
+    return False
+
+
+def artifact_publication_errors(metadata: dict[str, Any]) -> list[str]:
+    receipt = metadata.get("receipt_five") if isinstance(metadata.get("receipt_five"), dict) else {}
+    artifact_refs = string_list(receipt.get("artifact_paths"))
+    event = metadata.get("kanban_transition_event") if isinstance(metadata.get("kanban_transition_event"), dict) else {}
+    artifact_refs.extend(string_list(event.get("artifact_refs")))
+    contract = artifact_contract_for_refs(sorted(set(artifact_refs)))
+    errors: list[str] = []
+    if contract["private_run_evidence"]:
+        errors.append("publication artifacts must not reference private_run_evidence or transient_cache")
+    if contract["publication_candidates"]:
+        for field in PUBLICATION_SCANNER_FIELDS:
+            if not scan_result_passed(metadata.get(field)):
+                errors.append(f"publication_candidate artifacts require {field}=PASS")
+    return errors
+
+
 def read_project_version() -> str:
     if not PYPROJECT_PATH.exists():
         return "0.0.0"
@@ -1452,8 +1512,19 @@ def validate_receipt(data: dict[str, Any]) -> list[str]:
     missing = sorted(RECEIPT_REQUIRED - set(receipt))
     if missing:
         errors.append("missing receipt_five fields: " + ", ".join(missing))
+    verification_result = str(receipt.get("verification_result") or "").strip().upper()
+    if verification_result and verification_result not in {"PASS", "BLOCKED", "WAIVED"}:
+        errors.append("receipt_five.verification_result must be PASS, BLOCKED or WAIVED")
+    if verification_result == "PASS" and not string_list(receipt.get("verification_commands")):
+        errors.append("receipt_five PASS requires verification_commands")
     if receipt.get("reviewer_required") is True and not receipt.get("reviewer_result"):
         errors.append("reviewer_result required when reviewer_required=true")
+    if (
+        receipt.get("reviewer_required") is True
+        and verification_result == "PASS"
+        and str(receipt.get("reviewer_result") or "").strip().upper() != "PASS"
+    ):
+        errors.append("reviewer_result must be PASS when reviewer_required=true")
     transition_event = data.get("kanban_transition_event")
     if not isinstance(transition_event, dict):
         errors.append("kanban_transition_event object is required")
@@ -1468,6 +1539,13 @@ def validate_receipt(data: dict[str, Any]) -> list[str]:
         for field in ("receipt_refs", "artifact_refs"):
             if field in transition_event and not _non_empty_string_list(transition_event.get(field)):
                 errors.append(f"kanban_transition_event.{field} must be a non-empty string array")
+        allowed = transition_event.get("allowed")
+        event_to_status = str(transition_event.get("to_status") or "").strip().lower()
+        if allowed is not None and event_to_status in {"done", "closed", "complete"} and allowed is not True:
+            errors.append("kanban_transition_event.allowed must be true for promotion")
+        event_result = str(transition_event.get("result") or transition_event.get("predicate_result") or "").strip().upper()
+        if event_result and event_result not in {"PASS", "ALLOW", "APPROVED"}:
+            errors.append("kanban_transition_event result must be PASS, ALLOW or APPROVED")
     scan = data.get("security_scan_result")
     if isinstance(scan, dict):
         required = ["scanner_agent", "tool", "result", "findings_summary"]
@@ -1491,6 +1569,14 @@ def validate_receipt(data: dict[str, Any]) -> list[str]:
     auditor = data.get("auditor_result")
     if isinstance(auditor, dict):
         errors.extend(validate_auditor_result(auditor))
+    reconciliation = data.get("receipt_five_reconciliation_result")
+    if isinstance(reconciliation, dict):
+        reconciliation_result = str(reconciliation.get("result") or "").strip().upper()
+        if reconciliation_result not in {"PASS", "BLOCKED"}:
+            errors.append("receipt_five_reconciliation_result.result must be PASS or BLOCKED")
+        if reconciliation.get("valid") is True and reconciliation_result != "PASS":
+            errors.append("receipt_five_reconciliation_result.valid=true requires result PASS")
+    errors.extend(artifact_publication_errors(data))
     if data.get("hermes_legacy_completion_required") is True:
         if not any(_non_empty_string_list(data.get(field)) for field in ("evidence_paths", "evidence", "artifacts")):
             errors.append("Hermes V2 metadata requires evidence_paths, evidence or artifacts")
@@ -1530,6 +1616,11 @@ def validate_receipt(data: dict[str, Any]) -> list[str]:
 
 def validate_completion(card: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
     errors = validate_receipt(metadata)
+    receipt = metadata.get("receipt_five") if isinstance(metadata.get("receipt_five"), dict) else {}
+    if receipt.get("reviewer_required") is True and str(receipt.get("reviewer_result") or "").strip().upper() != "PASS":
+        errors.append("reviewer_result must be PASS when reviewer_required=true")
+    if receipt.get("reviewer_required") is True and "independent_review_result" not in metadata:
+        errors.append("independent_review_result is required when receipt_five.reviewer_required=true")
     if product_face_result_required(card):
         product_face = metadata.get("product_face_result")
         if not isinstance(product_face, dict):
@@ -1820,6 +1911,42 @@ def missing_required_inputs(worker: WorkerDefinition, card: dict[str, Any]) -> l
     return missing
 
 
+def unblock_guidance(missing_inputs: list[str]) -> list[dict[str, str]]:
+    return [
+        {
+            "field": field,
+            "action": f"populate card.{field} with public-safe contract data or attach the required worker evidence",
+            "authority": "operator may edit planning fields; worker/human evidence must be produced by the assigned authority",
+        }
+        for field in missing_inputs
+    ]
+
+
+def runtime_decision_profile(card: dict[str, Any]) -> dict[str, Any]:
+    decision = str(card.get("runtime_decision") or "").strip().lower()
+    contract = card.get("runtime_contract") if isinstance(card.get("runtime_contract"), dict) else {}
+    runtime = str(contract.get("runtime") or contract.get("adapter") or decision or "hermes").strip().lower()
+    if "local" in decision or runtime in {"factoryctl", "local", "none"}:
+        scope = "local_factoryctl_only"
+        allowed = ["validate-card", "gate-report", "worker-packet", "transition-plan"]
+        forbidden = ["spawn-worker", "mutate-live-board", "complete-main-task"]
+    elif "external" in decision:
+        scope = "external_runtime"
+        allowed = ["create-public-safe-packet", "wait-for-external-result"]
+        forbidden = ["assume-external-pass", "copy-private-auth", "complete-main-task-without-receipt"]
+    else:
+        scope = "hermes_runtime"
+        allowed = ["materialize-blocked-tasks", "link-worker-tasks", "enforce-done-after-pass"]
+        forbidden = ["spawn-without-route-readiness", "complete-without-receipt-five", "treat-artifact-existence-as-pass"]
+    return {
+        "decision": decision or "hermes_default",
+        "scope": scope,
+        "runtime_contract": contract,
+        "allowed_runtime_actions": allowed,
+        "forbidden_runtime_actions": forbidden,
+    }
+
+
 def required_worker_ids(card: dict[str, Any]) -> list[str]:
     return [worker_id for worker_id in WORKERS if worker_required(worker_id, card)[0]]
 
@@ -1830,6 +1957,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
     required, reason = worker_required(worker_id, card)
     missing_inputs = missing_required_inputs(worker, card)
     missing_profile_binding = profile_binding is None
+    runtime_decision = runtime_decision_profile(card)
     status = "requires_execution" if required else "not_required_by_current_card"
     if required and missing_inputs:
         status = "blocked_missing_inputs"
@@ -1865,16 +1993,28 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
         "input_contract": {
             "required_fields": list(worker.required_inputs),
             "missing_fields": missing_inputs,
+            "unblock_guidance": unblock_guidance(missing_inputs),
             "target_repo_paths": card.get("target_repo_paths", []),
             "authority_max": card.get("authority_max"),
             "forbidden_actions": card.get("forbidden_actions", []),
         },
+        "runtime_decision": runtime_decision,
         "output_contract": {
             "receipt_field": worker.output_field,
             "must_attach_artifact_refs": True,
             "must_state_blocking_findings": True,
             "must_record_tool_or_profile": True,
             "human_approval_must_be_real": worker_id == "human-gate-clerk",
+            "promotion_authority": {
+                "positive_results": sorted(PROMOTION_PASS_RESULTS),
+                "requires_valid_record": True,
+                "requires_blocking_findings_false": worker_id != "human-gate-clerk",
+            },
+            "artifact_policy": {
+                "allowed_public_classes": sorted(ARTIFACT_PUBLIC_CLASSES),
+                "private_classes": sorted(ARTIFACT_PRIVATE_CLASSES),
+                "publication_candidates_require_scanners": list(PUBLICATION_SCANNER_FIELDS),
+            },
         },
         "status": status,
     }
@@ -1906,7 +2046,13 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
     for worker_id in WORKERS:
         required, reason = worker_required(worker_id, card)
         status = build_worker_packet(worker_id, card, Path("<memory>"))["status"]
-        worker_rows[worker_id] = {"required": required, "reason": reason, "status": status}
+        missing_inputs = missing_required_inputs(WORKERS[worker_id], card)
+        worker_rows[worker_id] = {
+            "required": required,
+            "reason": reason,
+            "status": status,
+            "unblock_guidance": unblock_guidance(missing_inputs),
+        }
         if required:
             required_workers.append(worker_id)
         if str(status).startswith("blocked_"):
@@ -1925,9 +2071,20 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
         "risk_effective": card.get("risk_effective"),
         "surfaces": card.get("surfaces", []),
         "gate_status": gate_status,
+        "gate_predicate_result": "BLOCK" if gate_status == "blocked" else "PASS",
+        "promotion_authority": {
+            "predicate": "card validation has no errors and all required worker inputs are present",
+            "result": "BLOCK" if gate_status == "blocked" else "PASS",
+            "allowed_transition_scopes": [] if gate_status == "blocked" else ["create_worker_tasks"],
+        },
         "required_workers": required_workers,
         "blocked_workers": blocked_workers,
         "card_validation_errors": validation_errors,
+        "next_safe_actions": [
+            guidance
+            for row in worker_rows.values()
+            for guidance in row.get("unblock_guidance", [])
+        ],
         "workers": worker_rows,
     }
 
@@ -2018,6 +2175,25 @@ def _field_mismatch_errors(data: dict[str, Any], card: dict[str, Any] | None) ->
     expected_slice = card.get("slice_id")
     if expected_slice and card_ref.get("slice_id") != expected_slice:
         errors.append("card_ref.slice_id must match current card")
+    return errors
+
+
+def validate_human_gate_freshness(data: dict[str, Any], card: dict[str, Any] | None) -> list[str]:
+    errors: list[str] = []
+    if not str(data.get("decision_at") or "").strip():
+        errors.append("human gate decision_at is required")
+    if not str(data.get("approval_event_id") or data.get("approval_event_ref") or "").strip():
+        errors.append("human gate approval_event_id is required")
+    if card is None:
+        return errors
+    record_ref = data.get("card_ref") if isinstance(data.get("card_ref"), dict) else {}
+    for field in ("risk_effective", "phase"):
+        if record_ref.get(field) and card.get(field) and record_ref.get(field) != card.get(field):
+            errors.append(f"human gate card_ref.{field} must match current card")
+    forbidden = set(string_list(card.get("forbidden_actions")))
+    approved = set(string_list(data.get("approved_scope")))
+    if forbidden & approved:
+        errors.append("human gate approved_scope must not include forbidden_actions")
     return errors
 
 
@@ -2142,6 +2318,7 @@ def validate_worker_result_record(
         for field in ("risk_owner", "security_owner", "rollback_owner"):
             if not str(data.get(field) or "").strip() or str(data.get(field)).strip().upper() == "TBD":
                 errors.append(f"{field} must be explicit")
+        errors.extend(validate_human_gate_freshness(data, card))
     else:
         result = str(data.get("result") or "").strip()
         if result not in {"PASS", "WAIVED"}:
@@ -2158,12 +2335,26 @@ def validate_worker_result_record(
             expected_schema = worker_result_schema_url(expected_worker_id)
             if data.get("$schema") != expected_schema:
                 errors.append(f"$schema must be {expected_schema}")
+        authority = data.get("promotion_authority")
+        if not isinstance(authority, dict):
+            errors.append("promotion_authority object is required")
+        else:
+            if authority.get("active") is False:
+                errors.append("superseded worker result cannot satisfy promotion")
+            if str(authority.get("result") or "").strip().upper() != "PASS":
+                errors.append("promotion_authority.result must be PASS")
+            scopes = string_list(authority.get("allowed_transition_scopes"))
+            if "done" not in [scope.lower() for scope in scopes]:
+                errors.append("promotion_authority.allowed_transition_scopes must include done")
 
     evidence_refs = string_list(data.get("evidence_refs"))
     if not evidence_refs:
         errors.append("evidence_refs must contain at least one artifact ref")
     else:
         errors.extend(_evidence_ref_errors(evidence_refs, evidence_root))
+    contract = data.get("artifact_contract")
+    if isinstance(contract, dict) and contract.get("public_safe") is False and data.get("reusable_for_product") is True:
+        errors.append("private artifact_contract cannot be reusable_for_product=true")
     errors.extend(_field_mismatch_errors(data, card))
 
     evidence_kind = str(data.get("evidence_kind") or "").strip()
@@ -2188,37 +2379,40 @@ def validate_worker_result_record(
 def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None) -> dict[str, dict[str, Any]]:
     if results_dir is None or not results_dir.exists():
         return {}
-    records: dict[str, dict[str, Any]] = {}
-    paths_by_record_type: dict[str, list[str]] = {}
+    records_by_type: dict[str, list[dict[str, Any]]] = {}
     for path in sorted(results_dir.glob("*.json")):
         try:
             data = load_json_like(path)
         except (OSError, ValueError, json.JSONDecodeError):
             continue
         record_type = str(data.get("record_type") or "").strip()
-        if record_type:
-            paths_by_record_type.setdefault(record_type, []).append(source_card_ref(path))
-            expected_worker_id = _worker_id_for_output_field(record_type)
-            errors = validate_worker_result_record(
-                data,
-                expected_field=record_type,
-                expected_worker_id=expected_worker_id,
-                card=card,
-                evidence_root=ROOT,
-            )
-            records[record_type] = {
+        if not record_type:
+            continue
+        expected_worker_id = _worker_id_for_output_field(record_type)
+        errors = validate_worker_result_record(
+            data,
+            expected_field=record_type,
+            expected_worker_id=expected_worker_id,
+            card=card,
+            evidence_root=ROOT,
+        )
+        authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
+        records_by_type.setdefault(record_type, []).append(
+            {
                 "evidence_ref": source_card_ref(path),
+                "created_at": data.get("created_at") or data.get("decision_at"),
                 "result": data.get("result") or data.get("decision"),
+                "active": authority.get("active", data.get("active", True)) is not False and not data.get("superseded_by"),
                 "valid": not errors,
                 "validation_errors": errors,
             }
-    for record_type, paths in paths_by_record_type.items():
-        if len(paths) > 1 and record_type in records:
-            records[record_type]["valid"] = False
-            records[record_type]["validation_errors"] = [
-                *records[record_type].get("validation_errors", []),
-                f"duplicate worker result records for {record_type}: {', '.join(paths)}",
-            ]
+        )
+    records: dict[str, dict[str, Any]] = {}
+    for record_type, candidates in records_by_type.items():
+        active = [candidate for candidate in candidates if candidate.get("active")]
+        ordered = sorted(active or candidates, key=_worker_record_sort_key, reverse=True)
+        if ordered:
+            records[record_type] = ordered[0]
     return records
 
 
@@ -2246,6 +2440,13 @@ def receipt_result_fields(
                 "validation_errors": errors,
             }
     return fields
+
+
+def _worker_record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("created_at") or ""),
+        str(record.get("evidence_ref") or ""),
+    )
 
 
 def build_worker_task(worker_id: str, card: dict[str, Any], source_path: Path) -> dict[str, Any]:
@@ -2308,6 +2509,28 @@ def build_worker_closure(
     }
 
 
+def receipt_reconciliation_errors(metadata: dict[str, Any] | None) -> list[str]:
+    if not isinstance(metadata, dict):
+        return ["receipt_five_reconciliation_result is required for done promotion"]
+    event = metadata.get("kanban_transition_event") if isinstance(metadata.get("kanban_transition_event"), dict) else {}
+    if event.get("allowed") is not True:
+        errors = ["kanban_transition_event.allowed must be true for done promotion"]
+    else:
+        errors = []
+    reconciliation = metadata.get("receipt_five_reconciliation_result")
+    if not isinstance(reconciliation, dict):
+        errors.append("receipt_five_reconciliation_result is required for done promotion")
+        return errors
+    if str(reconciliation.get("result") or "").strip().upper() != "PASS":
+        errors.append("receipt_five_reconciliation_result.result must be PASS for done promotion")
+    if reconciliation.get("valid") is not True:
+        errors.append("receipt_five_reconciliation_result.valid must be true for done promotion")
+    authority = reconciliation.get("promotion_authority")
+    if isinstance(authority, dict) and str(authority.get("result") or "").strip().upper() != "PASS":
+        errors.append("receipt_five_reconciliation_result promotion_authority must be PASS")
+    return errors
+
+
 def build_transition_plan(
     card: dict[str, Any],
     source_path: Path,
@@ -2343,6 +2566,20 @@ def build_transition_plan(
         else:
             transition_action = "block_transition" if blocked_reasons else "allow_and_create_worker_tasks"
         completion = None
+    elif normalized_to in {"review", "review-ready", "ready_for_review"}:
+        blocked_reasons.extend(gate["card_validation_errors"])
+        for worker_id in gate["blocked_workers"]:
+            queue_class = worker_queue_class(worker_id, card)
+            blocked_reasons.append(f"{worker_id} missing inputs for {queue_class}")
+        before_ready = [
+            task["worker_id"]
+            for task in worker_tasks
+            if task["queue_class"] == "blocking-before-ready"
+        ]
+        for worker_id in before_ready:
+            blocked_reasons.append(f"{worker_id} result is required before review-ready")
+        transition_action = "block_transition" if blocked_reasons else "allow_review_ready"
+        completion = build_worker_closure(card, receipt or {}, worker_results_dir)
     elif normalized_to in {"done", "closed", "complete"}:
         blocked_reasons.extend(gate["card_validation_errors"])
         for worker_id in gate["blocked_workers"]:
@@ -2352,6 +2589,7 @@ def build_transition_plan(
             completion = build_worker_closure(card, {}, worker_results_dir)
         else:
             blocked_reasons.extend(validate_completion(card, receipt))
+            blocked_reasons.extend(receipt_reconciliation_errors(receipt))
             blocked_reasons.extend(
                 validate_transition_event_matches(
                     receipt,
@@ -2422,6 +2660,8 @@ def build_worker_result(
         raise ValueError("PASS cannot have blocking_findings=true")
 
     worker = WORKERS[worker_id]
+    artifact_contract = artifact_contract_for_refs(evidence_refs)
+    positive_authority = result in PROMOTION_PASS_RESULTS and blocking_findings is False
     payload = {
         "$schema": worker_result_schema_url(worker_id),
         "record_type": worker.output_field,
@@ -2438,9 +2678,17 @@ def build_worker_result(
         "tool_or_profile": tool_or_profile,
         "executed_by": executed_by,
         "evidence_refs": evidence_refs,
+        "artifact_contract": artifact_contract,
+        "artifact_classifications": artifact_contract["classifications"],
         "evidence_kind": evidence_kind,
         "reusable_for_product": reusable_for_product,
         "next_action": next_action,
+        "promotion_authority": {
+            "result": "PASS" if positive_authority else "BLOCK",
+            "predicate": "worker result is PASS/WAIVED, valid, scoped to the current card, and has blocking_findings=false",
+            "allowed_transition_scopes": ["done"] if positive_authority else [],
+            "active": True,
+        },
     }
     if worker_id == "codex-security":
         scan_packet = card.get("security_scan_packet", {}) if isinstance(card.get("security_scan_packet"), dict) else {}
@@ -2645,6 +2893,7 @@ def build_human_gate_record(
         "decision": decision,
         "human_actor": human_actor,
         "decision_at": utc_now(),
+        "approval_event_id": f"human:{card.get('card_id') or 'card'}:{utc_now()}",
         "approved_scope": approved_scope,
         "forbidden_scope": forbidden_scope or card.get("forbidden_actions", []),
         "required_changes": required_changes,
@@ -2717,6 +2966,25 @@ def command_gate_report(args: argparse.Namespace) -> int:
     card = load_json_like(args.card)
     write_json(args.out, build_gate_report(card))
     return 0
+
+
+def command_unblock_plan(args: argparse.Namespace) -> int:
+    report = build_gate_report(load_json_like(args.card))
+    plan = {
+        "$schema": "https://overkill-factory.dev/schemas/unblock-plan.schema.json",
+        "record_type": "operator_unblock_plan",
+        "created_at": utc_now(),
+        "card_id": report.get("card_id"),
+        "gate_predicate_result": report.get("gate_predicate_result"),
+        "blocked_workers": report.get("blocked_workers", []),
+        "next_safe_actions": report.get("next_safe_actions", []),
+        "limits": [
+            "This plan does not execute workers, approve gates, or bypass missing evidence.",
+            "Human/security/review evidence must be produced by the assigned authority.",
+        ],
+    }
+    write_json(args.out, plan)
+    return 1 if report.get("gate_predicate_result") == "BLOCK" else 0
 
 
 def command_evidence_record(args: argparse.Namespace) -> int:
@@ -2866,6 +3134,11 @@ def build_parser() -> argparse.ArgumentParser:
     gate_report_parser.add_argument("--out", type=Path)
     gate_report_parser.set_defaults(func=command_gate_report)
 
+    unblock_plan_parser = sub.add_parser("unblock-plan")
+    unblock_plan_parser.add_argument("--card", type=Path, required=True)
+    unblock_plan_parser.add_argument("--out", type=Path)
+    unblock_plan_parser.set_defaults(func=command_unblock_plan)
+
     evidence_record_parser = sub.add_parser("evidence-record")
     evidence_record_parser.add_argument(
         "--worker",
@@ -2873,7 +3146,7 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
     )
     evidence_record_parser.add_argument("--card", type=Path, required=True)
-    evidence_record_parser.add_argument("--result", choices=["PASS", "FAIL", "WAIVED", "PENDING"], required=True)
+    evidence_record_parser.add_argument("--result", choices=["PASS", "BLOCKED", "FAIL", "WAIVED", "PENDING"], required=True)
     evidence_record_parser.add_argument("--tool", required=True)
     evidence_record_parser.add_argument("--actor", required=True)
     evidence_record_parser.add_argument("--evidence-ref", action="append")

--- a/scripts/public_safety_scan.py
+++ b/scripts/public_safety_scan.py
@@ -137,6 +137,9 @@ def safe_ref(value: str | None) -> str | None:
 def build_summary(findings: list[str], *, git_ref: str | None = None, created_at: str | None = None) -> dict[str, object]:
     categories = Counter(finding_category(finding) for finding in findings)
     target = {"kind": "git_ref", "ref": safe_ref(git_ref)} if git_ref else {"kind": "worktree"}
+    artifact_classes = ["public_repository_tree"]
+    if git_ref:
+        artifact_classes.append("publication_candidate")
     return {
         "$schema": "https://overkill-factory.dev/schemas/public-safety-scan-summary.schema.json",
         "record_type": "public_safety_scan_summary",
@@ -144,6 +147,12 @@ def build_summary(findings: list[str], *, git_ref: str | None = None, created_at
         "target": target,
         "result": "PASS" if not findings else "FAIL",
         "finding_count": len(findings),
+        "artifact_classes_checked": sorted(set(artifact_classes)),
+        "publication_policy": {
+            "private_run_evidence": "not_scanned_for_publication",
+            "sanitized_report": "allowed_when_raw_private_markers_are_absent",
+            "publication_candidate": "fail_closed_on_any_private_marker",
+        },
         "forbidden_hits": [
             {"category": category, "count": count}
             for category, count in sorted(categories.items())

--- a/scripts/safe_shell.py
+++ b/scripts/safe_shell.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Safe subprocess helper for factory worker packets.
+
+The helper only accepts argv lists. It is intentionally small so worker packets
+can cite it when a shell string, heredoc, pipe, or sandbox-specific launcher
+would make evidence ambiguous.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SafeCommandResult:
+    status: str
+    returncode: int | None
+    stdout: str
+    stderr: str
+    remediation: str | None = None
+
+
+def run_command(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int = 120,
+    allowed_executables: set[str] | None = None,
+) -> SafeCommandResult:
+    if not argv or not all(isinstance(part, str) and part.strip() for part in argv):
+        raise ValueError("argv must be a non-empty list of non-empty strings")
+    executable = Path(argv[0]).name.lower()
+    if allowed_executables is not None and executable not in {item.lower() for item in allowed_executables}:
+        raise ValueError(f"executable is not allowed for this worker packet: {argv[0]}")
+    try:
+        completed = subprocess.run(  # nosec B603
+            argv,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            shell=False,
+        )
+    except OSError as exc:
+        message = str(exc)
+        if "CreateProcessAsUserW failed: 5" in message:
+            return SafeCommandResult(
+                status="BLOCKED",
+                returncode=None,
+                stdout="",
+                stderr=message,
+                remediation="Use the operator-approved fallback runner or rerun the same argv on an authorized local shell.",
+            )
+        raise
+    except subprocess.TimeoutExpired as exc:
+        return SafeCommandResult(
+            status="BLOCKED",
+            returncode=None,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+            remediation="Increase timeout only after checking the command is expected to run longer.",
+        )
+    return SafeCommandResult(
+        status="PASS" if completed.returncode == 0 else "BLOCKED",
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        remediation=None if completed.returncode == 0 else "Inspect stderr and rerun after fixing the blocking condition.",
+    )

--- a/scripts/secret_safety_scan.py
+++ b/scripts/secret_safety_scan.py
@@ -7,9 +7,12 @@ formats, private key blocks and high-entropy assignments in public artifacts.
 
 from __future__ import annotations
 
+import argparse
+import json
 import math
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -63,7 +66,26 @@ def allowed_fixture_line(line: str) -> bool:
     return any(hint in lowered for hint in ALLOW_HINTS)
 
 
-def main() -> int:
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def build_summary(findings: list[str]) -> dict[str, object]:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/secret-safety-scan-summary.schema.json",
+        "record_type": "secret_safety_scan_summary",
+        "created_at": utc_now(),
+        "result": "PASS" if not findings else "FAIL",
+        "finding_count": len(findings),
+        "artifact_classes_checked": ["public_repository_tree", "publication_candidate"],
+        "limits": [
+            "This summary intentionally omits raw secret-like values and exact matching lines.",
+            "Use stderr in a private operator context for remediation paths.",
+        ],
+    }
+
+
+def scan() -> list[str]:
     findings: list[str] = []
     for path in ROOT.rglob("*"):
         if not path.is_file() or not should_scan(path):
@@ -82,6 +104,21 @@ def main() -> int:
                 if len(candidate) >= 32 and entropy(candidate) >= 4.2:
                     findings.append(f"{rel}:{lineno}: high-entropy secret-like assignment")
                     break
+    return findings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summary-json", type=Path, help="Write public-safe JSON summary without raw secret material.")
+    return parser
+
+
+def main_with_args(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    findings = scan()
+    if args.summary_json:
+        args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_json.write_text(json.dumps(build_summary(findings), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     if findings:
         for finding in findings:
@@ -89,6 +126,10 @@ def main() -> int:
         return 1
     print("OK")
     return 0
+
+
+def main() -> int:
+    return main_with_args()
 
 
 if __name__ == "__main__":

--- a/tests/test_evidence_reconciler.py
+++ b/tests/test_evidence_reconciler.py
@@ -154,7 +154,7 @@ class EvidenceReconcilerTest(unittest.TestCase):
 
         self.assertFalse(index["receipt_five_ready"])
         self.assertIn("security_scan_result", index["missing_required_fields"])
-        self.assertEqual(result["result"], "FAIL")
+        self.assertEqual(result["result"], "BLOCKED")
         self.assertTrue(result["blocking_findings"])
 
     def test_extra_result_path_is_indexed_with_worker_results(self) -> None:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -65,9 +65,17 @@ def worker_result(record_type: str, *, result: str = "PASS", source_card: dict |
         "tool_or_profile": "fixture-tool",
         "executed_by": "fixture-runner",
         "evidence_refs": ["README.md"],
+        "artifact_contract": factoryctl.artifact_contract_for_refs(["README.md"]),
+        "artifact_classifications": factoryctl.artifact_contract_for_refs(["README.md"])["classifications"],
         "evidence_kind": "synthetic",
         "reusable_for_product": False,
         "next_action": "none",
+        "promotion_authority": {
+            "result": "PASS" if result in {"PASS", "WAIVED"} else "BLOCK",
+            "predicate": "synthetic fixture authority",
+            "allowed_transition_scopes": ["done"] if result in {"PASS", "WAIVED"} else [],
+            "active": True,
+        },
     }
     if record_type == "security_scan_result":
         payload["scanner_agent"] = "codex-security-runner"
@@ -86,6 +94,8 @@ def worker_result(record_type: str, *, result: str = "PASS", source_card: dict |
         payload["artifact_refs"] = ["reports/fixture.md"]
     if record_type == "handoff_packet_result":
         payload["handoff_packet_ref"] = "reports/fixture.md"
+    if record_type == "receipt_five_reconciliation_result":
+        payload["valid"] = result == "PASS"
     if result == "WAIVED":
         payload["waiver"] = {
             "owner": "fixture-owner",
@@ -112,6 +122,7 @@ def human_gate_record(source_card: dict | None = None) -> dict:
         "decision": "approved",
         "human_actor": "product-owner",
         "decision_at": "2026-06-06T00:00:00+00:00",
+        "approval_event_id": "evt_fixture_human_approval",
         "approved_scope": ["dry validation"],
         "forbidden_scope": ["deploy"],
         "risk_owner": "product-owner",
@@ -374,7 +385,9 @@ class FactoryCtlTest(unittest.TestCase):
                 "worker": "product-face",
                 "receipt_refs": ["receipt_five", "product_face_result"],
                 "artifact_refs": ["examples/cards/v35_valid_product_face.md", "reports/product-face.md"],
+                "allowed": True,
             },
+            "independent_review_result": worker_result("independent_review_result", source_card=card),
             "product_face_result": {
                 "result": "PASS",
                 "tool_or_profile": "browser-proof-runner",
@@ -698,7 +711,7 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(result["tool"], "codex-security:scoped-security-scan")
         self.assertIn("PDA", " ".join(result["scope"]))
 
-    def test_duplicate_worker_result_records_do_not_satisfy_gate(self) -> None:
+    def test_duplicate_worker_result_records_choose_latest_active_result(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md")
         result = factoryctl.build_worker_result(
             "codex-security",
@@ -719,10 +732,8 @@ class FactoryCtlTest(unittest.TestCase):
 
             records = factoryctl.collect_worker_result_fields(card, results_dir)
 
-        self.assertFalse(records["security_scan_result"]["valid"])
-        self.assertTrue(
-            any("duplicate worker result records for security_scan_result" in error for error in records["security_scan_result"]["validation_errors"])
-        )
+        self.assertTrue(records["security_scan_result"]["valid"])
+        self.assertEqual(records["security_scan_result"]["result"], "PASS")
 
     def test_inline_worker_result_requires_existing_evidence_ref_for_done(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
@@ -931,6 +942,7 @@ class FactoryCtlTest(unittest.TestCase):
                 "worker": "implementation-worker",
                 "receipt_refs": ["receipt_five"],
                 "artifact_refs": ["artifact"],
+                "allowed": True,
             },
         }
 
@@ -967,6 +979,7 @@ class FactoryCtlTest(unittest.TestCase):
                 "worker": "implementation-worker",
                 "receipt_refs": ["receipt_five"],
                 "artifact_refs": ["artifact"],
+                "allowed": True,
             },
             "security_scan_result": worker_result("security_scan_result", source_card=card),
             "auditor_result": worker_result("auditor_result", result="WAIVED", source_card=card),

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -38,9 +38,52 @@ class FakeHermes:
             self.counter += 1
             task_id = "t_" + f"{self.counter:08x}"
             return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
+        if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "block":
+            return subprocess.CompletedProcess(argv, 0, stdout='{"status":"blocked"}', stderr="")
+        if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout='{"status":"blocked","events":[{"type":"blocked","reason":"gate"}]}',
+                stderr="",
+            )
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "link":
             return subprocess.CompletedProcess(argv, 0, stdout="linked", stderr="")
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected command")
+
+
+def write_route_readiness(path: Path) -> None:
+    workers = [
+        "codex-security",
+        "solana-quasar-auditor",
+        "independent-reviewer",
+        "evidence-reconciler",
+        "human-gate-clerk",
+        "factory-orchestrator",
+        "source-ledger-worker",
+        "qa-verification-worker",
+        "autoreview-gate",
+        "security-orchestrator",
+        "handoff-packer",
+        "supply-chain-gate",
+    ]
+    path.write_text(
+        json.dumps(
+            {
+                "routes": {
+                    worker: {
+                        "profile_exists": True,
+                        "provider_configured": True,
+                        "model_configured": True,
+                        "credential_status": "pass",
+                        "capability_manifest_ok": True,
+                    }
+                    for worker in workers
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
@@ -48,6 +91,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         fake = FakeHermes()
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         with tempfile.TemporaryDirectory() as tmp:
+            readiness = Path(tmp) / "route-readiness.json"
+            write_route_readiness(readiness)
             args = adapter.build_parser().parse_args(
                 [
                     "materialize",
@@ -57,6 +102,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     TEST_BOARD,
                     "--ledger",
                     str(Path(tmp) / "ledger.json"),
+                    "--route-readiness",
+                    str(readiness),
                     "--ensure-board",
                     "--worker-ready",
                 ]

--- a/tests/test_operator_experience.py
+++ b/tests/test_operator_experience.py
@@ -26,10 +26,26 @@ class OperatorExperienceTest(unittest.TestCase):
         help_text = run_factoryctl("--help").stdout
         run_help = run_factoryctl("run", "--help").stdout
 
-        for command in ["doctor", "init", "run"]:
+        for command in ["doctor", "init", "run", "unblock-plan"]:
             with self.subTest(command=command):
                 self.assertIn(command, help_text)
         self.assertIn("minimal", run_help)
+
+    def test_unblock_plan_is_read_only_operator_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "unblock-plan.json"
+            run_factoryctl(
+                "unblock-plan",
+                "--card",
+                "examples/cards/v35_valid_onchain_auditor_scan.md",
+                "--out",
+                str(out),
+            )
+            payload = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["record_type"], "operator_unblock_plan")
+        self.assertIn("next_safe_actions", payload)
+        self.assertTrue(any("does not execute workers" in item for item in payload["limits"]))
 
     def test_doctor_reports_public_install_health_without_real_hermes_e2e(self) -> None:
         result = run_factoryctl("doctor", "--json")

--- a/tests/test_safe_shell.py
+++ b/tests/test_safe_shell.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "safe_shell.py"
+SPEC = importlib.util.spec_from_file_location("safe_shell", MODULE_PATH)
+assert SPEC is not None
+safe_shell = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["safe_shell"] = safe_shell
+SPEC.loader.exec_module(safe_shell)
+
+
+class SafeShellTest(unittest.TestCase):
+    def test_run_command_accepts_argv_and_returns_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = safe_shell.run_command(
+                [sys.executable, "--version"],
+                cwd=Path(tmpdir),
+                allowed_executables={Path(sys.executable).name},
+            )
+
+        self.assertEqual(result.status, "PASS")
+        self.assertEqual(result.returncode, 0)
+
+    def test_run_command_rejects_disallowed_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "not allowed"):
+                safe_shell.run_command(
+                    [sys.executable, "--version"],
+                    cwd=Path(tmpdir),
+                    allowed_executables={"not-python"},
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make gate/transition promotion require explicit positive authority, valid Receipt Five reconciliation, review-ready as a non-final transition, and machine-readable supersession
- fail closed for live Hermes dispatch with route readiness checks, durable blocked-event verification, non-empty task bodies, and safer operator unblock guidance
- add public/secret artifact-class summaries plus safe test-runner fallback docs and helper

## Validation
- python -m unittest discover -s tests -p "test_*.py" -q
- python scripts/validate_public_json_artifacts.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/supply_chain_proof.py --check --no-write
- git diff --check HEAD~1..HEAD

Closes #53
Closes #54
Closes #55
Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
