### PR TITLE
Add mandatory Product Face visual quality gate

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -41,6 +41,7 @@ Run for any card with surfaces:
 - packet comparison status;
 - source-promise coverage status;
 - design-fit review status;
+- visual-quality verdict;
 - evidence refs;
 - next action.
 
@@ -70,8 +71,11 @@ Useful options:
 - `--packet-ref`, `--packet-comparison-basis`,
   `--source-promise-coverage-basis` and `--design-fit-review-basis` to record
   product approval alignment.
+- `--visual-quality-status`, `--visual-quality-reviewer` and
+  `--visual-quality-basis` to record the professional visual quality verdict.
 - `--reusable-for-product` only after the three alignment fields above are
-  recorded as `pass`.
+  recorded as `pass` and `visual_quality_result` is `PASS` or
+  `PASS_WITH_RESIDUALS`.
 
 With Python Playwright available, the runner captures screenshots, console
 messages, DOM state, accessibility basics, overlap scan and a browser-local
@@ -80,11 +84,13 @@ performance note. Without Playwright, it writes a `WAIVED` result with
 rendered screenshot, console, layout, accessibility tree or performance claim
 was captured.
 
-For product-facing completion, Receipt Five must include
-`product_face_result`. A Product Face Packet is planning; a Product Face Result
-is proof. Browser screenshots alone are not product approval. A reusable product
-approval also needs packet comparison, source-promise coverage and design-fit
-review recorded as `pass`.
+For product-facing completion, Receipt Five must include `product_face_result`.
+A Product Face Packet is planning; a Product Face Result is proof. Browser
+screenshots, no console errors, no overflow, accessibility basics and state
+coverage are necessary but insufficient. A reusable product approval also needs
+packet comparison, source-promise coverage, design-fit review and
+`visual_quality_result` recorded as acceptable by a reviewer empowered to block
+visually unacceptable UI.
 
 Reusable product example:
 
@@ -101,6 +107,9 @@ python scripts/product_face_proof.py \
   --packet-comparison-basis "Screens, states and viewports match the Product Face Packet." \
   --source-promise-coverage-basis "The checked journey covers the stated product promise." \
   --design-fit-review-basis "The reviewer confirmed fit to the requested product direction." \
+  --visual-quality-status PASS \
+  --visual-quality-reviewer product-face-reviewer \
+  --visual-quality-basis "The UI meets the product-specific quality bar and does not show AI-generic symptoms." \
   --reusable-for-product \
   --product-id qvg-public-validation-product \
   --environment-class production-like-static-artifact \
@@ -146,7 +155,13 @@ Full Product Face PASS requires:
 - packet comparison;
 - source-promise coverage;
 - design-fit review;
+- visual-quality verdict distinct from mechanical proof;
 - evidence refs attached to Receipt Five.
+
+A mechanically passing UI must still block when it shows clear AI-generic
+symptoms: generic dashboard composition, excessive explanatory copy, weak
+hierarchy, synthetic visual language, audience mismatch, or controls/states that
+pass a checklist but fail a serious product/design review.
 
 ## Why This Is Better
 

--- a/examples/cards/v35_invalid_self_review.md
+++ b/examples/cards/v35_invalid_self_review.md
@@ -52,6 +52,12 @@
     "mobile_breakpoints": ["375", "768", "1440"],
     "a11y_acceptance": ["keyboard", "focus", "contrast"],
     "performance_budget": {"render": "not_applicable_docs_only"},
+    "visual_quality_bar": {
+      "reference_quality_bar": "A focused operator validation surface with clear status, evidence and review hierarchy.",
+      "anti_generic_criteria": ["no generic AI dashboard composition"],
+      "professional_review_required": true,
+      "block_when": ["surface looks templated or product-agnostic"]
+    },
     "visual_evidence_plan": ["desktop screenshot", "mobile screenshot"]
   }
 }

