### PR TITLE
Add Discord cockpit UX study gate

### DIFF
--- a/docs/control-tower/discord-cockpit-ux-study-gate.md
+++ b/docs/control-tower/discord-cockpit-ux-study-gate.md
@@ -1,0 +1,203 @@
+# Discord Cockpit UX Study Gate
+
+> Document status: CURRENT SUPPORTING GUIDE.
+> Current authority: `schemas/discord-control-tower-ux-audit.schema.json`,
+> `templates/discord-control-tower-ux-audit.json`, #80 status snapshots and #82
+> Product Face visual quality.
+> Runtime boundary: Discord is optional projection and operator interaction. It
+> is not the source of truth.
+
+This gate exists because Discord is attractive but risky as a factory cockpit.
+Chat is familiar, but factory operation needs state clarity, freshness,
+auditability, low noise, safe approvals and fast operator comprehension.
+
+No Discord cockpit implementation is accepted until the factory produces:
+
+1. a public-safe Discord Cockpit UX Study;
+2. a Discord Control Tower UX Proof Pack for the chosen shape;
+3. Product Face visual quality review for the visible operator surface.
+
+## Source Material
+
+The study must read Discord as it is, not as a generic chat metaphor. Required
+source areas include:
+
+- Discord interactions overview:
+  `https://docs.discord.com/developers/interactions/overview`;
+- receiving and responding to interactions:
+  `https://docs.discord.com/developers/interactions/receiving-and-responding`;
+- application commands:
+  `https://docs.discord.com/developers/interactions/application-commands`;
+- component reference:
+  `https://docs.discord.com/developers/components/reference`;
+- threads:
+  `https://docs.discord.com/developers/topics/threads`;
+- permissions:
+  `https://docs.discord.com/developers/topics/permissions`;
+- rate limits:
+  `https://docs.discord.com/developers/topics/rate-limits`;
+- webhooks:
+  `https://docs.discord.com/developers/resources/webhook`.
+
+## Discord Material Facts
+
+Discord gives the factory useful primitives:
+
+- server categories, text channels, forums, threads and pins for navigation;
+- slash commands, message commands and user commands for native actions;
+- buttons, select menus and modals for structured interaction;
+- roles, permission overwrites and command permissions for access control;
+- webhooks for low-friction message projection;
+- message edits for stable dashboard panels;
+- notification controls, thread membership and archive behavior for attention
+  management.
+
+Those primitives have consequences:
+
+- an interaction needs an initial response quickly, so long work needs defer,
+  follow-up or runtime handoff;
+- follow-up interaction tokens expire, so formal approvals need a durable
+  runtime registration path and a validated fallback;
+- component-rich messages use Discord's component model and layout limits, so
+  dense dashboards can become cramped;
+- threads can archive, hide from users without access, or split attention;
+- permissions are layered by guild, channel, thread, role and user, so the
+  study must test wrong-role and missing-permission cases;
+- rate limits are per-route and global, so active multi-agent updates must
+  coalesce, edit in place and retry from response headers;
+- webhooks are easy to post with but create token custody and attribution
+  boundaries;
+- mobile and desktop scanning differ enough that a desktop-only proof is not a
+  real cockpit proof.
+
+## Operator Comprehension Contract
+
+The cockpit has to answer different questions at different speeds.
+
+In the first 5 seconds, the operator must know:
+
+- whether anything needs attention;
+- whether the displayed state is fresh;
+- where the next safe action lives.
+
+In the first 30 seconds, the operator must know:
+
+- current phase;
+- real blockers;
+- pending approvals;
+- missing access;
+- latest evidence reference;
+- whether Discord is projecting canonical runtime state or stale/manual state.
+
+In the first 5 minutes, the operator must be able to inspect one project and
+decide whether to approve, wait, grant access, ask for clarification, or move
+to the local web cockpit for deeper inspection.
+
+If any of those jobs requires hunting across channels, reading a long transcript
+or guessing whether chat equals approval, Discord is not good enough for that
+job.
+
+## Recommended Role
+
+Default recommendation:
+
+```text
+Discord = secondary operator cockpit, notification surface and structured approval inbox
+local web cockpit = dense state, comparison, inspection and long-running control
+runtime/Hermes = source of truth
+```
+
+Discord may become a primary cockpit only after the proof pack shows equal or
+better comprehension, freshness and safety than the local web cockpit for the
+specific operator workflow.
+
+Discord should own:
+
+- attention routing;
+- short status projection;
+- project conversation thread entry;
+- structured approval request display;
+- access/blocker/release notifications;
+- links back to canonical evidence.
+
+Discord should not own:
+
+- canonical state;
+- dense multi-project comparison;
+- long-running evidence inspection;
+- visual Product Face review;
+- approval truth without runtime registration;
+- hidden worker chatter.
+
+## UX Proof Pack
+
+The proof pack must measure practical operator consequences, not architecture
+intent.
+
+Required proof:
+
+- comprehension at 5 seconds, 30 seconds and 5 minutes;
+- findability of the next safe action;
+- dashboard update behavior using edit-in-place where possible;
+- approval/request boundary clarity;
+- stale state display and recovery;
+- duplicate event replay/idempotency;
+- bridge-offline behavior;
+- rate-limit retry behavior;
+- notification volume during active multi-agent runs;
+- desktop and mobile readability;
+- public-safe output with no private Discord ids, tokens, channel names, raw
+  logs, runtime URLs or local paths.
+
+Required negative tests:
+
+- stale status snapshot;
+- duplicate bridge event;
+- expired interaction fallback;
+- approval from the wrong role;
+- free-form chat treated as approval;
+- missing runtime registration path;
+- rate limit response during dashboard projection;
+- archived or inaccessible thread.
+
+## Gate Decision
+
+Use `templates/discord-control-tower-ux-audit.json` to record the study gate.
+
+Allowed recommendations:
+
+- `reject`;
+- `notification_surface_only`;
+- `approval_inbox_only`;
+- `secondary_operator_cockpit`;
+- `primary_operator_cockpit_after_proof`.
+
+The public factory default is `secondary_operator_cockpit` with
+`required_for_dense_state` web cockpit boundary. That is intentionally
+conservative: Discord is useful, but the factory must prove it is excellent
+before it can carry dense operational control.
+
+## Dependencies
+
+The Discord cockpit study depends on:
+
+- #80 because Discord must project canonical status snapshots rather than make
+  up state;
+- #82 because visible cockpit UX needs Product Face visual quality review;
+- #84 because dense state and inspection should move to the local web cockpit
+  unless Discord proof demonstrates that the chat surface is better.
+
+## Public Safety
+
+Do not publish:
+
+- private Discord ids;
+- private channel names;
+- bot tokens or webhook tokens;
+- private runtime URLs;
+- raw Discord logs;
+- local operator paths;
+- screenshots from a private server unless explicitly sanitized and approved.
+
+Public artifacts should use schema-valid summaries, redacted evidence refs and
+stable methodology, not live workspace evidence.

