### PR TITLE
Add parallel lane governance and status snapshots

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,9 @@ state, public docs or adapter behavior.
 Use `operations/release-policy.md` before tagging, packaging or publishing a
 release.
 
+Use `operations/parallel-execution-and-status.md` before scaling agents,
+splitting work across branches/worktrees or presenting a cockpit/status view.
+
 ## Maintainer Internals
 
 Use `maintenance/repo-surface.md` to decide whether a file belongs in the

--- a/docs/operations/parallel-execution-and-status.md
+++ b/docs/operations/parallel-execution-and-status.md
@@ -1,0 +1,97 @@
+# Parallel Execution And Status
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: `scripts/factoryctl.py`, `schemas/parallel-lane-contract.schema.json`,
+> `schemas/factory-status-snapshot.schema.json`, Hermes runtime state.
+> Runtime boundary: this guide defines public contracts. Hermes or the operator's
+> runtime remains the source of truth.
+
+## Parallel Decision Ladder
+
+Default to the minimum viable parallelization:
+
+1. Single lane for small, sequential or high-ambiguity work.
+2. Read-only fork for research, audit, source intake or critique.
+3. Two-agent split when one lane can plan/review while another executes.
+4. Three to four bounded lanes only when write scopes are separable and a
+   synthesizer is named.
+5. Larger fan-out only with explicit budget, active-lane cap and approval.
+
+Parallelism is a cost and conflict decision. It is not a default throughput
+button.
+
+## Lane Contract
+
+Every parallel lane needs a `parallel_lane_contract` before it can affect the
+canonical card, repository, release branch or Receipt Five.
+
+Required fields include:
+
+- lane id and objective;
+- read scope and write scope;
+- branch or worktree ref;
+- owner agent and reviewer or synthesizer;
+- expected artifact;
+- timeout, token/cost budget and stop condition;
+- conflict risk;
+- merge/reconciliation policy with `no_self_promotion=true`;
+- cleanup policy for stale, failed or superseded lanes.
+
+Editing lanes need a worktree or branch ref different from the base ref. Read-only
+lanes may use the base ref, but their output still requires synthesis before it
+changes canonical state.
+
+## Cascade Operating Protocol
+
+Use a named-lane sweep:
+
+1. List active lanes from oldest to newest.
+2. Stop or mark superseded lanes that lost their source, budget or objective.
+3. Reconcile lane outputs before any merge, card update or receipt claim.
+4. Prefer one synthesizer over lane-by-lane self-approval.
+5. Keep cleanup explicit: branch/worktree, generated output and stale evidence.
+
+No merge happens by title, summary or agent confidence alone.
+
+## Status Snapshot
+
+`factory_status_snapshot` is a cockpit projection. It is not a source of truth.
+It links back to card, gate, lane and evidence refs so another operator can
+continue without reading chat history.
+
+A snapshot must show:
+
+- current phase and state;
+- gate status and blockers;
+- active workers and lanes;
+- evidence refs and Receipt Five status;
+- whether work is implemented, validated, integrated, released, blocked or
+  superseded;
+- next safe actions and forbidden actions;
+- staleness warning.
+
+Generate a local snapshot with:
+
+```bash
+factoryctl status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
+```
+
+Add lane contracts or evidence refs when applicable:
+
+```bash
+factoryctl status-snapshot \
+  --card examples/minimal-hermes-project/card.md \
+  --lane-contract templates/parallel-lane-contract.json \
+  --evidence-ref external:operator-summary \
+  --out .tmp/factory-status-snapshot.json
+```
+
+The snapshot must fail closed when source refs are missing, stale state claims
+ready/released, blocked gate state has no blockers, next action is missing or
+public/private boundary flags are false.
+
+## Receipt Five
+
+Receipt Five should mention the lane outputs that actually affected the final
+decision and the reconciliation decision that accepted, rejected or superseded
+them. Do not attach stale or failed lane output as completion proof.

--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -27,6 +27,7 @@ Use a card-specific check before sending work to Hermes:
 factoryctl validate-card examples/minimal-hermes-project/card.md
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+factoryctl status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
 ```
 
 What this proves:
@@ -34,6 +35,7 @@ What this proves:
 - the card has the required fields;
 - the risk, surface and phase routing can be inspected;
 - worker packets can be produced without inventing completion evidence.
+- operator status can be projected without becoming the source of truth.
 
 ## Public Release Preflight
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,12 @@ factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
+factoryctl status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
 ```
+
+`status-snapshot` projects card, gate, lane and evidence state for operators. It
+does not replace Hermes, card contracts, gate reports or Receipt Five as the
+source of truth.
 
 ### Test Runner Fallback
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,5 +20,6 @@ nav:
       - Security Matrix: security/security-control-matrix.md
   - Release:
       - Validation And Release: operations/validation-and-release.md