--- a/examples/cards/v35_valid_product_face.md
+++ b/examples/cards/v35_valid_product_face.md
@@ -85,6 +85,19 @@
     "wallet_flow_matrix": {"sign": "not_applicable_docs_only", "reject": "not_applicable_docs_only"},
     "a11y_acceptance": ["keyboard", "focus", "contrast", "labels"],
     "performance_budget": {"bundle": "not_applicable_docs_only", "render": "not_applicable_docs_only"},
+    "visual_quality_bar": {
+      "reference_quality_bar": "A focused operator validation surface with clear status, evidence and review hierarchy.",
+      "anti_generic_criteria": [
+        "no generic AI dashboard composition",
+        "no excessive explanatory copy",
+        "no weak hierarchy between status, evidence and next action"
+      ],
+      "professional_review_required": true,
+      "block_when": [
+        "screenshots pass mechanically but the surface looks templated or product-agnostic",
+        "visual hierarchy does not match the Product Face job"
+      ]
+    },
     "visual_evidence_plan": ["desktop screenshot", "mobile screenshot"]
   }
 }

--- a/examples/minimal-hermes-project/card.md
+++ b/examples/minimal-hermes-project/card.md
@@ -178,6 +178,19 @@
       "bundle": "not_applicable",
       "render": "local_static_page"
     },