--- a/docs/control-tower/discord-control-tower-os.md
+++ b/docs/control-tower/discord-control-tower-os.md
@@ -10,6 +10,20 @@ Factory.
 It makes the factory understandable and operable without turning Discord into
 the source of truth.
 
+Discord is not accepted as a cockpit because it can post messages. Before any
+Discord cockpit implementation is treated as product-ready, it must pass the
+mandatory UX study gate in:
+
+```text
+docs/control-tower/discord-cockpit-ux-study-gate.md
+```
+
+The gate requires a study of Discord primitives, limits, permissions,
+notifications, threads, commands, components, modals, webhooks, mobile/desktop
+behavior, rate limits, failure modes and operator comprehension. If the proof
+does not show near-zero avoidable friction, Discord remains a secondary layer
+and dense control moves to the local web cockpit.
+
 For the practical Portuguese production setup guide, see:
 
 ```text
@@ -17,7 +31,9 @@ docs/control-tower/discord-control-tower-setup-pt-br.md
 ```
 
 Dynamic behavior belongs in the bridge scripts, schemas and current setup guide,
-not in a separate historical study.
+not in a separate historical study. UX acceptance belongs in the Discord
+Cockpit UX Study Gate and its proof pack, not in setup screenshots or manual
+channel layout alone.
 
 ## Decision
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,5 +23,7 @@ nav:
       - Validation And Release: operations/validation-and-release.md
       - Parallel Execution And Status: operations/parallel-execution-and-status.md
       - Release Policy: operations/release-policy.md
