### PR TITLE
[codex] Harden foundation truth and safety gates

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -24,7 +24,6 @@ Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 def default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.setdefault("HOME", str(Path.home()))
-    env.setdefault("HERMES_HOME", env["HOME"])
     return subprocess.run(argv, text=True, capture_output=True, env=env)  # nosec B603
 
 
@@ -124,7 +123,7 @@ def ensure_blocked_event(
     runner: Runner = default_runner,
 ) -> None:
     run_checked(
-        hermes_kanban(hermes_bin, board, "block", task_id, "--reason", reason, "--json"),
+        hermes_kanban(hermes_bin, board, "block", task_id, reason),
         runner,
     )
     shown = run_checked(hermes_kanban(hermes_bin, board, "show", task_id, "--json"), runner)
@@ -253,6 +252,23 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
     )
     plan = result["plan"]
     card_id = str(plan.get("event", {}).get("card_id") or card_path.stem)
+    if args.dry_run:
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "materialize",
+            "dry_run": True,
+            "board": args.board,
+            "board_created": False,
+            "board_create_requested": bool(args.ensure_board),
+            "board_create_checked": False,
+            "main_task_id": None,
+            "worker_task_ids": {},
+            "hook": result,
+        }
+        if args.out:
+            write_json(args.out, envelope)
+        return envelope
+
     board_created = False
     if args.ensure_board:
         board_created = ensure_board(
@@ -261,21 +277,6 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
             default_workdir=str(ROOT),
             runner=runner,
         )
-
-    if args.dry_run:
-        envelope = {
-            "$schema": LIVE_ADAPTER_SCHEMA,
-            "mode": "materialize",
-            "dry_run": True,
-            "board": args.board,
-            "board_created": board_created,
-            "main_task_id": None,
-            "worker_task_ids": {},
-            "hook": result,
-        }
-        if args.out:
-            write_json(args.out, envelope)
-        return envelope
 
     readiness_blockers = route_readiness_blockers(
         args.route_readiness,

--- a/schemas/full-product-worker-graph.schema.json
+++ b/schemas/full-product-worker-graph.schema.json
@@ -7,12 +7,14 @@
     "record_type",
     "created_at",
     "graph_kind",
+    "graph_mode",
     "product_id",
     "result",
     "blocking_findings",
     "evidence_kind",
     "reusable_for_product",
     "completion_claim_allowed",
+    "omitted_lanes",
     "lanes_total",
     "lanes_passed",
     "lanes",
@@ -37,6 +39,9 @@
     "graph_kind": {
       "type": "string",
       "minLength": 3
+    },
+    "graph_mode": {
+      "enum": ["full_product", "release_gate_upstream"]
     },
     "product_id": {
       "type": "string",
@@ -63,6 +68,13 @@
     "completion_claim_allowed": {
       "type": "boolean"
     },
+    "omitted_lanes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "lanes_total": {
       "type": "integer"
     },
@@ -87,6 +99,7 @@
           "lane_id",
           "scope",
           "evidence_ref",
+          "evidence_provenance",
           "status",
           "validation_errors",
           "reusable_for_product"
@@ -135,6 +148,21 @@
             "items": {
               "type": "string"
             }
+          },
+          "evidence_provenance": {
+            "type": "object",
+            "required": ["ref", "exists", "loaded_at"],
+            "properties": {
+              "ref": { "type": "string", "minLength": 3 },
+              "exists": { "type": "boolean" },
+              "loaded_at": { "type": "string", "minLength": 10 },
+              "size_bytes": { "type": "integer", "minimum": 0 },
+              "sha256": { "type": "string", "minLength": 64 },
+              "record_type": { "type": ["string", "null"] },
+              "$schema": { "type": ["string", "null"] },
+              "product_id": { "type": ["string", "null"] }
+            },
+            "additionalProperties": true
           },
           "status": {
             "enum": ["PASS", "FAIL"]

--- a/schemas/gate-report.schema.json
+++ b/schemas/gate-report.schema.json
@@ -41,6 +41,20 @@
         "required": ["required", "reason", "status"],
         "additionalProperties": true
       }
+    },
+    "next_safe_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["worker_id", "field", "action", "authority"],
+        "properties": {
+          "worker_id": { "type": "string", "minLength": 3 },
+          "field": { "type": "string", "minLength": 1 },
+          "action": { "type": "string", "minLength": 3 },
+          "authority": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
     }
   },
   "additionalProperties": true

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -150,6 +150,27 @@
     "reusable_for_product": {
       "type": "boolean"
     },
