### PR TITLE
Improve README factory map preview

### DIFF
--- a/docs/visuals/overkill-factory-map-v0.1.0.svg
+++ b/docs/visuals/overkill-factory-map-v0.1.0.svg
@@ -1,101 +1,65 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
-  <title id="title">Overkill Factory visual map</title>
-  <desc id="desc">Static preview of the Overkill Factory production line from source intake to Product SOT, gates, execution, proof, release and learnback.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="360" viewBox="0 0 1280 360" role="img" aria-labelledby="title desc">
+  <title id="title">Overkill Factory map preview</title>
+  <desc id="desc">Readable GitHub README preview for the Overkill Factory flow: source, method, risk, execution and operations.</desc>
   <defs>
     <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
       <stop offset="0" stop-color="#151514"/>
-      <stop offset="0.45" stop-color="#1f201d"/>
-      <stop offset="1" stop-color="#111315"/>
+      <stop offset="1" stop-color="#20201e"/>
     </linearGradient>
-    <linearGradient id="rail" x1="0" x2="1" y1="0" y2="0">
+    <linearGradient id="line" x1="0" x2="1" y1="0" y2="0">
       <stop offset="0" stop-color="#74aaa3"/>
       <stop offset="0.25" stop-color="#a89bdb"/>
       <stop offset="0.5" stop-color="#e19b63"/>
       <stop offset="0.75" stop-color="#79a9d4"/>
       <stop offset="1" stop-color="#a4be77"/>
     </linearGradient>
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="140%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#000000" flood-opacity="0.32"/>
-    </filter>
     <style>