+  - Control Tower:
+      - Discord UX Study Gate: control-tower/discord-cockpit-ux-study-gate.md
   - Maintainer Internals: maintenance/repo-surface.md
   - Factory Learning OS: maintenance/factory-learning-skill-evolution-os.md

--- a/schemas/discord-control-tower-ux-audit.schema.json
+++ b/schemas/discord-control-tower-ux-audit.schema.json
@@ -10,6 +10,10 @@
     "result",
     "scope",
     "observed_model",
+    "study_gate",
+    "discord_mastery_matrix",
+    "operator_comprehension_model",
+    "proof_pack_contract",
     "checks",
     "findings",
     "live_corrections",
@@ -50,9 +54,144 @@
       },
       "additionalProperties": false
     },
+    "study_gate": {
+      "type": "object",
+      "required": [
+        "ux_study_required_before_implementation",
+        "proof_pack_required_before_acceptance",
+        "discord_is_source_of_truth",
+        "recommended_role",
+        "web_cockpit_boundary",
+        "status_snapshot_dependency",
+        "product_face_dependency"
+      ],
+      "properties": {
+        "ux_study_required_before_implementation": { "const": true },
+        "proof_pack_required_before_acceptance": { "const": true },
+        "discord_is_source_of_truth": { "const": false },
+        "recommended_role": {
+          "enum": [
+            "reject",
+            "notification_surface_only",
+            "approval_inbox_only",
+            "secondary_operator_cockpit",
+            "primary_operator_cockpit_after_proof"
+          ]
+        },
+        "web_cockpit_boundary": {
+          "enum": [
+            "required_for_dense_state",
+            "required_for_all_operational_state",
+            "not_required_after_discord_proof"
+          ]
+        },
+        "status_snapshot_dependency": { "type": "string", "minLength": 3 },
+        "product_face_dependency": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "discord_mastery_matrix": {
+      "type": "object",
+      "required": [
+        "official_source_refs",
+        "primitives_reviewed",
+        "limits_reviewed",
+        "client_surfaces_reviewed",
+        "failure_modes_reviewed",
+        "maintenance_costs_reviewed"
+      ],
+      "properties": {
+        "official_source_refs": {
+          "type": "array",
+          "minItems": 5,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "primitives_reviewed": {
+          "type": "array",
+          "minItems": 8,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "limits_reviewed": {
+          "type": "array",
+          "minItems": 5,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "client_surfaces_reviewed": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "failure_modes_reviewed": {
+          "type": "array",
+          "minItems": 5,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "maintenance_costs_reviewed": {
+          "type": "array",
+          "minItems": 3,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "operator_comprehension_model": {
+      "type": "object",
+      "required": [
+        "first_5_seconds",
+        "first_30_seconds",
+        "first_5_minutes",
+        "near_zero_friction_rule"
+      ],
+      "properties": {
+        "first_5_seconds": { "type": "string", "minLength": 20 },
+        "first_30_seconds": { "type": "string", "minLength": 20 },
+        "first_5_minutes": { "type": "string", "minLength": 20 },
+        "near_zero_friction_rule": { "type": "string", "minLength": 20 }
+      },
+      "additionalProperties": false
+    },
+    "proof_pack_contract": {
+      "type": "object",
+      "required": [
+        "required_before_acceptance",
+        "must_measure",
+        "must_include_negative_tests",
+        "public_safe_boundaries"
+      ],
+      "properties": {
+        "required_before_acceptance": { "const": true },
+        "must_measure": {
+          "type": "array",
+          "minItems": 6,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "must_include_negative_tests": {
+          "type": "array",
+          "minItems": 5,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "public_safe_boundaries": {
+          "type": "array",
+          "minItems": 4,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
     "checks": {
       "type": "object",
       "required": [
+        "official_discord_primitives_studied",
+        "rate_limits_and_retry_behavior_studied",
+        "interaction_expiry_and_fallback_studied",
+        "mobile_desktop_differences_studied",
+        "operator_5s_30s_5m_model_defined",
+        "staleness_and_idempotency_checks_defined",
+        "approval_ambiguity_checks_defined",
+        "notification_load_checks_defined",
+        "web_cockpit_boundary_defined",
+        "status_snapshot_dependency_recorded",
+        "product_face_quality_dependency_recorded",
         "portuguese_first_structure",
         "operator_journey_categories_ordered",
         "channel_names_are_owner_readable",
@@ -91,6 +230,17 @@
         "live_runtime_projection_automated"
       ],
       "properties": {
+        "official_discord_primitives_studied": { "type": "boolean" },
+        "rate_limits_and_retry_behavior_studied": { "type": "boolean" },
+        "interaction_expiry_and_fallback_studied": { "type": "boolean" },
+        "mobile_desktop_differences_studied": { "type": "boolean" },
+        "operator_5s_30s_5m_model_defined": { "type": "boolean" },
+        "staleness_and_idempotency_checks_defined": { "type": "boolean" },
+        "approval_ambiguity_checks_defined": { "type": "boolean" },
+        "notification_load_checks_defined": { "type": "boolean" },
+        "web_cockpit_boundary_defined": { "type": "boolean" },
+        "status_snapshot_dependency_recorded": { "type": "boolean" },
+        "product_face_quality_dependency_recorded": { "type": "boolean" },
         "portuguese_first_structure": { "type": "boolean" },
         "operator_journey_categories_ordered": { "type": "boolean" },
         "channel_names_are_owner_readable": { "type": "boolean" },

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -172,6 +172,33 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: active tool surfaces require reviewed trust status")
         if required_tools and not str(tools.get("supply_chain_review") or "").strip():
             errors.append(f"{at}: required tools require supply_chain_review")
+    if data.get("record_type") == "discord_control_tower_ux_audit":
+        serialized = json.dumps(data, sort_keys=True)
+        if "todo" in serialized.lower():
+            errors.append(f"{at}: discord_control_tower_ux_audit must not contain placeholder todo text")
+        if PRIVATE_MARKERS.search(serialized):
+            errors.append(f"{at}: discord_control_tower_ux_audit must not publish private Discord or local refs")
+        study_gate = data.get("study_gate") if isinstance(data.get("study_gate"), dict) else {}
+        if study_gate.get("discord_is_source_of_truth") is not False:
+            errors.append(f"{at}: Discord UX audit must keep Discord out of source-of-truth role")
+        if study_gate.get("recommended_role") == "primary_operator_cockpit_after_proof":
+            proof = data.get("proof_pack_contract") if isinstance(data.get("proof_pack_contract"), dict) else {}
+            if proof.get("required_before_acceptance") is not True:
+                errors.append(f"{at}: primary Discord cockpit recommendation requires proof pack")
+        required_checks = [
+            "official_discord_primitives_studied",
+            "rate_limits_and_retry_behavior_studied",
+            "interaction_expiry_and_fallback_studied",
+            "operator_5s_30s_5m_model_defined",
+            "staleness_and_idempotency_checks_defined",
+            "approval_ambiguity_checks_defined",
+            "notification_load_checks_defined",
+            "web_cockpit_boundary_defined",
+        ]
+        checks = data.get("checks") if isinstance(data.get("checks"), dict) else {}
+        for field in required_checks:
+            if checks.get(field) is not True:
+                errors.append(f"{at}: discord_control_tower_ux_audit requires {field}=true")
     return errors
 
 

--- a/templates/discord-control-tower-ux-audit.json
+++ b/templates/discord-control-tower-ux-audit.json
@@ -1,66 +1,187 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/discord-control-tower-ux-audit.schema.json",
   "record_type": "discord_control_tower_ux_audit",
-  "created_at": "2026-06-11T00:00:00Z",
+  "created_at": "2026-06-13T00:00:00Z",
   "result": "ATTENTION",
-  "scope": "Public-safe UX audit of a Discord Control Tower setup.",
+  "scope": "Public-safe Discord Cockpit UX Study Gate. This template is not proof that Discord is production-ready.",
   "observed_model": {
-    "runtime": "Hermes",
+    "runtime": "Hermes or selected runtime",
     "owner_language": "pt-BR",
-    "source_of_truth": "Hermes/Kanban",
-    "discord_role": "owner cockpit and project conversation surface"
+    "source_of_truth": "runtime cards, status snapshots, gates, receipts and worker results",
+    "discord_role": "optional projection, request and approval inbox; not canonical state"
+  },
+  "study_gate": {
+    "ux_study_required_before_implementation": true,
+    "proof_pack_required_before_acceptance": true,
+    "discord_is_source_of_truth": false,
+    "recommended_role": "secondary_operator_cockpit",
+    "web_cockpit_boundary": "required_for_dense_state",
+    "status_snapshot_dependency": "#80 factory status snapshot is the canonical state input",
+    "product_face_dependency": "#82 Product Face visual quality gate is required before accepting cockpit UX"
+  },
+  "discord_mastery_matrix": {
+    "official_source_refs": [
+      "https://docs.discord.com/developers/interactions/overview",
+      "https://docs.discord.com/developers/interactions/receiving-and-responding",
+      "https://docs.discord.com/developers/interactions/application-commands",
+      "https://docs.discord.com/developers/components/reference",
+      "https://docs.discord.com/developers/topics/threads",
+      "https://docs.discord.com/developers/topics/permissions",
+      "https://docs.discord.com/developers/topics/rate-limits",
+      "https://docs.discord.com/developers/resources/webhook"
+    ],
+    "primitives_reviewed": [
+      "categories",
+      "text channels",
+      "forum channels",
+      "threads",
+      "pins",
+      "embeds",
+      "message components",
+      "buttons",
+      "select menus",
+      "modals",
+      "slash commands",
+      "message commands",
+      "roles and permission overwrites",
+      "webhooks"
+    ],
+    "limits_reviewed": [
+      "interaction initial response deadline",
+      "interaction followup token lifetime",
+      "component count and component message mode",
+      "thread archive and visibility behavior",
+      "per-route and global API rate limits",
+      "webhook token custody",
+      "message edit and duplicate event idempotency"
+    ],
+    "client_surfaces_reviewed": [
+      "desktop client scanning and thread navigation",
+      "mobile client scanning and notification load"
+    ],
+    "failure_modes_reviewed": [
+      "operator misses an approval message",
+      "operator sees stale runtime state",
+      "free-form chat is mistaken for formal approval",
+      "bridge retries duplicate project topics",
+      "Discord is offline while runtime progresses",
+      "rate limit delays dashboard updates"
+    ],
+    "maintenance_costs_reviewed": [
+      "server and channel drift",
+      "role and permission drift",
+      "thread archive cleanup",
+      "bot token and webhook rotation",
+      "operator notification tuning"
+    ]
+  },
+  "operator_comprehension_model": {
+    "first_5_seconds": "The operator sees whether anything needs attention, whether state is fresh, and where the next safe action lives.",
+    "first_30_seconds": "The operator can identify project phase, blockers, pending approvals, missing access and the canonical evidence link.",
+    "first_5_minutes": "The operator can inspect one project, understand risk and decide whether to approve, wait, grant access or ask for clarification.",
+    "near_zero_friction_rule": "Discord is acceptable only for jobs where the operator does not need to hunt across channels, infer freshness or translate casual chat into formal state."
+  },
+  "proof_pack_contract": {
+    "required_before_acceptance": true,
+    "must_measure": [
+      "operator comprehension in 5 seconds, 30 seconds and 5 minutes",
+      "findability of next safe action",
+      "dashboard update latency and edit behavior",
+      "approval/request boundary clarity",
+      "staleness and idempotency handling",
+      "notification burden during active multi-agent work",
+      "mobile and desktop readability"
+    ],
+    "must_include_negative_tests": [
+      "stale snapshot displayed",
+      "duplicate bridge event replayed",
+      "expired interaction fallback attempted",
+      "wrong role attempts approval",
+      "free-form project-thread message attempts approval",
+      "rate limit response delays projection"
+    ],
+    "public_safe_boundaries": [
+      "no private Discord ids",
+      "no private channel names",
+      "no webhook tokens",
+      "no private runtime URLs",
+      "no raw Discord logs",
+      "no local operator paths"
+    ]
   },
   "checks": {
-    "portuguese_first_structure": false,
-    "operator_journey_categories_ordered": false,
-    "channel_names_are_owner_readable": false,
-    "single_owner_intake_door": false,
-    "global_portfolio_view_defined": false,
-    "project_index_not_detail_dump": false,
-    "main_dashboard_pinned": false,
-    "per_channel_onboarding_pinned": false,
-    "gerente_channel_exists": false,
-    "project_registry_channel_exists": false,
-    "kanban_forum_exists": false,
-    "kanban_forum_has_phase_tags": false,
-    "kanban_forum_has_guidance_tags": false,
-    "multi_project_kanban_shape_ready": false,
+    "official_discord_primitives_studied": true,
+    "rate_limits_and_retry_behavior_studied": true,
+    "interaction_expiry_and_fallback_studied": true,
+    "mobile_desktop_differences_studied": true,
+    "operator_5s_30s_5m_model_defined": true,
+    "staleness_and_idempotency_checks_defined": true,
+    "approval_ambiguity_checks_defined": true,
+    "notification_load_checks_defined": true,
+    "web_cockpit_boundary_defined": true,
+    "status_snapshot_dependency_recorded": true,
+    "product_face_quality_dependency_recorded": true,
+    "portuguese_first_structure": true,
+    "operator_journey_categories_ordered": true,
+    "channel_names_are_owner_readable": true,
+    "single_owner_intake_door": true,
+    "global_portfolio_view_defined": true,
+    "project_index_not_detail_dump": true,
+    "main_dashboard_pinned": true,
+    "per_channel_onboarding_pinned": true,
+    "gerente_channel_exists": true,
+    "project_registry_channel_exists": true,
+    "kanban_forum_exists": true,
+    "kanban_forum_has_phase_tags": true,
+    "kanban_forum_has_guidance_tags": true,
+    "multi_project_kanban_shape_ready": true,
     "multi_project_kanban_idempotence_automated": false,
-    "project_cockpit_pipeline_panel_required": false,
+    "project_cockpit_pipeline_panel_required": true,
     "pilot_project_cockpit_pipeline_panel_created": false,
-    "project_pipeline_progress_visible": false,
+    "project_pipeline_progress_visible": true,
     "project_pipeline_projection_automated": false,
-    "approval_lane_guided": false,
-    "access_lane_guided": false,
-    "blocker_lane_guided": false,
-    "evidence_lane_guided": false,
-    "release_lane_guided": false,
-    "health_lane_guided": false,
+    "approval_lane_guided": true,
+    "access_lane_guided": true,
+    "blocker_lane_guided": true,
+    "evidence_lane_guided": true,
+    "release_lane_guided": true,
+    "health_lane_guided": true,
     "pilot_project_thread_created": false,
     "pilot_forum_card_created": false,
-    "kanban_guide_not_marked_as_blocked_project": false,
-    "active_bot_messages_threaded_or_linked": false,
-    "free_response_threading_conflict_documented": false,
-    "manager_reception_thread_launcher_only": false,
-    "project_conversation_stays_in_single_thread": false,
+    "kanban_guide_not_marked_as_blocked_project": true,
+    "active_bot_messages_threaded_or_linked": true,
+    "free_response_threading_conflict_documented": true,
+    "manager_reception_thread_launcher_only": true,
+    "project_conversation_stays_in_single_thread": true,
     "thread_first_project_intake_automated": false,
-    "formal_approvals_lane_bound": false,
+    "formal_approvals_lane_bound": true,
     "structured_approval_interactions_automated": false,
     "live_runtime_projection_automated": false
   },
   "findings": [
     {
       "severity": "P1",
-      "finding": "todo",
-      "impact": "todo",
-      "required_fix": "todo"
+      "finding": "Discord is not accepted as a primary cockpit from setup alone.",
+      "impact": "A familiar chat UI can hide stale state, duplicate events, noisy updates or ambiguous approvals.",
+      "required_fix": "Run the Discord Cockpit UX Study and proof pack before accepting any Discord cockpit implementation."
+    },
+    {
+      "severity": "P1",
+      "finding": "Dense state belongs in a local web cockpit unless Discord proof shows equal or better comprehension.",
+      "impact": "The operator may need to compare phases, blockers, evidence and approvals faster than Discord channels can support.",
+      "required_fix": "Use Discord for projection, notification and approvals first; route dense inspection to the local web cockpit."
     }
   ],
   "live_corrections": [],
   "next_required_actions": [
-    "todo"
+    "Generate a product-specific Discord Control Tower UX Proof Pack before treating Discord as accepted cockpit UX.",
+    "Keep #80 status snapshots as canonical state input for Discord projections.",
+    "Apply #82 Product Face visual quality review to any visible cockpit surface before acceptance.",
+    "Use #84 local web cockpit for dense state, comparison, inspection and long-running control."
   ],
   "evidence_refs": [
-    "external:private-discord-audit"
+    "docs/control-tower/discord-cockpit-ux-study-gate.md",
+    "templates/factory-status-snapshot.json",
+    "templates/discord-control-tower-ux-audit.json"
   ]
 }

--- a/tests/test_discord_control_tower_ux_audit.py
+++ b/tests/test_discord_control_tower_ux_audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 from pathlib import Path
 
@@ -12,6 +13,49 @@ def read_text(rel: str) -> str:
 
 
 class DiscordControlTowerUxAuditTest(unittest.TestCase):
+    def test_discord_ux_study_gate_is_a_real_contract_not_placeholder(self) -> None:
+        template = json.loads(read_text("templates/discord-control-tower-ux-audit.json"))
+
+        self.assertEqual(template["record_type"], "discord_control_tower_ux_audit")
+        self.assertEqual(template["result"], "ATTENTION")
+        self.assertFalse(template["study_gate"]["discord_is_source_of_truth"])
+        self.assertTrue(template["study_gate"]["ux_study_required_before_implementation"])
+        self.assertTrue(template["study_gate"]["proof_pack_required_before_acceptance"])
+        self.assertEqual(template["study_gate"]["recommended_role"], "secondary_operator_cockpit")
+        self.assertEqual(template["study_gate"]["web_cockpit_boundary"], "required_for_dense_state")
+        self.assertIn("#80", template["study_gate"]["status_snapshot_dependency"])
+        self.assertIn("#82", template["study_gate"]["product_face_dependency"])
+        self.assertGreaterEqual(len(template["discord_mastery_matrix"]["official_source_refs"]), 5)
+        self.assertGreaterEqual(len(template["discord_mastery_matrix"]["primitives_reviewed"]), 8)
+        self.assertGreaterEqual(len(template["proof_pack_contract"]["must_include_negative_tests"]), 5)
+        self.assertNotIn("todo", json.dumps(template).lower())
+
+    def test_discord_study_gate_doc_covers_platform_limits_and_web_boundary(self) -> None:
+        study = read_text("docs/control-tower/discord-cockpit-ux-study-gate.md")
+        os_doc = read_text("docs/control-tower/discord-control-tower-os.md")
+        combined = f"{study}\n{os_doc}"
+
+        for expected in [
+            "https://docs.discord.com/developers/interactions/overview",
+            "https://docs.discord.com/developers/interactions/receiving-and-responding",
+            "https://docs.discord.com/developers/components/reference",
+            "https://docs.discord.com/developers/topics/threads",
+            "https://docs.discord.com/developers/topics/permissions",
+            "https://docs.discord.com/developers/topics/rate-limits",
+            "first 5 seconds",
+            "first 30 seconds",
+            "first 5 minutes",
+            "rate limits",
+            "web cockpit",
+            "#80",
+            "#82",
+            "#84",
+            "Discord is optional projection",
+            "not the source of truth",
+        ]:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, combined)
+
     def test_project_intake_is_thread_first_in_docs(self) -> None:
         setup_guide = read_text("docs/control-tower/discord-control-tower-setup-pt-br.md")
         os_doc = read_text("docs/control-tower/discord-control-tower-os.md")


### PR DESCRIPTION
Summary: adds a public-safe Discord Cockpit UX Study Gate, upgrades the Discord UX audit schema/template into an enforceable study/proof contract, updates the Discord Control Tower OS to block cockpit acceptance without proof, and adds validation rules/tests for Discord source-of-truth, placeholder, platform-limit, #80, #82 and #84 boundaries. Validation: python -m unittest tests.test_discord_control_tower_ux_audit -q; python scripts/validate_public_json_artifacts.py; python scripts/public_safety_scan.py; python scripts/secret_safety_scan.py; python scripts/supply_chain_proof.py --check --no-write; python scripts/validate_document_governance.py; python scripts/validate_worker_profiles.py; python scripts/quickstart_smoke.py; git diff --check; python -m unittest discover -s tests -p "test_*.py" -q. Closes #83.