### PR TITLE
Add Factory Learning Skill Evolution OS

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,3 +51,7 @@ operator surface, maintainer internals or generated output.
 Use `maintenance/self-improvement-loop.md` for learnback issue candidates,
 missing-capability completion plans, owner issue intake, reasoning policy,
 reference quality packets and governance audit artifacts.
+
+Use `maintenance/factory-learning-skill-evolution-os.md` when repeated
+execution findings should become validated skills, rules, gates, tests, workers,
+schemas, hooks, MCP/tool proposals, install profiles, issues or rejections.

--- a/docs/maintenance/factory-learning-skill-evolution-os.md
+++ b/docs/maintenance/factory-learning-skill-evolution-os.md
@@ -1,0 +1,133 @@
+# Factory Learning And Skill Evolution OS
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: `schemas/factory-learning-proposal.schema.json`,
+> `scripts/factory_self_improvement.py`, `skill-eval-distiller`, tests.
+> Runtime boundary: this OS creates inactive proposals and public-safe issue
+> candidates. It does not auto-activate rules, skills, workers, hooks, MCPs,
+> install profiles or gates.
+
+## Purpose
+
+The factory should improve from execution evidence without becoming a pile of
+agent-written notes. Learnback, plan-review findings, repeated corrections and
+reusable workflow patterns must become typed proposals that can be validated,
+reviewed, activated or rejected.
+
+The source of a learning proposal can be:
+
+- `execution_learnback_record`;
+- independent plan review;
+- recurring Receipt Five reconciliation finding;
+- governance audit;
+- issue intake from an owner-controlled factory instance;
+- public research summarized through a read-only source pass.
+
+Raw private evidence is not a learning artifact. Public proposals use redacted
+evidence refs such as `external:run-summary`, `.tmp` outputs during validation,
+or public-safe issue links.
+
+## Proposal Contract
+
+Use `templates/factory-learning-proposal.json` as the starting point. Each
+proposal must name:
+
+- source evidence refs;
+- source trust level;
+- classification;
+- proposed artifact type;
+- risk;
+- owner;
+- validation plan;
+- activation policy;
+- untrusted input handling;
+- tool governance;
+- rejection rationale.
+
+Supported classifications are:
+
+`rule`, `skill`, `worker`, `gate`, `schema`, `test`, `doc`, `reference`,
+`issue`, `hook`, `mcp_or_tool`, `install_profile`, and `reject`.
+
+Every non-rejected proposal needs independent review before activation. Worker,
+gate, hook, MCP/tool and install-profile proposals land as inactive candidates
+and require explicit review. Sensitive domains such as production, secrets,
+credentials, custody, mainnet, legal, privacy, billing or hardware require a
+human gate before mutation.
+
+## Skill Promotion
+
+A workflow can become a factory skill only after this lifecycle:
+
+1. repeated workflow, correction or failure is observed;
+2. `factory_learning_proposal` is created as `inactive_candidate`;
+3. trigger conditions and source evidence refs are recorded;
+4. focused tests or eval fixtures prove the skill helps;
+5. independent review checks scope, safety and maintainability;
+6. public-safety, secret-safety and supply-chain checks pass;
+7. activation policy names scope, budget, tools and stop condition;
+8. learnback after real use confirms the skill remains useful.
+
+Skills should carry scripts or fixtures when that prevents agents from
+recreating boilerplate from memory. Large references stay on demand; they should
+not bloat always-loaded context.
+
+## Plan Review
+
+Material work should not move from plan to implementation only because the
+generating agent likes its own plan. Require independent critical review for:
+
+- security-sensitive work;
+- architecture or registry/binding changes;
+- product-facing surfaces;
+- release or production operations;
+- reusable skills, hooks, MCPs, gates, schemas or worker profiles.
+
+The reviewer looks for missing security decisions, weak auth assumptions,
+architecture drift, convenience implementations, missing tests, unclear owners,
+missing rollback/release gates and invented details. Repeated review corrections
+become learning proposals.
+
+## Scheduled Learning
+
+Scheduled or dream passes are allowed only as public-safe proposal generation.
+They may read structured execution evidence, issue snapshots and governance
+reports, then produce `factory_learning_proposal` or
+`factory_improvement_issue_candidate` records. They must not dispatch workers,
+approve gates, post public comments or mutate runtime state without a separate
+owner-approved scope, cadence, budget and stop condition.
+
+## Untrusted Sources
+
+External posts, articles, repositories and docs are inputs, not authority. Use a
+reader/actor split:
+
+- a read-only source pass summarizes raw external content;
+- privileged factory actors consume only structured summaries and source refs;
+- copied code/assets require license or terms evidence;
+- rejected ideas keep rejection rationale instead of disappearing.
+
+This protects the factory from prompt injection, vendor lock-in and accidental
+adoption of patterns that do not fit the factory spine.
+
+## Parallel Workflows
+
+Parallelism is a tool, not a default. Use fan-out, adversarial verification,
+tournament, generate-and-filter or loop-until-done patterns when the task
+benefits from independent evidence, review pressure or scale. Detailed
+lane/worktree boundaries, write scopes and reconciliation stay in
+`operations/parallel-execution-and-status.md`.
+
+## Completion Bar
+
+A learning proposal is complete only when it has:
+
+- public-safe source evidence refs;
+- validation commands or evals;
+- independent review provenance;
+- explicit activation policy;
+- budget, max agents, timeout and stop condition;
+- tool/MCP/hook trust and supply-chain posture;
+- rejection rationale when not adopted.
+
+Narrative alone is not learning. Unvalidated learning is only a candidate.

