### PR TITLE
Add external operator maturity workflow

### DIFF
--- a/.github/workflows/release-cli-smoke.yml
+++ b/.github/workflows/release-cli-smoke.yml
@@ -1,0 +1,36 @@
+name: release-cli-smoke
+
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "scripts/**"
+      - ".github/workflows/release-cli-smoke.yml"
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package-cli-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install package from clean checkout
+        run: python -m pip install .
+      - name: CLI entrypoint smoke
+        run: factoryctl --help
+      - name: Quickstart entrypoint smoke
+        run: overkill-quickstart
+      - name: Public safety before publication
+        run: python scripts/public_safety_scan.py
+      - name: Secret safety before publication
+        run: python scripts/secret_safety_scan.py

--- a/agents/capability-packs.public.json
+++ b/agents/capability-packs.public.json
@@ -273,6 +273,36 @@
       "evidence_required": ["permission review", "browser smoke", "packaging proof"],
       "reference_sources": ["gstack browser/sidebar designs", "ring prompt/security reviewers"]
     },
+    "operator-onboarding-pack": {
+      "pack_id": "operator-onboarding-pack",
+      "status": "core_ready",
+      "plain_purpose": "Covers external operator install, first local smoke, Hermes adapter handoff and first walkthrough.",
+      "covers_surfaces": ["onboarding", "operator", "fresh-install", "walkthrough", "hermes-install", "adapter-install"],
+      "existing_workers": ["docs-os-worker", "qa-verification-worker", "factory-orchestrator", "public-safety-gate"],
+      "missing_worker_templates": [],
+      "required_before_execution": true,
+      "activation_rule": "Available by default for public onboarding and operator walkthrough work that does not mutate a real Hermes runtime.",
+      "evidence_required": ["fresh install commands", "quickstart smoke", "worker packet output under .tmp", "public safety scan"],
+      "input_contract": ["fresh checkout", "operator-owned Hermes target or deferred adapter boundary", "minimal public example card"],
+      "output_contract": ["validated install path", "worker packets under .tmp", "operator next-step checklist"],
+      "local_smoke_path": "python scripts/quickstart_smoke.py",
+      "reference_sources": ["README.md", "docs/getting-started/install-in-hermes.md", "examples/minimal-hermes-project/card.md"]
+    },
+    "public-docs-knowledge-pack": {
+      "pack_id": "public-docs-knowledge-pack",
+      "status": "core_ready",
+      "plain_purpose": "Covers public-safe docs, examples, knowledge artifacts, guides and repository navigation for external users.",
+      "covers_surfaces": ["public-docs", "docs", "documentation", "guide", "manual", "knowledge", "example-gallery"],
+      "existing_workers": ["docs-os-worker", "public-safety-gate", "qa-verification-worker", "skill-eval-distiller"],
+      "missing_worker_templates": [],
+      "required_before_execution": true,
+      "activation_rule": "Available by default for documentation and knowledge artifacts when generated evidence stays out of the public repo.",
+      "evidence_required": ["document governance validation", "public safety scan", "secret safety scan", "focused doc tests"],
+      "input_contract": ["public-safe source refs", "target reader", "validation commands"],
+      "output_contract": ["current guide or template", "clear source-of-truth boundary", "no historical private evidence"],
+      "local_smoke_path": "python scripts/validate_document_governance.py",
+      "reference_sources": ["docs/maintenance/repo-surface.md", "CONTRIBUTING.md", "examples/README.md"]
+    },
     "hardware-iot-pack": {
       "pack_id": "hardware-iot-pack",
       "status": "blocked_until_installed",

--- a/docs/agents/capability-packs.md
+++ b/docs/agents/capability-packs.md
@@ -19,6 +19,14 @@ Every Factory card names its surfaces, such as `frontend`, `api`, `solana`,
 `scripts/factoryctl.py validate-card` checks those surfaces against
 `agents/capability-packs.public.json`.
 
+Reusable packs should also state their practical operator contract:
+
+- input contract;
+- output contract;
+- local smoke path.
+
+This keeps packs executable for external users instead of becoming broad labels.
+
 The result is simple:
 
 | Pack state | Meaning | Execution rule |
@@ -38,6 +46,8 @@ These packs are ready in the public Factory:
 | `cloud-native-core` | CI/CD, runtime, deploy wiring, cloud security, observability and rollback planning. |
 | `agent-runtime-core` | Hermes, Factory adapter, profiles, skills, tools, memory, MCP and agentic workflow changes. |
 | `solana-quasar-core` | Quasar-first Solana/onchain program work, wallet transactions, signer boundaries and onchain QA. |
+| `operator-onboarding-pack` | Fresh install, first local smoke, Hermes adapter handoff and first walkthrough. |
+| `public-docs-knowledge-pack` | Public-safe docs, examples, guides and repository navigation for external users. |
 
 ## Template Packs
 

--- a/docs/getting-started/first-external-operator-walkthrough.md
+++ b/docs/getting-started/first-external-operator-walkthrough.md
@@ -1,0 +1,96 @@
+# First External Operator Walkthrough
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: README.md, `scripts/factoryctl.py`,
+> `examples/minimal-hermes-project/`, tests.
+> Runtime boundary: this walkthrough proves the public factory path locally. It
+> does not mutate a real Hermes board.
+
+## Goal
+
+This is the shortest complete run for a new operator. It starts from a fresh
+clone, validates the public example, shows which gates matter and writes all
+generated output under `.tmp/`.
+
+## 1. Fresh Clone
+
+```bash
+git clone https://github.com/<owner>/overkill-factory.git
+cd overkill-factory
+python -m pip install -e .
+```
+
+## 2. Local Health Check
+
+```bash
+factoryctl doctor
+overkill-quickstart
+```
+
+Expected result: quickstart prints `PASS` and writes
+`.tmp/quickstart-result.json`.
+
+## 3. Read The Minimal Product Input
+
+The sample input is `examples/minimal-hermes-project/input-paper.md`. It is a
+domain-neutral paper used to prove the factory path. It is not evidence from a
+past run.
+
+The matching card is `examples/minimal-hermes-project/card.md`.
+
+## 4. Run The Ready Gate
+
+```bash
+factoryctl gate-report --card examples/minimal-hermes-project/card.md
+```
+
+The gate report explains:
+
+- which workers are required;
+- which worker results are still missing;
+- which planning fields are present;
+- whether the card can create worker tasks.
+
+This is a planning gate, not product completion.
+
+## 5. Generate Worker Packets
+
+```bash
+factoryctl worker-packet \
+  --worker all \
+  --required-only \
+  --card examples/minimal-hermes-project/card.md \
+  --out .tmp/external-operator-worker-packets
+```
+
+These JSON files are what an operator would hand to their runtime routing layer.
+Keep them in `.tmp/`; do not commit generated packets.
+
+## 6. Understand The Decisions
+
+The minimal card stays honest about these boundaries:
+
+- Product Face is required because the card has visible product surfaces.
+- Independent review is required before completion.
+- Receipt Five is required before done.
+- Human approval is real evidence only; the factory must not invent it.
+- Generated outputs remain local unless they are intentionally promoted as
+  public-safe examples.
+
+## 7. Local Release Hygiene
+
+Before publishing a branch, run:
+
+```bash
+python scripts/validate_public_json_artifacts.py
+python scripts/validate_worker_profiles.py
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+python scripts/supply_chain_proof.py --check --no-write
+python -m unittest discover -s tests -p "test_*.py" -q
+```
+
+## Next Step
+
+Use `docs/getting-started/install-in-hermes.md` when you are ready to wire the
+adapter into your own Hermes test runtime.

--- a/docs/getting-started/install-in-hermes.md
+++ b/docs/getting-started/install-in-hermes.md
@@ -22,6 +22,29 @@ factoryctl run minimal
 factoryctl init --out ../my-product-factory --project-name my-product
 ```
 
+## Fresh Adapter Smoke
+
+Before touching a real Hermes board, prove the public adapter path locally:
+
+```bash
+factoryctl gate-report --card examples/minimal-hermes-project/card.md
+factoryctl worker-packet \
+  --worker all \
+  --required-only \
+  --card examples/minimal-hermes-project/card.md \
+  --out .tmp/external-hermes-worker-packets
+python adapters/hermes/transition_hook.py \
+  --card examples/minimal-hermes-project/card.md \
+  --from-status draft \
+  --to-status ready \
+  --ledger .tmp/external-hermes-worker-ledger.json \
+  --out .tmp/external-hermes-ready-hook-result.json \
+  --report-only
+```
+
+All generated output stays under `.tmp/`. Do not commit worker packets, ledgers,
+screenshots or runtime proof from your own Hermes instance.
+
 ## What Gets Installed
 
 - `factoryctl`: the supported CLI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ Use this order from a fresh checkout:
 4. Read `getting-started/install-in-hermes.md`
 5. Connect generated worker packets to your Hermes only after local checks pass.
 
+For the first full public run, use
+`getting-started/first-external-operator-walkthrough.md`.
+
 ## Install In Your Hermes
 
 Start with `getting-started/install-in-hermes.md`. Hermes is your runtime floor;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ docs_dir: docs
 nav:
   - Operator Path: index.md
   - Install In Your Hermes: getting-started/install-in-hermes.md
+  - First Operator Walkthrough: getting-started/first-external-operator-walkthrough.md
   - CLI Reference: reference/cli.md
   - Examples: examples/gallery.md
   - Concepts:

--- a/schemas/capability-pack-registry.schema.json
+++ b/schemas/capability-pack-registry.schema.json
@@ -65,6 +65,17 @@
             "minItems": 1,
             "items": { "type": "string", "minLength": 3 }
           },
+          "input_contract": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "output_contract": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "local_smoke_path": { "type": "string", "minLength": 3 },
           "reference_sources": {
             "type": "array",
             "minItems": 1,

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -19,10 +19,22 @@ from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
-ROOT = Path(__file__).resolve().parents[1]
+CODE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def default_work_root() -> Path:
+    cwd = Path.cwd()
+    if (cwd / "agents" / "hermes-profile-bindings.public.json").exists() and (
+        cwd / "examples" / "minimal-hermes-project" / "card.md"
+    ).exists():
+        return cwd
+    return CODE_ROOT
+
+
+ROOT = default_work_root()
 PROFILE_BINDINGS_PATH = ROOT / "agents" / "hermes-profile-bindings.public.json"
 CAPABILITY_PACKS_PATH = ROOT / "agents" / "capability-packs.public.json"
-CANONICAL_RUNTIME_ENFORCEMENT_PATH = ROOT / "scripts" / "canonical_runtime_enforcement.py"
+CANONICAL_RUNTIME_ENFORCEMENT_PATH = CODE_ROOT / "scripts" / "canonical_runtime_enforcement.py"
 DEFAULT_MINIMAL_CARD = ROOT / "examples" / "minimal-hermes-project" / "card.md"
 DEFAULT_QUICKSTART_OUT = ROOT / ".tmp" / "quickstart-result.json"
 DEFAULT_PACKETS_OUT = ROOT / ".tmp" / "minimal-worker-packets"

--- a/scripts/quickstart_smoke.py
+++ b/scripts/quickstart_smoke.py
@@ -11,11 +11,21 @@ from pathlib import Path
 from typing import Any
 
 
-ROOT = Path(__file__).resolve().parents[1]
-FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
-DEFAULT_CARD = ROOT / "examples" / "minimal-hermes-project" / "card.md"
-DEFAULT_OUT = ROOT / ".tmp" / "quickstart-result.json"
-DEFAULT_PACKETS_OUT = ROOT / ".tmp" / "minimal-worker-packets"
+CODE_ROOT = Path(__file__).resolve().parents[1]
+FACTORYCTL_PATH = CODE_ROOT / "scripts" / "factoryctl.py"
+
+
+def default_work_root() -> Path:
+    cwd = Path.cwd()
+    if (cwd / "examples" / "minimal-hermes-project" / "card.md").exists():
+        return cwd
+    return CODE_ROOT
+
+
+WORK_ROOT = default_work_root()
+DEFAULT_CARD = WORK_ROOT / "examples" / "minimal-hermes-project" / "card.md"
+DEFAULT_OUT = WORK_ROOT / ".tmp" / "quickstart-result.json"
+DEFAULT_PACKETS_OUT = WORK_ROOT / ".tmp" / "minimal-worker-packets"
 
 
 def load_factoryctl() -> Any:
@@ -29,10 +39,12 @@ def load_factoryctl() -> Any:
 
 
 def repo_ref(path: Path) -> str:
-    try:
-        return path.resolve().relative_to(ROOT).as_posix()
-    except (OSError, ValueError):
-        return f"external:{path.name or 'artifact'}"
+    for root in (WORK_ROOT, CODE_ROOT):
+        try:
+            return path.resolve().relative_to(root).as_posix()
+        except (OSError, ValueError):
+            continue
+    return f"external:{path.name or 'artifact'}"
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/tests/test_capability_packs.py
+++ b/tests/test_capability_packs.py
@@ -27,6 +27,8 @@ class CapabilityPacksTest(unittest.TestCase):
 
         for pack_id in [
             "web-saas-core",
+            "operator-onboarding-pack",
+            "public-docs-knowledge-pack",
             "mobile-app-pack",
             "desktop-app-pack",
             "game-product-pack",
@@ -41,6 +43,18 @@ class CapabilityPacksTest(unittest.TestCase):
                 self.assertIn(pack_id, packs)
                 self.assertTrue(packs[pack_id]["covers_surfaces"])
                 self.assertTrue(packs[pack_id]["evidence_required"])
+
+    def test_new_operator_packs_have_executable_contracts(self) -> None:
+        packs = json.loads((ROOT / "agents" / "capability-packs.public.json").read_text(encoding="utf-8"))["packs"]
+
+        for pack_id in ["operator-onboarding-pack", "public-docs-knowledge-pack"]:
+            with self.subTest(pack_id=pack_id):
+                pack = packs[pack_id]
+                self.assertTrue(pack["plain_purpose"])
+                self.assertTrue(pack["input_contract"])
+                self.assertTrue(pack["output_contract"])
+                self.assertTrue(pack["local_smoke_path"].startswith("python scripts/"))
+                self.assertNotIn(".tmp/", json.dumps(pack))
 
     def test_template_pack_surfaces_pass_capability_coverage(self) -> None:
         card = base_card()

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -363,8 +363,9 @@ class OpenSourceDocsTest(unittest.TestCase):
 
     def test_quickstart_and_operations_docs_include_runnable_validation_commands(self) -> None:
         quickstart = read_text("docs/getting-started/quickstart-hermes.md")
+        walkthrough = read_text("docs/getting-started/first-external-operator-walkthrough.md")
         operations = read_text("docs/operations/validation-and-release.md")
-        combined = f"{quickstart}\n{operations}"
+        combined = f"{quickstart}\n{walkthrough}\n{operations}"
         required_commands = [
             "factoryctl doctor",
             "factoryctl run minimal",
@@ -385,6 +386,40 @@ class OpenSourceDocsTest(unittest.TestCase):
         for command in required_commands:
             with self.subTest(command=command):
                 self.assertIn(command, combined)
+
+    def test_external_operator_walkthrough_stays_public_and_tmp_scoped(self) -> None:
+        walkthrough = read_text("docs/getting-started/first-external-operator-walkthrough.md")
+        install = read_text("docs/getting-started/install-in-hermes.md")
+        combined = f"{walkthrough}\n{install}"
+
+        for expected in [
+            "git clone https://github.com/<owner>/overkill-factory.git",
+            "factoryctl gate-report --card examples/minimal-hermes-project/card.md",
+            "--out .tmp/external-operator-worker-packets",
+            "--out .tmp/external-hermes-worker-packets",
+            "does not mutate a real Hermes board",
+            "All generated output stays under `.tmp/`",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, combined)
+
+        self.assertNotIn("C:" + "\\" + "Users", combined)
+        self.assertNotIn("historical pilot", combined.lower())
+
+    def test_release_cli_smoke_installs_package_and_runs_entrypoints(self) -> None:
+        workflow = read_text(".github/workflows/release-cli-smoke.yml")
+
+        for expected in [
+            "python -m pip install .",
+            "factoryctl --help",
+            "overkill-quickstart",
+            "python scripts/public_safety_scan.py",
+            "python scripts/secret_safety_scan.py",
+            "tags:",
+            '"v*"',
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, workflow)
 
     def test_minimal_example_is_public_safe_and_reproducible(self) -> None:
         example = read_text("examples/minimal-hermes-project/README.md")


### PR DESCRIPTION
Summary: adds first external operator walkthrough, packaged CLI smoke workflow, operator/public-docs capability packs, and package-aware CLI root resolution. Validation: focused tests, public JSON validation, package install smoke with factoryctl and overkill-quickstart, public_safety_scan, secret_safety_scan, supply_chain_proof, document governance, worker profiles, quickstart_smoke, git diff --check, and full unittest discovery. Closes #28. Closes #29. Closes #31. Closes #32.