### PR TITLE
Add factory self-improvement contracts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,3 +44,7 @@ release.
 
 Use `maintenance/repo-surface.md` to decide whether a file belongs in the
 operator surface, maintainer internals or generated output.
+
+Use `maintenance/self-improvement-loop.md` for learnback issue candidates,
+missing-capability completion plans, owner issue intake, reasoning policy,
+reference quality packets and governance audit artifacts.

--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -1,0 +1,112 @@
+# Factory Self-Improvement Loop
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: `scripts/factory_self_improvement.py`, schemas, tests.
+> Runtime boundary: these helpers produce dry-run plans and public-safe
+> candidates. They do not dispatch Hermes, activate workers, post GitHub
+> comments or approve gates.
+
+## Purpose
+
+The factory should learn from its own execution without leaking private run
+evidence or turning every observation into a public issue. The self-improvement
+loop converts blocked capability gaps, execution learnback records, owner issue
+intake and governance checks into structured artifacts.
+
+## Contracts
+
+- `schemas/missing-capability-completion-plan.schema.json`
+- `schemas/execution-learnback-record.schema.json`
+- `schemas/factory-improvement-issue-candidate.schema.json`
+- `schemas/owner-issue-intake-config.schema.json`
+- `schemas/owner-issue-intake-report.schema.json`
+- `schemas/ai-codebase-governance-report.schema.json`
+- `schemas/reasoning-policy.schema.json`
+- `schemas/reference-quality-packet.schema.json`
+- `schemas/reference-source-registry.schema.json`
+
+## Missing Capability Completion
+
+When a gate report shows blocked workers, missing profile bindings or capability
+coverage gaps, use:
+
+```bash
+python scripts/factory_self_improvement.py missing-capability-plan \
+  --gate-report .tmp/gate-report.json \
+  --out .tmp/missing-capability-plan.json
+```
+
+The output is a candidate plan. It can propose worker/profile/schema/binding
+artifacts, but material execution remains blocked until validation, independent
+review and any required human gate pass.
+
+Sensitive domains such as production, credentials, secrets, funds, custody,
+mainnet, legal/regulatory, privacy or hardware must not auto-activate.
+
+## Execution Learnback
+
+After material execution, write an `execution_learnback_record` and generate
+issue candidates:
+
+```bash
+python scripts/factory_self_improvement.py learnback-issues \
+  --record .tmp/execution-learnback-record.json \
+  --out .tmp/factory-improvement-issue-candidates.json
+```
+
+Public issue candidates must be generalized and redacted. Raw private logs,
+local paths, private board ids, Discord ids and screenshots do not belong in
+public issue bodies.
+
+## Owner Issue Intake
+
+An operator-owned factory instance may review selected GitHub issues and convert
+them into blocked factory work:
+
+```bash
+python scripts/factory_self_improvement.py issue-intake \
+  --config templates/owner-issue-intake-config.json \
+  --issues .tmp/issues.json \
+  --out .tmp/owner-issue-intake-report.json
+```
+
+This is off by default for external users. The public project supports the
+contract, but each owner instance decides which repos, labels and milestones it
+trusts.
+
+Critical factory changes still require human gate before implementation.
+
+Accepted intake rows include an `owner_issue_factory_card_candidate`. This is
+not an executed card. It is a bounded draft with source issue, risk, required
+gates, done definition and activation policy so the owner instance can hand it
+to the factory without losing auditability.
+
+## Reasoning Policy
+
+`reasoning_policy` makes the reasoning depth, profile class, review intensity
+and durable evidence policy explicit on vFinal cards. It controls what a worker
+must be able to do; it must not store or publish raw chain-of-thought.
+
+If the active worker route cannot satisfy the policy, the card should block
+instead of silently falling back to a weaker profile.
+
+## Reference Quality Packet
+
+For vFinal product-facing work, `reference_quality_packet` is a sub-contract of
+Product Experience OS/Product Face. It establishes the quality bar before
+generation. It does not approve UI and it is not a separate UX operating system.
+
+References are benchmarks or inspiration unless a license is recorded for code
+or asset reuse. Product Face remains the proof layer after implementation.
+
+## Governance Audit
+
+Use:
+
+```bash
+python scripts/factory_self_improvement.py governance-audit \
+  --out .tmp/ai-codebase-governance-report.json
+```
+
+The report is a public-safe maintainer artifact for architecture risk, generated
+artifact policy and mandatory validation checks.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,3 +58,18 @@ traceable worker result.
 Scripts outside `factoryctl` are maintainer tools or compatibility entrypoints.
 Promote repeated operator flows into `factoryctl` instead of adding another
 script name to the public path.
+
+### `scripts/factory_self_improvement.py`
+
+Creates dry-run self-improvement artifacts for maintainers:
+
+```bash
+python scripts/factory_self_improvement.py reference-registry --out .tmp/reference-source-registry.json
+python scripts/factory_self_improvement.py missing-capability-plan --gate-report .tmp/gate-report.json --out .tmp/missing-capability-plan.json
+python scripts/factory_self_improvement.py learnback-issues --record .tmp/execution-learnback-record.json --out .tmp/issue-candidates.json
+python scripts/factory_self_improvement.py issue-intake --config templates/owner-issue-intake-config.json --issues .tmp/issues.json --out .tmp/issue-intake-report.json
+python scripts/factory_self_improvement.py governance-audit --out .tmp/ai-codebase-governance-report.json
+```
+
+These commands do not dispatch Hermes, activate workers, post GitHub comments or
+approve gates. They prepare public-safe plans and candidates for review.