-      .label { fill: #fbf7ec; font-family: ui-serif, Georgia, "Times New Roman", serif; font-weight: 700; }
-      .body { fill: #d7d0c2; font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif; }
-      .muted { fill: #9b958b; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-      .tiny { font-size: 13px; letter-spacing: 0; }
-      .small { font-size: 16px; letter-spacing: 0; }
-      .mid { font-size: 20px; letter-spacing: 0; }
-      .big { font-size: 38px; letter-spacing: 0; }
-      .node-title { fill: #fbf7ec; font: 700 15px system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif; }
-      .node-mini { fill: #b9b1a3; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .title { fill: #fbf7ec; font: 700 52px Georgia, "Times New Roman", serif; letter-spacing: 0; }
+      .subtitle { fill: #d7d0c2; font: 22px system-ui, -apple-system, "Segoe UI", Arial, sans-serif; letter-spacing: 0; }
+      .eyebrow { fill: #9b958b; font: 15px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: 0; }
+      .stage { fill: #fbf7ec; font: 700 22px system-ui, -apple-system, "Segoe UI", Arial, sans-serif; letter-spacing: 0; }
+      .mini { fill: #c9c1b4; font: 15px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: 0; }
+      .note { fill: #b9b1a3; font: 17px system-ui, -apple-system, "Segoe UI", Arial, sans-serif; letter-spacing: 0; }
     </style>
   </defs>
 
-  <rect width="1280" height="720" fill="url(#bg)"/>
-  <rect x="34" y="34" width="1212" height="652" rx="18" fill="#20201e" opacity="0.82" stroke="#454139"/>
-  <path d="M64 115 H1216" stroke="url(#rail)" stroke-width="5" stroke-linecap="round"/>
+  <rect width="1280" height="360" rx="0" fill="url(#bg)"/>
+  <rect x="28" y="28" width="1224" height="304" rx="18" fill="#1b1b19" stroke="#3f3b34"/>
+  <path d="M64 124 H1216" stroke="url(#line)" stroke-width="6" stroke-linecap="round"/>
 
-  <text x="64" y="85" class="label big">Overkill Factory</text>
-  <text x="430" y="82" class="muted small">visual map v0.1.0</text>
-  <text x="64" y="136" class="body mid">A public onboarding map for the factory line. It explains the flow; executable contracts remain authoritative.</text>
+  <text x="64" y="88" class="title">Overkill Factory</text>
+  <text x="64" y="155" class="subtitle">From raw request to controlled agentic execution, proof, review and release.</text>
 
-  <g transform="translate(64 175)">
-    <rect width="216" height="92" rx="12" fill="#22302d" stroke="#74aaa3" filter="url(#shadow)"/>
-    <text x="18" y="30" class="muted tiny">01-05</text>
-    <text x="18" y="56" class="node-title">Truth Before Work</text>
-    <text x="18" y="78" class="node-mini">source - outcome - SOT</text>
+  <g transform="translate(64 198)">
+    <rect width="205" height="82" rx="12" fill="#22302d" stroke="#74aaa3"/>
+    <text x="18" y="30" class="eyebrow">01-05</text>
+    <text x="18" y="57" class="stage">Truth</text>
+    <text x="92" y="57" class="mini">sources -> SOT</text>
   </g>
-  <g transform="translate(300 175)">
-    <rect width="216" height="92" rx="12" fill="#292633" stroke="#a89bdb" filter="url(#shadow)"/>
-    <text x="18" y="30" class="muted tiny">06-15</text>
-    <text x="18" y="56" class="node-title">Method And Plans</text>
-    <text x="18" y="78" class="node-mini">router - packs - specs</text>
+  <g transform="translate(295 198)">
+    <rect width="205" height="82" rx="12" fill="#292633" stroke="#a89bdb"/>
+    <text x="18" y="30" class="eyebrow">06-15</text>
+    <text x="18" y="57" class="stage">Method</text>
+    <text x="110" y="57" class="mini">plans -> specs</text>
   </g>
-  <g transform="translate(536 175)">
-    <rect width="216" height="92" rx="12" fill="#33281f" stroke="#e19b63" filter="url(#shadow)"/>
-    <text x="18" y="30" class="muted tiny">09, 16-19, 34</text>
-    <text x="18" y="56" class="node-title">Risk And Authority</text>
-    <text x="18" y="78" class="node-mini">R0-R4 - gates - human</text>
+  <g transform="translate(526 198)">
+    <rect width="205" height="82" rx="12" fill="#33281f" stroke="#e19b63"/>
+    <text x="18" y="30" class="eyebrow">R0-R4</text>
+    <text x="18" y="57" class="stage">Risk</text>
+    <text x="82" y="57" class="mini">gates -> human</text>
   </g>
-  <g transform="translate(772 175)">
-    <rect width="216" height="92" rx="12" fill="#202b34" stroke="#79a9d4" filter="url(#shadow)"/>
-    <text x="18" y="30" class="muted tiny">20-27</text>
-    <text x="18" y="56" class="node-title">Execution And Proof</text>
-    <text x="18" y="78" class="node-mini">Hermes - agents - Receipt Five</text>
+  <g transform="translate(757 198)">
+    <rect width="205" height="82" rx="12" fill="#202b34" stroke="#79a9d4"/>
+    <text x="18" y="30" class="eyebrow">20-27</text>
+    <text x="18" y="57" class="stage">Execution</text>
+    <text x="134" y="57" class="mini">Receipt Five</text>
   </g>
-  <g transform="translate(1008 175)">
-    <rect width="216" height="92" rx="12" fill="#293021" stroke="#a4be77" filter="url(#shadow)"/>
-    <text x="18" y="30" class="muted tiny">28-33</text>
-    <text x="18" y="56" class="node-title">Operations</text>
-    <text x="18" y="78" class="node-mini">release - monitor - learnback</text>
-  </g>
-
-  <g fill="none" stroke="#615b50" stroke-width="2" stroke-dasharray="7 9">
-    <path d="M280 221 H300"/>
-    <path d="M516 221 H536"/>
-    <path d="M752 221 H772"/>
-    <path d="M988 221 H1008"/>
+  <g transform="translate(988 198)">
+    <rect width="228" height="82" rx="12" fill="#293021" stroke="#a4be77"/>
+    <text x="18" y="30" class="eyebrow">28-33</text>
+    <text x="18" y="57" class="stage">Operations</text>
+    <text x="154" y="57" class="mini">learnback</text>
   </g>
 
-  <g transform="translate(64 327)">
-    <rect width="540" height="274" rx="16" fill="#181817" stroke="#39352f"/>
-    <text x="26" y="42" class="label mid">What the map makes visible</text>
-    <text x="26" y="82" class="body small">1. A raw request does not become execution until sources and outcome are clear.</text>
-    <text x="26" y="120" class="body small">2. Method, product surface, security, data and evals are routed before work starts.</text>
-    <text x="26" y="158" class="body small">3. R0-R4 gates decide authority, review, rollback and human approval strength.</text>
-    <text x="26" y="196" class="body small">4. Hermes runs worker cards, but completion requires evidence and Receipt Five.</text>
-    <text x="26" y="234" class="body small">5. Release is followed by monitoring, support, learnback and maturity audit.</text>
-  </g>
-
-  <g transform="translate(646 327)">
-    <rect width="578" height="274" rx="16" fill="#181817" stroke="#39352f"/>
-    <text x="28" y="42" class="label mid">Public boundary</text>
-    <text x="28" y="82" class="body small">This SVG is an onboarding preview of the interactive HTML guide.</text>
-    <text x="28" y="120" class="body small">It is not runtime evidence, not an approval record and not a source of truth.</text>
-    <text x="28" y="158" class="body small">Use it to understand the factory; use scripts, schemas, tests and Hermes state</text>
-    <text x="28" y="184" class="body small">to prove whether a real card is ready, blocked, complete or releasable.</text>
-    <rect x="28" y="216" width="330" height="36" rx="8" fill="#252520" stroke="#454139"/>
-    <text x="45" y="240" class="muted tiny">docs/visuals/overkill-factory-map-v0.1.0.html</text>
-  </g>
-
-  <text x="64" y="646" class="muted tiny">Static preview for GitHub README. Open the HTML from the docs site or a local checkout for keyboard navigation and step details.</text>
+  <text x="64" y="313" class="note">Preview only. Open the interactive map for step details; scripts, schemas, tests and Hermes state remain authoritative.</text>
 </svg>

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -263,8 +263,9 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("onboarding aid, not runtime evidence or source authority", readme)
         self.assertIn("Static README preview", visuals)
         self.assertIn("Interactive map", visuals)
-        self.assertIn("Static preview for GitHub README", svg)
-        self.assertIn("interactive HTML guide", svg)
+        self.assertIn("Readable GitHub README preview", svg)
+        self.assertIn("Preview only", svg)
+        self.assertIn("Open the interactive map", svg)
         self.assertIn("Overkill Factory", html)
 
     def test_release_security_and_example_gallery_are_professional_surfaces(self) -> None:


### PR DESCRIPTION
## Summary
- replace the dense README SVG with a shorter, legible banner preview
- keep the interactive HTML as the detailed map
- update the docs test to enforce the new readable preview intent

## Validation
- python -m unittest tests.test_open_source_docs -q
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- git diff --check