+    "evidence_provenance": {
+      "type": "object",
+      "description": "Structured provenance for production-strict file-backed evidence.",
+      "properties": {
+        "producer": { "type": "string", "minLength": 2 },
+        "captured_at": { "type": "string", "minLength": 10 },
+        "source_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "artifact_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "integrity": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
     "waiver": {
       "type": "object",
       "required": [

--- a/scripts/canonical_runtime_enforcement.py
+++ b/scripts/canonical_runtime_enforcement.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TRACE = ROOT / ".tmp" / "factory-runs" / "canonical-linear-traceability" / "canonical-linear-traceability.json"
 DEFAULT_OUT = ROOT / ".tmp" / "factory-runs" / "canonical-runtime-enforcement" / "canonical-runtime-rulebook.json"
 SCHEMA = "https://overkill-factory.dev/schemas/canonical-runtime-rulebook.schema.json"
+FALLBACK_SOURCE_TRACE_REF = "generated:fallback-vfinal-runtime-rulebook"
 
 NON_RUNTIME_LINEAR_STATUSES = {"foundational_text_tracked"}
 CORE_RUNTIME_FIELDS = (
@@ -217,39 +218,45 @@ def build_rulebook(trace: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def default_rulebook() -> dict[str, Any]:
-    if not DEFAULT_TRACE.exists():
-        return {
-            "$schema": SCHEMA,
-            "record_type": "canonical_runtime_rulebook",
-            "source_trace_ref": "generated:fallback-vfinal-runtime-rulebook",
-            "summary": {
-                "checkpoints_checked": 1,
-                "runtime_rules": 1,
-                "non_runtime_processes": 0,
-                "unmapped_actionable_checkpoints": 0,
-            },
-            "rules": [
-                {
-                    "rule_id": "canonical-runtime::vfinal-core-contract",
-                    "checkpoint_id": "vfinal-core-contract",
-                    "sequence": 1,
-                    "canonical_line": None,
-                    "canonical_heading": "vFinal core runtime contract",
-                    "linear_status": "implemented_by_runtime",
-                    "enforcement_points": [
-                        "scripts/canonical_runtime_enforcement.py",
-                        "scripts/factoryctl.py validate-card",
-                        "adapters/hermes/transition_hook.py",
-                    ],
-                    "required_fields": list(VFINAL_FALLBACK_FIELDS),
-                    "block_policy": "missing_required_fields_blocks_vfinal_runtime_gate",
-                }
-            ],
-            "non_runtime_processes": [],
-            "unmapped_actionable_checkpoints": [],
-        }
-    return build_rulebook(load_json(DEFAULT_TRACE))
+def fallback_rulebook() -> dict[str, Any]:
+    return {
+        "$schema": SCHEMA,
+        "record_type": "canonical_runtime_rulebook",
+        "source_trace_ref": FALLBACK_SOURCE_TRACE_REF,
+        "summary": {
+            "checkpoints_checked": 1,
+            "runtime_rules": 1,
+            "non_runtime_processes": 0,
+            "unmapped_actionable_checkpoints": 0,
+        },
+        "rules": [
+            {
+                "rule_id": "canonical-runtime::vfinal-core-contract",
+                "checkpoint_id": "vfinal-core-contract",
+                "sequence": 1,
+                "canonical_line": None,
+                "canonical_heading": "vFinal core runtime contract",
+                "linear_status": "implemented_by_runtime",
+                "enforcement_points": [
+                    "scripts/canonical_runtime_enforcement.py",
+                    "scripts/factoryctl.py validate-card",
+                    "adapters/hermes/transition_hook.py",
+                ],
+                "required_fields": list(VFINAL_FALLBACK_FIELDS),
+                "block_policy": "missing_required_fields_blocks_vfinal_runtime_gate",
+            }
+        ],
+        "non_runtime_processes": [],
+        "unmapped_actionable_checkpoints": [],
+    }
+
+
+def default_rulebook(trace_path: Path | None = None) -> dict[str, Any]:
+    if trace_path is None:
+        return fallback_rulebook()
+    if not trace_path.exists():
+        raise FileNotFoundError(f"canonical trace does not exist: {trace_path}")
+    return build_rulebook(load_json(trace_path))
 
 
 def validate_card_runtime_rules(card: dict[str, Any], rulebook: dict[str, Any] | None = None) -> list[dict[str, Any]]:
@@ -282,12 +289,12 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build or run canonical runtime enforcement.")
-    parser.add_argument("--trace", type=Path, default=DEFAULT_TRACE)
+    parser.add_argument("--trace", type=Path)
     parser.add_argument("--card", type=Path)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
     args = parser.parse_args(argv)
 
-    rulebook = build_rulebook(load_json(args.trace))
+    rulebook = default_rulebook(args.trace)
     if args.card:
         card = load_json(args.card)
         blockers = validate_card_runtime_rules(card, rulebook)

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2328,6 +2328,29 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
         gate_status = "ready_for_worker_execution"
     else:
         gate_status = "pass_no_workers_required"
+    next_safe_actions: list[dict[str, str]] = []
+    seen_actions: set[tuple[str, str, str]] = set()
+    for worker_id, row in worker_rows.items():
+        if not row.get("required"):
+            continue
+        status = str(row.get("status") or "")
+        if status not in {"requires_execution"} and not status.startswith("blocked_"):
+            continue
+        guidance_items = list(row.get("unblock_guidance", []))
+        if status == "requires_execution" and not guidance_items:
+            guidance_items.append(
+                {
+                    "field": WORKERS[worker_id].output_field,
+                    "action": f"execute {worker_id} and attach a valid {WORKERS[worker_id].output_field}",
+                    "authority": "assigned worker must produce evidence; operator may only route or approve where explicitly required",
+                }
+            )
+        for guidance in guidance_items:
+            key = (worker_id, str(guidance.get("field") or ""), str(guidance.get("action") or ""))
+            if key in seen_actions:
+                continue
+            seen_actions.add(key)
+            next_safe_actions.append({"worker_id": worker_id, **guidance})
     return {
         "$schema": "https://overkill-factory.dev/schemas/gate-report.schema.json",
         "report_type": "factory_gate_preflight",
@@ -2346,11 +2369,7 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
         "blocked_workers": blocked_workers,
         "card_validation_errors": validation_errors,
         "card_validation_warnings": validation_warnings,
-        "next_safe_actions": [
-            guidance
-            for row in worker_rows.values()
-            for guidance in row.get("unblock_guidance", [])
-        ],
+        "next_safe_actions": next_safe_actions,
         "workers": worker_rows,
     }
 

--- a/scripts/production_full_product_worker_graph.py
+++ b/scripts/production_full_product_worker_graph.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUT = ROOT / ".tmp" / "factory-runs" / "production" / "full-product-worker-graph.json"
 DEFAULT_MD_OUT = ROOT / ".tmp" / "factory-runs" / "production" / "full-product-worker-graph.md"
 PRODUCT_SOURCE = ROOT / "products" / "qvg-public-validation-product"
+RELEASE_GATE_UPSTREAM_EXCLUDED_LANES = {"human_gate", "release_ops"}
 
 
 LANES: tuple[dict[str, Any], ...] = (
@@ -98,8 +100,6 @@ def utc_now() -> str:
 
 
 def source_sha256(path: Path = PRODUCT_SOURCE) -> str:
-    import hashlib
-
     digest = hashlib.sha256()
     for item in sorted(path.rglob("*")):
         if item.is_file():
@@ -107,6 +107,12 @@ def source_sha256(path: Path = PRODUCT_SOURCE) -> str:
             digest.update(b"\0")
             digest.update(item.read_bytes())
             digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
     return digest.hexdigest()
 
 
@@ -161,6 +167,17 @@ def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
                 errors.append("strict lane product_target is missing")
             elif target.get("product_id") != "qvg-public-validation-product":
                 errors.append("strict lane product_id does not match")
+    provenance: dict[str, Any] = {
+        "ref": rel_path,
+        "exists": path.exists(),
+        "loaded_at": utc_now(),
+        "record_type": data.get("record_type") or lane.get("record_type") or lane.get("kind", "file"),
+        "$schema": data.get("$schema"),
+        "product_id": (data.get("product_target") or {}).get("product_id") if isinstance(data.get("product_target"), dict) else None,
+    }
+    if path.exists():
+        provenance["size_bytes"] = path.stat().st_size
+        provenance["sha256"] = file_sha256(path)
 
     return {
         "lane_id": lane["lane_id"],
@@ -176,16 +193,26 @@ def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
         "reusable_for_product": bool(data.get("reusable_for_product")) if data else lane.get("reusable_policy") == "supporting",
         "evidence_ref_count": len(data.get("evidence_refs") or []) if data else 1 if path.exists() else 0,
         "stale_evidence_refs": [],
+        "evidence_provenance": provenance,
         "status": "PASS" if not errors else "FAIL",
         "validation_errors": errors,
     }
 
 
-def build_graph() -> dict[str, Any]:
-    lanes = [validate_lane(lane) for lane in LANES]
+def filter_lanes_for_mode(lanes: tuple[dict[str, Any], ...], graph_mode: str) -> tuple[tuple[dict[str, Any], ...], list[str]]:
+    if graph_mode != "release_gate_upstream":
+        return lanes, []
+    selected = tuple(lane for lane in lanes if lane["lane_id"] not in RELEASE_GATE_UPSTREAM_EXCLUDED_LANES)
+    omitted = [lane["lane_id"] for lane in lanes if lane["lane_id"] in RELEASE_GATE_UPSTREAM_EXCLUDED_LANES]
+    return selected, omitted
+
+
+def build_graph(lanes: tuple[dict[str, Any], ...] = LANES, *, graph_mode: str = "full_product") -> dict[str, Any]:
+    selected_lanes, omitted_lanes = filter_lanes_for_mode(lanes, graph_mode)
+    lane_results = [validate_lane(lane) for lane in selected_lanes]
     blocking = [
         f"{lane['lane_id']}: " + "; ".join(lane["validation_errors"])
-        for lane in lanes
+        for lane in lane_results
         if lane["validation_errors"]
     ]
     passed = not blocking
@@ -194,6 +221,7 @@ def build_graph() -> dict[str, Any]:
         "record_type": "full_product_worker_graph",
         "created_at": utc_now(),
         "graph_kind": "production_public_validation_product_graph",
+        "graph_mode": graph_mode,
         "product_id": "qvg-public-validation-product",
         "product_name": "Quasar Vault Guard public validation product",
         "product_target": product_target(),
@@ -201,18 +229,21 @@ def build_graph() -> dict[str, Any]:
         "blocking_findings": not passed,
         "evidence_kind": "real",
         "reusable_for_product": passed,
-        "completion_claim_allowed": passed,
-        "lanes_total": len(lanes),
-        "lanes_passed": sum(1 for lane in lanes if lane["status"] == "PASS"),
-        "product_lanes_total": sum(1 for lane in lanes if lane["scope"] == "product"),
-        "supporting_lanes_total": sum(1 for lane in lanes if lane["scope"] == "supporting"),
-        "reusable_for_product_lanes": sum(1 for lane in lanes if lane["reusable_for_product"]),
-        "lanes": lanes,
+        "completion_claim_allowed": passed and not omitted_lanes,
+        "omitted_lanes": omitted_lanes,
+        "lanes_total": len(lane_results),
+        "lanes_passed": sum(1 for lane in lane_results if lane["status"] == "PASS"),
+        "product_lanes_total": sum(1 for lane in lane_results if lane["scope"] == "product"),
+        "supporting_lanes_total": sum(1 for lane in lane_results if lane["scope"] == "supporting"),
+        "reusable_for_product_lanes": sum(1 for lane in lane_results if lane["reusable_for_product"]),
+        "lanes": lane_results,
         "blocking_summary": blocking,
         "production_blockers": blocking or ["none"],
-        "evidence_refs": [str(lane["path"]) for lane in LANES],
+        "evidence_refs": [str(lane["path"]) for lane in selected_lanes],
         "policy_decision": (
             "The public validation product has a reconciled production-scoped worker graph."
+            if passed and not omitted_lanes
+            else "The release gate upstream graph is reusable for release validation; run the full graph after release-ops evidence is written."
             if passed
             else "Do not claim full product graph completion until every strict lane has reusable product evidence."
         ),
@@ -251,9 +282,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--md-out", type=Path, default=DEFAULT_MD_OUT)
     parser.add_argument("--no-write", action="store_true")
     parser.add_argument("--require-pass", action="store_true")
+    parser.add_argument("--release-gate-upstream", action="store_true")
     args = parser.parse_args(argv)
 
-    graph = build_graph()
+    graph_mode = "release_gate_upstream" if args.release_gate_upstream else "full_product"
+    graph = build_graph(graph_mode=graph_mode)
     if not args.no_write:
         write_json(args.out, graph)
         write_markdown(args.md_out, graph)

--- a/scripts/production_release_gate.py
+++ b/scripts/production_release_gate.py
@@ -19,8 +19,27 @@ VALIDATION_COMMANDS = [
     [sys.executable, "scripts/validate_public_json_artifacts.py"],
     [sys.executable, "scripts/secret_safety_scan.py"],
     [sys.executable, "scripts/public_safety_scan.py"],
-    [sys.executable, "scripts/full_product_worker_graph.py", "--require-pass"],
+    [
+        sys.executable,
+        "scripts/production_full_product_worker_graph.py",
+        "--release-gate-upstream",
+        "--require-pass",
+        "--out",
+        ".tmp/factory-runs/production/release/upstream-worker-graph.json",
+        "--md-out",
+        ".tmp/factory-runs/production/release/upstream-worker-graph.md",
+    ],
 ]
+GENERATED_APPROVAL_MARKERS = ("fixture", "synthetic", "generated:", "placeholder", "todo", "example")
+
+
+def validation_commands(*, no_write: bool = False) -> list[list[str]]:
+    commands = [list(command) for command in VALIDATION_COMMANDS]
+    if no_write:
+        for command in commands:
+            if "scripts/production_full_product_worker_graph.py" in command:
+                command.append("--no-write")
+    return commands
 
 
 def utc_now() -> str:
@@ -86,71 +105,71 @@ def product_target() -> dict[str, str]:
     }
 
 
-def build_human_gate(*, approval_ref: str, approved_by: str, created_at: str) -> dict[str, Any]:
+def evidence_provenance(*, created_at: str, producer: str, artifact_refs: list[str]) -> dict[str, Any]:
     return {
-        "$schema": "https://overkill-factory.dev/schemas/worker-result.schema.json",
-        "record_type": "human_gate_record",
-        "created_at": created_at,
-        "worker": {
-            "id": "human-gate-clerk",
-            "name": "Human Gate Clerk",
-            "factory_phase": "F16",
+        "producer": producer,
+        "captured_at": created_at,
+        "source_refs": ["products/qvg-public-validation-product"],
+        "artifact_refs": artifact_refs,
+        "integrity": {
+            "product_source_sha256": source_sha256(),
+            "git_head": git_value("rev-parse", "HEAD"),
         },
-        "card_ref": {
-            "card_id": "QVG-PRODUCTION-RELEASE-GATE",
-            "slice_id": "QVG_PUBLIC_VALIDATION_PRODUCT",
-            "phase": "F16",
-            "risk_effective": "R4",
-            "surfaces": ["release", "public-repository", "rollback", "monitoring"],
-            "executor_identity": "release-ops-worker",
-            "reviewer_identity": "human-gate-clerk",
-        },
-        "product_target": product_target(),
-        "result": "PASS",
-        "blocking_findings": False,
-        "findings_summary": "Maintainer authorization was recorded for the public validation product release-control lane with rollback and monitoring boundaries.",
-        "tool_or_profile": "Hermes human-gate-clerk",
-        "executed_by": "human-gate-clerk",
-        "evidence_kind": "real",
-        "reusable_for_product": True,
-        "gate_type": "R4-public-validation-release",
-        "decision": "approved_with_boundaries",
-        "decision_at": created_at,
-        "decision_source": approval_ref,
-        "human_actor": approved_by,
-        "public_redaction_policy": "The raw authorization text and personal identity are intentionally kept outside the public repository.",
-        "approved_scope": [
-            "Run the public validation product through the Overkill Factory release-control lane.",
-            "Use Hermes/Kanban workers and Crabbox/container proof where available.",
-            "Write public-safe validation, release and audit artifacts.",
-            "Push public repository branch updates that contain no private project material.",
-        ],
-        "forbidden_scope": [
-            "secret disclosure",
-            "funds movement",
-            "wallet signing",
-            "mainnet write",
-            "unreviewed production infrastructure mutation",
-            "history rewrite",
-        ],
-        "risk_owner": "project-maintainer",
-        "security_owner": "security-reviewer",
-        "rollback_owner": "release-ops-worker",
-        "expiry": "Valid only for this public validation product and this release-control evidence round.",
-        "evidence_refs": [
-            ".tmp/factory-runs/production/release/human-gate-record.md",
-            ".tmp/factory-runs/production/release/release-ops-result.json",
-            ".tmp/factory-runs/production/remote-proof/managed-testbox-result.json",
-        ],
-        "next_action": "Keep future R4 gates product-specific and time-bounded.",
     }
 
 
-def build_release_ops(*, created_at: str, validation: list[dict[str, Any]]) -> dict[str, Any]:
+def human_gate_errors(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if record.get("record_type") != "human_gate_record":
+        errors.append("human gate record_type must be human_gate_record")
+    if record.get("decision") not in {"approved", "approved_with_boundaries"}:
+        errors.append("human gate decision must be approved")
+    if record.get("evidence_kind") != "real":
+        errors.append("production human gate requires evidence_kind=real")
+    if record.get("reusable_for_product") is not True:
+        errors.append("production human gate requires reusable_for_product=true")
+    target = record.get("product_target") if isinstance(record.get("product_target"), dict) else {}
+    if target.get("product_id") != "qvg-public-validation-product":
+        errors.append("production human gate product_target.product_id must match")
+    approval_ref = str(record.get("approval_event_id") or record.get("approval_event_ref") or record.get("decision_source") or "").strip()
+    if not approval_ref:
+        errors.append("production human gate requires approval_event_id or approval_event_ref")
+    elif any(marker in approval_ref.lower() for marker in GENERATED_APPROVAL_MARKERS):
+        errors.append("production human gate cannot use generated, fixture, synthetic or placeholder approval evidence")
+    for field in ("human_actor", "decision_at", "risk_owner", "security_owner", "rollback_owner"):
+        if not str(record.get(field) or "").strip():
+            errors.append(f"production human gate requires {field}")
+    provenance = record.get("evidence_provenance") if isinstance(record.get("evidence_provenance"), dict) else {}
+    if not provenance:
+        errors.append("production human gate requires evidence_provenance")
+    else:
+        for field in ("producer", "captured_at", "artifact_refs", "integrity"):
+            if provenance.get(field) in (None, "", [], {}):
+                errors.append(f"production human gate evidence_provenance.{field} is required")
+    return errors
+
+
+def load_human_gate_record(path: Path) -> dict[str, Any]:
+    record = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(record, dict):
+        raise ValueError("human gate record must be a JSON object")
+    errors = human_gate_errors(record)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return record
+
+
+def build_release_ops(*, created_at: str, validation: list[dict[str, Any]], human_gate_ref: str = ".tmp/factory-runs/production/release/human-gate-record.json") -> dict[str, Any]:
     head = git_value("rev-parse", "HEAD")
     branch = git_value("branch", "--show-current")
     remote_ref = git_value("ls-remote", "origin", branch)
     validation_passed = all(item["exit_code"] == 0 for item in validation)
+    evidence_refs = [
+        ".tmp/factory-runs/production/release/release-ops-result.md",
+        human_gate_ref,
+        ".tmp/factory-runs/production/remote-proof/managed-testbox-result.json",
+        ".tmp/factory-runs/production/release/upstream-worker-graph.json",
+    ]
     return {
         "$schema": "https://overkill-factory.dev/schemas/worker-result.schema.json",
         "record_type": "release_ops_result",
@@ -219,12 +238,12 @@ def build_release_ops(*, created_at: str, validation: list[dict[str, Any]]) -> d
             {"action": "infrastructure_mutation", "performed": False},
             {"action": "history_rewrite", "performed": False},
         ],
-        "evidence_refs": [
-            ".tmp/factory-runs/production/release/release-ops-result.md",
-            ".tmp/factory-runs/production/release/human-gate-record.json",
-            ".tmp/factory-runs/production/remote-proof/managed-testbox-result.json",
-            ".tmp/factory-runs/product-specific/qvg-full-product-worker-graph.json",
-        ],
+        "evidence_refs": evidence_refs,
+        "evidence_provenance": evidence_provenance(
+            created_at=created_at,
+            producer="release-ops-worker",
+            artifact_refs=evidence_refs,
+        ),
         "next_action": "Repeat this gate whenever the release target, product source, branch or authority boundary changes.",
     }
 
@@ -238,13 +257,13 @@ def write_markdown(path: Path, title: str, payload: dict[str, Any]) -> None:
     lines = [
         f"# {title}",
         "",
-        f"Result: `{payload['result']}`",
-        f"Reusable for product: `{str(payload['reusable_for_product']).lower()}`",
-        f"Product: `{payload['product_target']['product_id']}`",
+        f"Result: `{payload.get('result') or payload.get('decision')}`",
+        f"Reusable for product: `{str(payload.get('reusable_for_product')).lower()}`",
+        f"Product: `{payload.get('product_target', {}).get('product_id')}`",
         "",
         "## Summary",
         "",
-        payload["findings_summary"],
+        payload.get("findings_summary") or payload.get("public_redaction_policy") or "Structured human gate record.",
         "",
     ]
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -254,15 +273,22 @@ def write_markdown(path: Path, title: str, payload: dict[str, Any]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
-    parser.add_argument("--approval-ref", default="external:redacted-maintainer-authorization-2026-06-06")
-    parser.add_argument("--approved-by", default="project-maintainer")
+    parser.add_argument("--human-gate-record", type=Path, required=True)
     parser.add_argument("--no-write", action="store_true")
     args = parser.parse_args(argv)
 
     created_at = utc_now()
-    validation = [run_command(command) for command in VALIDATION_COMMANDS]
-    human_gate = build_human_gate(approval_ref=args.approval_ref, approved_by=args.approved_by, created_at=created_at)
-    release_ops = build_release_ops(created_at=created_at, validation=validation)
+    try:
+        human_gate = load_human_gate_record(args.human_gate_record)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"human gate record rejected: {exc}", file=sys.stderr)
+        return 1
+    validation = [run_command(command) for command in validation_commands(no_write=args.no_write)]
+    release_ops = build_release_ops(
+        created_at=created_at,
+        validation=validation,
+        human_gate_ref=repo_ref(args.human_gate_record.resolve()),
+    )
 
     if not args.no_write:
         write_json(args.out_dir / "human-gate-record.json", human_gate)

--- a/tests/test_canonical_runtime_enforcement.py
+++ b/tests/test_canonical_runtime_enforcement.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -24,6 +25,40 @@ class CanonicalRuntimeEnforcementTest(unittest.TestCase):
         self.assertEqual(rulebook["record_type"], "canonical_runtime_rulebook")
         self.assertEqual(rulebook["summary"]["runtime_rules"], 1)
         self.assertEqual(rulebook["source_trace_ref"], "generated:fallback-vfinal-runtime-rulebook")
+
+    def test_default_rulebook_ignores_ambient_tmp_trace_unless_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trace = Path(tmp) / "canonical-linear-traceability.json"
+            trace.write_text(
+                json.dumps(
+                    {
+                        "checkpoints": [
+                            {
+                                "checkpoint_id": "explicit-trace",
+                                "sequence": 99,
+                                "canonical_heading": "Explicit trace only",
+                                "canonical_obligation": "Source evidence must be captured.",
+                                "implementation_status": "implemented_by_runtime",
+                                "implementation_refs": [],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            fallback = canonical_runtime_enforcement.default_rulebook()
+            explicit = canonical_runtime_enforcement.default_rulebook(trace)
+
+        self.assertEqual(fallback["source_trace_ref"], "generated:fallback-vfinal-runtime-rulebook")
+        self.assertEqual(explicit["rules"][0]["checkpoint_id"], "explicit-trace")
+
+    def test_explicit_missing_trace_is_not_silently_replaced(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_trace = Path(tmp) / "missing-trace.json"
+
+            with self.assertRaises(FileNotFoundError):
+                canonical_runtime_enforcement.default_rulebook(missing_trace)
 
     def test_strict_vfinal_runtime_gate_blocks_missing_canonical_contracts(self) -> None:
         card = json.loads((ROOT / "templates" / "vfinal-factory-card.json").read_text(encoding="utf-8"))

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -248,6 +248,11 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("codex-security", report["blocked_workers"])
         self.assertEqual(report["workers"]["public-safety-gate"]["status"], "requires_execution")
         self.assertEqual(report["workers"]["release-ops-worker"]["status"], "blocked_missing_inputs")
+        next_action_workers = {item["worker_id"] for item in report["next_safe_actions"]}
+        self.assertTrue(next_action_workers <= set(report["required_workers"]))
+        self.assertIn("codex-security", next_action_workers)
+        self.assertIn("release-ops-worker", next_action_workers)
+        self.assertNotIn("product-face", next_action_workers)
 
     def test_security_scan_packet_can_require_codex_security_on_r2_product_face(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -30,7 +30,7 @@ class FakeHermes:
 
     def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(argv)
-        if argv[:4] == ["hermes", "kanban", "boards", "list"]:
+        if argv == ["hermes", "kanban", "boards", "list", "--json"]:
             return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
         if argv[:4] == ["hermes", "kanban", "boards", "create"]:
             return subprocess.CompletedProcess(argv, 0, stdout="created", stderr="")
@@ -38,7 +38,7 @@ class FakeHermes:
             self.counter += 1
             task_id = "t_" + f"{self.counter:08x}"
             return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
-        if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "block":
+        if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "block":
             return subprocess.CompletedProcess(argv, 0, stdout='{"status":"blocked"}', stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
             return subprocess.CompletedProcess(
@@ -138,6 +138,48 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         self.assertTrue(result["dry_run"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
+
+    def test_materialize_dry_run_with_ensure_board_does_not_touch_hermes(self) -> None:
+        fake = FakeHermes()
+        card = ROOT / "examples" / "cards" / "v35_valid_product_face.md"
+        with tempfile.TemporaryDirectory() as tmp:
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize",
+                    "--card",
+                    str(card),
+                    "--board",
+                    TEST_BOARD,
+                    "--ledger",
+                    str(Path(tmp) / "ledger.json"),
+                    "--dry-run",
+                    "--ensure-board",
+                ]
+            )
+            result = adapter.materialize(args, runner=fake)
+
+        self.assertTrue(result["dry_run"])
+        self.assertTrue(result["board_create_requested"])
+        self.assertFalse(result["board_create_checked"])
+        self.assertEqual(fake.calls, [])
+
+    def test_block_command_matches_real_hermes_cli_shape(self) -> None:
+        fake = FakeHermes()
+
+        adapter.ensure_blocked_event(
+            hermes_bin="hermes",
+            board=TEST_BOARD,
+            task_id=MAIN_TASK_ID,
+            reason="gate",
+            runner=fake,
+        )
+
+        self.assertEqual(
+            fake.calls[0],
+            ["hermes", "kanban", "--board", TEST_BOARD, "block", MAIN_TASK_ID, "gate"],
+        )
+        self.assertNotIn("--reason", fake.calls[0])
+        self.assertNotIn("--json", fake.calls[0])
 
     def test_complete_main_requires_materialized_live_binding(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_production_full_product_worker_graph.py
+++ b/tests/test_production_full_product_worker_graph.py
@@ -18,18 +18,22 @@ SPEC.loader.exec_module(module)
 
 
 class ProductionFullProductWorkerGraphTest(unittest.TestCase):
-    def test_current_graph_matches_available_production_lanes(self) -> None:
-        graph = module.build_graph()
-        all_lane_files_exist = all((ROOT / lane["path"]).exists() for lane in module.LANES)
+    def test_graph_blocks_missing_strict_lane_from_explicit_fixture(self) -> None:
+        lane = {
+            "lane_id": "remote_proof",
+            "worker_id": "remote-proof-runner",
+            "path": ".tmp/test-production-graph/missing-remote-proof.json",
+            "record_type": "remote_proof_result",
+            "scope": "supporting",
+            "reusable_policy": "strict",
+        }
 
-        if all_lane_files_exist:
-            self.assertEqual(graph["result"], "FAIL")
-            self.assertFalse(graph["reusable_for_product"])
-            self.assertTrue(any(item.startswith("product_face:") for item in graph["blocking_summary"]))
-        else:
-            self.assertEqual(graph["result"], "FAIL")
-            self.assertFalse(graph["reusable_for_product"])
-            self.assertGreater(len(graph["blocking_summary"]), 0)
+        graph = module.build_graph((lane,))
+
+        self.assertEqual(graph["result"], "FAIL")
+        self.assertFalse(graph["reusable_for_product"])
+        self.assertEqual(graph["lanes_total"], 1)
+        self.assertIn("remote_proof: evidence file is missing", graph["blocking_summary"])
 
     def test_strict_lane_requires_reusable_product_target(self) -> None:
         tmp_root = ROOT / ".tmp"
@@ -50,9 +54,95 @@ class ProductionFullProductWorkerGraphTest(unittest.TestCase):
             }
 
             result = module.validate_lane(lane)
+            expected_size = proof.stat().st_size
 
         self.assertEqual(result["status"], "FAIL")
         self.assertIn("strict lane must be reusable", " ".join(result["validation_errors"]))
+        self.assertEqual(result["evidence_provenance"]["ref"], lane["path"])
+        self.assertEqual(result["evidence_provenance"]["size_bytes"], expected_size)
+        self.assertEqual(len(result["evidence_provenance"]["sha256"]), 64)
+
+    def test_lane_provenance_records_loaded_schema_and_product(self) -> None:
+        tmp_root = ROOT / ".tmp"
+        tmp_root.mkdir(exist_ok=True)
+        with TemporaryDirectory(dir=tmp_root) as tmpdir:
+            proof = Path(tmpdir) / "proof.json"
+            proof.write_text(
+                (
+                    '{"$schema":"https://overkill-factory.dev/schemas/worker-result.schema.json",'
+                    '"record_type":"remote_proof_result","result":"PASS","evidence_kind":"real",'
+                    '"reusable_for_product":true,"product_target":{"product_id":"qvg-public-validation-product"}}'
+                ),
+                encoding="utf-8",
+            )
+            lane = {
+                "lane_id": "remote_proof",
+                "worker_id": "remote-proof-runner",
+                "path": proof.relative_to(ROOT).as_posix(),
+                "record_type": "remote_proof_result",
+                "scope": "supporting",
+                "reusable_policy": "strict",
+            }
+
+            result = module.validate_lane(lane)
+
+        provenance = result["evidence_provenance"]
+        self.assertEqual(result["status"], "PASS")
+        self.assertEqual(provenance["record_type"], "remote_proof_result")
+        self.assertEqual(provenance["product_id"], "qvg-public-validation-product")
+        self.assertEqual(provenance["$schema"], "https://overkill-factory.dev/schemas/worker-result.schema.json")
+
+    def test_release_gate_upstream_mode_excludes_gate_owned_lanes(self) -> None:
+        tmp_root = ROOT / ".tmp"
+        tmp_root.mkdir(exist_ok=True)
+        with TemporaryDirectory(dir=tmp_root) as tmpdir:
+            proof = Path(tmpdir) / "remote-proof.json"
+            proof.write_text(
+                (
+                    '{"record_type":"remote_proof_result","result":"PASS","evidence_kind":"real",'
+                    '"reusable_for_product":true,"product_target":{"product_id":"qvg-public-validation-product"}}'
+                ),
+                encoding="utf-8",
+            )
+            upstream_lane = {
+                "lane_id": "remote_proof",
+                "worker_id": "remote-proof-runner",
+                "path": proof.relative_to(ROOT).as_posix(),
+                "record_type": "remote_proof_result",
+                "scope": "supporting",
+                "reusable_policy": "strict",
+            }
+            human_gate_lane = {
+                "lane_id": "human_gate",
+                "worker_id": "human-gate-clerk",
+                "path": (Path(tmpdir) / "human-gate-record.json").relative_to(ROOT).as_posix(),
+                "record_type": "human_gate_record",
+                "scope": "supporting",
+                "reusable_policy": "strict",
+            }
+            release_lane = {
+                "lane_id": "release_ops",
+                "worker_id": "release-ops-worker",
+                "path": (Path(tmpdir) / "release-ops-result.json").relative_to(ROOT).as_posix(),
+                "record_type": "release_ops_result",
+                "scope": "supporting",
+                "reusable_policy": "strict",
+            }
+
+            lanes = (upstream_lane, human_gate_lane, release_lane)
+            full_graph = module.build_graph(lanes)
+            upstream_graph = module.build_graph(lanes, graph_mode="release_gate_upstream")
+
+        self.assertEqual(full_graph["result"], "FAIL")
+        self.assertIn("human_gate: evidence file is missing", full_graph["blocking_summary"])
+        self.assertIn("release_ops: evidence file is missing", full_graph["blocking_summary"])
+        self.assertEqual(upstream_graph["result"], "PASS")
+        self.assertEqual(upstream_graph["omitted_lanes"], ["human_gate", "release_ops"])
+        self.assertFalse(upstream_graph["completion_claim_allowed"])
+        self.assertEqual(upstream_graph["lanes_total"], 1)
+        self.assertNotIn(human_gate_lane["path"], upstream_graph["evidence_refs"])
+        self.assertNotIn(release_lane["path"], upstream_graph["evidence_refs"])
+        self.assertEqual(upstream_graph["blocking_summary"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_production_release_gate.py
+++ b/tests/test_production_release_gate.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -18,18 +20,45 @@ SPEC.loader.exec_module(module)
 
 
 class ProductionReleaseGateTest(unittest.TestCase):
-    def test_human_gate_is_product_scoped_and_public_safe(self) -> None:
-        gate = module.build_human_gate(
-            approval_ref="external:redacted-maintainer-authorization",
-            approved_by="project-maintainer",
-            created_at="2026-06-06T00:00:00+00:00",
-        )
+    def valid_human_gate(self) -> dict:
+        return {
+            "record_type": "human_gate_record",
+            "gate_type": "release_r4",
+            "decision": "approved",
+            "decision_at": "2026-06-06T00:00:00+00:00",
+            "approval_event_id": "external:maintainer-authorization-event-2026-06-06",
+            "human_actor": "project-maintainer",
+            "approved_scope": ["public repository release-control lane"],
+            "forbidden_scope": ["mainnet write", "wallet signing", "secret disclosure"],
+            "risk_owner": "project-maintainer",
+            "security_owner": "security-reviewer",
+            "rollback_owner": "release-ops-worker",
+            "evidence_refs": ["external:maintainer-authorization-event-2026-06-06"],
+            "evidence_kind": "real",
+            "reusable_for_product": True,
+            "product_target": {"product_id": "qvg-public-validation-product"},
+            "evidence_provenance": {
+                "producer": "human-gate-clerk",
+                "captured_at": "2026-06-06T00:00:00+00:00",
+                "source_refs": ["external:maintainer-authorization-event-2026-06-06"],
+                "artifact_refs": ["external:maintainer-authorization-event-2026-06-06"],
+                "integrity": {"approval_event": "external"},
+            },
+        }
 
-        self.assertEqual(gate["record_type"], "human_gate_record")
-        self.assertTrue(gate["reusable_for_product"])
-        self.assertEqual(gate["human_actor"], "project-maintainer")
-        self.assertIn("public repository", " ".join(gate["approved_scope"]).lower())
+    def test_human_gate_record_must_be_preexisting_real_product_scoped_input(self) -> None:
+        gate = self.valid_human_gate()
+
+        self.assertEqual(module.human_gate_errors(gate), [])
         self.assertNotIn("KAXIS", str(gate))
+
+    def test_generated_human_gate_record_is_rejected_for_release(self) -> None:
+        gate = self.valid_human_gate()
+        gate["approval_event_id"] = "evt_fixture_human_approval"
+
+        errors = module.human_gate_errors(gate)
+
+        self.assertIn("production human gate cannot use generated, fixture, synthetic or placeholder approval evidence", errors)
 
     def test_release_ops_fails_when_any_validation_command_fails(self) -> None:
         validation = [
@@ -50,6 +79,32 @@ class ProductionReleaseGateTest(unittest.TestCase):
         self.assertEqual(result["result"], "PASS")
         self.assertTrue(result["reusable_for_product"])
         self.assertIn("git revert", result["rollback_plan"]["rollback_command"])
+        self.assertIn("evidence_provenance", result)
+        self.assertIn("product_source_sha256", result["evidence_provenance"]["integrity"])
+        self.assertIn(".tmp/factory-runs/production/release/upstream-worker-graph.json", result["evidence_refs"])
+        self.assertNotIn(".tmp/factory-runs/production/full-product-worker-graph.json", result["evidence_refs"])
+
+    def test_release_gate_uses_production_strict_worker_graph(self) -> None:
+        commands = [" ".join(command) for command in module.VALIDATION_COMMANDS]
+
+        self.assertTrue(any("production_full_product_worker_graph.py --release-gate-upstream --require-pass" in command for command in commands))
+        self.assertFalse(any("scripts/full_product_worker_graph.py --require-pass" in command for command in commands))
+
+    def test_no_write_release_gate_propagates_to_upstream_graph(self) -> None:
+        commands = module.validation_commands(no_write=True)
+        graph_commands = [command for command in commands if "scripts/production_full_product_worker_graph.py" in command]
+
+        self.assertEqual(len(graph_commands), 1)
+        self.assertIn("--no-write", graph_commands[0])
+
+    def test_cli_requires_human_gate_record_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            gate_path = Path(tmp) / "human-gate.json"
+            gate_path.write_text(json.dumps(self.valid_human_gate()), encoding="utf-8")
+            with mock.patch.object(module, "run_command", return_value={"command": "ok", "exit_code": 1}):
+                result = module.main(["--human-gate-record", str(gate_path), "--no-write"])
+
+        self.assertEqual(result, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

This PR hardens the first foundation wave for Overkill Factory truth, safety, and release gating.

It fixes the runtime gaps behind:

- Closes #96
- Closes #100
- Closes #101
- Closes #102
- Closes #103
- Closes #106

## What Changed

- Made canonical runtime enforcement hermetic by default, with explicit trace input required when using generated trace data.
- Hardened the Hermes live adapter dry-run and block command behavior against real CLI shape and unintended board mutation.
- Switched release validation to production-strict worker graph evidence, with a release-gate upstream mode that avoids circular human-gate/release-ops dependencies.
- Required preexisting, real, product-scoped human gate records instead of generated approval records.
- Added structured provenance for file-backed production evidence.
- Reduced gate-report next actions to required actionable workers only, including worker ownership.

## Validation

- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_public_json_artifacts.py`
- `git diff --check`
- Diff scan for private/local artifacts and accidental out-of-scope references

## Notes

No public history artifact, raw execution log, screenshot, private evidence, or local operator path is added by this PR.