--- a/schemas/ai-codebase-governance-report.schema.json
+++ b/schemas/ai-codebase-governance-report.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/ai-codebase-governance-report.schema.json",
+  "title": "Overkill Factory AI Codebase Governance Report",
+  "type": "object",
+  "required": ["record_type", "architecture_map", "risks", "recommendations", "mandatory_checks"],
+  "properties": {
+    "record_type": { "const": "ai_codebase_governance_report" },
+    "architecture_map": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "risks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["severity", "area", "risk", "recommended_issue"],
+        "properties": {
+          "severity": { "enum": ["low", "medium", "high", "critical"] },
+          "area": { "type": "string", "minLength": 2 },
+          "risk": { "type": "string", "minLength": 3 },
+          "recommended_issue": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "recommendations": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "mandatory_checks": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "generated_artifact_policy": { "type": "array", "items": { "type": "string" } },
+    "ownership_map": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/execution-learnback-record.schema.json
+++ b/schemas/execution-learnback-record.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/execution-learnback-record.schema.json",
+  "title": "Overkill Factory Execution Learnback Record",
+  "type": "object",
+  "required": ["record_type", "project_ref", "method_version", "findings", "public_safety_boundary"],
+  "properties": {
+    "record_type": { "const": "execution_learnback_record" },
+    "project_ref": { "type": "string", "minLength": 3 },
+    "method_version": { "type": "string", "minLength": 3 },
+    "attempted_transitions": { "type": "array", "items": { "type": "string" } },
+    "workers_required": { "type": "array", "items": { "type": "string" } },
+    "workers_executed": { "type": "array", "items": { "type": "string" } },
+    "blockers": { "type": "array", "items": { "type": "string" } },
+    "operator_friction": { "type": "array", "items": { "type": "string" } },
+    "test_scan_results": { "type": "array", "items": { "type": "string" } },
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["summary", "severity", "area", "recommended_route"],
+        "properties": {
+          "summary": { "type": "string", "minLength": 3 },
+          "severity": { "enum": ["low", "medium", "high", "critical"] },
+          "area": { "type": "string", "minLength": 2 },
+          "recommended_route": {
+            "enum": ["no_issue", "private_followup", "public_issue", "critical_change_proposal", "docs_update", "eval_or_test"]
+          },
+          "reproduction_condition": { "type": "string" },
+          "acceptance_hint": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "public_safety_boundary": {
+      "type": "object",
+      "required": ["raw_private_evidence_forbidden", "public_issue_requires_redaction"],
+      "properties": {
+        "raw_private_evidence_forbidden": { "type": "boolean" },
+        "public_issue_requires_redaction": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -78,6 +78,8 @@
     "onchain_work_package": { "type": "object" },
     "security_scan_packet": { "type": "object" },
     "human_gate_packet": { "type": "object" },
+    "reasoning_policy": { "$ref": "reasoning-policy.schema.json" },
+    "reference_quality_packet": { "$ref": "reference-quality-packet.schema.json" },
     "r4_gate": { "type": "object" },
     "outcome_contract": { "type": "object" },
     "discovery_brief": { "type": "object" },

--- a/schemas/factory-improvement-issue-candidate.schema.json
+++ b/schemas/factory-improvement-issue-candidate.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-improvement-issue-candidate.schema.json",
+  "title": "Overkill Factory Improvement Issue Candidate",
+  "type": "object",
+  "required": ["record_type", "title", "body", "route", "severity", "area", "public_safe"],
+  "properties": {
+    "record_type": { "const": "factory_improvement_issue_candidate" },
+    "title": { "type": "string", "minLength": 3 },
+    "body": { "type": "string", "minLength": 3 },
+    "route": { "enum": ["public_issue", "private_followup", "critical_change_proposal", "docs_update", "eval_or_test"] },
+    "severity": { "enum": ["low", "medium", "high", "critical"] },
+    "area": { "type": "string", "minLength": 2 },
+    "public_safe": { "type": "boolean" },
+    "requires_human_gate": { "type": "boolean" },
+    "dedupe_key": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/missing-capability-completion-plan.schema.json
+++ b/schemas/missing-capability-completion-plan.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/missing-capability-completion-plan.schema.json",
+  "title": "Overkill Factory Missing Capability Completion Plan",
+  "type": "object",
+  "required": [
+    "record_type",
+    "status",
+    "detected_gaps",
+    "candidate_artifacts",
+    "quality_gates",
+    "activation_policy",
+    "human_gate_required"
+  ],
+  "properties": {
+    "record_type": { "const": "missing_capability_completion_plan" },
+    "status": { "enum": ["candidate", "blocked_needs_human_gate", "validated_ready_for_activation", "rejected"] },
+    "detected_gaps": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "candidate_artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["artifact_type", "status", "purpose", "validation_gate"],
+        "properties": {
+          "artifact_type": { "type": "string", "minLength": 3 },
+          "status": { "enum": ["sandbox_only", "inactive_candidate", "active"] },
+          "purpose": { "type": "string", "minLength": 10 },
+          "validation_gate": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "quality_gates": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "activation_policy": {
+      "type": "object",
+      "required": ["default_state", "auto_activation_allowed", "sensitive_domains_require_human_gate"],
+      "properties": {
+        "default_state": { "enum": ["sandbox_only", "inactive_candidate", "active"] },
+        "auto_activation_allowed": { "type": "boolean" },
+        "sensitive_domains_require_human_gate": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "human_gate_required": { "type": "boolean" },
+    "next_actions": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": true
+}

--- a/schemas/owner-issue-intake-config.schema.json
+++ b/schemas/owner-issue-intake-config.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/owner-issue-intake-config.schema.json",
+  "title": "Overkill Factory Owner Issue Intake Config",
+  "type": "object",
+  "required": ["record_type", "mode", "sources", "filters", "default_card_status"],
+  "properties": {
+    "record_type": { "const": "owner_issue_intake_config" },
+    "mode": { "enum": ["dry_run", "blocked_card_creation"] },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["repo", "labels"],
+        "properties": {
+          "repo": { "type": "string", "minLength": 3 },
+          "labels": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": true
+      }
+    },
+    "filters": {
+      "type": "object",
+      "properties": {
+        "include_labels": { "type": "array", "items": { "type": "string" } },
+        "exclude_labels": { "type": "array", "items": { "type": "string" } },
+        "critical_change_terms": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "default_card_status": { "enum": ["blocked", "planning"] },
+    "public_comment_policy": { "enum": ["never", "dry_run_only", "after_human_gate"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/owner-issue-intake-report.schema.json
+++ b/schemas/owner-issue-intake-report.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/owner-issue-intake-report.schema.json",
+  "title": "Overkill Factory Owner Issue Intake Report",
+  "type": "object",
+  "required": ["record_type", "mode", "issues_reviewed", "decisions"],
+  "properties": {
+    "record_type": { "const": "owner_issue_intake_report" },
+    "mode": { "enum": ["dry_run", "blocked_card_creation"] },
+    "issues_reviewed": { "type": "integer", "minimum": 0 },
+    "decisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["issue_ref", "decision", "reason"],
+        "properties": {
+          "issue_ref": { "type": "string", "minLength": 1 },
+          "decision": {
+            "enum": ["ignore", "needs_human_triage", "documentation_only", "implementation_candidate", "critical_factory_change", "private_operator_only"]
+          },
+          "reason": { "type": "string", "minLength": 3 },
+          "card_status": { "enum": ["blocked", "planning", "not_created"] },
+          "dedupe_key": { "type": "string", "minLength": 1 },
+          "factory_card_candidate": {
+            "type": "object",
+            "required": [
+              "record_type",
+              "source_issue_ref",
+              "title",
+              "status",
+              "factory_method_version",
+              "risk_initial",
+              "risk_effective",
+              "required_gates",
+              "done_definition",
+              "activation_policy"
+            ],
+            "properties": {
+              "record_type": { "const": "owner_issue_factory_card_candidate" },
+              "source_issue_ref": { "type": "string", "minLength": 1 },
+              "title": { "type": "string", "minLength": 1 },
+              "status": { "enum": ["blocked", "planning"] },
+              "factory_method_version": { "const": "OVERKILL_VFINAL" },
+              "risk_initial": { "type": "string", "minLength": 2 },
+              "risk_effective": { "type": "string", "minLength": 2 },
+              "required_gates": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+              "done_definition": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+              "activation_policy": {
+                "type": "object",
+                "required": ["auto_dispatch_allowed", "human_gate_required", "public_comment_allowed"],
+                "properties": {
+                  "auto_dispatch_allowed": { "type": "boolean" },
+                  "human_gate_required": { "type": "boolean" },
+                  "public_comment_allowed": { "type": "boolean" }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/reasoning-policy.schema.json
+++ b/schemas/reasoning-policy.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/reasoning-policy.schema.json",
+  "title": "Overkill Factory Task Reasoning Policy",
+  "type": "object",
+  "required": [
+    "record_type",
+    "reasoning_class",
+    "allowed_profile_classes",
+    "review_intensity",
+    "evidence_policy",
+    "private_reasoning_policy",
+    "block_when"
+  ],
+  "properties": {
+    "record_type": { "const": "reasoning_policy" },
+    "reasoning_class": { "enum": ["light", "standard", "deep", "adversarial", "human_decision"] },
+    "allowed_profile_classes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 2 }
+    },
+    "review_intensity": { "enum": ["none", "self_check", "independent_review", "specialist_matrix", "human_gate"] },
+    "evidence_policy": {
+      "type": "object",
+      "required": ["durable_summary_required", "raw_chain_of_thought_forbidden", "evidence_refs_required"],
+      "properties": {
+        "durable_summary_required": { "type": "boolean" },
+        "raw_chain_of_thought_forbidden": { "type": "boolean" },
+        "evidence_refs_required": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "private_reasoning_policy": {
+      "enum": ["never_store_raw", "summarize_only", "tool_internal_only"]
+    },
+    "block_when": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "derived_from": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": true
+}

--- a/schemas/reference-quality-packet.schema.json
+++ b/schemas/reference-quality-packet.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/reference-quality-packet.schema.json",
+  "title": "Overkill Factory Reference Quality Packet",
+  "type": "object",
+  "required": [
+    "record_type",
+    "experience_category",
+    "quality_bar",
+    "anti_generic_criteria",
+    "references",
+    "design_rationale",
+    "reuse_policy",
+    "accessibility_constraints",
+    "performance_constraints",
+    "acceptance_criteria"
+  ],
+  "properties": {
+    "record_type": { "const": "reference_quality_packet" },
+    "experience_category": { "type": "string", "minLength": 3 },
+    "quality_bar": { "type": "string", "minLength": 3 },
+    "anti_generic_criteria": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "references": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source_id", "source_url_or_ref", "use_type", "what_to_learn", "copy_policy"],
+        "properties": {
+          "source_id": { "type": "string", "minLength": 2 },
+          "source_url_or_ref": { "type": "string", "minLength": 3 },
+          "use_type": {
+            "enum": ["inspiration", "benchmark", "licensed_component", "prompt_reference", "style_reference"]
+          },
+          "what_to_learn": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "copy_policy": {
+            "enum": ["do_not_copy", "copy_only_with_license_recorded", "internal_reference_only"]
+          },
+          "license_or_terms_ref": { "type": "string" },
+          "public_safety_notes": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "design_rationale": { "type": "string", "minLength": 3 },
+    "component_expectations": { "type": "array", "items": { "type": "string" } },
+    "interaction_expectations": { "type": "array", "items": { "type": "string" } },
+    "visual_constraints": { "type": "array", "items": { "type": "string" } },
+    "reuse_policy": {
+      "type": "object",
+      "required": ["allowed", "forbidden", "license_required_for_code_or_assets"],
+      "properties": {
+        "allowed": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "forbidden": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "license_required_for_code_or_assets": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "accessibility_constraints": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "performance_constraints": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "acceptance_criteria": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "product_experience_fields_informed": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/reference-source-registry.schema.json
+++ b/schemas/reference-source-registry.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/reference-source-registry.schema.json",
+  "title": "Overkill Factory Reference Source Registry",
+  "type": "object",
+  "required": ["record_type", "sources"],
+  "properties": {
+    "record_type": { "const": "reference_source_registry" },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source_id", "name", "url", "allowed_use", "forbidden_use", "license_terms_status", "public_safety_notes"],
+        "properties": {
+          "source_id": { "type": "string", "minLength": 2 },
+          "name": { "type": "string", "minLength": 2 },
+          "url": { "type": "string", "minLength": 3 },
+          "allowed_use": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "forbidden_use": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "license_terms_status": { "type": "string", "minLength": 3 },
+          "public_safety_notes": { "type": "string", "minLength": 3 },
+          "informs_product_experience_fields": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/factory_self_improvement.py
+++ b/scripts/factory_self_improvement.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Self-improvement helpers for Overkill Factory.
+
+The script stays public-safe: it turns blocked reports, learnback records and
+issue snapshots into structured plans. It does not dispatch workers, mutate
+Hermes, post GitHub comments or activate capabilities.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRIVATE_USERS_PATH = "C:" + r"[\\/]+" + "Users"
+PRIVATE_SYNC_ROOT = "One" + "Drive"
+PRIVATE_PRODUCT_MARKER = "KA" + "XIS"
+PRIVATE_CHAT_MARKER = "Dis" + "cord"
+PRIVATE_MARKERS = re.compile(
+    PRIVATE_USERS_PATH
+    + r"|"
+    + PRIVATE_SYNC_ROOT
+    + r"|"
+    + PRIVATE_PRODUCT_MARKER
+    + r"|"
+    + PRIVATE_CHAT_MARKER
+    + r"|guild_ref|channel_ref|thread_id|message_id",
+    re.IGNORECASE,
+)
+CRITICAL_TERMS = {
+    "registry",
+    "binding",
+    "adapter",
+    "authority",
+    "release",
+    "security",
+    "methodology",
+    "production",
+    "credential",
+    "secret",
+    "billing",
+}
+SENSITIVE_TERMS = CRITICAL_TERMS | {"funds", "custody", "signing", "mainnet", "legal", "regulated", "privacy", "hardware"}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path | None, data: Any) -> None:
+    text = json.dumps(data, indent=2, ensure_ascii=True) + "\n"
+    if path is None:
+        print(text, end="")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    print(f"Wrote {path}")
+
+
+def clean_public_text(value: Any) -> str:
+    text = str(value or "").strip()
+    return PRIVATE_MARKERS.sub("[redacted]", text)
+
+
+def slug(value: str) -> str:
+    lowered = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return lowered[:80] or "factory-improvement"
+
+
+def contains_any(text: str, terms: set[str]) -> bool:
+    normalized = text.lower()
+    return any(term in normalized for term in terms)
+
+
+def default_reference_source_registry() -> dict[str, Any]:
+    return load_json(ROOT / "templates" / "reference-source-registry.json")
+
+
+def build_missing_capability_plan(gate_report: dict[str, Any]) -> dict[str, Any]:
+    blocked_workers = [str(worker) for worker in gate_report.get("blocked_workers", [])]
+    validation_errors = [str(error) for error in gate_report.get("card_validation_errors", [])]
+    worker_rows = gate_report.get("workers") if isinstance(gate_report.get("workers"), dict) else {}
+    detected: list[str] = []
+    for worker_id in blocked_workers:
+        row = worker_rows.get(worker_id) if isinstance(worker_rows.get(worker_id), dict) else {}
+        status = str(row.get("status") or "blocked")
+        reason = str(row.get("reason") or "missing worker capability")
+        detected.append(f"{worker_id}: {status}; {reason}")
+    detected.extend(validation_errors)
+    if not detected:
+        detected.append("No blocked worker was found; inspect capability coverage before activation.")
+    combined = " ".join(detected)
+    human_gate_required = contains_any(combined, SENSITIVE_TERMS)
+    candidate_artifacts = [
+        {
+            "artifact_type": "worker_registry_entry",
+            "status": "inactive_candidate",
+            "purpose": "Declare the missing capability without enabling dispatch.",
+            "validation_gate": "validate public JSON artifacts",
+        },
+        {
+            "artifact_type": "worker_profile",
+            "status": "inactive_candidate",
+            "purpose": "Define inputs, outputs, authority and forbidden actions for the capability.",
+            "validation_gate": "validate worker profiles and focused tests",
+        },
+        {
+            "artifact_type": "runtime_binding",
+            "status": "inactive_candidate",
+            "purpose": "Bind the profile to the runtime only after review accepts the capability.",
+            "validation_gate": "route readiness expectation and independent review",
+        },
+        {
+            "artifact_type": "result_schema",
+            "status": "inactive_candidate",
+            "purpose": "Make the capability output machine-checkable before execution.",
+            "validation_gate": "schema validation and eval fixture",
+        },
+        {
+            "artifact_type": "smoke_eval_fixture",
+            "status": "inactive_candidate",
+            "purpose": "Prove the capability can fail closed and produce usable evidence.",
+            "validation_gate": "focused unit test or disposable runtime smoke",
+        },
+    ]
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/missing-capability-completion-plan.schema.json",
+        "record_type": "missing_capability_completion_plan",
+        "created_at": utc_now(),
+        "source_gate_report": gate_report.get("card_id") or "external:gate-report",
+        "status": "blocked_needs_human_gate" if human_gate_required else "candidate",
+        "detected_gaps": detected,
+        "candidate_artifacts": candidate_artifacts,
+        "quality_gates": [
+            "validate public JSON artifacts",
+            "validate worker profiles",
+            "run focused unit tests",
+            "independent review before activation",
+        ],
+        "activation_policy": {
+            "default_state": "inactive_candidate",
+            "auto_activation_allowed": not human_gate_required,
+            "sensitive_domains_require_human_gate": True,
+        },
+        "human_gate_required": human_gate_required,
+        "next_actions": [
+            "generate candidate artifacts in sandbox state",
+            "run validation and eval fixtures",
+            "route independent review",
+        ],
+    }
+
+
+def build_issue_candidate(finding: dict[str, Any]) -> dict[str, Any] | None:
+    route = str(finding.get("recommended_route") or "").strip()
+    if route in {"no_issue", ""}:
+        return None
+    summary = clean_public_text(finding.get("summary"))
+    area = clean_public_text(finding.get("area") or "factory")
+    severity = str(finding.get("severity") or "medium").lower()
+    if severity not in {"low", "medium", "high", "critical"}:
+        severity = "medium"
+    public_safe = route in {"public_issue", "docs_update", "eval_or_test"} and not PRIVATE_MARKERS.search(summary)
+    requires_human_gate = route == "critical_change_proposal" or contains_any(summary + " " + area, CRITICAL_TERMS)
+    title = summary if summary.lower().startswith("factory") else f"Factory improvement: {summary}"
+    body = "\n".join(
+        [
+            "## Problem",
+            summary,
+            "",
+            "## Reproduction condition",
+            clean_public_text(finding.get("reproduction_condition") or "Captured by execution learnback."),
+            "",
+            "## Acceptance criteria",
+            clean_public_text(finding.get("acceptance_hint") or "Add a public-safe fix with validation coverage."),
+        ]
+    )
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-improvement-issue-candidate.schema.json",
+        "record_type": "factory_improvement_issue_candidate",
+        "title": title,
+        "body": body,
+        "route": route if route != "public_issue" else "public_issue",
+        "severity": severity,
+        "area": area,
+        "public_safe": public_safe,
+        "requires_human_gate": requires_human_gate,
+        "dedupe_key": slug(f"{area}-{summary}"),
+    }
+
+
+def build_issue_candidates(learnback: dict[str, Any]) -> dict[str, Any]:
+    candidates = []
+    for finding in learnback.get("findings", []):
+        if isinstance(finding, dict):
+            candidate = build_issue_candidate(finding)
+            if candidate:
+                candidates.append(candidate)
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-improvement-issue-candidate.schema.json",
+        "record_type": "factory_improvement_issue_candidate_list",
+        "created_at": utc_now(),
+        "source_project_ref": clean_public_text(learnback.get("project_ref")),
+        "candidates": candidates,
+        "issue_count": len(candidates),
+    }
+
+
+def issue_labels(issue: dict[str, Any]) -> set[str]:
+    raw = issue.get("labels", [])
+    labels: set[str] = set()
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, dict):
+                name = item.get("name")
+            else:
+                name = item
+            if str(name or "").strip():
+                labels.add(str(name).strip())
+    return labels
+
+
+def build_factory_card_candidate(
+    issue_ref: str,
+    title: str,
+    body: str,
+    decision: str,
+    labels: set[str],
+    default_status: str,
+) -> dict[str, Any]:
+    critical = decision == "critical_factory_change"
+    documentation = decision == "documentation_only"
+    risk = "R3" if critical else "R1" if documentation else "R2"
+    required_gates = [
+        "public safety scan",
+        "secret safety scan",
+        "focused tests",
+        "independent review",
+    ]
+    if critical:
+        required_gates.append("explicit human approval before mutation")
+    return {
+        "record_type": "owner_issue_factory_card_candidate",
+        "source_issue_ref": issue_ref,
+        "title": title,
+        "summary": body[:600],
+        "status": default_status,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "phase": "planning",
+        "surfaces": sorted(labels) or ["factory"],
+        "risk_initial": risk,
+        "risk_effective": risk,
+        "owner_worker": "factory-mechanic-loop",
+        "executor_identity": "unassigned",
+        "reviewer_identity": "independent-review-required",
+        "required_gates": required_gates,
+        "done_definition": [
+            "issue scope is converted into a bounded factory card",
+            "implementation changes are validated by tests and required scans",
+            "Receipt Five evidence records commands, artifacts and residual risk",
+        ],
+        "source_refs": [issue_ref],
+        "activation_policy": {
+            "auto_dispatch_allowed": False,
+            "human_gate_required": critical,
+            "public_comment_allowed": False,
+        },
+    }
+
+
+def build_issue_intake_report(config: dict[str, Any], issues: list[dict[str, Any]]) -> dict[str, Any]:
+    filters = config.get("filters") if isinstance(config.get("filters"), dict) else {}
+    include = {str(label).strip() for label in filters.get("include_labels", []) if str(label).strip()}
+    exclude = {str(label).strip() for label in filters.get("exclude_labels", []) if str(label).strip()}
+    critical_terms = {str(term).strip().lower() for term in filters.get("critical_change_terms", []) if str(term).strip()} or CRITICAL_TERMS
+    decisions: list[dict[str, Any]] = []
+    for issue in issues:
+        labels = issue_labels(issue)
+        title = clean_public_text(issue.get("title"))
+        body = clean_public_text(issue.get("body"))
+        issue_ref = str(issue.get("url") or issue.get("html_url") or issue.get("number") or title)
+        if exclude & labels:
+            decision, reason = "ignore", "excluded label present"
+        elif include and not (include & labels):
+            decision, reason = "needs_human_triage", "no configured intake label matched"
+        elif contains_any(title + " " + body, critical_terms):
+            decision, reason = "critical_factory_change", "critical factory-change term matched"
+        elif "doc" in (title + " " + " ".join(labels)).lower():
+            decision, reason = "documentation_only", "documentation-oriented issue"
+        else:
+            decision, reason = "implementation_candidate", "matches owner-instance intake filters"
+        card_status = "not_created" if decision == "ignore" else config.get("default_card_status", "blocked")
+        row = {
+            "issue_ref": issue_ref,
+            "decision": decision,
+            "reason": reason,
+            "card_status": card_status,
+            "dedupe_key": slug(f"{issue_ref}-{title}"),
+        }
+        if decision != "ignore":
+            row["factory_card_candidate"] = build_factory_card_candidate(
+                issue_ref,
+                title,
+                body,
+                decision,
+                labels,
+                card_status,
+            )
+        decisions.append(row)
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/owner-issue-intake-report.schema.json",
+        "record_type": "owner_issue_intake_report",
+        "created_at": utc_now(),
+        "mode": config.get("mode", "dry_run"),
+        "issues_reviewed": len(issues),
+        "decisions": decisions,
+        "public_comment_policy": config.get("public_comment_policy", "after_human_gate"),
+    }
+
+
+def governance_report() -> dict[str, Any]:
+    scripts = sorted((ROOT / "scripts").glob("*.py"))
+    schemas = sorted((ROOT / "schemas").glob("*.schema.json"))
+    tests = sorted((ROOT / "tests").glob("test_*.py"))
+    factoryctl_lines = (ROOT / "scripts" / "factoryctl.py").read_text(encoding="utf-8").count("\n") + 1
+    risks = [
+        {
+            "severity": "high" if factoryctl_lines > 2500 else "medium",
+            "area": "runtime",
+            "risk": "factoryctl.py concentrates many public contracts and can become hard to evolve safely.",
+            "recommended_issue": "Split stable contract validation from command orchestration after self-improvement contracts land.",
+        },
+        {
+            "severity": "high",
+            "area": "agent-contracts",
+            "risk": "AI worker behavior can drift unless schemas, templates, docs and tests stay synchronized.",
+            "recommended_issue": "Add contract synchronization checks for worker-facing schemas/templates/docs.",
+        },
+        {
+            "severity": "medium",
+            "area": "evidence",
+            "risk": "Generated evidence can pollute the public repo when private run artifacts are not separated.",
+            "recommended_issue": "Keep generated run evidence in private stores or .tmp and scan public artifacts before release.",
+        },
+    ]
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/ai-codebase-governance-report.schema.json",
+        "record_type": "ai_codebase_governance_report",
+        "created_at": utc_now(),
+        "architecture_map": [
+            f"{len(schemas)} schemas define public contracts",
+            f"{len(scripts)} scripts implement public tooling and probes",
+            f"{len(tests)} test modules protect contract behavior",
+            "agents/*.public.json define worker registry, profiles and Hermes bindings",
+            "Product Experience OS and Product Face define visible product planning/proof",
+        ],
+        "risks": risks,
+        "recommendations": [
+            "Prefer schema-backed contracts over prose-only AI instructions.",
+            "Keep generated evidence out of the public repo unless it has public-safe purpose and validation.",
+            "Add focused tests whenever a worker authority, gate or schema changes.",
+            "Treat public docs as external operator product surface.",
+        ],
+        "mandatory_checks": [
+            "python -m unittest discover -s tests -p \"test_*.py\" -q",
+            "python scripts/validate_public_json_artifacts.py",
+            "python scripts/public_safety_scan.py",
+            "python scripts/secret_safety_scan.py",
+            "python scripts/supply_chain_proof.py --check --no-write",
+        ],
+        "generated_artifact_policy": [
+            "worker packets and reports are generated under .tmp or private evidence stores by default",
+            "public examples must be minimal, current and validated",
+            "raw private execution logs are never public issue bodies",
+        ],
+        "ownership_map": {
+            "schemas": "contract owners",
+            "agents": "worker authority and routing owners",
+            "adapters": "runtime integration owners",
+            "docs": "external operator product surface",
+            "tests": "regression and gate evidence",
+        },
+    }
+
+
+def command_reference_registry(args: argparse.Namespace) -> int:
+    write_json(args.out, default_reference_source_registry())
+    return 0
+
+
+def command_missing_capability_plan(args: argparse.Namespace) -> int:
+    write_json(args.out, build_missing_capability_plan(load_json(args.gate_report)))
+    return 0
+
+
+def command_learnback_issues(args: argparse.Namespace) -> int:
+    write_json(args.out, build_issue_candidates(load_json(args.record)))
+    return 0
+
+
+def command_issue_intake(args: argparse.Namespace) -> int:
+    issues = load_json(args.issues)
+    if not isinstance(issues, list):
+        raise SystemExit("issues input must be a JSON array")
+    write_json(args.out, build_issue_intake_report(load_json(args.config), issues))
+    return 0
+
+
+def command_governance_audit(args: argparse.Namespace) -> int:
+    write_json(args.out, governance_report())
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Overkill Factory self-improvement helpers")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    ref = sub.add_parser("reference-registry", help="Write the default reference source registry")
+    ref.add_argument("--out", type=Path)
+    ref.set_defaults(func=command_reference_registry)
+
+    missing = sub.add_parser("missing-capability-plan", help="Build a completion plan from a gate report")
+    missing.add_argument("--gate-report", type=Path, required=True)
+    missing.add_argument("--out", type=Path)
+    missing.set_defaults(func=command_missing_capability_plan)
+
+    learnback = sub.add_parser("learnback-issues", help="Turn a learnback record into issue candidates")
+    learnback.add_argument("--record", type=Path, required=True)
+    learnback.add_argument("--out", type=Path)
+    learnback.set_defaults(func=command_learnback_issues)
+
+    intake = sub.add_parser("issue-intake", help="Dry-run owner-instance issue intake")
+    intake.add_argument("--config", type=Path, required=True)
+    intake.add_argument("--issues", type=Path, required=True)
+    intake.add_argument("--out", type=Path)
+    intake.set_defaults(func=command_issue_intake)
+
+    governance = sub.add_parser("governance-audit", help="Write a public-safe codebase governance report")
+    governance.add_argument("--out", type=Path)
+    governance.set_defaults(func=command_governance_audit)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -212,6 +212,29 @@ PRODUCT_FACE_PACKET_REQUIRED_FIELDS = (
     "done_definition",
     "human_gate",
 )
+REFERENCE_QUALITY_REQUIRED_FIELDS = (
+    "record_type",
+    "experience_category",
+    "quality_bar",
+    "anti_generic_criteria",
+    "references",
+    "design_rationale",
+    "reuse_policy",
+    "accessibility_constraints",
+    "performance_constraints",
+    "acceptance_criteria",
+)
+REASONING_POLICY_REQUIRED_FIELDS = (
+    "record_type",
+    "reasoning_class",
+    "allowed_profile_classes",
+    "review_intensity",
+    "evidence_policy",
+    "private_reasoning_policy",
+    "block_when",
+)
+REASONING_CLASSES = {"light", "standard", "deep", "adversarial", "human_decision"}
+REASONING_REVIEW_INTENSITIES = {"none", "self_check", "independent_review", "specialist_matrix", "human_gate"}
 PRODUCT_FACE_RESULT_ALIGNMENT_FIELDS = (
     "packet_comparison",
     "source_promise_coverage",
@@ -1184,6 +1207,81 @@ def validate_product_experience_plan(plan: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_reference_quality_packet(packet: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in REFERENCE_QUALITY_REQUIRED_FIELDS:
+        value = packet.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"reference_quality_packet.{field} must be a non-empty array")
+        elif isinstance(value, dict):
+            if not value:
+                errors.append(f"reference_quality_packet.{field} must be a non-empty object")
+        elif not _non_empty_text(value):
+            errors.append(f"reference_quality_packet.{field} is required")
+
+    if packet.get("record_type") not in (None, "reference_quality_packet"):
+        errors.append("reference_quality_packet.record_type must be reference_quality_packet")
+
+    for idx, ref in enumerate(packet.get("references", []) if isinstance(packet.get("references"), list) else []):
+        if not isinstance(ref, dict):
+            errors.append(f"reference_quality_packet.references[{idx}] must be an object")
+            continue
+        for field in ("source_id", "source_url_or_ref", "use_type", "what_to_learn", "copy_policy"):
+            value = ref.get(field)
+            if isinstance(value, list):
+                if not _list_items(value):
+                    errors.append(f"reference_quality_packet.references[{idx}].{field} must be a non-empty array")
+            elif not _non_empty_text(value):
+                errors.append(f"reference_quality_packet.references[{idx}].{field} is required")
+        if ref.get("copy_policy") == "copy_only_with_license_recorded" and not _non_empty_text(ref.get("license_or_terms_ref")):
+            errors.append(f"reference_quality_packet.references[{idx}].license_or_terms_ref is required for copied code/assets")
+        if str(ref.get("copy_policy") or "").strip().lower() in {"copy", "blind_copy"}:
+            errors.append(f"reference_quality_packet.references[{idx}].copy_policy must not allow blind copying")
+
+    reuse = packet.get("reuse_policy") if isinstance(packet.get("reuse_policy"), dict) else {}
+    forbidden = " ".join(_list_items(reuse.get("forbidden"))).lower()
+    if "blind copy" not in forbidden and "unlicensed" not in forbidden:
+        errors.append("reference_quality_packet.reuse_policy.forbidden must ban blind copy or unlicensed reuse")
+    if reuse and reuse.get("license_required_for_code_or_assets") is not True:
+        errors.append("reference_quality_packet.reuse_policy.license_required_for_code_or_assets must be true")
+    return errors
+
+
+def validate_reasoning_policy(policy: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in REASONING_POLICY_REQUIRED_FIELDS:
+        value = policy.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"reasoning_policy.{field} must be a non-empty array")
+        elif isinstance(value, dict):
+            if not value:
+                errors.append(f"reasoning_policy.{field} must be a non-empty object")
+        elif not _non_empty_text(value):
+            errors.append(f"reasoning_policy.{field} is required")
+
+    if policy.get("record_type") not in (None, "reasoning_policy"):
+        errors.append("reasoning_policy.record_type must be reasoning_policy")
+    reasoning_class = str(policy.get("reasoning_class") or "").strip()
+    if reasoning_class and reasoning_class not in REASONING_CLASSES:
+        errors.append("reasoning_policy.reasoning_class must be one of " + ", ".join(sorted(REASONING_CLASSES)))
+    review_intensity = str(policy.get("review_intensity") or "").strip()
+    if review_intensity and review_intensity not in REASONING_REVIEW_INTENSITIES:
+        errors.append("reasoning_policy.review_intensity must be one of " + ", ".join(sorted(REASONING_REVIEW_INTENSITIES)))
+    evidence = policy.get("evidence_policy") if isinstance(policy.get("evidence_policy"), dict) else {}
+    if evidence:
+        if evidence.get("raw_chain_of_thought_forbidden") is not True:
+            errors.append("reasoning_policy.evidence_policy.raw_chain_of_thought_forbidden must be true")
+        if reasoning_class in {"deep", "adversarial", "human_decision"} and evidence.get("durable_summary_required") is not True:
+            errors.append("reasoning_policy.evidence_policy.durable_summary_required must be true for high reasoning classes")
+        if reasoning_class in {"deep", "adversarial", "human_decision"} and evidence.get("evidence_refs_required") is not True:
+            errors.append("reasoning_policy.evidence_policy.evidence_refs_required must be true for high reasoning classes")
+    if policy.get("private_reasoning_policy") not in (None, "never_store_raw", "summarize_only", "tool_internal_only"):
+        errors.append("reasoning_policy.private_reasoning_policy must be never_store_raw, summarize_only or tool_internal_only")
+    return errors
+
+
 def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
     if data.get("factory_method_version") != "OVERKILL_VFINAL":
         return []
@@ -1251,6 +1349,11 @@ def validate_card(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_vfinal_card_contract(data))
     errors.extend(validate_canonical_runtime_gate(data))
     errors.extend(validate_capability_coverage(data))
+    if data.get("factory_method_version") == "OVERKILL_VFINAL":
+        if not isinstance(data.get("reasoning_policy"), dict):
+            errors.append("reasoning_policy required for OVERKILL_VFINAL cards")
+        else:
+            errors.extend(validate_reasoning_policy(data["reasoning_policy"]))
     if data.get("executor_identity") == data.get("reviewer_identity"):
         errors.append("executor_identity and reviewer_identity must differ")
     product_facing = bool(surfaces & PRODUCT_FACE_SURFACES)
@@ -1269,6 +1372,14 @@ def validate_card(data: dict[str, Any]) -> list[str]:
                 review_human_gate = review.get("human_gate_required") is True
                 if not review_human_gate and not isinstance(data.get("human_gate_packet"), dict):
                     errors.append("product_experience_plan.human_gate.required=true requires review.human_gate_required=true or human_gate_packet")
+            reference_waiver = data["product_experience_plan"].get("reference_quality_waiver")
+            if not isinstance(data.get("reference_quality_packet"), dict):
+                if not isinstance(reference_waiver, dict):
+                    errors.append("reference_quality_packet required for vFinal product-facing surfaces")
+                elif not _non_empty_text(reference_waiver.get("owner")) or not _non_empty_text(reference_waiver.get("reason")):
+                    errors.append("product_experience_plan.reference_quality_waiver requires owner and reason")
+            else:
+                errors.extend(validate_reference_quality_packet(data["reference_quality_packet"]))
     phase = str(data.get("phase", "")).upper()
     if surfaces & PRODUCT_FACE_SURFACES and phase in {"F11", "F16", "F17"}:
         if not isinstance(data.get("product_face_result"), dict) and not str(data.get("product_face_result_ref") or "").strip():
@@ -1997,6 +2108,8 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "target_repo_paths": card.get("target_repo_paths", []),
             "authority_max": card.get("authority_max"),
             "forbidden_actions": card.get("forbidden_actions", []),
+            "reasoning_policy": card.get("reasoning_policy"),
+            "reference_quality_packet": card.get("reference_quality_packet"),
         },
         "runtime_decision": runtime_decision,
         "output_contract": {

--- a/templates/execution-learnback-record.json
+++ b/templates/execution-learnback-record.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/execution-learnback-record.schema.json",
+  "record_type": "execution_learnback_record",
+  "project_ref": "external:current-product",
+  "method_version": "OVERKILL_VFINAL",
+  "attempted_transitions": ["ready", "done"],
+  "workers_required": ["factory-orchestrator", "qa-verification-worker"],
+  "workers_executed": ["factory-orchestrator"],
+  "blockers": ["qa evidence missing before done"],
+  "operator_friction": ["operator had to manually convert run finding into issue"],
+  "test_scan_results": ["unit tests pass"],
+  "findings": [
+    {
+      "summary": "Done gate needs clearer missing-evidence guidance.",
+      "severity": "medium",
+      "area": "runtime",
+      "recommended_route": "public_issue",
+      "reproduction_condition": "done transition attempted before QA result exists",
+      "acceptance_hint": "unblock plan names the missing worker result"
+    }
+  ],
+  "public_safety_boundary": {
+    "raw_private_evidence_forbidden": true,
+    "public_issue_requires_redaction": true
+  }
+}

--- a/templates/owner-issue-intake-config.json
+++ b/templates/owner-issue-intake-config.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/owner-issue-intake-config.schema.json",
+  "record_type": "owner_issue_intake_config",
+  "mode": "dry_run",
+  "sources": [
+    {
+      "repo": "owner/overkill-factory",
+      "labels": ["factory-improvement"]
+    }
+  ],
+  "filters": {
+    "include_labels": ["factory-improvement"],
+    "exclude_labels": ["wontfix"],
+    "critical_change_terms": ["registry", "binding", "adapter", "authority", "release", "security", "methodology"]
+  },
+  "default_card_status": "blocked",
+  "public_comment_policy": "after_human_gate"
+}

--- a/templates/reasoning-policy.json
+++ b/templates/reasoning-policy.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/reasoning-policy.schema.json",
+  "record_type": "reasoning_policy",
+  "reasoning_class": "standard",
+  "allowed_profile_classes": ["bounded-worker", "review-capable-worker"],
+  "review_intensity": "independent_review",
+  "evidence_policy": {
+    "durable_summary_required": true,
+    "raw_chain_of_thought_forbidden": true,
+    "evidence_refs_required": true
+  },
+  "private_reasoning_policy": "summarize_only",
+  "block_when": [
+    "selected profile cannot satisfy reasoning class",
+    "required review intensity is unavailable",
+    "worker result lacks durable evidence"
+  ],
+  "derived_from": ["risk_effective", "phase", "surfaces", "authority_max"]
+}

--- a/templates/reference-quality-packet.json
+++ b/templates/reference-quality-packet.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/reference-quality-packet.schema.json",
+  "record_type": "reference_quality_packet",
+  "experience_category": "web product surface",
+  "quality_bar": "Specific, product-fit experience that avoids generic generated UI.",
+  "anti_generic_criteria": [
+    "The output must reflect the product job, not a generic landing-page template.",
+    "The design direction must name concrete density, tone and interaction expectations."
+  ],
+  "references": [
+    {
+      "source_id": "refero-styles",
+      "source_url_or_ref": "https://styles.refero.design/",
+      "use_type": "style_reference",
+      "what_to_learn": ["agent-readable style structure", "DESIGN.md pattern"],
+      "copy_policy": "do_not_copy",
+      "license_or_terms_ref": "operator must verify current terms before reuse",
+      "public_safety_notes": "Use as a benchmark reference, not as copied content."
+    }
+  ],
+  "design_rationale": "References establish the quality baseline before generation.",
+  "component_expectations": ["components must match the job-to-be-done"],
+  "interaction_expectations": ["states and transitions must be observable"],
+  "visual_constraints": ["avoid stock/generic composition"],
+  "reuse_policy": {
+    "allowed": ["benchmarking", "inspiration", "licensed component reuse with recorded license"],
+    "forbidden": ["blind copy", "unlicensed asset reuse", "private reference leakage"],
+    "license_required_for_code_or_assets": true
+  },
+  "accessibility_constraints": ["keyboard path", "labels", "contrast"],
+  "performance_constraints": ["no decorative motion that blocks the primary task"],
+  "acceptance_criteria": ["Product Face design-fit review passes"],
+  "product_experience_fields_informed": ["experience_sot", "design_direction", "proof_required"]
+}

--- a/templates/reference-source-registry.json
+++ b/templates/reference-source-registry.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/reference-source-registry.schema.json",
+  "record_type": "reference_source_registry",
+  "sources": [
+    {
+      "source_id": "motionsites",
+      "name": "MotionSites",
+      "url": "https://motionsites.ai/",
+      "allowed_use": ["animated hero inspiration", "motion prompt benchmark"],
+      "forbidden_use": ["copying protected assets", "treating prompts as product proof"],
+      "license_terms_status": "operator must verify current terms before reuse",
+      "public_safety_notes": "Use as reference only unless license is recorded.",
+      "informs_product_experience_fields": ["design_direction", "interaction_style"]
+    },
+    {
+      "source_id": "uiverse",
+      "name": "Uiverse",
+      "url": "https://uiverse.io/",
+      "allowed_use": ["component inspiration", "licensed component reuse when license is recorded"],
+      "forbidden_use": ["blind copy without attribution/license check"],
+      "license_terms_status": "site advertises open-source UI elements; verify current item/license before reuse",
+      "public_safety_notes": "Record source and license when code/assets are reused.",
+      "informs_product_experience_fields": ["component expectations", "interaction_style"]
+    },
+    {
+      "source_id": "21st-dev",
+      "name": "21st.dev",
+      "url": "https://21st.dev/",
+      "allowed_use": ["React/Tailwind component benchmark", "Shadcn-style block reference"],
+      "forbidden_use": ["unlicensed code reuse", "copying premium/private components"],
+      "license_terms_status": "operator must verify component-level terms before reuse",
+      "public_safety_notes": "Use as benchmark unless license metadata is attached.",
+      "informs_product_experience_fields": ["design_direction", "component expectations"]
+    },
+    {
+      "source_id": "sceneai",
+      "name": "SceneAI",
+      "url": "https://sceneai.art/",
+      "allowed_use": ["visual direction reference", "prompt structure reference"],
+      "forbidden_use": ["treating prompt output as licensed product asset without review"],
+      "license_terms_status": "operator must verify current terms before reuse",
+      "public_safety_notes": "Keep generated/reference assets out of public artifacts unless cleared.",
+      "informs_product_experience_fields": ["visual_tone", "product_fit"]
+    },
+    {
+      "source_id": "refero-styles",
+      "name": "Refero Styles",
+      "url": "https://styles.refero.design/",
+      "allowed_use": ["DESIGN.md structure benchmark", "agent-readable style reference"],
+      "forbidden_use": ["copying private product-specific style text blindly"],
+      "license_terms_status": "operator must verify current terms before reuse",
+      "public_safety_notes": "Prefer as structure/reference for original style packets.",
+      "informs_product_experience_fields": ["experience_sot", "design_direction"]
+    }
+  ]
+}

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -114,6 +114,59 @@
       "review": ["independent-reviewer"]
     }
   },
+  "reasoning_policy": {
+    "$schema": "https://overkill-factory.dev/schemas/reasoning-policy.schema.json",
+    "record_type": "reasoning_policy",
+    "reasoning_class": "standard",
+    "allowed_profile_classes": ["bounded-worker", "review-capable-worker"],
+    "review_intensity": "independent_review",
+    "evidence_policy": {
+      "durable_summary_required": true,
+      "raw_chain_of_thought_forbidden": true,
+      "evidence_refs_required": true
+    },
+    "private_reasoning_policy": "summarize_only",
+    "block_when": [
+      "selected profile cannot satisfy reasoning class",
+      "required review intensity is unavailable",
+      "worker result lacks durable evidence"
+    ],
+    "derived_from": ["risk_effective", "phase", "surfaces", "authority_max"]
+  },
+  "reference_quality_packet": {
+    "$schema": "https://overkill-factory.dev/schemas/reference-quality-packet.schema.json",
+    "record_type": "reference_quality_packet",
+    "experience_category": "software product surface",
+    "quality_bar": "Specific, product-fit experience that avoids generic generated UI.",
+    "anti_generic_criteria": [
+      "The output must reflect the product job, not a generic demo.",
+      "Design direction must be concrete enough for Product Face review."
+    ],
+    "references": [
+      {
+        "source_id": "operator-approved-benchmark",
+        "source_url_or_ref": "external:operator-approved-reference",
+        "use_type": "benchmark",
+        "what_to_learn": ["quality bar", "interaction expectations"],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "not_applicable_for_benchmark_only",
+        "public_safety_notes": "Benchmark only; no copied text, code or assets."
+      }
+    ],
+    "design_rationale": "The reference packet feeds Product Experience and Product Face before implementation.",
+    "component_expectations": ["components fit the job-to-be-done"],
+    "interaction_expectations": ["states and transitions are observable"],
+    "visual_constraints": ["avoid generic generated composition"],
+    "reuse_policy": {
+      "allowed": ["benchmarking", "inspiration"],
+      "forbidden": ["blind copy", "unlicensed code or asset reuse"],
+      "license_required_for_code_or_assets": true
+    },
+    "accessibility_constraints": ["keyboard path", "labels", "contrast"],
+    "performance_constraints": ["no decorative work that blocks the primary task"],
+    "acceptance_criteria": ["Product Face design-fit review passes"],
+    "product_experience_fields_informed": ["experience_sot", "design_direction", "proof_required"]
+  },
   "software_development_plan": {
     "$schema": "https://overkill-factory.dev/schemas/software-development-plan.schema.json",
     "work_units": ["one bounded implementation slice"],

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FACTORYCTL_SPEC = importlib.util.spec_from_file_location("factoryctl", ROOT / "scripts" / "factoryctl.py")
+assert FACTORYCTL_SPEC is not None
+factoryctl = importlib.util.module_from_spec(FACTORYCTL_SPEC)
+assert FACTORYCTL_SPEC.loader is not None
+sys.modules["factoryctl"] = factoryctl
+FACTORYCTL_SPEC.loader.exec_module(factoryctl)
+
+SELF_SPEC = importlib.util.spec_from_file_location("factory_self_improvement", ROOT / "scripts" / "factory_self_improvement.py")
+assert SELF_SPEC is not None
+self_improvement = importlib.util.module_from_spec(SELF_SPEC)
+assert SELF_SPEC.loader is not None
+sys.modules["factory_self_improvement"] = self_improvement
+SELF_SPEC.loader.exec_module(self_improvement)
+
+
+def vfinal_card() -> dict:
+    return json.loads((ROOT / "templates" / "vfinal-factory-card.json").read_text(encoding="utf-8"))
+
+
+class FactorySelfImprovementTest(unittest.TestCase):
+    def test_vfinal_card_requires_reasoning_policy(self) -> None:
+        card = vfinal_card()
+        card.pop("reasoning_policy")
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("reasoning_policy required for OVERKILL_VFINAL cards", errors)
+
+    def test_vfinal_product_surface_requires_reference_quality_packet(self) -> None:
+        card = vfinal_card()
+        card["surfaces"] = ["frontend"]
+        card["product_face_packet"]["surface"] = "web_app"
+        card["product_face_packet"]["mode"] = "greenfield"
+        card.pop("reference_quality_packet")
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("reference_quality_packet required for vFinal product-facing surfaces", errors)
+
+    def test_reference_quality_rejects_copy_without_license_ref(self) -> None:
+        packet = dict(vfinal_card()["reference_quality_packet"])
+        packet["references"] = [
+            {
+                "source_id": "component-library",
+                "source_url_or_ref": "https://example.invalid/component",
+                "use_type": "licensed_component",
+                "what_to_learn": ["button pattern"],
+                "copy_policy": "copy_only_with_license_recorded",
+            }
+        ]
+
+        errors = factoryctl.validate_reference_quality_packet(packet)
+
+        self.assertIn("reference_quality_packet.references[0].license_or_terms_ref is required for copied code/assets", errors)
+
+    def test_worker_packet_carries_reasoning_and_reference_contracts(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = vfinal_card()
+
+        packet = factoryctl.build_worker_packet("implementation-worker", card, card_path)
+
+        self.assertEqual(packet["input_contract"]["reasoning_policy"]["record_type"], "reasoning_policy")
+        self.assertEqual(packet["input_contract"]["reference_quality_packet"]["record_type"], "reference_quality_packet")
+
+    def test_default_reference_registry_contains_post_sources_as_catalog_entries(self) -> None:
+        registry = self_improvement.default_reference_source_registry()
+        source_ids = {source["source_id"] for source in registry["sources"]}
+
+        self.assertIn("motionsites", source_ids)
+        self.assertIn("uiverse", source_ids)
+        self.assertIn("21st-dev", source_ids)
+        self.assertIn("sceneai", source_ids)
+        self.assertIn("refero-styles", source_ids)
+
+    def test_missing_capability_plan_blocks_sensitive_gap_for_human_gate(self) -> None:
+        gate_report = {
+            "card_id": "CARD-1",
+            "blocked_workers": ["cloud-infra-security-specialist"],
+            "workers": {
+                "cloud-infra-security-specialist": {
+                    "status": "blocked_missing_inputs",
+                    "reason": "credential_status failed for production deploy",
+                }
+            },
+            "card_validation_errors": [],
+        }
+
+        plan = self_improvement.build_missing_capability_plan(gate_report)
+
+        self.assertTrue(plan["human_gate_required"])
+        self.assertEqual(plan["status"], "blocked_needs_human_gate")
+        self.assertFalse(plan["activation_policy"]["auto_activation_allowed"])
+        self.assertEqual(plan["candidate_artifacts"][0]["status"], "inactive_candidate")
+        self.assertIn("validation_gate", plan["candidate_artifacts"][0])
+
+    def test_learnback_issue_candidates_redact_private_paths(self) -> None:
+        private_users_path = "C:" + "\\" + "Users"
+        private_ref = private_users_path + "\\owner\\private-card"
+        learnback = {
+            "record_type": "execution_learnback_record",
+            "project_ref": private_ref,
+            "method_version": "OVERKILL_VFINAL",
+            "findings": [
+                {
+                    "summary": private_ref + " leaked into public packet",
+                    "severity": "high",
+                    "area": "public-safety",
+                    "recommended_route": "public_issue",
+                    "reproduction_condition": "worker packet used local path",
+                    "acceptance_hint": "redact local path",
+                }
+            ],
+            "public_safety_boundary": {
+                "raw_private_evidence_forbidden": True,
+                "public_issue_requires_redaction": True,
+            },
+        }
+
+        result = self_improvement.build_issue_candidates(learnback)
+
+        candidate = result["candidates"][0]
+        self.assertNotIn(private_users_path, candidate["title"])
+        self.assertNotIn(private_users_path, candidate["body"])
+        self.assertTrue(candidate["public_safe"])
+
+    def test_owner_issue_intake_routes_critical_factory_change_to_human_gate_path(self) -> None:
+        config = json.loads((ROOT / "templates" / "owner-issue-intake-config.json").read_text(encoding="utf-8"))
+        issues = [
+            {
+                "number": 101,
+                "title": "Change worker registry authority",
+                "body": "Update registry and release authority.",
+                "labels": ["factory-improvement"],
+            }
+        ]
+
+        report = self_improvement.build_issue_intake_report(config, issues)
+
+        self.assertEqual(report["decisions"][0]["decision"], "critical_factory_change")
+        self.assertEqual(report["decisions"][0]["card_status"], "blocked")
+        candidate = report["decisions"][0]["factory_card_candidate"]
+        self.assertEqual(candidate["record_type"], "owner_issue_factory_card_candidate")
+        self.assertFalse(candidate["activation_policy"]["auto_dispatch_allowed"])
+        self.assertTrue(candidate["activation_policy"]["human_gate_required"])
+
+    def test_governance_report_declares_mandatory_public_checks(self) -> None:
+        report = self_improvement.governance_report()
+        checks = "\n".join(report["mandatory_checks"])
+
+        self.assertIn("public_safety_scan.py", checks)
+        self.assertIn("secret_safety_scan.py", checks)
+        self.assertIn("supply_chain_proof.py", checks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the factory self-improvement issue package (#71-#76):

- missing-capability completion plans
- execution learnback issue candidates
- owner-instance issue intake with blocked factory-card candidates
- reasoning policy contracts
- reference-quality packets
- governance audit helpers
- docs and tests

Validation run:

- `python -m unittest tests.test_factory_self_improvement -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/supply_chain_proof.py --check --no-write`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `git diff --check`