+      - Parallel Execution And Status: operations/parallel-execution-and-status.md
       - Release Policy: operations/release-policy.md
   - Maintainer Internals: maintenance/repo-surface.md

--- a/schemas/factory-status-snapshot.schema.json
+++ b/schemas/factory-status-snapshot.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-status-snapshot.schema.json",
+  "title": "Overkill Factory Status Snapshot",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "card",
+    "current_state",
+    "phase",
+    "risk_effective",
+    "source_refs",
+    "staleness",
+    "workers",
+    "lanes",
+    "gates",
+    "blockers",
+    "evidence",
+    "state_flags",
+    "next_safe_actions",
+    "forbidden_actions",
+    "public_private_boundary",
+    "continuation"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-status-snapshot.schema.json" },
+    "record_type": { "const": "factory_status_snapshot" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "card": {
+      "type": "object",
+      "required": ["id", "title", "ref"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    },
+    "current_state": {
+      "enum": ["planning", "blocked", "ready", "executing", "reviewing", "human_gate", "release_candidate", "released", "archived", "superseded"]
+    },
+    "phase": { "type": "string", "minLength": 1 },
+    "risk_effective": { "type": "string", "minLength": 1 },
+    "source_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["claim", "ref"],
+        "properties": {
+          "claim": { "type": "string", "minLength": 1 },
+          "ref": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "staleness": {
+      "type": "object",
+      "required": ["status", "last_updated_ref", "warning"],
+      "properties": {
+        "status": { "enum": ["fresh", "manual_estimate", "stale", "blocked"] },
+        "last_updated_ref": { "type": "string", "minLength": 1 },
+        "warning": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "workers": { "type": "object", "additionalProperties": true },
+    "lanes": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "gates": { "type": "object", "additionalProperties": true },
+    "blockers": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "evidence": { "type": "object", "additionalProperties": true },
+    "state_flags": {
+      "type": "object",
+      "required": ["implemented", "validated", "integrated", "released", "blocked", "superseded"],
+      "properties": {
+        "implemented": { "type": "boolean" },
+        "validated": { "type": "boolean" },
+        "integrated": { "type": "boolean" },
+        "released": { "type": "boolean" },
+        "blocked": { "type": "boolean" },
+        "superseded": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "next_safe_actions": { "type": "array", "items": { "type": "string" } },
+    "forbidden_actions": { "type": "array", "items": { "type": "string" } },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["projection_not_source_of_truth", "no_raw_logs", "no_private_paths", "no_private_ids"],
+      "properties": {
+        "projection_not_source_of_truth": { "const": true },
+        "no_raw_logs": { "const": true },
+        "no_private_paths": { "const": true },
+        "no_private_ids": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "continuation": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": true
+}

--- a/schemas/parallel-lane-contract.schema.json
+++ b/schemas/parallel-lane-contract.schema.json
@@ -8,7 +8,11 @@
     "record_type",
     "lane_id",
     "lane_kind",
+    "objective",
+    "read_scope",
+    "write_scope",
     "owner_agent",
+    "reviewer_or_synthesizer",
     "status",
     "base_ref",
     "worktree_ref",
@@ -17,6 +21,13 @@
     "forbidden_paths",
     "changed_paths",
     "expected_outputs",
+    "expected_artifact",
+    "timeout",
+    "budget",
+    "stop_condition",
+    "conflict_risk",
+    "merge_reconciliation_policy",
+    "cleanup_policy",
     "validation_commands",
     "validation_result",
     "evidence_refs",
@@ -31,8 +42,20 @@
     },
     "record_type": { "const": "parallel_lane_contract" },
     "lane_id": { "type": "string", "minLength": 3 },
-    "lane_kind": { "enum": ["read_only", "write"] },
+    "lane_kind": { "enum": ["read_only", "write", "research", "planning", "execution", "review"] },
+    "objective": { "type": "string", "minLength": 3 },
+    "read_scope": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "write_scope": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
     "owner_agent": { "type": "string", "minLength": 1 },
+    "reviewer_or_synthesizer": { "type": "string", "minLength": 1 },
     "status": {
       "enum": [
         "planned",
@@ -40,6 +63,7 @@
         "blocked",
         "ready_for_integration",
         "integrated",
+        "superseded",
         "abandoned"
       ]
     },
@@ -64,6 +88,48 @@
     "expected_outputs": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
+    },
+    "expected_artifact": { "type": "string", "minLength": 1 },
+    "timeout": {
+      "type": "object",
+      "required": ["limit", "unit"],
+      "properties": {
+        "limit": { "type": "integer", "minimum": 1 },
+        "unit": { "enum": ["minutes", "hours", "days"] }
+      },
+      "additionalProperties": false
+    },
+    "budget": {
+      "type": "object",
+      "required": ["token_budget", "cost_budget", "approval_required_above_budget"],
+      "properties": {
+        "token_budget": { "type": "integer", "minimum": 1 },
+        "cost_budget": { "type": "string", "minLength": 1 },
+        "approval_required_above_budget": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "stop_condition": { "type": "string", "minLength": 1 },
+    "conflict_risk": { "enum": ["low", "medium", "high"] },
+    "merge_reconciliation_policy": {
+      "type": "object",
+      "required": ["synthesizer", "decision_rule", "no_self_promotion"],
+      "properties": {
+        "synthesizer": { "type": "string", "minLength": 1 },
+        "decision_rule": { "type": "string", "minLength": 1 },
+        "no_self_promotion": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "cleanup_policy": {
+      "type": "object",
+      "required": ["owner", "when", "stale_or_failed_lane_action"],
+      "properties": {
+        "owner": { "type": "string", "minLength": 1 },
+        "when": { "type": "string", "minLength": 1 },
+        "stale_or_failed_lane_action": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
     },
     "validation_commands": {
       "type": "array",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -86,6 +86,7 @@ PROMOTION_PASS_RESULTS = {"PASS", "WAIVED"}
 ARTIFACT_PUBLIC_CLASSES = {"public_safe", "sanitized_report", "publication_candidate"}
 ARTIFACT_PRIVATE_CLASSES = {"private_run_evidence", "transient_cache"}
 PUBLICATION_SCANNER_FIELDS = ("public_safety_scan", "secret_safety_scan")
+PARALLEL_EDIT_LANE_KINDS = {"write", "execution"}
 V2_APPROVAL_KEYS = [
     "qa",
     "independent_review",
@@ -1131,6 +1132,114 @@ def _status_value(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
+def _card_parallel_execution_requested(card: dict[str, Any]) -> bool:
+    runtime_contract = card.get("runtime_contract") if isinstance(card.get("runtime_contract"), dict) else {}
+    loop_plan = card.get("loop_plan") if isinstance(card.get("loop_plan"), dict) else {}
+    return any(
+        value is True
+        for value in (
+            card.get("parallel_execution_requested"),
+            runtime_contract.get("parallel_execution_requested"),
+            runtime_contract.get("parallel_execution"),
+            loop_plan.get("parallel_execution_requested"),
+        )
+    )
+
+
+def _lane_write_scope(lane: dict[str, Any]) -> list[str]:
+    scope = _list_items(lane.get("write_scope"))
+    if scope:
+        return scope
+    return _list_items(lane.get("intended_write_scope"))
+
+
+def _lane_is_editing(lane: dict[str, Any]) -> bool:
+    lane_kind = str(lane.get("lane_kind") or "").strip().lower()
+    write_scope = [item.lower() for item in _lane_write_scope(lane)]
+    return lane_kind in PARALLEL_EDIT_LANE_KINDS or any(item not in {"none", "read-only", "readonly"} for item in write_scope)
+
+
+def validate_parallel_lane_contract(lane: dict[str, Any], *, at: str = "parallel_lane_contract") -> list[str]:
+    errors: list[str] = []
+    required_fields = [
+        "lane_id",
+        "objective",
+        "read_scope",
+        "write_scope",
+        "worktree_ref",
+        "owner_agent",
+        "reviewer_or_synthesizer",
+        "expected_artifact",
+        "timeout",
+        "budget",
+        "stop_condition",
+        "conflict_risk",
+        "merge_reconciliation_policy",
+        "cleanup_policy",
+    ]
+    for field in required_fields:
+        value = lane.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"{at}.{field} must be a non-empty array")
+        elif isinstance(value, dict):
+            if not value:
+                errors.append(f"{at}.{field} must be a non-empty object")
+        elif not _non_empty_text(value):
+            errors.append(f"{at}.{field} is required")
+
+    if _lane_is_editing(lane):
+        worktree_ref = str(lane.get("worktree_ref") or "").strip()
+        base_ref = str(lane.get("base_ref") or "").strip()
+        if not worktree_ref:
+            errors.append(f"{at}.worktree_ref is required for editing lanes")
+        if worktree_ref and base_ref and worktree_ref == base_ref:
+            errors.append(f"{at}.worktree_ref must differ from base_ref for editing lanes")
+        if not _lane_write_scope(lane):
+            errors.append(f"{at}.write_scope is required for editing lanes")
+
+    budget = lane.get("budget") if isinstance(lane.get("budget"), dict) else {}
+    if budget:
+        if not isinstance(budget.get("token_budget"), int) or budget.get("token_budget", 0) <= 0:
+            errors.append(f"{at}.budget.token_budget must be a positive integer")
+        if not _non_empty_text(budget.get("cost_budget")):
+            errors.append(f"{at}.budget.cost_budget is required")
+        if budget.get("approval_required_above_budget") is not True:
+            errors.append(f"{at}.budget.approval_required_above_budget must be true")
+
+    merge_policy = lane.get("merge_reconciliation_policy") if isinstance(lane.get("merge_reconciliation_policy"), dict) else {}
+    if merge_policy and merge_policy.get("no_self_promotion") is not True:
+        errors.append(f"{at}.merge_reconciliation_policy.no_self_promotion must be true")
+    if merge_policy and not _non_empty_text(merge_policy.get("synthesizer")):
+        errors.append(f"{at}.merge_reconciliation_policy.synthesizer is required")
+
+    return errors
+
+
+def parallel_lane_warnings(lanes: list[dict[str, Any]]) -> list[str]:
+    warnings: list[str] = []
+    write_owners: dict[str, str] = {}
+    for lane in lanes:
+        lane_id = str(lane.get("lane_id") or "unknown-lane")
+        for scope in _lane_write_scope(lane):
+            normalized = scope.strip().replace("\\", "/").rstrip("/")
+            if not normalized or normalized.lower() in {"none", "read-only", "readonly"}:
+                continue
+            previous = write_owners.get(normalized)
+            if previous and previous != lane_id:
+                warnings.append(f"parallel lane write scope overlap: {previous} and {lane_id} both write {normalized}")
+            else:
+                write_owners[normalized] = lane_id
+    return warnings
+
+
+def card_parallel_lane_contracts(card: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = card.get("parallel_lane_contracts")
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
 def normalized_surfaces(card: dict[str, Any]) -> set[str]:
     raw = card.get("surfaces", [])
     if not isinstance(raw, list):
@@ -1354,6 +1463,11 @@ def validate_card(data: dict[str, Any]) -> list[str]:
             errors.append("reasoning_policy required for OVERKILL_VFINAL cards")
         else:
             errors.extend(validate_reasoning_policy(data["reasoning_policy"]))
+    lane_contracts = card_parallel_lane_contracts(data)
+    if _card_parallel_execution_requested(data) and not lane_contracts:
+        errors.append("parallel execution requested but parallel_lane_contracts is missing")
+    for index, lane in enumerate(lane_contracts):
+        errors.extend(validate_parallel_lane_contract(lane, at=f"parallel_lane_contracts[{index}]"))
     if data.get("executor_identity") == data.get("reviewer_identity"):
         errors.append("executor_identity and reviewer_identity must differ")
     product_facing = bool(surfaces & PRODUCT_FACE_SURFACES)
@@ -2069,6 +2183,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
     missing_inputs = missing_required_inputs(worker, card)
     missing_profile_binding = profile_binding is None
     runtime_decision = runtime_decision_profile(card)
+    lane_contracts = card_parallel_lane_contracts(card)
     status = "requires_execution" if required else "not_required_by_current_card"
     if required and missing_inputs:
         status = "blocked_missing_inputs"
@@ -2108,6 +2223,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "target_repo_paths": card.get("target_repo_paths", []),
             "authority_max": card.get("authority_max"),
             "forbidden_actions": card.get("forbidden_actions", []),
+            "parallel_lane_contracts": lane_contracts,
             "reasoning_policy": card.get("reasoning_policy"),
             "reference_quality_packet": card.get("reference_quality_packet"),
         },
@@ -2153,6 +2269,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
 
 def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
     validation_errors = validate_card(card)
+    validation_warnings = parallel_lane_warnings(card_parallel_lane_contracts(card))
     worker_rows: dict[str, dict[str, Any]] = {}
     required_workers: list[str] = []
     blocked_workers: list[str] = []
@@ -2193,6 +2310,7 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
         "required_workers": required_workers,
         "blocked_workers": blocked_workers,
         "card_validation_errors": validation_errors,
+        "card_validation_warnings": validation_warnings,
         "next_safe_actions": [
             guidance
             for row in worker_rows.values()
@@ -3026,6 +3144,180 @@ def build_human_gate_record(
     }
 
 
+def _snapshot_state_from_gate(card: dict[str, Any], gate_report: dict[str, Any]) -> str:
+    explicit_state = str(card.get("status") or "").strip().lower()
+    if explicit_state in {
+        "planning",
+        "blocked",
+        "ready",
+        "executing",
+        "reviewing",
+        "human_gate",
+        "release_candidate",
+        "released",
+        "archived",
+        "superseded",
+    }:
+        return explicit_state
+    if card.get("superseded_by"):
+        return "superseded"
+    gate_status = str(gate_report.get("gate_status") or "").strip()
+    if gate_status == "blocked":
+        return "blocked"
+    if gate_status == "ready_for_worker_execution":
+        return "ready"
+    return "planning"
+
+
+def _snapshot_blockers(gate_report: dict[str, Any]) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    for error in _list_items(gate_report.get("card_validation_errors")):
+        blockers.append(
+            {
+                "kind": "card_validation",
+                "owner": "operator",
+                "summary": error,
+                "unblock_condition": "Fix the canonical card contract and rerun gate-report.",
+            }
+        )
+    for worker_id in _list_items(gate_report.get("blocked_workers")):
+        blockers.append(
+            {
+                "kind": "worker_input",
+                "owner": worker_id,
+                "summary": f"{worker_id} is blocked by missing inputs",
+                "unblock_condition": "Attach required source fields or worker evidence before dispatch.",
+            }
+        )
+    return blockers
+
+
+def build_status_snapshot(
+    card: dict[str, Any],
+    card_path: Path,
+    *,
+    gate_report: dict[str, Any] | None = None,
+    lane_contracts: list[dict[str, Any]] | None = None,
+    evidence_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    effective_gate_report = gate_report or build_gate_report(card)
+    effective_lanes = lane_contracts if lane_contracts is not None else card_parallel_lane_contracts(card)
+    blockers = _snapshot_blockers(effective_gate_report)
+    current_state = _snapshot_state_from_gate(card, effective_gate_report)
+    evidence = sorted(set(evidence_refs or _list_items(card.get("evidence_refs"))))
+    source_refs = [
+        {"claim": "card", "ref": source_card_ref(card_path)},
+        {"claim": "gate_report", "ref": "factoryctl:gate-report"},
+    ]
+    if effective_lanes:
+        source_refs.append({"claim": "parallel_lanes", "ref": "card.parallel_lane_contracts"})
+    if evidence:
+        source_refs.append({"claim": "evidence", "ref": "operator-provided-evidence-refs"})
+
+    lane_rows = [
+        {
+            "lane_id": lane.get("lane_id"),
+            "status": lane.get("status"),
+            "owner_agent": lane.get("owner_agent"),
+            "worktree_ref": lane.get("worktree_ref"),
+            "write_scope": _lane_write_scope(lane),
+            "expected_artifact": lane.get("expected_artifact"),
+            "reviewer_or_synthesizer": lane.get("reviewer_or_synthesizer"),
+            "conflict_risk": lane.get("conflict_risk"),
+        }
+        for lane in effective_lanes
+    ]
+
+    gate_status = str(effective_gate_report.get("gate_status") or "not_run")
+    validation_passed = gate_status in {"ready_for_worker_execution", "pass_no_workers_required"} and not blockers
+    state_flags = {
+        "implemented": bool(card.get("implementation_result") or card.get("changed_paths")),
+        "validated": validation_passed,
+        "integrated": bool(card.get("integrated_ref")),
+        "released": current_state == "released" or bool(card.get("release_ref")),
+        "blocked": current_state == "blocked" or bool(blockers),
+        "superseded": current_state == "superseded",
+    }
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-status-snapshot.schema.json",
+        "record_type": "factory_status_snapshot",
+        "created_at": utc_now(),
+        "card": {
+            "id": str(card.get("card_id") or card.get("id") or "unknown-card"),
+            "title": str(card.get("title") or card.get("card_id") or "Untitled factory card"),
+            "ref": source_card_ref(card_path),
+        },
+        "current_state": current_state,
+        "phase": str(card.get("phase") or "unknown"),
+        "risk_effective": str(card.get("risk_effective") or "unknown"),
+        "source_refs": source_refs,
+        "staleness": {
+            "status": "manual_estimate" if gate_report is None else "fresh",
+            "last_updated_ref": source_card_ref(card_path),
+            "warning": (
+                "Snapshot was built from local card data and a generated gate report; Hermes remains source of truth."
+                if gate_report is None
+                else "Snapshot was built from caller-provided gate report; verify it is current."
+            ),
+        },
+        "workers": {
+            "required": effective_gate_report.get("required_workers", []),
+            "blocked": effective_gate_report.get("blocked_workers", []),
+            "rows": effective_gate_report.get("workers", {}),
+        },
+        "lanes": lane_rows,
+        "gates": {
+            "gate_status": gate_status,
+            "gate_predicate_result": effective_gate_report.get("gate_predicate_result"),
+            "warnings": effective_gate_report.get("card_validation_warnings", []),
+        },
+        "blockers": blockers,
+        "evidence": {
+            "receipt_five_status": "attached" if isinstance(card.get("receipt_five"), dict) else "not_attached",
+            "evidence_refs": evidence,
+        },
+        "state_flags": state_flags,
+        "next_safe_actions": [
+            str(item.get("action") if isinstance(item, dict) else item)
+            for item in effective_gate_report.get("next_safe_actions", [])
+            if str(item.get("action") if isinstance(item, dict) else item).strip()
+        ],
+        "forbidden_actions": _list_items(card.get("forbidden_actions")) + ["treat-snapshot-as-source-of-truth"],
+        "public_private_boundary": {
+            "projection_not_source_of_truth": True,
+            "no_raw_logs": True,
+            "no_private_paths": True,
+            "no_private_ids": True,
+            "note": "Link to canonical evidence; do not embed private runtime logs or screenshots.",
+        },
+        "continuation": "Continue from the canonical card, gate report, lane contracts and worker results; do not use this snapshot as authority.",
+    }
+
+
+def validate_status_snapshot(snapshot: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(snapshot.get("source_refs"), list) or not snapshot.get("source_refs"):
+        errors.append("factory_status_snapshot.source_refs is required")
+    staleness = snapshot.get("staleness") if isinstance(snapshot.get("staleness"), dict) else {}
+    if staleness.get("status") == "stale" and snapshot.get("current_state") in {"ready", "released"}:
+        errors.append("stale snapshot cannot claim ready or released")
+    gates = snapshot.get("gates") if isinstance(snapshot.get("gates"), dict) else {}
+    blockers = snapshot.get("blockers") if isinstance(snapshot.get("blockers"), list) else []
+    flags = snapshot.get("state_flags") if isinstance(snapshot.get("state_flags"), dict) else {}
+    if gates.get("gate_status") == "blocked" and not blockers:
+        errors.append("blocked gate state requires blockers")
+    if flags.get("blocked") is True and not blockers:
+        errors.append("state_flags.blocked=true requires blockers")
+    if not _list_items(snapshot.get("next_safe_actions")):
+        errors.append("factory_status_snapshot.next_safe_actions is required")
+    boundary = snapshot.get("public_private_boundary") if isinstance(snapshot.get("public_private_boundary"), dict) else {}
+    for field in ("projection_not_source_of_truth", "no_raw_logs", "no_private_paths", "no_private_ids"):
+        if boundary.get(field) is not True:
+            errors.append(f"factory_status_snapshot.public_private_boundary.{field} must be true")
+    return errors
+
+
 def command_validate_card(args: argparse.Namespace) -> int:
     errors = validate_card(load_json_like(args.path))
     if errors:
@@ -3165,6 +3457,28 @@ def command_transition_plan(args: argparse.Namespace) -> int:
     return 1 if action.startswith("block") and args.enforce else 0
 
 
+def command_status_snapshot(args: argparse.Namespace) -> int:
+    card = load_json_like(args.card)
+    gate_report = load_json_like(args.gate_report) if args.gate_report else None
+    lane_contracts = [load_json_like(path) for path in args.lane_contract or []]
+    if not lane_contracts:
+        lane_contracts = card_parallel_lane_contracts(card)
+    snapshot = build_status_snapshot(
+        card,
+        args.card,
+        gate_report=gate_report,
+        lane_contracts=lane_contracts,
+        evidence_refs=args.evidence_ref or [],
+    )
+    errors = validate_status_snapshot(snapshot)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, snapshot)
+    return 0
+
+
 def command_doctor(args: argparse.Namespace) -> int:
     report = build_doctor_report(args.hermes_home)
     if args.json:
@@ -3299,12 +3613,26 @@ def build_parser() -> argparse.ArgumentParser:
     transition_plan_parser.add_argument("--out", type=Path)
     transition_plan_parser.set_defaults(func=command_transition_plan)
 
+    status_snapshot_parser = sub.add_parser("status-snapshot")
+    status_snapshot_parser.add_argument("--card", type=Path, required=True)
+    status_snapshot_parser.add_argument("--gate-report", type=Path)
+    status_snapshot_parser.add_argument("--lane-contract", type=Path, action="append")
+    status_snapshot_parser.add_argument("--evidence-ref", action="append")
+    status_snapshot_parser.add_argument("--out", type=Path)
+    status_snapshot_parser.set_defaults(func=command_status_snapshot)
+
     return parser
 
 
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+    return int(args.func(args))
+
+
+def main_with_args_for_test(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
     return int(args.func(args))
 
 

--- a/templates/factory-status-snapshot.json
+++ b/templates/factory-status-snapshot.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-status-snapshot.schema.json",
+  "record_type": "factory_status_snapshot",
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "card": {
+    "id": "CARD-001",
+    "title": "Example factory card",
+    "ref": "cards/example-card.md"
+  },
+  "current_state": "planning",
+  "phase": "F11",
+  "risk_effective": "R1",
+  "source_refs": [
+    {
+      "claim": "card",
+      "ref": "cards/example-card.md"
+    }
+  ],
+  "staleness": {
+    "status": "manual_estimate",
+    "last_updated_ref": "cards/example-card.md",
+    "warning": "Template snapshot is not runtime evidence."
+  },
+  "workers": {},
+  "lanes": [],
+  "gates": {
+    "gate_status": "not_run"
+  },
+  "blockers": [],
+  "evidence": {
+    "receipt_five_status": "not_attached",
+    "evidence_refs": []
+  },
+  "state_flags": {
+    "implemented": false,
+    "validated": false,
+    "integrated": false,
+    "released": false,
+    "blocked": false,
+    "superseded": false
+  },
+  "next_safe_actions": [
+    "Run factoryctl gate-report before execution."
+  ],
+  "forbidden_actions": [
+    "treat-snapshot-as-source-of-truth"
+  ],
+  "public_private_boundary": {
+    "projection_not_source_of_truth": true,
+    "no_raw_logs": true,
+    "no_private_paths": true,
+    "no_private_ids": true
+  },
+  "continuation": "Use the canonical card, gate report and lane contracts before continuing."
+}

--- a/templates/parallel-lane-contract.json
+++ b/templates/parallel-lane-contract.json
@@ -3,7 +3,16 @@
   "record_type": "parallel_lane_contract",
   "lane_id": "example-readonly-audit",
   "lane_kind": "read_only",
+  "objective": "Audit the public factory flow without writing to the repository.",
+  "read_scope": [
+    "docs/concepts/factory-flow.md",
+    "scripts/factoryctl.py"
+  ],
+  "write_scope": [
+    "none"
+  ],
   "owner_agent": "external:subagent",
+  "reviewer_or_synthesizer": "main-agent",
   "status": "ready_for_integration",
   "base_ref": "main",
   "worktree_ref": "main",
@@ -22,6 +31,28 @@
   "expected_outputs": [
     "read-only audit summary"
   ],
+  "expected_artifact": "external:subagent-summary",
+  "timeout": {
+    "limit": 45,
+    "unit": "minutes"
+  },
+  "budget": {
+    "token_budget": 12000,
+    "cost_budget": "operator-approved local budget",
+    "approval_required_above_budget": true
+  },
+  "stop_condition": "Stop after producing the audit summary or after finding a blocking source conflict.",
+  "conflict_risk": "low",
+  "merge_reconciliation_policy": {
+    "synthesizer": "main-agent",
+    "decision_rule": "Read-only findings must be reconciled against canonical card/source refs before they affect Receipt Five.",
+    "no_self_promotion": true
+  },
+  "cleanup_policy": {
+    "owner": "main-agent",
+    "when": "after synthesis",
+    "stale_or_failed_lane_action": "mark superseded or blocked and keep only public-safe summary refs"
+  },
   "validation_commands": [
     "python scripts/public_safety_scan.py",
     "python scripts/secret_safety_scan.py"

--- a/tests/test_parallel_status_snapshot.py
+++ b/tests/test_parallel_status_snapshot.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_factoryctl():
+    spec = importlib.util.spec_from_file_location("factoryctl_parallel_status", ROOT / "scripts" / "factoryctl.py")
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["factoryctl_parallel_status"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+factoryctl = load_factoryctl()
+
+
+def load_minimal_card() -> dict:
+    return factoryctl.load_json_like(ROOT / "examples" / "minimal-hermes-project" / "card.md")
+
+
+def load_lane_template() -> dict:
+    return json.loads((ROOT / "templates" / "parallel-lane-contract.json").read_text(encoding="utf-8"))
+
+
+class ParallelStatusSnapshotTest(unittest.TestCase):
+    def test_parallel_execution_request_fails_closed_without_lane_contracts(self) -> None:
+        card = load_minimal_card()
+        card["parallel_execution_requested"] = True
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("parallel execution requested but parallel_lane_contracts is missing", errors)
+
+    def test_editing_lane_requires_separate_worktree_ref(self) -> None:
+        lane = load_lane_template()
+        lane["lane_kind"] = "write"
+        lane["write_scope"] = ["scripts/factoryctl.py"]
+        lane["intended_write_scope"] = ["scripts/factoryctl.py"]
+        lane["base_ref"] = "main"
+        lane["worktree_ref"] = "main"
+
+        errors = factoryctl.validate_parallel_lane_contract(lane)
+
+        self.assertIn("parallel_lane_contract.worktree_ref must differ from base_ref for editing lanes", errors)
+
+    def test_gate_report_warns_on_overlapping_parallel_write_scope(self) -> None:
+        card = load_minimal_card()
+        first = load_lane_template()
+        first.update(
+            {
+                "lane_id": "lane-a",
+                "lane_kind": "write",
+                "write_scope": ["scripts"],
+                "intended_write_scope": ["scripts"],
+                "worktree_ref": "codex/lane-a",
+            }
+        )
+        second = load_lane_template()
+        second.update(
+            {
+                "lane_id": "lane-b",
+                "lane_kind": "write",
+                "write_scope": ["scripts"],
+                "intended_write_scope": ["scripts"],
+                "worktree_ref": "codex/lane-b",
+            }
+        )
+        card["parallel_lane_contracts"] = [first, second]
+
+        report = factoryctl.build_gate_report(card)
+
+        self.assertIn("parallel lane write scope overlap: lane-a and lane-b both write scripts", report["card_validation_warnings"])
+
+    def test_worker_packet_carries_parallel_lane_contracts(self) -> None:
+        card = load_minimal_card()
+        lane = load_lane_template()
+        card["parallel_lane_contracts"] = [lane]
+
+        packet = factoryctl.build_worker_packet("factory-orchestrator", card, ROOT / "examples" / "minimal-hermes-project" / "card.md")
+
+        self.assertEqual(packet["input_contract"]["parallel_lane_contracts"][0]["lane_id"], lane["lane_id"])
+
+    def test_status_snapshot_projects_gate_state_without_becoming_truth(self) -> None:
+        card = load_minimal_card()
+        lane = load_lane_template()
+        card["parallel_lane_contracts"] = [lane]
+
+        snapshot = factoryctl.build_status_snapshot(
+            card,
+            ROOT / "examples" / "minimal-hermes-project" / "card.md",
+            evidence_refs=["external:operator-summary"],
+        )
+
+        self.assertEqual(snapshot["record_type"], "factory_status_snapshot")
+        self.assertTrue(snapshot["public_private_boundary"]["projection_not_source_of_truth"])
+        self.assertTrue(snapshot["source_refs"])
+        self.assertEqual(snapshot["lanes"][0]["lane_id"], lane["lane_id"])
+        self.assertEqual(factoryctl.validate_status_snapshot(snapshot), [])
+
+    def test_status_snapshot_blocks_contradictory_stale_ready_state(self) -> None:
+        snapshot = factoryctl.build_status_snapshot(
+            load_minimal_card(),
+            ROOT / "examples" / "minimal-hermes-project" / "card.md",
+        )
+        snapshot["current_state"] = "ready"
+        snapshot["staleness"]["status"] = "stale"
+
+        errors = factoryctl.validate_status_snapshot(snapshot)
+
+        self.assertIn("stale snapshot cannot claim ready or released", errors)
+
+    def test_status_snapshot_cli_writes_public_safe_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "snapshot.json"
+            rc = factoryctl.main_with_args_for_test(
+                [
+                    "status-snapshot",
+                    "--card",
+                    str(ROOT / "examples" / "minimal-hermes-project" / "card.md"),
+                    "--lane-contract",
+                    str(ROOT / "templates" / "parallel-lane-contract.json"),
+                    "--evidence-ref",
+                    "external:operator-summary",
+                    "--out",
+                    str(out),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(payload["record_type"], "factory_status_snapshot")
+            self.assertEqual(payload["evidence"]["evidence_refs"], ["external:operator-summary"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Strengthen parallel_lane_contract with objective, read/write scope, budget, timeout, stop condition, synthesizer, reconciliation and cleanup policy.
- Add factory_status_snapshot schema/template plus factoryctl status-snapshot CLI.
- Fail closed when parallel execution is requested without lane contracts; add overlap warnings and pass lane contracts into worker packets.
- Document the parallel decision ladder, cascade protocol and cockpit/status projection boundary.

Closes #79.
Closes #80.

## Validation
- python -m unittest tests.test_parallel_status_snapshot -q
- python scripts/validate_public_json_artifacts.py
- python scripts/factoryctl.py status-snapshot --card examples/minimal-hermes-project/card.md --lane-contract templates/parallel-lane-contract.json --evidence-ref external:operator-summary --out .tmp/factory-status-snapshot.json
- python -m unittest tests.test_worker_profiles tests.test_open_source_docs -q
- python scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
- python scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
- python scripts/factoryctl.py worker-packet --worker factory-orchestrator --card examples/minimal-hermes-project/card.md --out .tmp/factory-orchestrator-request.json
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/supply_chain_proof.py --check --no-write
- python scripts/validate_document_governance.py
- python scripts/validate_worker_profiles.py
- git diff --check
- python -m unittest discover -s tests -p test_*.py -q