--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -17,6 +17,7 @@ intake and governance checks into structured artifacts.
 
 - `schemas/missing-capability-completion-plan.schema.json`
 - `schemas/execution-learnback-record.schema.json`
+- `schemas/factory-learning-proposal.schema.json`
 - `schemas/factory-improvement-issue-candidate.schema.json`
 - `schemas/owner-issue-intake-config.schema.json`
 - `schemas/owner-issue-intake-report.schema.json`
@@ -57,6 +58,26 @@ python scripts/factory_self_improvement.py learnback-issues \
 Public issue candidates must be generalized and redacted. Raw private logs,
 local paths, private board ids, Discord ids and screenshots do not belong in
 public issue bodies.
+
+## Learning Proposals
+
+Use `factory_learning_proposal` when a finding should become a durable rule,
+skill, worker, gate, schema, test, doc, reference, issue, hook, MCP/tool,
+install profile or recorded rejection:
+
+```bash
+python scripts/factory_self_improvement.py learning-proposals \
+  --record .tmp/execution-learnback-record.json \
+  --out .tmp/factory-learning-proposals.json
+```
+
+Learning proposals land as inactive candidates. They need validation,
+independent review and explicit activation policy before they can change factory
+behavior. Sensitive artifacts such as workers, gates, hooks, MCPs and install
+profiles must not auto-activate.
+
+See `maintenance/factory-learning-skill-evolution-os.md` for the operating
+rules.
 
 ## Owner Issue Intake
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,6 +72,7 @@ Creates dry-run self-improvement artifacts for maintainers:
 python scripts/factory_self_improvement.py reference-registry --out .tmp/reference-source-registry.json
 python scripts/factory_self_improvement.py missing-capability-plan --gate-report .tmp/gate-report.json --out .tmp/missing-capability-plan.json
 python scripts/factory_self_improvement.py learnback-issues --record .tmp/execution-learnback-record.json --out .tmp/issue-candidates.json
+python scripts/factory_self_improvement.py learning-proposals --record .tmp/execution-learnback-record.json --out .tmp/learning-proposals.json
 python scripts/factory_self_improvement.py issue-intake --config templates/owner-issue-intake-config.json --issues .tmp/issues.json --out .tmp/issue-intake-report.json
 python scripts/factory_self_improvement.py governance-audit --out .tmp/ai-codebase-governance-report.json
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,3 +23,4 @@ nav:
       - Parallel Execution And Status: operations/parallel-execution-and-status.md
       - Release Policy: operations/release-policy.md
   - Maintainer Internals: maintenance/repo-surface.md
+  - Factory Learning OS: maintenance/factory-learning-skill-evolution-os.md