+    "visual_quality_bar": {
+      "reference_quality_bar": "A quiet, inspectable operator receipt/status surface; not a generic marketing dashboard.",
+      "anti_generic_criteria": [
+        "no generic AI dashboard composition",
+        "no excessive explanatory copy where status structure should carry meaning",
+        "no decorative visual treatment that hides receipt state or next action"
+      ],
+      "professional_review_required": true,
+      "block_when": [
+        "mechanical screenshots pass but hierarchy, density or product fit feels generic",
+        "the UI looks like a template rather than a purpose-built factory operator surface"
+      ]
+    },
     "visual_evidence_plan": [
       "desktop screenshot",
       "mobile screenshot",

--- a/schemas/product-experience-plan.schema.json
+++ b/schemas/product-experience-plan.schema.json
@@ -12,6 +12,7 @@
     "main_flows",
     "required_states",
     "design_direction",
+    "visual_quality_bar",
     "proof_required",
     "reviewers_required",
     "done_definition",
@@ -72,6 +73,25 @@
         "product_fit": { "type": "string", "minLength": 3 },
         "density": { "type": "string", "minLength": 3 },
         "interaction_style": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "visual_quality_bar": {
+      "type": "object",
+      "required": ["reference_quality_bar", "anti_generic_criteria", "professional_review_required", "block_when"],
+      "properties": {
+        "reference_quality_bar": { "type": "string", "minLength": 3 },
+        "anti_generic_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "professional_review_required": { "type": "boolean" },
+        "block_when": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
       },
       "additionalProperties": true
     },

--- a/schemas/product-face-packet.schema.json
+++ b/schemas/product-face-packet.schema.json
@@ -11,6 +11,7 @@
     "main_flows",
     "required_states",
     "design_direction",
+    "visual_quality_bar",
     "proof_required",
     "reviewers_required",
     "done_definition",
@@ -52,6 +53,25 @@
         "product_fit": { "type": "string", "minLength": 3 },
         "density": { "type": "string", "minLength": 3 },
         "interaction_style": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "visual_quality_bar": {
+      "type": "object",
+      "required": ["reference_quality_bar", "anti_generic_criteria", "professional_review_required", "block_when"],
+      "properties": {
+        "reference_quality_bar": { "type": "string", "minLength": 3 },
+        "anti_generic_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "professional_review_required": { "type": "boolean" },
+        "block_when": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
       },
       "additionalProperties": true
     },

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -17,6 +17,7 @@
     "packet_comparison",
     "source_promise_coverage",
     "design_fit_review",
+    "visual_quality_result",
     "blocking_findings",
     "evidence_refs",
     "evidence_kind",
@@ -109,6 +110,25 @@
       "properties": {
         "status": { "enum": ["pass", "warn", "fail", "pending"] },
         "basis": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "visual_quality_result": {
+      "type": "object",
+      "required": ["status", "reviewer", "basis", "reference_quality_bar_checked", "ai_generic_symptoms"],
+      "properties": {
+        "status": { "enum": ["PASS", "BLOCK", "PASS_WITH_RESIDUALS"] },
+        "reviewer": { "type": "string", "minLength": 3 },
+        "basis": { "type": "string", "minLength": 3 },
+        "reference_quality_bar_checked": { "type": "boolean" },
+        "ai_generic_symptoms": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "residuals": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
       },
       "additionalProperties": true
     },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -195,6 +195,7 @@ PRODUCT_EXPERIENCE_REQUIRED_FIELDS = (
     "main_flows",
     "required_states",
     "design_direction",
+    "visual_quality_bar",
     "proof_required",
     "reviewers_required",
     "done_definition",
@@ -208,6 +209,7 @@ PRODUCT_FACE_PACKET_REQUIRED_FIELDS = (
     "main_flows",
     "required_states",
     "design_direction",
+    "visual_quality_bar",
     "proof_required",
     "reviewers_required",
     "done_definition",
@@ -241,6 +243,7 @@ PRODUCT_FACE_RESULT_ALIGNMENT_FIELDS = (
     "source_promise_coverage",
     "design_fit_review",
 )
+VISUAL_QUALITY_ALLOWED_RESULTS = {"PASS", "PASS_WITH_RESIDUALS", "BLOCK"}
 
 
 @dataclass(frozen=True)
@@ -1558,6 +1561,25 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
         errors.append("product_face_result PASS requires console.status=pass")
     if result.get("blocking_findings") is True and not str(result.get("next_action") or "").strip():
         errors.append("product_face_result blocking findings require next_action")
+    visual_quality = result.get("visual_quality_result") if isinstance(result.get("visual_quality_result"), dict) else {}
+    if not visual_quality:
+        errors.append("product_face_result.visual_quality_result is required")
+    else:
+        visual_status = str(visual_quality.get("status") or "").strip().upper()
+        if visual_status not in VISUAL_QUALITY_ALLOWED_RESULTS:
+            errors.append("product_face_result.visual_quality_result.status must be PASS, PASS_WITH_RESIDUALS or BLOCK")
+        if not _non_empty_text(visual_quality.get("reviewer")):
+            errors.append("product_face_result.visual_quality_result.reviewer is required")
+        if not _non_empty_text(visual_quality.get("basis")):
+            errors.append("product_face_result.visual_quality_result.basis is required")
+        if visual_status in {"PASS", "PASS_WITH_RESIDUALS"} and visual_quality.get("reference_quality_bar_checked") is not True:
+            errors.append("product_face_result.visual_quality_result.reference_quality_bar_checked must be true")
+        if is_pass and visual_status == "BLOCK":
+            errors.append("product_face_result visual_quality_result BLOCK prevents Product Face PASS")
+        if is_pass and visual_status not in {"PASS", "PASS_WITH_RESIDUALS"}:
+            errors.append("product_face_result PASS requires visual_quality_result.status PASS or PASS_WITH_RESIDUALS")
+        if is_pass and visual_status == "PASS_WITH_RESIDUALS" and not _list_items(visual_quality.get("residuals")):
+            errors.append("product_face_result PASS_WITH_RESIDUALS requires residuals")
     return errors
 
 
@@ -2966,6 +2988,18 @@ def build_worker_result(
                 "design_fit_review": {
                     "status": "pass" if not blocking_findings else "fail",
                     "basis": "Design fit reviewed by Product Face validator for this bounded card.",
+                },
+                "visual_quality_result": {
+                    "status": "PASS" if not blocking_findings else "BLOCK",
+                    "reviewer": "product-face-validator",
+                    "basis": (
+                        "Professional visual quality bar reviewed for this bounded card."
+                        if not blocking_findings
+                        else "Product Face result is blocked; professional visual quality approval was not granted."
+                    ),
+                    "reference_quality_bar_checked": not blocking_findings,
+                    "ai_generic_symptoms": [] if not blocking_findings else ["visual quality approval blocked"],
+                    "residuals": [],
                 },
             }
         )

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -27,6 +27,7 @@ PRODUCT_ALIGNMENT_FIELDS = (
     "source_promise_coverage",
     "design_fit_review",
 )
+VISUAL_QUALITY_PASS_RESULTS = {"PASS", "PASS_WITH_RESIDUALS"}
 
 
 class PlaywrightUnavailable(RuntimeError):
@@ -349,6 +350,14 @@ def base_result(
             "status": "pending",
             "basis": "Visual/product-fit review must be recorded by Product Face reviewer before promotion.",
         },
+        "visual_quality_result": {
+            "status": "BLOCK",
+            "reviewer": "product-face-proof-runner",
+            "basis": "Mechanical browser proof is necessary but not sufficient for professional visual approval.",
+            "reference_quality_bar_checked": False,
+            "ai_generic_symptoms": ["visual quality review not recorded"],
+            "residuals": [],
+        },
         "evidence_refs": [],
         "evidence_kind": "real",
         "reusable_for_product": False,
@@ -383,6 +392,9 @@ def validate_reusable_product_scope(
             "--reusable-for-product requires Product Face alignment: packet_ref, "
             "packet_comparison=pass, source_promise_coverage=pass and design_fit_review=pass"
         )
+    visual_quality = result.get("visual_quality_result") if isinstance(result.get("visual_quality_result"), dict) else {}
+    if visual_quality.get("status") not in VISUAL_QUALITY_PASS_RESULTS or visual_quality.get("reference_quality_bar_checked") is not True:
+        raise ValueError("reusable Product Face evidence requires visual_quality_result PASS or PASS_WITH_RESIDUALS")
 
 
 def product_alignment_passes(result: dict[str, Any]) -> bool:
@@ -394,6 +406,23 @@ def product_alignment_passes(result: dict[str, Any]) -> bool:
             return False
         if not str(value.get("basis") or "").strip():
             return False
+    return True
+
+
+def visual_quality_passes(result: dict[str, Any]) -> bool:
+    visual_quality = result.get("visual_quality_result")
+    if not isinstance(visual_quality, dict):
+        return False
+    if visual_quality.get("status") not in VISUAL_QUALITY_PASS_RESULTS:
+        return False
+    if visual_quality.get("reference_quality_bar_checked") is not True:
+        return False
+    if not str(visual_quality.get("reviewer") or "").strip():
+        return False
+    if not str(visual_quality.get("basis") or "").strip():
+        return False
+    if visual_quality.get("status") == "PASS_WITH_RESIDUALS" and not visual_quality.get("residuals"):
+        return False
     return True
 
 
@@ -430,6 +459,51 @@ def apply_product_alignment(
         "status": "pass",
         "basis": str(design_fit_review_basis).strip(),
     }
+
+
+def apply_visual_quality_review(
+    *,
+    result: dict[str, Any],
+    status: str | None,
+    reviewer: str | None,
+    basis: str | None,
+    residuals: list[str] | None = None,
+) -> None:
+    supplied = any(str(value or "").strip() for value in (status, reviewer, basis)) or bool(residuals)
+    if not supplied:
+        return
+    normalized_status = str(status or "").strip().upper()
+    if normalized_status not in {"PASS", "BLOCK", "PASS_WITH_RESIDUALS"}:
+        raise ValueError("--visual-quality-status must be PASS, BLOCK or PASS_WITH_RESIDUALS")
+    missing = []
+    if not str(reviewer or "").strip():
+        missing.append("visual-quality-reviewer")
+    if not str(basis or "").strip():
+        missing.append("visual-quality-basis")
+    if normalized_status == "PASS_WITH_RESIDUALS" and not residuals:
+        missing.append("visual-quality-residual")
+    if missing:
+        raise ValueError("Visual quality review is incomplete: missing " + ", ".join(missing))
+    result["visual_quality_result"] = {
+        "status": normalized_status,
+        "reviewer": str(reviewer).strip(),
+        "basis": str(basis).strip(),
+        "reference_quality_bar_checked": normalized_status in VISUAL_QUALITY_PASS_RESULTS,
+        "ai_generic_symptoms": [] if normalized_status in VISUAL_QUALITY_PASS_RESULTS else ["reviewer-blocked-visual-quality"],
+        "residuals": residuals or [],
+    }
+
+
+def enforce_visual_quality_gate(result: dict[str, Any]) -> None:
+    if result.get("result") == "PASS" and not visual_quality_passes(result):
+        result["result"] = "WAIVED"
+        result["blocking_findings"] = True
+        result["findings_summary"] = (
+            "Mechanical Product Face proof ran, but professional visual quality approval is missing or blocked."
+        )
+        result["next_action"] = (
+            "Record visual_quality_result PASS or PASS_WITH_RESIDUALS from an empowered Product Face reviewer before promotion."
+        )
 
 
 def apply_product_reuse_scope(
@@ -746,6 +820,10 @@ def build_product_face_proof(
     packet_comparison_basis: str | None = None,
     source_promise_coverage_basis: str | None = None,
     design_fit_review_basis: str | None = None,
+    visual_quality_status: str | None = None,
+    visual_quality_reviewer: str | None = None,
+    visual_quality_basis: str | None = None,
+    visual_quality_residuals: list[str] | None = None,
 ) -> dict[str, Any]:
     output_dir = out if out.suffix == "" else out.parent
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -805,6 +883,14 @@ def build_product_face_proof(
         source_promise_coverage_basis=source_promise_coverage_basis,
         design_fit_review_basis=design_fit_review_basis,
     )
+    apply_visual_quality_review(
+        result=result,
+        status=visual_quality_status,
+        reviewer=visual_quality_reviewer,
+        basis=visual_quality_basis,
+        residuals=visual_quality_residuals,
+    )
+    enforce_visual_quality_gate(result)
     if reusable_for_product:
         apply_product_reuse_scope(
             result=result,
@@ -845,6 +931,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--packet-comparison-basis", help="Why this proof matches the Product Face Packet.")
     parser.add_argument("--source-promise-coverage-basis", help="Why this proof covers the source/product promise.")
     parser.add_argument("--design-fit-review-basis", help="Why this proof fits the intended product/design direction.")
+    parser.add_argument("--visual-quality-status", choices=["PASS", "BLOCK", "PASS_WITH_RESIDUALS"], help="Professional visual quality verdict.")
+    parser.add_argument("--visual-quality-reviewer", help="Reviewer empowered to block visually unacceptable UI.")
+    parser.add_argument("--visual-quality-basis", help="Why the surface meets or fails the product-specific quality bar.")
+    parser.add_argument("--visual-quality-residual", action="append", help="Residual visual quality issue when status is PASS_WITH_RESIDUALS.")
     return parser.parse_args(argv)
 
 
@@ -870,6 +960,10 @@ def main(argv: list[str] | None = None) -> int:
             packet_comparison_basis=args.packet_comparison_basis,
             source_promise_coverage_basis=args.source_promise_coverage_basis,
             design_fit_review_basis=args.design_fit_review_basis,
+            visual_quality_status=args.visual_quality_status,
+            visual_quality_reviewer=args.visual_quality_reviewer,
+            visual_quality_basis=args.visual_quality_basis,
+            visual_quality_residuals=args.visual_quality_residual,
         )
     except Exception as exc:
         print(f"product_face_proof failed: {exc}", file=sys.stderr)

--- a/templates/product-experience-plan.json
+++ b/templates/product-experience-plan.json
@@ -21,11 +21,25 @@
     "density": "State whether this should be dense/operational, editorial, playful, or another fit.",
     "interaction_style": "Describe how the user should move through the surface."
   },
+  "visual_quality_bar": {
+    "reference_quality_bar": "State the relevant quality bar: existing product conventions, best-in-class references, or professional cockpit/UI standard.",
+    "anti_generic_criteria": [
+      "avoid generic AI dashboard composition",
+      "avoid excessive explanatory copy",
+      "avoid weak hierarchy, synthetic polish or audience mismatch"
+    ],
+    "professional_review_required": true,
+    "block_when": [
+      "mechanical proof passes but the UI is not credible for a real operator/user",
+      "reviewer identifies AI-generic symptoms that make the surface unacceptable"
+    ]
+  },
   "proof_required": [
     "desktop screenshot",
     "mobile screenshot",
     "keyboard/a11y check",
-    "Product Face Result comparing output to this plan"
+    "Product Face Result comparing output to this plan",
+    "visual_quality_result verdict"
   ],
   "reviewers_required": [
     "product-face",
@@ -35,7 +49,8 @@
   "done_definition": [
     "Product Face Packet exists before implementation",
     "Product Face Result compares screenshots/states/flows against the packet",
-    "review confirms evidence matches the original product promise"
+    "review confirms evidence matches the original product promise",
+    "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"
   ],
   "human_gate": {
     "required": false,

--- a/templates/product-face-packet.json
+++ b/templates/product-face-packet.json
@@ -20,6 +20,19 @@
     "density": "State the right density for this product surface.",
     "interaction_style": "Describe the interaction model and motion/feedback expectations."
   },
+  "visual_quality_bar": {
+    "reference_quality_bar": "Name the product-specific quality bar or reference class this surface must meet.",
+    "anti_generic_criteria": [
+      "no generic dashboard composition when the product needs a tailored cockpit",
+      "no excessive explanatory copy where structure and interaction should carry meaning",
+      "no templated visual language disconnected from the product audience"
+    ],
+    "professional_review_required": true,
+    "block_when": [
+      "mechanical screenshots pass but the surface looks obviously AI-generated",
+      "visual hierarchy, density or controls would fail a serious product/design review"
+    ]
+  },
   "data_context": "Describe the kind of real data, long data, empty data and sensitive data shown.",
   "accessibility_scope": [
     "keyboard",
@@ -38,7 +51,8 @@
     "desktop screenshot",
     "mobile screenshot when mobile is in scope",
     "states evidence",
-    "Product Face Result comparison to packet"
+    "Product Face Result comparison to packet",
+    "visual_quality_result verdict"
   ],
   "reviewers_required": [
     "product-face",
@@ -48,7 +62,8 @@
   "done_definition": [
     "result covers required flows and states",
     "result includes evidence for required viewports",
-    "review confirms result fits the product promise and visual direction"
+    "review confirms result fits the product promise and visual direction",
+    "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"
   ],
   "human_gate": {
     "required": false,

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -262,9 +262,22 @@
       "density": "appropriate to repeated operational use",
       "interaction_style": "direct, observable and reversible when risk exists"
     },
-    "proof_required": ["state evidence", "review evidence"],
+    "visual_quality_bar": {
+      "reference_quality_bar": "A product-specific operator surface benchmark, existing product convention or best-in-class reference class named before execution.",
+      "anti_generic_criteria": [
+        "no generic AI dashboard composition",
+        "no excessive explanatory copy where structure and interaction should carry meaning",
+        "no templated visual hierarchy disconnected from the user job"
+      ],
+      "professional_review_required": true,
+      "block_when": [
+        "mechanical screenshots pass but the surface feels generic, synthetic or audience-mismatched",
+        "the implementation cannot name and meet a reference quality bar"
+      ]
+    },
+    "proof_required": ["state evidence", "review evidence", "visual_quality_result verdict"],
     "reviewers_required": ["product-face", "qa-verification-worker", "independent-reviewer"],
-    "done_definition": ["experience evidence exists", "states are checked"],
+    "done_definition": ["experience evidence exists", "states are checked", "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"],
     "human_gate": {"required": false, "approver": "", "reason": "No material human product decision in this template."},
     "evidence_refs": ["templates/vfinal-factory-card.json"]
   },
@@ -282,9 +295,22 @@
       "density": "appropriate to repeated operational use",
       "interaction_style": "direct, observable and reversible when risk exists"
     },
-    "proof_required": ["state evidence", "review evidence"],
+    "visual_quality_bar": {
+      "reference_quality_bar": "A product-specific operator surface benchmark, existing product convention or best-in-class reference class named before execution.",
+      "anti_generic_criteria": [
+        "no generic AI dashboard composition",
+        "no excessive explanatory copy where structure and interaction should carry meaning",
+        "no templated visual hierarchy disconnected from the user job"
+      ],
+      "professional_review_required": true,
+      "block_when": [
+        "mechanical screenshots pass but the surface feels generic, synthetic or audience-mismatched",
+        "the implementation cannot name and meet a reference quality bar"
+      ]
+    },
+    "proof_required": ["state evidence", "review evidence", "visual_quality_result verdict"],
     "reviewers_required": ["product-face", "qa-verification-worker", "independent-reviewer"],
-    "done_definition": ["experience evidence exists", "states are checked"],
+    "done_definition": ["experience evidence exists", "states are checked", "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"],
     "human_gate": {"required": false, "approver": "", "reason": "No material human product decision in this template."}
   },
   "data_metrics_plan": {

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -412,6 +412,13 @@ class FactoryCtlTest(unittest.TestCase):
                     "status": "pass",
                     "basis": "The validator confirmed this bounded SaaS surface matches the Product Face packet."
                 },
+                "visual_quality_result": {
+                    "status": "PASS",
+                    "reviewer": "product-face-reviewer",
+                    "basis": "The surface meets the Product Face packet quality bar and does not show AI-generic UI symptoms.",
+                    "reference_quality_bar_checked": True,
+                    "ai_generic_symptoms": [],
+                },
                 "blocking_findings": False,
                 "evidence_refs": ["reports/product-face.md"],
                 "next_action": "independent review",
@@ -464,6 +471,71 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_result.packet_comparison is required for product-facing completion", errors)
         self.assertIn("product_face_result.source_promise_coverage is required for product-facing completion", errors)
         self.assertIn("product_face_result.design_fit_review is required for product-facing completion", errors)
+        self.assertIn("product_face_result.visual_quality_result is required", errors)
+
+    def test_product_face_completion_blocks_mechanically_ok_but_ai_generic_ui(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_face_result_required"] = True
+        receipt = {
+            "receipt_five": {
+                "changed": "validated visible SaaS scenario",
+                "artifact_paths": ["examples/cards/v35_valid_product_face.md"],
+                "verification_commands": ["python scripts/factoryctl.py validate-card examples/cards/v35_valid_product_face.md"],
+                "verification_result": "PASS",
+                "reviewer_required": True,
+                "reviewer_result": "PASS",
+                "next_action": "ready for independent review",
+            },
+            "kanban_transition_event": {
+                "from_status": "review",
+                "to_status": "done",
+                "actor": "qa-verification-worker",
+                "worker": "product-face",
+                "receipt_refs": ["receipt_five", "product_face_result"],
+                "artifact_refs": ["examples/cards/v35_valid_product_face.md", "reports/product-face.md"],
+            },
+            "product_face_result": {
+                "result": "PASS",
+                "tool_or_profile": "browser-proof-runner",
+                "executed_by": "product-face-validator",
+                "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
+                "viewports": ["desktop 1440x900", "mobile 390x844"],
+                "checked_states": ["empty", "loading", "success", "error"],
+                "user_journeys_checked": ["dashboard to detail", "settings save"],
+                "a11y": {"status": "pass"},
+                "overlap_check": {"status": "pass"},
+                "console": {"status": "pass"},
+                "performance_note": "static validation scenario only",
+                "packet_ref": "examples/cards/v35_valid_product_face.md#product_face_packet",
+                "packet_comparison": {
+                    "status": "pass",
+                    "basis": "All planned screens, states and viewports are covered."
+                },
+                "source_promise_coverage": {
+                    "status": "pass",
+                    "basis": "The checked journey covers the product promise."
+                },
+                "design_fit_review": {
+                    "status": "pass",
+                    "basis": "Mechanical layout and state checks passed."
+                },
+                "visual_quality_result": {
+                    "status": "BLOCK",
+                    "reviewer": "product-face-reviewer",
+                    "basis": "The UI uses a generic dashboard composition with excessive explanatory copy and no product-specific visual direction.",
+                    "reference_quality_bar_checked": True,
+                    "ai_generic_symptoms": ["generic dashboard composition", "excessive explanatory copy"],
+                },
+                "blocking_findings": False,
+                "evidence_refs": ["reports/product-face.md"],
+                "next_action": "redesign visual system",
+            },
+        }
+
+        errors = factoryctl.validate_completion(card, receipt)
+
+        self.assertIn("product_face_result visual_quality_result BLOCK prevents Product Face PASS", errors)
+        self.assertIn("product_face_result PASS requires visual_quality_result.status PASS or PASS_WITH_RESIDUALS", errors)
 
     def test_product_face_pass_rejects_blocking_or_warning_result(self) -> None:
         result = {
@@ -488,6 +560,7 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_result screenshots must reference captured artifacts", errors)
         self.assertIn("product_face_result PASS requires a11y.status=pass", errors)
         self.assertIn("product_face_result PASS requires overlap_check.status=pass", errors)
+        self.assertIn("product_face_result.visual_quality_result is required", errors)
 
     def test_auditor_preflight_cannot_claim_pass(self) -> None:
         bad = {

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -99,6 +99,7 @@ class ProductFaceProofTest(unittest.TestCase):
             "packet_comparison",
             "source_promise_coverage",
             "design_fit_review",
+            "visual_quality_result",
             "blocking_findings",
             "evidence_refs",
             "next_action",
@@ -109,6 +110,7 @@ class ProductFaceProofTest(unittest.TestCase):
             self.assertTrue(result[field])
         self.assertTrue(result["a11y"])
         self.assertTrue(result["overlap_check"])
+        self.assertIn(result["visual_quality_result"]["status"], {"BLOCK", "PASS", "PASS_WITH_RESIDUALS"})
 
     def test_card_binding_and_factory_alias_fields_are_present(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
@@ -182,6 +184,12 @@ class ProductFaceProofTest(unittest.TestCase):
                 packet_comparison_basis="Unit proof is explicitly matched to the packet.",
                 source_promise_coverage_basis="Unit proof covers the named product promise.",
                 design_fit_review_basis="Unit proof includes an explicit design-fit review.",
+            )
+            product_face_proof.apply_visual_quality_review(
+                result=result,
+                status="PASS",
+                reviewer="product-face-reviewer",
+                basis="Unit proof meets the reference quality bar for this bounded fixture.",
             )
 
             product_face_proof.apply_product_reuse_scope(


### PR DESCRIPTION
Summary: require Product Face/Product Experience contracts to name a visual quality bar and anti-generic blocking criteria; require product_face_result.visual_quality_result before Product Face PASS can promote; update proof runner, public examples, vFinal template and tests for mechanically passing but visually unacceptable UI. Validation: focused unittest, validate_public_json_artifacts, validate-card for minimal and v35 Product Face examples, public_safety_scan, secret_safety_scan, supply_chain_proof --check --no-write, validate_document_governance, validate_worker_profiles, quickstart_smoke, gate-report, product-face worker-packet, git diff --check, full unittest discover.