### PR TITLE
Define public fixture evidence policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,32 @@ python scripts/supply_chain_proof.py --check --no-write
   runtime identifiers.
 - Prefer small pull requests with one clear outcome.
 
+## Fixture And Generated Evidence Policy
+
+Public fixtures are source material for tests, examples and contract checks.
+They must be minimal, domain-neutral, public-safe and stable enough for another
+operator to rerun without private context.
+
+Generated evidence is different. Worker packets, gate reports, validation
+summaries, scan summaries, screenshots, runtime logs and Receipt Five output
+from an execution belong in `.tmp/`, `$RUNNER_TEMP`, release artifacts or a
+private evidence store. They must not be committed as public examples or docs.
+
+Allowed public fixtures:
+
+- small source cards, input papers, expected flows and expected receipt examples;
+- schema fixtures that prove one contract behavior at a time;
+- test fixtures with placeholder identifiers and no private product, board,
+  runtime, local path or operator-specific data.
+
+Disallowed public fixtures:
+
+- old pilot output or narrative execution history;
+- generated worker packets, gate reports or scan output copied from a run;
+- screenshots, raw logs, private runtime payloads or local workspace paths;
+- broad fixture archives when one small domain-neutral fixture would prove the
+  behavior.
+
 ## Pull Request Shape
 
 Include:

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ factory path.
 - Source examples that can be read, validated and rerun by a new operator.
 - Minimal cards, papers, expected flows and public-safe receipt examples.
 - Fixtures that support tests without storing generated proof archives.
+- Expected receipt files only when they are hand-authored public fixtures, not
+  copied output from a previous run.
 
 ## What Does Not Belong Here
 
@@ -16,6 +18,8 @@ factory path.
   directory.
 - Do not store old pilot evidence, private product material, screenshots,
   raw logs or local workspace paths here.
+- Do not add fixture archives when a small domain-neutral fixture can prove the
+  same behavior.
 
 ## Source Of Truth
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,12 +8,17 @@ Tests are the regression suite for the public path and contract behavior.
   quickstart.
 - Tests that make public onboarding, worker routing and safety rules durable.
 - Small fixtures required to reproduce contract behavior.
+- Domain-neutral fixtures that prove one behavior without depending on private
+  products, boards, paths, screenshots or runtime history.
 
 ## What Does Not Belong Here
 
 - Manual evidence archives, screenshots or generated proof outputs.
 - Tests that rely on private local paths, private boards or operator secrets.
 - Narrative validation history.
+- Generated worker packets, gate reports, scan summaries or Receipt Five output
+  committed as reusable proof instead of being created under `.tmp/` during the
+  test.
 
 ## Source Of Truth
 

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -186,7 +186,51 @@ class OpenSourceDocsTest(unittest.TestCase):
 
         self.assertIn("Generated worker packets and gate reports belong in `.tmp/`", examples)
         self.assertIn("Do not commit generated run output", examples)
+        self.assertIn("hand-authored public fixtures", examples)
+        self.assertIn("domain-neutral fixture", examples)
         self.assertIn("examples/minimal-hermes-project/", examples)
+
+    def test_fixture_policy_separates_fixtures_from_generated_evidence(self) -> None:
+        contributing = read_text("CONTRIBUTING.md")
+        tests_readme = read_text("tests/README.md")
+        combined = f"{contributing}\n{tests_readme}"
+
+        for phrase in [
+            "Fixture And Generated Evidence Policy",
+            "minimal, domain-neutral, public-safe",
+            "Generated evidence is different",
+            "belong in `.tmp/`, `$RUNNER_TEMP`, release artifacts or a",
+            "private evidence store",
+            "old pilot output or narrative execution history",
+            "Generated worker packets, gate reports, scan summaries or Receipt Five output",
+        ]:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, combined)
+
+    def test_documented_generated_evidence_commands_use_temp_outputs(self) -> None:
+        docs_to_check = [
+            "README.md",
+            "CONTRIBUTING.md",
+            "examples/README.md",
+            "tests/README.md",
+            "docs/automation/worker-automation-v0.md",
+            "docs/getting-started/quickstart-hermes.md",
+            "docs/operations/validation-and-release.md",
+            "docs/reference/cli.md",
+            ".github/workflows/ci.yml",
+        ]
+        allowed_output_markers = (".tmp/", ".tmp\\", "$RUNNER_TEMP", "path/to/", "../my-product-factory")
+
+        for rel in docs_to_check:
+            text = read_text(rel)
+            for line in text.splitlines():
+                if "--out " not in line and "--summary-json " not in line and "--packets-out " not in line:
+                    continue
+                with self.subTest(path=rel, line=line.strip()):
+                    self.assertTrue(
+                        any(marker in line for marker in allowed_output_markers),
+                        f"generated evidence command should write to a temp or external path: {line}",
+                    )
 
     def test_products_readme_sets_public_validation_boundary(self) -> None:
         products = read_text("products/README.md")


### PR DESCRIPTION
## Summary
- Define a public fixture vs generated evidence policy in CONTRIBUTING.md.
- Clarify examples/tests boundaries for hand-authored fixtures, generated outputs, and domain-neutral test data.
- Add regression coverage that documented generated-evidence commands write to temp/external paths instead of public example folders.

Closes #30.

## Validation
- python -m unittest tests.test_open_source_docs -q
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/supply_chain_proof.py --check --no-write
- python scripts/validate_document_governance.py
- python scripts/validate_public_json_artifacts.py
- python scripts/validate_worker_profiles.py
- python scripts/quickstart_smoke.py
- python scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
- python scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
- git diff --check
- python -m unittest discover -s tests -p test_*.py -q