--- a/schemas/factory-learning-proposal.schema.json
+++ b/schemas/factory-learning-proposal.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-learning-proposal.schema.json",
+  "title": "Overkill Factory Learning Proposal",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "source_evidence_refs",
+    "source_trust",
+    "classification",
+    "proposed_artifact_type",
+    "risk",
+    "owner",
+    "validation_plan",
+    "activation_policy",
+    "untrusted_input_handling",
+    "tool_governance",
+    "rejection_rationale"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-learning-proposal.schema.json"
+    },
+    "record_type": {
+      "const": "factory_learning_proposal"
+    },
+    "source_evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "source_trust": {
+      "enum": ["internal_structured", "external_untrusted", "mixed"]
+    },
+    "classification": {
+      "enum": [
+        "rule",
+        "skill",
+        "worker",
+        "gate",
+        "schema",
+        "test",
+        "doc",
+        "reference",
+        "issue",
+        "hook",
+        "mcp_or_tool",
+        "install_profile",
+        "reject"
+      ]
+    },
+    "proposed_artifact_type": {
+      "enum": [
+        "rule",
+        "skill",
+        "worker",
+        "gate",
+        "schema",
+        "test",
+        "doc",
+        "reference",
+        "issue",
+        "hook",
+        "mcp_or_tool",
+        "install_profile",
+        "reject"
+      ]
+    },
+    "risk": {
+      "enum": ["R1", "R2", "R3", "R4"]
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 3
+    },
+    "proposal_summary": {
+      "type": "string"
+    },
+    "validation_plan": {
+      "type": "object",
+      "required": ["tests_or_evals", "verification_commands", "independent_review_required", "success_criteria"],
+      "properties": {
+        "tests_or_evals": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "verification_commands": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "independent_review_required": { "type": "boolean" },
+        "plan_review_ref": { "type": "string" },
+        "success_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "activation_policy": {
+      "type": "object",
+      "required": ["default_state", "auto_activation_allowed", "human_gate_required", "scope", "budget"],
+      "properties": {
+        "default_state": { "enum": ["inactive_candidate", "active", "rejected"] },
+        "auto_activation_allowed": { "type": "boolean" },
+        "human_gate_required": { "type": "boolean" },
+        "scope": { "type": "string", "minLength": 3 },
+        "active_tool_surfaces": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "budget": {
+          "type": "object",
+          "required": ["max_agents", "timeout_minutes", "token_or_cost_budget", "stop_condition"],
+          "properties": {
+            "max_agents": { "type": "integer" },
+            "timeout_minutes": { "type": "integer" },
+            "token_or_cost_budget": { "type": "string", "minLength": 1 },
+            "stop_condition": { "type": "string", "minLength": 3 }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "untrusted_input_handling": {
+      "type": "object",
+      "required": [
+        "reader_actor_split",
+        "raw_external_content_quarantined",
+        "privileged_actors_consume_structured_summary_only"
+      ],
+      "properties": {
+        "reader_actor_split": { "type": "boolean" },
+        "raw_external_content_quarantined": { "type": "boolean" },
+        "privileged_actors_consume_structured_summary_only": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "tool_governance": {
+      "type": "object",
+      "required": ["required", "optional", "disabled", "forbidden", "third_party_trust_status", "supply_chain_review"],
+      "properties": {
+        "required": { "type": "array", "items": { "type": "string" } },
+        "optional": { "type": "array", "items": { "type": "string" } },
+        "disabled": { "type": "array", "items": { "type": "string" } },
+        "forbidden": { "type": "array", "items": { "type": "string" } },
+        "third_party_trust_status": { "enum": ["first_party", "reviewed_third_party", "untrusted", "unknown"] },
+        "supply_chain_review": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "parallel_workflow_guidance": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "rejection_rationale": {
+      "type": "string",
+      "minLength": 3
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/factory_self_improvement.py
+++ b/scripts/factory_self_improvement.py
@@ -46,6 +46,21 @@ CRITICAL_TERMS = {
     "billing",
 }
 SENSITIVE_TERMS = CRITICAL_TERMS | {"funds", "custody", "signing", "mainnet", "legal", "regulated", "privacy", "hardware"}
+LEARNING_CLASSIFICATIONS = {
+    "rule",
+    "skill",
+    "worker",
+    "gate",
+    "schema",
+    "test",
+    "doc",
+    "reference",
+    "issue",
+    "hook",
+    "mcp_or_tool",
+    "install_profile",
+    "reject",
+}
 
 
 def utc_now() -> str:
@@ -212,6 +227,105 @@ def build_issue_candidates(learnback: dict[str, Any]) -> dict[str, Any]:
         "source_project_ref": clean_public_text(learnback.get("project_ref")),
         "candidates": candidates,
         "issue_count": len(candidates),
+    }
+
+
+def learning_classification_for(finding: dict[str, Any]) -> str:
+    explicit = str(finding.get("learning_classification") or "").strip()
+    if explicit in LEARNING_CLASSIFICATIONS:
+        return explicit
+    route = str(finding.get("recommended_route") or "").strip()
+    if route == "eval_or_test":
+        return "test"
+    if route == "docs_update":
+        return "doc"
+    if route == "public_issue":
+        return "issue"
+    if route == "critical_change_proposal":
+        return "gate"
+    return "reject" if route in {"no_issue", "private_followup"} else "issue"
+
+
+def build_learning_proposal(finding: dict[str, Any], source_ref: str) -> dict[str, Any]:
+    summary = clean_public_text(finding.get("summary"))
+    area = clean_public_text(finding.get("area") or "factory")
+    classification = learning_classification_for(finding)
+    evidence_ref = clean_public_text(finding.get("evidence_ref") or source_ref)
+    combined = " ".join([summary, area, clean_public_text(finding.get("reproduction_condition"))])
+    human_gate_required = classification in {"worker", "gate", "hook", "mcp_or_tool", "install_profile"} or contains_any(combined, CRITICAL_TERMS)
+    sensitive = human_gate_required or contains_any(combined, SENSITIVE_TERMS)
+    rejected = classification == "reject"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-learning-proposal.schema.json",
+        "record_type": "factory_learning_proposal",
+        "source_evidence_refs": [evidence_ref],
+        "source_trust": "internal_structured",
+        "classification": classification,
+        "proposed_artifact_type": classification,
+        "risk": "R3" if human_gate_required else "R2" if classification in {"skill", "schema", "test"} else "R1",
+        "owner": "skill-eval-distiller",
+        "proposal_summary": summary,
+        "validation_plan": {
+            "tests_or_evals": [clean_public_text(finding.get("acceptance_hint") or "focused validation fixture")],
+            "verification_commands": [
+                "python scripts/validate_public_json_artifacts.py",
+                "python -m unittest tests.test_factory_self_improvement -q",
+            ],
+            "independent_review_required": not rejected,
+            "plan_review_ref": "external:independent-plan-review-required" if not rejected else "not_applicable",
+            "success_criteria": [
+                "proposal remains inactive until validation passes",
+                "public-safe evidence refs replace raw run evidence",
+            ],
+        },
+        "activation_policy": {
+            "default_state": "rejected" if rejected else "inactive_candidate",
+            "auto_activation_allowed": False if sensitive or not rejected else False,
+            "human_gate_required": human_gate_required,
+            "scope": f"{area} learning proposal",
+            "active_tool_surfaces": [],
+            "budget": {
+                "max_agents": 2,
+                "timeout_minutes": 60,
+                "token_or_cost_budget": "operator-defined",
+                "stop_condition": "validation fails, review blocks, or scope expands",
+            },
+        },
+        "untrusted_input_handling": {
+            "reader_actor_split": True,
+            "raw_external_content_quarantined": True,
+            "privileged_actors_consume_structured_summary_only": True,
+        },
+        "tool_governance": {
+            "required": [],
+            "optional": [],
+            "disabled": [],
+            "forbidden": ["auto-permission for sensitive work"],
+            "third_party_trust_status": "first_party",
+            "supply_chain_review": "required before activating skills, hooks, MCPs or install profiles",
+        },
+        "parallel_workflow_guidance": [
+            "use fan-out, adversarial review or tournament patterns only when evidence value justifies isolation",
+            "use issue #79 lane/worktree governance for detailed parallel execution controls",
+        ],
+        "rejection_rationale": clean_public_text(finding.get("rejection_rationale") or ("finding rejected or private" if rejected else "not_rejected")),
+    }
+
+
+def build_learning_proposals(learnback: dict[str, Any]) -> dict[str, Any]:
+    source_ref = clean_public_text(learnback.get("project_ref") or "external:learnback-record")
+    proposals = [
+        build_learning_proposal(finding, source_ref)
+        for finding in learnback.get("findings", [])
+        if isinstance(finding, dict)
+    ]
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-learning-proposal.schema.json",
+        "record_type": "factory_learning_proposal_list",
+        "created_at": utc_now(),
+        "source_project_ref": source_ref,
+        "proposals": proposals,
+        "proposal_count": len(proposals),
     }
 
 
@@ -407,6 +521,11 @@ def command_learnback_issues(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_learning_proposals(args: argparse.Namespace) -> int:
+    write_json(args.out, build_learning_proposals(load_json(args.record)))
+    return 0
+
+
 def command_issue_intake(args: argparse.Namespace) -> int:
     issues = load_json(args.issues)
     if not isinstance(issues, list):
@@ -437,6 +556,11 @@ def build_parser() -> argparse.ArgumentParser:
     learnback.add_argument("--record", type=Path, required=True)
     learnback.add_argument("--out", type=Path)
     learnback.set_defaults(func=command_learnback_issues)
+
+    learning = sub.add_parser("learning-proposals", help="Turn a learnback record into typed learning proposals")
+    learning.add_argument("--record", type=Path, required=True)
+    learning.add_argument("--out", type=Path)
+    learning.set_defaults(func=command_learning_proposals)
 
     intake = sub.add_parser("issue-intake", help="Dry-run owner-instance issue intake")
     intake.add_argument("--config", type=Path, required=True)

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2248,6 +2248,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "parallel_lane_contracts": lane_contracts,
             "reasoning_policy": card.get("reasoning_policy"),
             "reference_quality_packet": card.get("reference_quality_packet"),
+            "learning_proposal_refs": card.get("learning_proposal_refs", []),
         },
         "runtime_decision": runtime_decision,
         "output_contract": {

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -10,6 +10,7 @@ additionalProperties and arrays.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,13 @@ PRODUCT_FACE_ALIGNMENT_FIELDS = (
     "source_promise_coverage",
     "design_fit_review",
 )
+PRIVATE_USERS_PATH = "C:" + r"[\\/]+" + "Users"
+PRIVATE_SYNC_ROOT = "One" + "Drive"
+PRIVATE_MARKERS = re.compile(
+    PRIVATE_USERS_PATH + r"|" + PRIVATE_SYNC_ROOT + r"|guild_ref|channel_ref|thread_id|message_id",
+    re.IGNORECASE,
+)
+SENSITIVE_LEARNING_ARTIFACTS = {"worker", "gate", "hook", "mcp_or_tool", "install_profile"}
 
 
 def load_json(path: Path) -> Any:
@@ -137,6 +145,33 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             value = data.get(field)
             if not isinstance(value, dict) or value.get("status") != "pass":
                 errors.append(f"{at}: reusable product_face_result requires {field}.status=pass")
+    if data.get("record_type") == "factory_learning_proposal":
+        serialized_refs = "\n".join(str(ref) for ref in data.get("source_evidence_refs", []))
+        if PRIVATE_MARKERS.search(serialized_refs):
+            errors.append(f"{at}: factory_learning_proposal source_evidence_refs must be public-safe")
+        validation = data.get("validation_plan") if isinstance(data.get("validation_plan"), dict) else {}
+        if data.get("classification") != "reject" and validation.get("independent_review_required") is not True:
+            errors.append(f"{at}: factory_learning_proposal requires independent review before activation")
+        if data.get("classification") != "reject" and not str(validation.get("plan_review_ref") or "").strip():
+            errors.append(f"{at}: factory_learning_proposal requires plan_review_ref")
+        activation = data.get("activation_policy") if isinstance(data.get("activation_policy"), dict) else {}
+        if data.get("proposed_artifact_type") in SENSITIVE_LEARNING_ARTIFACTS and activation.get("auto_activation_allowed") is True:
+            errors.append(f"{at}: sensitive factory learning artifacts must not auto-activate")
+        if activation.get("default_state") == "active" and activation.get("auto_activation_allowed") is True:
+            errors.append(f"{at}: factory_learning_proposal must land inactive before activation")
+        untrusted = data.get("untrusted_input_handling") if isinstance(data.get("untrusted_input_handling"), dict) else {}
+        if data.get("source_trust") in {"external_untrusted", "mixed"}:
+            if untrusted.get("reader_actor_split") is not True:
+                errors.append(f"{at}: untrusted learning input requires reader_actor_split")
+            if untrusted.get("privileged_actors_consume_structured_summary_only") is not True:
+                errors.append(f"{at}: privileged actors must consume structured summaries only")
+        tools = data.get("tool_governance") if isinstance(data.get("tool_governance"), dict) else {}
+        active_tools = list(activation.get("active_tool_surfaces") or [])
+        required_tools = list(tools.get("required") or [])
+        if active_tools and tools.get("third_party_trust_status") in {"untrusted", "unknown"}:
+            errors.append(f"{at}: active tool surfaces require reviewed trust status")
+        if required_tools and not str(tools.get("supply_chain_review") or "").strip():
+            errors.append(f"{at}: required tools require supply_chain_review")
     return errors
 
 

--- a/templates/factory-learning-proposal.json
+++ b/templates/factory-learning-proposal.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-learning-proposal.schema.json",
+  "record_type": "factory_learning_proposal",
+  "source_evidence_refs": [
+    "external:execution-learnback-record"
+  ],
+  "source_trust": "internal_structured",
+  "classification": "skill",
+  "proposed_artifact_type": "skill",
+  "risk": "R2",
+  "owner": "skill-eval-distiller",
+  "proposal_summary": "Promote a repeated, validated workflow into an inactive candidate skill.",
+  "validation_plan": {
+    "tests_or_evals": [
+      "focused eval fixture proving the skill improves the repeated workflow",
+      "regression test that fails before the skill or contract exists"
+    ],
+    "verification_commands": [
+      "python scripts/validate_public_json_artifacts.py",
+      "python -m unittest tests.test_factory_self_improvement -q"
+    ],
+    "independent_review_required": true,
+    "plan_review_ref": "external:independent-plan-review",
+    "success_criteria": [
+      "proposal stays inactive until tests and review pass",
+      "activation policy names scope, budget and stop condition",
+      "raw private evidence is not published"
+    ]
+  },
+  "activation_policy": {
+    "default_state": "inactive_candidate",
+    "auto_activation_allowed": false,
+    "human_gate_required": false,
+    "scope": "bounded factory skill candidate",
+    "active_tool_surfaces": [],
+    "budget": {
+      "max_agents": 2,
+      "timeout_minutes": 60,
+      "token_or_cost_budget": "operator-defined",
+      "stop_condition": "validation fails, independent review blocks, or scope expands"
+    }
+  },
+  "untrusted_input_handling": {
+    "reader_actor_split": true,
+    "raw_external_content_quarantined": true,
+    "privileged_actors_consume_structured_summary_only": true
+  },
+  "tool_governance": {
+    "required": [],
+    "optional": [],
+    "disabled": [],
+    "forbidden": [
+      "auto-permission for sensitive work"
+    ],
+    "third_party_trust_status": "first_party",
+    "supply_chain_review": "public safety, secret safety and supply-chain proof before activation"
+  },
+  "parallel_workflow_guidance": [
+    "use fan-out only when independent evidence, adversarial review or scale justifies it",
+    "use issue #79 lane/worktree governance for detailed isolation and reconciliation"
+  ],
+  "rejection_rationale": "not_rejected"
+}

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -167,6 +167,9 @@
     "acceptance_criteria": ["Product Face design-fit review passes"],
     "product_experience_fields_informed": ["experience_sot", "design_direction", "proof_required"]
   },
+  "learning_proposal_refs": [
+    "templates/factory-learning-proposal.json"
+  ],
   "software_development_plan": {
     "$schema": "https://overkill-factory.dev/schemas/software-development-plan.schema.json",
     "work_units": ["one bounded implementation slice"],

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -72,6 +72,7 @@ class FactorySelfImprovementTest(unittest.TestCase):
 
         self.assertEqual(packet["input_contract"]["reasoning_policy"]["record_type"], "reasoning_policy")
         self.assertEqual(packet["input_contract"]["reference_quality_packet"]["record_type"], "reference_quality_packet")
+        self.assertEqual(packet["input_contract"]["learning_proposal_refs"], ["templates/factory-learning-proposal.json"])
 
     def test_default_reference_registry_contains_post_sources_as_catalog_entries(self) -> None:
         registry = self_improvement.default_reference_source_registry()
@@ -133,6 +134,68 @@ class FactorySelfImprovementTest(unittest.TestCase):
         self.assertNotIn(private_users_path, candidate["title"])
         self.assertNotIn(private_users_path, candidate["body"])
         self.assertTrue(candidate["public_safe"])
+
+    def test_learning_proposals_classify_findings_and_stay_inactive(self) -> None:
+        learnback = {
+            "record_type": "execution_learnback_record",
+            "project_ref": "external:factory-run",
+            "method_version": "OVERKILL_VFINAL",
+            "findings": [
+                {
+                    "summary": "Repeated review correction should become a reusable skill.",
+                    "severity": "medium",
+                    "area": "skill-evolution",
+                    "recommended_route": "eval_or_test",
+                    "learning_classification": "skill",
+                    "evidence_ref": "external:review-summary",
+                    "acceptance_hint": "eval fixture proves the skill improves the workflow",
+                }
+            ],
+            "public_safety_boundary": {
+                "raw_private_evidence_forbidden": True,
+                "public_issue_requires_redaction": True,
+            },
+        }
+
+        result = self_improvement.build_learning_proposals(learnback)
+
+        proposal = result["proposals"][0]
+        self.assertEqual(proposal["classification"], "skill")
+        self.assertEqual(proposal["proposed_artifact_type"], "skill")
+        self.assertEqual(proposal["activation_policy"]["default_state"], "inactive_candidate")
+        self.assertFalse(proposal["activation_policy"]["auto_activation_allowed"])
+        self.assertTrue(proposal["validation_plan"]["independent_review_required"])
+        self.assertIn("max_agents", proposal["activation_policy"]["budget"])
+
+    def test_learning_proposal_domain_rules_fail_closed(self) -> None:
+        validator_spec = importlib.util.spec_from_file_location(
+            "validate_public_json_artifacts",
+            ROOT / "scripts" / "validate_public_json_artifacts.py",
+        )
+        assert validator_spec is not None
+        validator = importlib.util.module_from_spec(validator_spec)
+        assert validator_spec.loader is not None
+        sys.modules["validate_public_json_artifacts"] = validator
+        validator_spec.loader.exec_module(validator)
+
+        proposal = json.loads((ROOT / "templates" / "factory-learning-proposal.json").read_text(encoding="utf-8"))
+        private_windows_path = "C:" + "\\" + "Users" + "\\owner\\private-run.json"
+        proposal["source_evidence_refs"] = [private_windows_path]
+        proposal["proposed_artifact_type"] = "mcp_or_tool"
+        proposal["activation_policy"]["auto_activation_allowed"] = True
+        proposal["activation_policy"]["active_tool_surfaces"] = ["third-party-mcp"]
+        proposal["activation_policy"]["default_state"] = "active"
+        proposal["tool_governance"]["third_party_trust_status"] = "unknown"
+        proposal["source_trust"] = "external_untrusted"
+        proposal["untrusted_input_handling"]["reader_actor_split"] = False
+
+        errors = validator.validate_domain_rules(proposal, "$")
+
+        self.assertIn("$: factory_learning_proposal source_evidence_refs must be public-safe", errors)
+        self.assertIn("$: sensitive factory learning artifacts must not auto-activate", errors)
+        self.assertIn("$: factory_learning_proposal must land inactive before activation", errors)
+        self.assertIn("$: untrusted learning input requires reader_actor_split", errors)
+        self.assertIn("$: active tool surfaces require reviewed trust status", errors)
 
     def test_owner_issue_intake_routes_critical_factory_change_to_human_gate_path(self) -> None:
         config = json.loads((ROOT / "templates" / "owner-issue-intake-config.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
Summary: add a public Factory Learning and Skill Evolution OS; add schema/template for factory_learning_proposal; add dry-run learning-proposals command; carry learning proposal refs in worker packets; add fail-closed validation for private evidence, sensitive auto-activation, untrusted input, tool trust and missing review; add focused tests. Validation: python -m unittest tests.test_factory_self_improvement -q; python scripts/validate_public_json_artifacts.py; python scripts/factory_self_improvement.py learning-proposals --record templates/execution-learnback-record.json --out .tmp/issue-78-learning-proposals.json; python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json; python scripts/public_safety_scan.py; python scripts/secret_safety_scan.py; python scripts/supply_chain_proof.py --check --no-write; python scripts/validate_document_governance.py; python scripts/validate_worker_profiles.py; python scripts/quickstart_smoke.py; git diff --check; python -m unittest discover -s tests -p test_*.py -q.