### PR TITLE
[codex] Add evidence truth and sanitized Hermes status

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,6 +50,22 @@ factoryctl status-snapshot --card examples/minimal-hermes-project/card.md --out 
 does not replace Hermes, card contracts, gate reports or Receipt Five as the
 source of truth.
 
+## Evidence And Truth Commands
+
+```bash
+factoryctl export-hermes-evidence --board my-board --workspace ../my-hermes-workspace --out .tmp/factory-runs/hermes-evidence/sanitized-package.json
+factoryctl evidence-graph --card examples/minimal-hermes-project/card.md --worker-results-dir .tmp/worker-results --out .tmp/factory-runs/evidence/evidence-graph.json
+factoryctl readiness-ledger --card examples/minimal-hermes-project/card.md --evidence-graph .tmp/factory-runs/evidence/evidence-graph.json --out .tmp/factory-runs/readiness/readiness-truth-ledger.json
+factoryctl truth --target issue-94 --card examples/minimal-hermes-project/card.md --out .tmp/factory-runs/truth/truth-packet.json
+factoryctl prepilot-checklist --evidence-graph .tmp/factory-runs/evidence/evidence-graph.json --readiness-ledger .tmp/factory-runs/readiness/readiness-truth-ledger.json
+```
+
+These commands are JSON-first. They summarize cards, worker results, receipts,
+readiness and sanitized Hermes evidence without importing raw private runtime
+evidence into the public repository. A weaker truth layer such as
+`contract_exists` or `runtime_enforced` must not be read as
+`production_ready`.
+
 ### Test Runner Fallback
 
 Worker packets should run commands as argv lists, not shell strings. Use

--- a/schemas/evidence-graph.schema.json
+++ b/schemas/evidence-graph.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/evidence-graph.schema.json",
+  "title": "Overkill Factory Evidence Graph",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "target",
+    "result",
+    "nodes",
+    "edges",
+    "findings",
+    "public_private_boundary",
+    "limits"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/evidence-graph.schema.json" },
+    "record_type": { "const": "evidence_graph" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "target": {
+      "type": "object",
+      "required": ["card_id", "card_ref"],
+      "additionalProperties": true
+    },
+    "result": { "enum": ["PASS", "BLOCKED"] },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "node_type", "ref", "status", "evidence_level"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "node_type": { "type": "string", "minLength": 3 },
+          "ref": { "type": "string", "minLength": 1 },
+          "status": { "enum": ["PASS", "BLOCKED", "MISSING"] },
+          "evidence_level": { "type": "string", "minLength": 3 },
+          "staleness": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "target", "relation"],
+        "additionalProperties": true
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "node_id", "message"],
+        "additionalProperties": true
+      }
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["public_safe_summary_only", "no_raw_logs", "no_private_paths", "no_private_ids"],
+      "properties": {
+        "public_safe_summary_only": { "const": true },
+        "no_raw_logs": { "const": true },
+        "no_private_paths": { "const": true },
+        "no_private_ids": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "limits": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/factory-completion-audit.schema.json
+++ b/schemas/factory-completion-audit.schema.json
@@ -15,6 +15,7 @@
     "requirements_blocking",
     "requirements",
     "blocking_summary",
+    "blocker_economics",
     "policy_decision"
   ],
   "properties": {
@@ -111,6 +112,25 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "blocker_economics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "blocker_id",
+          "owner",
+          "risk_controlled",
+          "cost_time_class",
+          "dependency",
+          "smallest_safe_next_action",
+          "mutation_risk",
+          "route",
+          "expiry",
+          "status"
+        ],
+        "additionalProperties": true
       }
     },
     "policy_decision": {

--- a/schemas/factory-production-readiness.schema.json
+++ b/schemas/factory-production-readiness.schema.json
@@ -9,6 +9,7 @@
     "summary",
     "components",
     "blocking_items",
+    "blocker_economics",
     "attention_items",
     "evidence_refs",
     "next_required_actions",
@@ -49,6 +50,25 @@
     "blocking_items": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
+    },
+    "blocker_economics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "blocker_id",
+          "owner",
+          "risk_controlled",
+          "cost_time_class",
+          "dependency",
+          "smallest_safe_next_action",
+          "mutation_risk",
+          "route",
+          "expiry",
+          "status"
+        ],
+        "additionalProperties": true
+      }
     },
     "attention_items": {
       "type": "array",

--- a/schemas/factory-status-snapshot.schema.json
+++ b/schemas/factory-status-snapshot.schema.json
@@ -17,6 +17,7 @@
     "lanes",
     "gates",
     "blockers",
+    "blocker_economics",
     "evidence",
     "state_flags",
     "next_safe_actions",
@@ -70,6 +71,7 @@
     "lanes": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
     "gates": { "type": "object", "additionalProperties": true },
     "blockers": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "blocker_economics": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
     "evidence": { "type": "object", "additionalProperties": true },
     "state_flags": {
       "type": "object",

--- a/schemas/factory-truth-packet.schema.json
+++ b/schemas/factory-truth-packet.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-truth-packet.schema.json",
+  "title": "Overkill Factory Truth Packet",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "target",
+    "repo",
+    "github",
+    "hermes",
+    "evidence_graph",
+    "readiness_ledger",
+    "current_blockers",
+    "next_smallest_safe_action",
+    "truth_level",
+    "production_ready",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-truth-packet.schema.json" },
+    "record_type": { "const": "factory_truth_packet" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "target": { "type": "string", "minLength": 1 },
+    "repo": { "type": "object", "additionalProperties": true },
+    "github": { "type": "object", "additionalProperties": true },
+    "hermes": { "type": "object", "additionalProperties": true },
+    "evidence_graph": { "type": "object", "additionalProperties": true },
+    "readiness_ledger": { "type": "object", "additionalProperties": true },
+    "current_blockers": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "next_smallest_safe_action": { "type": "string", "minLength": 3 },
+    "truth_level": { "type": "string", "minLength": 3 },
+    "production_ready": { "type": "boolean" },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["json_first", "no_raw_logs", "no_private_paths", "no_private_ids"],
+      "properties": {
+        "json_first": { "const": true },
+        "no_raw_logs": { "const": true },
+        "no_private_paths": { "const": true },
+        "no_private_ids": { "const": true }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/gate-report.schema.json
+++ b/schemas/gate-report.schema.json
@@ -41,6 +41,37 @@
         "required": ["required", "reason", "status"],
         "additionalProperties": true
       }
+    },
+    "blocker_economics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "blocker_id",
+          "owner",
+          "risk_controlled",
+          "cost_time_class",
+          "dependency",
+          "smallest_safe_next_action",
+          "mutation_risk",
+          "route",
+          "expiry",
+          "status"
+        ],
+        "properties": {
+          "blocker_id": { "type": "string", "minLength": 3 },
+          "owner": { "type": "string", "minLength": 2 },
+          "risk_controlled": { "type": "string", "minLength": 3 },
+          "cost_time_class": { "type": "string", "minLength": 3 },
+          "dependency": { "type": "string", "minLength": 1 },
+          "smallest_safe_next_action": { "type": "string", "minLength": 3 },
+          "mutation_risk": { "type": "string", "minLength": 3 },
+          "route": { "enum": ["local", "hermes", "github", "human_approval", "must_not_proceed"] },
+          "expiry": { "type": "string", "minLength": 3 },
+          "status": { "enum": ["blocked", "actionable", "deferred"] }
+        },
+        "additionalProperties": true
+      }
     }
   },
   "additionalProperties": true

--- a/schemas/hermes-evidence-package.schema.json
+++ b/schemas/hermes-evidence-package.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/hermes-evidence-package.schema.json",
+  "title": "Overkill Factory Hermes Evidence Package",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "result",
+    "board_ref",
+    "workspace_ref",
+    "evidence_level",
+    "state",
+    "records",
+    "redaction_findings",
+    "missing_or_stale",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/hermes-evidence-package.schema.json" },
+    "record_type": { "const": "hermes_evidence_package" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "result": { "enum": ["PASS", "BLOCKED"] },
+    "board_ref": { "type": "string", "minLength": 3 },
+    "workspace_ref": { "const": "external:operator-owned-hermes-workspace" },
+    "evidence_level": { "enum": ["live_hermes_summary", "missing"] },
+    "state": { "enum": ["planning", "partially_executed", "done", "release-ready", "blocked"] },
+    "records": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["record_ref", "record_type", "result", "evidence_refs"],
+        "additionalProperties": true
+      }
+    },
+    "redaction_findings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "missing_or_stale": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["sanitized_summary_only", "no_raw_logs", "no_private_paths", "no_private_ids"],
+      "properties": {
+        "sanitized_summary_only": { "const": true },
+        "no_raw_logs": { "const": true },
+        "no_private_paths": { "const": true },
+        "no_private_ids": { "const": true }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/prepilot-loose-end-checklist.schema.json
+++ b/schemas/prepilot-loose-end-checklist.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/prepilot-loose-end-checklist.schema.json",
+  "title": "Overkill Factory Prepilot Loose-End Checklist",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "result",
+    "items",
+    "blocking_items",
+    "pilot_completion_claim_allowed",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/prepilot-loose-end-checklist.schema.json" },
+    "record_type": { "const": "prepilot_loose_end_checklist" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "result": { "enum": ["BLOCKED", "PASS_WITH_DEFERRED_ITEMS"] },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "evidence_ref", "next_action"],
+        "properties": {
+          "id": { "type": "string", "minLength": 3 },
+          "status": { "enum": ["closed", "deferred", "blocking"] },
+          "evidence_ref": { "type": "string", "minLength": 3 },
+          "next_action": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "blocking_items": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "pilot_completion_claim_allowed": { "type": "boolean" },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["no_private_product_evidence", "no_raw_logs", "no_private_paths"],
+      "properties": {
+        "no_private_product_evidence": { "const": true },
+        "no_raw_logs": { "const": true },
+        "no_private_paths": { "const": true }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/readiness-truth-ledger.schema.json
+++ b/schemas/readiness-truth-ledger.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/readiness-truth-ledger.schema.json",
+  "title": "Overkill Factory Readiness Truth Ledger",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "target",
+    "overall_truth_level",
+    "production_ready",
+    "classification_order",
+    "components",
+    "blocker_economics",
+    "limits"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/readiness-truth-ledger.schema.json" },
+    "record_type": { "const": "readiness_truth_ledger" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "overall_truth_level": {
+      "enum": [
+        "blocked_missing_evidence",
+        "contract_exists",
+        "runtime_enforced",
+        "bounded_public_proof",
+        "live_hermes_proof",
+        "product_specific_proof",
+        "production_ready"
+      ]
+    },
+    "production_ready": { "type": "boolean" },
+    "classification_order": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["capability_id", "truth_level", "result", "evidence_refs", "next_required_action"],
+        "additionalProperties": true
+      }
+    },
+    "blocker_economics": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/factory_completion_audit.py
+++ b/scripts/factory_completion_audit.py
@@ -78,6 +78,21 @@ def production_worker_result(rel_path: str, *, record_type: str | None = None) -
     return True
 
 
+def blocker_economics_entry(requirement: dict[str, Any]) -> dict[str, str]:
+    return {
+        "blocker_id": f"completion:{requirement['id']}",
+        "owner": "operator",
+        "risk_controlled": requirement["why_it_matters"],
+        "cost_time_class": "product_specific_validation",
+        "dependency": ",".join(requirement.get("expected_evidence_refs") or requirement.get("evidence_refs") or []),
+        "smallest_safe_next_action": requirement["next_action"],
+        "mutation_risk": "none_read_only",
+        "route": "local",
+        "expiry": "until completion evidence changes",
+        "status": "blocked",
+    }
+
+
 def production_cu_svm_economic_result(rel_path: str) -> bool:
     path = ROOT / rel_path
     if not path.exists():
@@ -687,6 +702,7 @@ def build_audit() -> dict[str, Any]:
         "requirements_blocking": len(blocking),
         "requirements": requirements,
         "blocking_summary": [item["id"] for item in blocking],
+        "blocker_economics": [blocker_economics_entry(item) for item in blocking],
         "policy_decision": (
             "Do not mark Overkill Factory as practical 10/10 until every blocking requirement has product-specific or provider-backed evidence."
             if blocking

--- a/scripts/factory_production_readiness.py
+++ b/scripts/factory_production_readiness.py
@@ -70,6 +70,21 @@ def component(component_id: str, path: Path, expected_pass: bool = True) -> dict
     }
 
 
+def blocker_economics_entry(component_id: str, reason: str | None, action: str) -> dict[str, str]:
+    return {
+        "blocker_id": f"readiness:{component_id}",
+        "owner": "operator",
+        "risk_controlled": reason or "production readiness evidence is missing or blocked",
+        "cost_time_class": "bounded_validation_run",
+        "dependency": component_id,
+        "smallest_safe_next_action": action,
+        "mutation_risk": "none_read_only",
+        "route": "local",
+        "expiry": "until readiness evidence changes",
+        "status": "blocked",
+    }
+
+
 def build_readiness(
     *,
     prepilot_master_path: Path = DEFAULT_PREPILOT_MASTER,
@@ -82,6 +97,7 @@ def build_readiness(
     public_worktree_path: Path = DEFAULT_PUBLIC_WORKTREE,
     public_head_path: Path = DEFAULT_PUBLIC_HEAD,
     public_origin_path: Path = DEFAULT_PUBLIC_ORIGIN,
+    evidence_graph_path: Path | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
     components = [
@@ -96,6 +112,8 @@ def build_readiness(
         component("public_safety_head", public_head_path),
         component("public_safety_origin_main", public_origin_path),
     ]
+    if evidence_graph_path is not None:
+        components.append(component("evidence_graph", evidence_graph_path))
 
     blocking_items: list[str] = []
     attention_items: list[str] = []
@@ -148,6 +166,26 @@ def build_readiness(
             "apply the explicit real-runtime update gate only after human approval",
         ]
 
+    action_by_component = {
+        "operator_control_tower_private_evidence_doctor": "replace private Control Tower placeholders with real runtime evidence",
+        "prepilot_master_task_readiness": "complete the 9-task prepilot readiness receipt",
+        "hermes_vfinal_runtime_status_check": "rerun and pass the public-safe read-only Hermes runtime status check",
+        "operator_control_tower_production_readiness": "run operator_control_tower_proof.py to create the production proof",
+        "hermes_real_runtime_update_preflight": "regenerate the complete Hermes update receipt and rerun the real-runtime update preflight",
+        "release_integration_preflight": "pass the release integration preflight",
+        "public_safety_origin_main": "integrate the public-safe worktree into the release ref and rerun public-safety scans",
+        "evidence_graph": "rebuild a PASS evidence graph from current worker results, receipts and sanitized Hermes evidence",
+    }
+    blocker_economics = [
+        blocker_economics_entry(
+            item["id"],
+            item.get("reason"),
+            action_by_component.get(item["id"], f"produce or refresh {item['id']} evidence"),
+        )
+        for item in components
+        if item["status"] in {"BLOCKED", "MISSING"}
+    ]
+
     evidence_refs = sorted({item["evidence_ref"] for item in components})
     readiness = {
         "$schema": "https://overkill-factory.dev/schemas/factory-production-readiness.schema.json",
@@ -157,6 +195,7 @@ def build_readiness(
         "summary": summary,
         "components": components,
         "blocking_items": sorted(set(blocking_items)),
+        "blocker_economics": blocker_economics,
         "attention_items": sorted(set(attention_items)),
         "evidence_refs": evidence_refs,
         "next_required_actions": next_required_actions,
@@ -173,12 +212,13 @@ def build_readiness(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--evidence-graph", type=Path)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    receipt = build_readiness()
+    receipt = build_readiness(evidence_graph_path=args.evidence_graph)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
     print(json.dumps({"result": receipt["result"], "out": repo_ref(args.out)}))

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -39,6 +41,15 @@ DEFAULT_MINIMAL_CARD = ROOT / "examples" / "minimal-hermes-project" / "card.md"
 DEFAULT_QUICKSTART_OUT = ROOT / ".tmp" / "quickstart-result.json"
 DEFAULT_PACKETS_OUT = ROOT / ".tmp" / "minimal-worker-packets"
 PYPROJECT_PATH = ROOT / "pyproject.toml"
+DEFAULT_TRUTH_OUT = ROOT / ".tmp" / "factory-runs" / "truth" / "truth-packet.json"
+DEFAULT_EVIDENCE_GRAPH_OUT = ROOT / ".tmp" / "factory-runs" / "evidence" / "evidence-graph.json"
+DEFAULT_READINESS_LEDGER_OUT = ROOT / ".tmp" / "factory-runs" / "readiness" / "readiness-truth-ledger.json"
+DEFAULT_HERMES_EVIDENCE_OUT = ROOT / ".tmp" / "factory-runs" / "hermes-evidence" / "sanitized-package.json"
+DEFAULT_PREPILOT_CHECKLIST_OUT = ROOT / ".tmp" / "factory-runs" / "prepilot" / "loose-end-checklist.json"
+PRIVATE_RUNTIME_REF_RE = re.compile(
+    r"([A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
+    re.IGNORECASE,
+)
 
 CARD_REQUIRED = {
     "factory_method_version",
@@ -868,6 +879,92 @@ def artifact_contract_for_refs(refs: list[str]) -> dict[str, Any]:
         ],
         "public_safe": all(bool(item.get("public_safe")) for item in classifications),
     }
+
+
+def public_safe_text(value: Any) -> bool:
+    return PRIVATE_RUNTIME_REF_RE.search(str(value or "")) is None
+
+
+def sanitize_slug(value: Any, *, fallback: str = "item") -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip()).strip("-._")
+    return cleaned[:80] or fallback
+
+
+def redact_private_text(value: Any) -> str:
+    text = str(value or "")
+    text = re.sub(r"[A-Za-z]:[\\/][^ \];,\"]+", "[redacted-private-ref]", text)
+    text = re.sub(r"/(?:home|Users|srv|var)/[^ \];,\"]+", "[redacted-private-ref]", text)
+    text = PRIVATE_RUNTIME_REF_RE.sub("[redacted-private-marker]", text)
+    return text
+
+
+def sanitize_public_ref(ref: Any) -> tuple[str, dict[str, Any] | None]:
+    value = str(ref or "").strip()
+    classification = classify_artifact_ref(value)
+    trusted_external_prefixes = (
+        "external:sanitized",
+        "external:operator",
+        "external:public",
+        "external:maintainer",
+        "external:source-card",
+        "external:memory",
+    )
+    if value.startswith("external:") and not value.startswith(trusted_external_prefixes):
+        classification = {**classification, "public_safe": False, "reason": "untrusted external ref requires explicit sanitized/operator/public prefix"}
+    if classification.get("public_safe") and public_safe_text(value):
+        return value, None
+    redacted = {
+        "ref": "redacted:private-runtime-ref",
+        "artifact_class": classification.get("artifact_class") or "private_run_evidence",
+        "reason": classification.get("reason") or "private runtime marker",
+    }
+    return redacted["ref"], {"raw_ref_redacted": True, **redacted}
+
+
+def blocker_economics_entry(
+    *,
+    blocker_id: str,
+    owner: str,
+    risk_controlled: str,
+    cost_time_class: str,
+    dependency: str,
+    smallest_safe_next_action: str,
+    mutation_risk: str,
+    route: str,
+    status: str = "blocked",
+    expiry: str = "until evidence changes",
+) -> dict[str, str]:
+    return {
+        "blocker_id": sanitize_slug(blocker_id, fallback="blocker"),
+        "owner": owner,
+        "risk_controlled": risk_controlled,
+        "cost_time_class": cost_time_class,
+        "dependency": dependency,
+        "smallest_safe_next_action": smallest_safe_next_action,
+        "mutation_risk": mutation_risk,
+        "route": route,
+        "expiry": expiry,
+        "status": status,
+    }
+
+
+def worker_blocker_economics(worker_id: str, status: str, reason: str) -> dict[str, str]:
+    worker = WORKERS[worker_id]
+    route = "human_approval" if worker_id == "human-gate-clerk" else "hermes"
+    action = f"run {worker_id} and attach {worker.output_field}"
+    if status.startswith("blocked_"):
+        action = f"provide missing inputs for {worker_id}, then rerun gate-report"
+    return blocker_economics_entry(
+        blocker_id=f"worker:{worker_id}:{status}",
+        owner=worker_id,
+        risk_controlled=reason or "required worker evidence",
+        cost_time_class="bounded_worker_run",
+        dependency=worker.output_field,
+        smallest_safe_next_action=action,
+        mutation_risk="none_without_explicit_worker_execution",
+        route=route,
+        status="blocked" if status.startswith("blocked_") else "actionable",
+    )
 
 
 def scan_result_passed(value: Any) -> bool:
@@ -2308,6 +2405,7 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
     worker_rows: dict[str, dict[str, Any]] = {}
     required_workers: list[str] = []
     blocked_workers: list[str] = []
+    blocker_economics: list[dict[str, str]] = []
     for worker_id in WORKERS:
         required, reason = worker_required(worker_id, card)
         status = build_worker_packet(worker_id, card, Path("<memory>"))["status"]
@@ -2320,8 +2418,23 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
         }
         if required:
             required_workers.append(worker_id)
+            if status == "requires_execution" or str(status).startswith("blocked_"):
+                blocker_economics.append(worker_blocker_economics(worker_id, str(status), reason))
         if str(status).startswith("blocked_"):
             blocked_workers.append(worker_id)
+    for index, error in enumerate(validation_errors, start=1):
+        blocker_economics.append(
+            blocker_economics_entry(
+                blocker_id=f"card-validation:{index}",
+                owner="operator",
+                risk_controlled="canonical card contract integrity",
+                cost_time_class="local_edit",
+                dependency="card_contract",
+                smallest_safe_next_action=error,
+                mutation_risk="local_repo_only",
+                route="local",
+            )
+        )
     if validation_errors or blocked_workers:
         gate_status = "blocked"
     elif required_workers:
@@ -2346,6 +2459,7 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
         "blocked_workers": blocked_workers,
         "card_validation_errors": validation_errors,
         "card_validation_warnings": validation_warnings,
+        "blocker_economics": blocker_economics,
         "next_safe_actions": [
             guidance
             for row in worker_rows.values()
@@ -3320,6 +3434,7 @@ def build_status_snapshot(
             "warnings": effective_gate_report.get("card_validation_warnings", []),
         },
         "blockers": blockers,
+        "blocker_economics": effective_gate_report.get("blocker_economics", []),
         "evidence": {
             "receipt_five_status": "attached" if isinstance(card.get("receipt_five"), dict) else "not_attached",
             "evidence_refs": evidence,
@@ -3363,6 +3478,575 @@ def validate_status_snapshot(snapshot: dict[str, Any]) -> list[str]:
         if boundary.get(field) is not True:
             errors.append(f"factory_status_snapshot.public_private_boundary.{field} must be true")
     return errors
+
+
+def load_optional_json(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    try:
+        data = load_json_like(path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def collect_worker_result_records(worker_results_dir: Path | None) -> dict[str, dict[str, Any]]:
+    records: dict[str, dict[str, Any]] = {}
+    if worker_results_dir is None or not worker_results_dir.exists():
+        return records
+    for path in sorted(worker_results_dir.glob("*.json")):
+        data = load_optional_json(path)
+        if not data:
+            continue
+        record_type = str(data.get("record_type") or "").strip()
+        if not record_type:
+            continue
+        current = records.get(record_type)
+        if current is None or str(data.get("created_at") or "") >= str(current.get("created_at") or ""):
+            records[record_type] = {**data, "_public_ref": source_card_ref(path)}
+    return records
+
+
+def graph_add_node(nodes: dict[str, dict[str, Any]], node: dict[str, Any]) -> None:
+    nodes[str(node["id"])] = node
+
+
+def graph_add_edge(edges: list[dict[str, str]], source: str, target: str, relation: str) -> None:
+    edges.append({"source": source, "target": target, "relation": relation})
+
+
+def build_evidence_graph(
+    card: dict[str, Any],
+    card_path: Path,
+    *,
+    gate_report: dict[str, Any] | None = None,
+    worker_results_dir: Path | None = None,
+    receipt_path: Path | None = None,
+    hermes_evidence_path: Path | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    effective_gate = gate_report or build_gate_report(card)
+    worker_results = collect_worker_result_records(worker_results_dir)
+    receipt = load_optional_json(receipt_path)
+    hermes_package = load_optional_json(hermes_evidence_path)
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, str]] = []
+    findings: list[dict[str, str]] = []
+
+    card_id = str(card.get("card_id") or card.get("id") or "unknown-card")
+    graph_add_node(
+        nodes,
+        {
+            "id": "card",
+            "node_type": "factory_card",
+            "ref": source_card_ref(card_path),
+            "status": "PASS" if not validate_card(card) else "BLOCKED",
+            "evidence_level": "contract_exists",
+        },
+    )
+    for index, source in enumerate(_list_items(card.get("source_refs")), start=1):
+        safe_ref, finding = sanitize_public_ref(source)
+        node_id = f"source:{index}"
+        graph_add_node(
+            nodes,
+            {
+                "id": node_id,
+                "node_type": "source_input",
+                "ref": safe_ref,
+                "status": "PASS" if finding is None else "BLOCKED",
+                "evidence_level": "source_ref",
+            },
+        )
+        graph_add_edge(edges, node_id, "card", "defines")
+        if finding:
+            findings.append({"severity": "BLOCKED", "node_id": node_id, "message": redact_private_text(finding["reason"])})
+
+    gate_status = str(effective_gate.get("gate_status") or "missing")
+    graph_add_node(
+        nodes,
+        {
+            "id": "gate-report",
+            "node_type": "gate_report",
+            "ref": "factoryctl:gate-report",
+            "status": "PASS" if gate_status != "blocked" else "BLOCKED",
+            "evidence_level": "runtime_enforced",
+        },
+    )
+    graph_add_edge(edges, "card", "gate-report", "validated_by")
+
+    for worker_id in _list_items(effective_gate.get("required_workers")):
+        worker = WORKERS[worker_id]
+        packet_id = f"worker-packet:{worker_id}"
+        result_id = f"worker-result:{worker.output_field}"
+        graph_add_node(
+            nodes,
+            {
+                "id": packet_id,
+                "node_type": "worker_packet",
+                "ref": f"factoryctl:worker-packet:{worker_id}",
+                "status": "PASS",
+                "worker_id": worker_id,
+                "evidence_level": "runtime_enforced",
+            },
+        )
+        graph_add_edge(edges, "gate-report", packet_id, "requires")
+        result = worker_results.get(worker.output_field)
+        if result is None:
+            graph_add_node(
+                nodes,
+                {
+                    "id": result_id,
+                    "node_type": "worker_result",
+                    "ref": f"missing:{worker.output_field}",
+                    "status": "MISSING",
+                    "worker_id": worker_id,
+                    "evidence_level": "blocked_missing_evidence",
+                    "staleness": "missing",
+                },
+            )
+            findings.append(
+                {
+                    "severity": "BLOCKED",
+                    "node_id": result_id,
+                    "message": f"{worker.output_field} is missing",
+                }
+            )
+        else:
+            validation_errors = validate_worker_result_record(
+                result,
+                expected_field=worker.output_field,
+                expected_worker_id=worker_id,
+                card=card,
+                evidence_root=ROOT,
+            )
+            safe_validation_errors = [redact_private_text(error) for error in validation_errors]
+            result_status = str(result.get("result") or result.get("decision") or "UNKNOWN")
+            stale = bool(result.get("superseded_by") or result.get("active") is False)
+            graph_add_node(
+                nodes,
+                {
+                    "id": result_id,
+                    "node_type": "worker_result",
+                    "ref": str(result.get("_public_ref") or f"external:{worker.output_field}"),
+                    "status": "BLOCKED" if validation_errors or stale or result_status not in PROMOTION_PASS_RESULTS else "PASS",
+                    "worker_id": worker_id,
+                    "evidence_level": "worker_result",
+                    "staleness": "stale" if stale else "current",
+                    "validation_errors": safe_validation_errors,
+                },
+            )
+            for ref_index, ref in enumerate(_list_items(result.get("evidence_refs")), start=1):
+                safe_ref, finding = sanitize_public_ref(ref)
+                artifact_id = f"artifact:{worker.output_field}:{ref_index}"
+                graph_add_node(
+                    nodes,
+                    {
+                        "id": artifact_id,
+                        "node_type": "artifact_ref",
+                        "ref": safe_ref,
+                        "status": "PASS" if finding is None else "BLOCKED",
+                        "evidence_level": "artifact_ref",
+                    },
+                )
+                graph_add_edge(edges, result_id, artifact_id, "cites")
+                if finding:
+                    findings.append({"severity": "BLOCKED", "node_id": artifact_id, "message": redact_private_text(finding["reason"])})
+            if validation_errors:
+                findings.append(
+                    {
+                        "severity": "BLOCKED",
+                        "node_id": result_id,
+                        "message": "; ".join(safe_validation_errors),
+                    }
+                )
+        graph_add_edge(edges, packet_id, result_id, "expects")
+
+    if receipt_path is not None:
+        receipt_errors = validate_completion(card, receipt or {})
+        graph_add_node(
+            nodes,
+            {
+                "id": "receipt-five",
+                "node_type": "receipt_five",
+                "ref": source_card_ref(receipt_path),
+                "status": "PASS" if receipt and not receipt_errors else "BLOCKED",
+                "evidence_level": "receipt_five",
+                "validation_errors": receipt_errors,
+            },
+        )
+        graph_add_edge(edges, "gate-report", "receipt-five", "closed_by")
+        if receipt_errors:
+            findings.append({"severity": "BLOCKED", "node_id": "receipt-five", "message": "; ".join(receipt_errors)})
+
+    if hermes_evidence_path is not None:
+        package_result = str((hermes_package or {}).get("result") or "MISSING")
+        graph_add_node(
+            nodes,
+            {
+                "id": "hermes-evidence",
+                "node_type": "hermes_evidence_package",
+                "ref": source_card_ref(hermes_evidence_path),
+                "status": "PASS" if package_result == "PASS" else "BLOCKED",
+                "evidence_level": "live_hermes_summary",
+            },
+        )
+        graph_add_edge(edges, "gate-report", "hermes-evidence", "summarized_by")
+        if package_result != "PASS":
+            findings.append({"severity": "BLOCKED", "node_id": "hermes-evidence", "message": "Hermes evidence package is missing or blocked"})
+
+    blocked = any(item["severity"] == "BLOCKED" for item in findings)
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/evidence-graph.schema.json",
+        "record_type": "evidence_graph",
+        "created_at": created_at or utc_now(),
+        "target": {"card_id": card_id, "card_ref": source_card_ref(card_path)},
+        "result": "BLOCKED" if blocked else "PASS",
+        "nodes": list(nodes.values()),
+        "edges": edges,
+        "findings": findings,
+        "public_private_boundary": {
+            "public_safe_summary_only": True,
+            "no_raw_logs": True,
+            "no_private_paths": True,
+            "no_private_ids": True,
+        },
+        "limits": [
+            "Graph existence is not completion proof.",
+            "Private Hermes evidence remains operator-owned and is represented only by sanitized summaries.",
+        ],
+    }
+
+
+TRUTH_LEVEL_ORDER = [
+    "contract_exists",
+    "runtime_enforced",
+    "bounded_public_proof",
+    "live_hermes_proof",
+    "product_specific_proof",
+    "production_ready",
+]
+
+
+def readiness_component(
+    capability_id: str,
+    truth_level: str,
+    result: str,
+    evidence_refs: list[str],
+    next_required_action: str,
+) -> dict[str, Any]:
+    return {
+        "capability_id": capability_id,
+        "truth_level": truth_level,
+        "result": result,
+        "evidence_refs": evidence_refs,
+        "next_required_action": next_required_action,
+        "blocker_economics": []
+        if result == "PASS"
+        else [
+            blocker_economics_entry(
+                blocker_id=f"truth:{capability_id}",
+                owner="operator",
+                risk_controlled=f"{capability_id} cannot be over-claimed as a stronger truth layer",
+                cost_time_class="bounded_followup",
+                dependency=capability_id,
+                smallest_safe_next_action=next_required_action,
+                mutation_risk="none_without_operator_action",
+                route="local",
+            )
+        ],
+    }
+
+
+def build_readiness_truth_ledger(
+    card: dict[str, Any],
+    card_path: Path,
+    *,
+    evidence_graph: dict[str, Any] | None = None,
+    production_readiness: dict[str, Any] | None = None,
+    hermes_evidence: dict[str, Any] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    gate = build_gate_report(card)
+    card_ok = not validate_card(card)
+    graph_ok = bool(evidence_graph and evidence_graph.get("result") == "PASS")
+    hermes_ok = bool(hermes_evidence and hermes_evidence.get("result") == "PASS")
+    receipt_ok = bool(evidence_graph and any(node.get("id") == "receipt-five" and node.get("status") == "PASS" for node in evidence_graph.get("nodes", [])))
+    production_ok = bool(production_readiness and production_readiness.get("result") == "PASS")
+    components = [
+        readiness_component(
+            "card_contract",
+            "contract_exists",
+            "PASS" if card_ok else "BLOCKED",
+            [source_card_ref(card_path)],
+            "fix card contract and rerun factoryctl validate-card",
+        ),
+        readiness_component(
+            "gate_report",
+            "runtime_enforced",
+            "PASS" if gate.get("gate_status") != "blocked" else "BLOCKED",
+            ["factoryctl:gate-report"],
+            "fix blocked gate inputs and rerun factoryctl gate-report",
+        ),
+        readiness_component(
+            "evidence_graph",
+            "bounded_public_proof",
+            "PASS" if graph_ok else "BLOCKED",
+            ["factoryctl:evidence-graph"],
+            "supply missing worker results, receipts or sanitized Hermes evidence and rebuild the graph",
+        ),
+        readiness_component(
+            "hermes_evidence_package",
+            "live_hermes_proof",
+            "PASS" if hermes_ok else "BLOCKED",
+            ["factoryctl:export-hermes-evidence"],
+            "export a sanitized local Hermes evidence package from the operator-owned runtime",
+        ),
+        readiness_component(
+            "receipt_five",
+            "product_specific_proof",
+            "PASS" if receipt_ok else "BLOCKED",
+            ["receipt-five"],
+            "reconcile worker results and attach a valid Receipt Five",
+        ),
+        readiness_component(
+            "production_readiness",
+            "production_ready",
+            "PASS" if production_ok else "BLOCKED",
+            ["scripts/factory_production_readiness.py"],
+            "pass production readiness only after product-specific and live proof receipts exist",
+        ),
+    ]
+    passed_levels = [item["truth_level"] for item in components if item["result"] == "PASS"]
+    overall = passed_levels[-1] if passed_levels else "blocked_missing_evidence"
+    blockers = [item for component in components for item in component["blocker_economics"]]
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/readiness-truth-ledger.schema.json",
+        "record_type": "readiness_truth_ledger",
+        "created_at": created_at or utc_now(),
+        "target": {"card_id": card.get("card_id"), "card_ref": source_card_ref(card_path)},
+        "overall_truth_level": overall,
+        "production_ready": overall == "production_ready",
+        "classification_order": TRUTH_LEVEL_ORDER,
+        "components": components,
+        "blocker_economics": blockers,
+        "limits": [
+            "A PASS in one truth layer never implies PASS in a stronger layer.",
+            "Public-safe summaries do not replace private runtime evidence or human approval.",
+        ],
+    }
+
+
+def build_hermes_evidence_package(
+    *,
+    board: str,
+    workspace: Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    redactions: list[dict[str, str]] = []
+    if workspace.exists():
+        for index, path in enumerate(sorted(workspace.rglob("*.json")), start=1):
+            data = load_optional_json(path)
+            if not data:
+                continue
+            evidence_refs: list[str] = []
+            for ref in _list_items(data.get("evidence_refs")):
+                safe_ref, finding = sanitize_public_ref(ref)
+                evidence_refs.append(safe_ref)
+                if finding:
+                    redactions.append({"record_ref": f"external:hermes-record-{index}", "reason": finding["reason"]})
+            worker = data.get("worker") if isinstance(data.get("worker"), dict) else {}
+            card_ref_value = data.get("card_ref") if isinstance(data.get("card_ref"), dict) else {}
+            records.append(
+                {
+                    "record_ref": f"external:hermes-record-{index}",
+                    "record_type": str(data.get("record_type") or "unknown"),
+                    "card_id": str(card_ref_value.get("card_id") or data.get("card_id") or ""),
+                    "worker_id": str(worker.get("id") or data.get("worker_id") or ""),
+                    "result": str(data.get("result") or data.get("decision") or "UNKNOWN"),
+                    "created_at": str(data.get("created_at") or data.get("decision_at") or ""),
+                    "evidence_refs": evidence_refs,
+                }
+            )
+    state = "blocked"
+    if records:
+        record_types = {record["record_type"] for record in records}
+        if "release_ops_result" in record_types:
+            state = "release-ready"
+        elif any("receipt" in item for item in record_types):
+            state = "done"
+        elif any(record["worker_id"] or record["record_type"] != "unknown" for record in records):
+            state = "partially_executed"
+        else:
+            state = "planning"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/hermes-evidence-package.schema.json",
+        "record_type": "hermes_evidence_package",
+        "created_at": created_at or utc_now(),
+        "result": "PASS" if workspace.exists() and records and not redactions else "BLOCKED",
+        "board_ref": f"board:{sanitize_slug(board, fallback='operator-board')}",
+        "workspace_ref": "external:operator-owned-hermes-workspace",
+        "evidence_level": "live_hermes_summary" if records else "missing",
+        "state": state,
+        "records": records,
+        "redaction_findings": redactions,
+        "missing_or_stale": [] if records else ["no JSON evidence records found in workspace"],
+        "public_private_boundary": {
+            "sanitized_summary_only": True,
+            "no_raw_logs": True,
+            "no_private_paths": True,
+            "no_private_ids": True,
+        },
+    }
+
+
+def build_prepilot_loose_end_checklist(
+    *,
+    evidence_graph: dict[str, Any] | None,
+    readiness_ledger: dict[str, Any] | None,
+    hermes_evidence: dict[str, Any] | None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    graph_ok = bool(evidence_graph)
+    ledger_ok = bool(readiness_ledger)
+    hermes_path_ok = bool(hermes_evidence)
+    items = [
+        {
+            "id": "evidence_graph_path",
+            "status": "closed" if graph_ok else "blocking",
+            "evidence_ref": "factoryctl:evidence-graph",
+            "next_action": "build evidence graph before pilot execution",
+        },
+        {
+            "id": "readiness_truth_levels",
+            "status": "closed" if ledger_ok else "blocking",
+            "evidence_ref": "factoryctl:readiness-ledger",
+            "next_action": "build readiness truth ledger before pilot execution",
+        },
+        {
+            "id": "hermes_evidence_import_path",
+            "status": "closed" if hermes_path_ok else "deferred",
+            "evidence_ref": "factoryctl:export-hermes-evidence",
+            "next_action": "export sanitized Hermes package when operator runtime exists",
+        },
+        {
+            "id": "tests_hermetic_against_tmp",
+            "status": "deferred",
+            "evidence_ref": "PR-121",
+            "next_action": "land the foundation hermeticity PR before claiming pilot completion",
+        },
+        {
+            "id": "blockers_next_smallest_safe_action",
+            "status": "closed" if readiness_ledger and readiness_ledger.get("blocker_economics") is not None else "blocking",
+            "evidence_ref": "readiness_ledger.blocker_economics",
+            "next_action": "include blocker economics in gate, readiness and completion reports",
+        },
+        {
+            "id": "production_evidence_expectations_known",
+            "status": "closed",
+            "evidence_ref": "factoryctl:truth",
+            "next_action": "keep Product Face, security, remote proof, human gate and release evidence explicit in the truth packet",
+        },
+        {
+            "id": "pilot_success_definition",
+            "status": "closed",
+            "evidence_ref": "readiness_ledger.overall_truth_level",
+            "next_action": "state whether the pilot proves repo-only, Hermes-backed, bounded product proof or production readiness",
+        },
+    ]
+    blocking = [item["id"] for item in items if item["status"] == "blocking"]
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/prepilot-loose-end-checklist.schema.json",
+        "record_type": "prepilot_loose_end_checklist",
+        "created_at": created_at or utc_now(),
+        "result": "BLOCKED" if blocking else "PASS_WITH_DEFERRED_ITEMS",
+        "items": items,
+        "blocking_items": blocking,
+        "pilot_completion_claim_allowed": not blocking and bool(evidence_graph and evidence_graph.get("result") == "PASS"),
+        "public_private_boundary": {
+            "no_private_product_evidence": True,
+            "no_raw_logs": True,
+            "no_private_paths": True,
+        },
+    }
+
+
+def run_json_command(command: list[str]) -> dict[str, Any]:
+    try:
+        result = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, timeout=20)  # nosec B603
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": False, "error": exc.__class__.__name__}
+    if result.returncode != 0:
+        return {"available": False, "error": "command_failed"}
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"available": False, "error": "invalid_json"}
+    return {"available": True, "data": data}
+
+
+def run_text_command(command: list[str]) -> dict[str, Any]:
+    try:
+        result = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, timeout=20)  # nosec B603
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": False, "error": exc.__class__.__name__, "text": ""}
+    return {
+        "available": result.returncode == 0,
+        "error": None if result.returncode == 0 else "command_failed",
+        "text": result.stdout.strip(),
+    }
+
+
+def build_truth_packet(
+    *,
+    target: str,
+    card: dict[str, Any],
+    card_path: Path,
+    issue: str | None = None,
+    pr: str | None = None,
+    worker_results_dir: Path | None = None,
+    hermes_evidence_path: Path | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    branch = run_text_command(["git", "branch", "--show-current"])
+    dirty = subprocess.run(["git", "status", "--porcelain"], cwd=ROOT, text=True, capture_output=True)  # nosec B603
+    issue_state = run_json_command(["gh", "issue", "view", issue, "--json", "number,title,state"]) if issue else {"available": False}
+    pr_state = run_json_command(["gh", "pr", "view", pr, "--json", "number,title,state,isDraft"]) if pr else {"available": False}
+    hermes_package = load_optional_json(hermes_evidence_path)
+    graph = build_evidence_graph(card, card_path, worker_results_dir=worker_results_dir, hermes_evidence_path=hermes_evidence_path)
+    ledger = build_readiness_truth_ledger(card, card_path, evidence_graph=graph, hermes_evidence=hermes_package)
+    blockers = ledger.get("blocker_economics", [])
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-truth-packet.schema.json",
+        "record_type": "factory_truth_packet",
+        "created_at": created_at or utc_now(),
+        "target": sanitize_slug(target, fallback="factory-target"),
+        "repo": {
+            "branch": branch.get("text") or "unknown",
+            "dirty": bool(dirty.stdout.strip()),
+            "dirty_file_count": len([line for line in dirty.stdout.splitlines() if line.strip()]),
+        },
+        "github": {
+            "issue": issue_state,
+            "pr": pr_state,
+        },
+        "hermes": {
+            "mode": "sanitized_package" if hermes_package else "repo_only_degraded",
+            "status": (hermes_package or {}).get("result") or "DEGRADED",
+        },
+        "evidence_graph": graph,
+        "readiness_ledger": ledger,
+        "current_blockers": blockers,
+        "next_smallest_safe_action": blockers[0]["smallest_safe_next_action"] if blockers else "review and approve only after stronger evidence remains current",
+        "truth_level": ledger["overall_truth_level"],
+        "production_ready": ledger["production_ready"],
+        "public_private_boundary": {
+            "json_first": True,
+            "no_raw_logs": True,
+            "no_private_paths": True,
+            "no_private_ids": True,
+        },
+    }
 
 
 def command_validate_card(args: argparse.Namespace) -> int:
@@ -3526,6 +4210,93 @@ def command_status_snapshot(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_evidence_graph(args: argparse.Namespace) -> int:
+    card = load_json_like(args.card)
+    graph = build_evidence_graph(
+        card,
+        args.card,
+        gate_report=load_optional_json(args.gate_report),
+        worker_results_dir=args.worker_results_dir,
+        receipt_path=args.receipt,
+        hermes_evidence_path=args.hermes_evidence,
+    )
+    write_json(args.out, graph)
+    return 0 if graph["result"] == "PASS" else 1
+
+
+def command_readiness_ledger(args: argparse.Namespace) -> int:
+    card = load_json_like(args.card)
+    graph = load_optional_json(args.evidence_graph)
+    readiness = load_optional_json(args.production_readiness)
+    hermes = load_optional_json(args.hermes_evidence)
+    ledger = build_readiness_truth_ledger(
+        card,
+        args.card,
+        evidence_graph=graph,
+        production_readiness=readiness,
+        hermes_evidence=hermes,
+    )
+    write_json(args.out, ledger)
+    return 0 if ledger["production_ready"] else 1
+
+
+def command_export_hermes_evidence(args: argparse.Namespace) -> int:
+    package = build_hermes_evidence_package(board=args.board, workspace=args.workspace)
+    write_json(args.out, package)
+    if args.md_out:
+        lines = [
+            "# Hermes Evidence Package",
+            "",
+            f"Result: `{package['result']}`",
+            f"State: `{package['state']}`",
+            f"Records: `{len(package['records'])}`",
+            "",
+            "This is a sanitized operator-owned summary. Raw Hermes evidence stays local.",
+            "",
+        ]
+        args.md_out.parent.mkdir(parents=True, exist_ok=True)
+        args.md_out.write_text("\n".join(lines), encoding="utf-8")
+    return 0 if package["result"] == "PASS" else 1
+
+
+def command_prepilot_checklist(args: argparse.Namespace) -> int:
+    checklist = build_prepilot_loose_end_checklist(
+        evidence_graph=load_optional_json(args.evidence_graph),
+        readiness_ledger=load_optional_json(args.readiness_ledger),
+        hermes_evidence=load_optional_json(args.hermes_evidence),
+    )
+    write_json(args.out, checklist)
+    return 0 if checklist["pilot_completion_claim_allowed"] else 1
+
+
+def command_truth(args: argparse.Namespace) -> int:
+    card = load_json_like(args.card)
+    packet = build_truth_packet(
+        target=args.target,
+        card=card,
+        card_path=args.card,
+        issue=args.issue,
+        pr=args.pr,
+        worker_results_dir=args.worker_results_dir,
+        hermes_evidence_path=args.hermes_evidence,
+    )
+    write_json(args.out, packet)
+    if args.md_out:
+        lines = [
+            "# Factory Truth Packet",
+            "",
+            f"Target: `{packet['target']}`",
+            f"Truth level: `{packet['truth_level']}`",
+            f"Production ready: `{str(packet['production_ready']).lower()}`",
+            "",
+            f"Next action: {packet['next_smallest_safe_action']}",
+            "",
+        ]
+        args.md_out.parent.mkdir(parents=True, exist_ok=True)
+        args.md_out.write_text("\n".join(lines), encoding="utf-8")
+    return 0 if packet["production_ready"] else 1
+
+
 def command_doctor(args: argparse.Namespace) -> int:
     report = build_doctor_report(args.hermes_home)
     if args.json:
@@ -3667,6 +4438,48 @@ def build_parser() -> argparse.ArgumentParser:
     status_snapshot_parser.add_argument("--evidence-ref", action="append")
     status_snapshot_parser.add_argument("--out", type=Path)
     status_snapshot_parser.set_defaults(func=command_status_snapshot)
+
+    evidence_graph_parser = sub.add_parser("evidence-graph")
+    evidence_graph_parser.add_argument("--card", type=Path, required=True)
+    evidence_graph_parser.add_argument("--gate-report", type=Path)
+    evidence_graph_parser.add_argument("--worker-results-dir", type=Path)
+    evidence_graph_parser.add_argument("--receipt", type=Path)
+    evidence_graph_parser.add_argument("--hermes-evidence", type=Path)
+    evidence_graph_parser.add_argument("--out", type=Path, default=DEFAULT_EVIDENCE_GRAPH_OUT)
+    evidence_graph_parser.set_defaults(func=command_evidence_graph)
+
+    readiness_ledger_parser = sub.add_parser("readiness-ledger")
+    readiness_ledger_parser.add_argument("--card", type=Path, required=True)
+    readiness_ledger_parser.add_argument("--evidence-graph", type=Path)
+    readiness_ledger_parser.add_argument("--production-readiness", type=Path)
+    readiness_ledger_parser.add_argument("--hermes-evidence", type=Path)
+    readiness_ledger_parser.add_argument("--out", type=Path, default=DEFAULT_READINESS_LEDGER_OUT)
+    readiness_ledger_parser.set_defaults(func=command_readiness_ledger)
+
+    export_hermes_parser = sub.add_parser("export-hermes-evidence")
+    export_hermes_parser.add_argument("--board", required=True)
+    export_hermes_parser.add_argument("--workspace", type=Path, required=True)
+    export_hermes_parser.add_argument("--out", type=Path, default=DEFAULT_HERMES_EVIDENCE_OUT)
+    export_hermes_parser.add_argument("--md-out", type=Path)
+    export_hermes_parser.set_defaults(func=command_export_hermes_evidence)
+
+    prepilot_parser = sub.add_parser("prepilot-checklist")
+    prepilot_parser.add_argument("--evidence-graph", type=Path)
+    prepilot_parser.add_argument("--readiness-ledger", type=Path)
+    prepilot_parser.add_argument("--hermes-evidence", type=Path)
+    prepilot_parser.add_argument("--out", type=Path, default=DEFAULT_PREPILOT_CHECKLIST_OUT)
+    prepilot_parser.set_defaults(func=command_prepilot_checklist)
+
+    truth_parser = sub.add_parser("truth")
+    truth_parser.add_argument("--target", required=True)
+    truth_parser.add_argument("--card", type=Path, required=True)
+    truth_parser.add_argument("--issue")
+    truth_parser.add_argument("--pr")
+    truth_parser.add_argument("--worker-results-dir", type=Path)
+    truth_parser.add_argument("--hermes-evidence", type=Path)
+    truth_parser.add_argument("--out", type=Path, default=DEFAULT_TRUTH_OUT)
+    truth_parser.add_argument("--md-out", type=Path)
+    truth_parser.set_defaults(func=command_truth)
 
     return parser
 

--- a/templates/factory-status-snapshot.json
+++ b/templates/factory-status-snapshot.json
@@ -27,6 +27,7 @@
     "gate_status": "not_run"
   },
   "blockers": [],
+  "blocker_economics": [],
   "evidence": {
     "receipt_five_status": "not_attached",
     "evidence_refs": []

--- a/tests/test_evidence_graph_truth.py
+++ b/tests/test_evidence_graph_truth.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl_evidence_truth", FACTORYCTL_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl_evidence_truth"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+
+class EvidenceGraphTruthTest(unittest.TestCase):
+    def minimal_card_path(self) -> Path:
+        return ROOT / "examples" / "minimal-hermes-project" / "card.md"
+
+    def minimal_card(self) -> dict:
+        return factoryctl.load_json_like(self.minimal_card_path())
+
+    def test_evidence_graph_blocks_missing_worker_results_without_private_leakage(self) -> None:
+        graph = factoryctl.build_evidence_graph(self.minimal_card(), self.minimal_card_path())
+        serialized = json.dumps(graph, sort_keys=True)
+
+        self.assertEqual(graph["record_type"], "evidence_graph")
+        self.assertEqual(graph["result"], "BLOCKED")
+        self.assertIn("blocked_missing_evidence", serialized)
+        self.assertNotIn("webhook-marker", serialized)
+        self.assertTrue(graph["public_private_boundary"]["public_safe_summary_only"])
+
+    def test_evidence_graph_redacts_private_artifact_refs_fail_closed(self) -> None:
+        card = self.minimal_card()
+        worker_id = factoryctl.required_worker_ids(card)[0]
+        worker = factoryctl.WORKERS[worker_id]
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            results_dir = Path(tmp)
+            result = factoryctl.build_worker_result(
+                worker_id,
+                card,
+                result="PASS",
+                tool_or_profile="fixture",
+                executed_by=worker_id,
+                evidence_refs=["webhook-marker"],
+                blocking_findings=False,
+                findings_summary="fixture",
+                next_action="continue",
+            )
+            (results_dir / f"{worker_id}.json").write_text(json.dumps(result), encoding="utf-8")
+
+            graph = factoryctl.build_evidence_graph(card, self.minimal_card_path(), worker_results_dir=results_dir)
+
+        serialized = json.dumps(graph, sort_keys=True)
+        self.assertEqual(graph["result"], "BLOCKED")
+        self.assertIn(f"worker-result:{worker.output_field}", serialized)
+        self.assertIn("redacted:private-runtime-ref", serialized)
+        self.assertNotIn("webhook-marker", serialized)
+
+    def test_hermes_evidence_exporter_redacts_record_names_and_private_refs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "operator-hermes"
+            workspace.mkdir()
+            private_named = workspace / "sensitive-board.json"
+            private_named.write_text(
+                json.dumps(
+                    {
+                        "record_type": "security_scan_result",
+                        "result": "PASS",
+                        "worker": {"id": "codex-security"},
+                        "evidence_refs": ["external:untrusted-proof"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            package = factoryctl.build_hermes_evidence_package(board="operator board", workspace=workspace)
+
+        serialized = json.dumps(package, sort_keys=True)
+        self.assertEqual(package["result"], "BLOCKED")
+        self.assertEqual(package["records"][0]["record_ref"], "external:hermes-record-1")
+        self.assertIn("redacted:private-runtime-ref", serialized)
+        self.assertNotIn("sensitive-board", serialized)
+        self.assertNotIn("untrusted-proof", serialized)
+
+    def test_hermes_evidence_exporter_accepts_sanitized_operator_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "operator-hermes"
+            workspace.mkdir()
+            (workspace / "worker-result.json").write_text(
+                json.dumps(
+                    {
+                        "record_type": "security_scan_result",
+                        "result": "PASS",
+                        "worker": {"id": "codex-security"},
+                        "evidence_refs": ["external:operator-summary"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            package = factoryctl.build_hermes_evidence_package(board="operator board", workspace=workspace)
+
+        self.assertEqual(package["result"], "PASS")
+        self.assertEqual(package["state"], "partially_executed")
+        self.assertEqual(package["records"][0]["evidence_refs"], ["external:operator-summary"])
+
+    def test_evidence_graph_can_link_sanitized_hermes_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package_path = Path(tmp) / "hermes-package.json"
+            package_path.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://overkill-factory.dev/schemas/hermes-evidence-package.schema.json",
+                        "record_type": "hermes_evidence_package",
+                        "result": "PASS",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            graph = factoryctl.build_evidence_graph(
+                self.minimal_card(),
+                self.minimal_card_path(),
+                hermes_evidence_path=package_path,
+            )
+
+        hermes_nodes = [node for node in graph["nodes"] if node["id"] == "hermes-evidence"]
+        self.assertEqual(hermes_nodes[0]["status"], "PASS")
+
+    def test_readiness_ledger_never_promotes_bounded_graph_to_production_ready(self) -> None:
+        graph = factoryctl.build_evidence_graph(self.minimal_card(), self.minimal_card_path())
+        ledger = factoryctl.build_readiness_truth_ledger(self.minimal_card(), self.minimal_card_path(), evidence_graph=graph)
+
+        self.assertFalse(ledger["production_ready"])
+        self.assertNotEqual(ledger["overall_truth_level"], "production_ready")
+        self.assertTrue(ledger["blocker_economics"])
+
+    def test_truth_cli_writes_repo_only_degraded_packet(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "truth.json"
+            rc = factoryctl.main_with_args_for_test(
+                [
+                    "truth",
+                    "--target",
+                    "issue-94",
+                    "--card",
+                    str(self.minimal_card_path()),
+                    "--out",
+                    str(out),
+                ]
+            )
+            packet = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(packet["record_type"], "factory_truth_packet")
+        self.assertEqual(packet["hermes"]["mode"], "repo_only_degraded")
+        self.assertFalse(packet["production_ready"])
+        self.assertTrue(packet["current_blockers"])
+
+    def test_prepilot_checklist_requires_graph_and_truth_ledger(self) -> None:
+        checklist = factoryctl.build_prepilot_loose_end_checklist(
+            evidence_graph=None,
+            readiness_ledger=None,
+            hermes_evidence=None,
+        )
+
+        self.assertEqual(checklist["result"], "BLOCKED")
+        self.assertIn("evidence_graph_path", checklist["blocking_items"])
+        self.assertFalse(checklist["pilot_completion_claim_allowed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_factory_completion_audit.py
+++ b/tests/test_factory_completion_audit.py
@@ -19,12 +19,15 @@ class FactoryCompletionAuditTests(unittest.TestCase):
             self.assertFalse(result["completion_claim_allowed"])
             self.assertEqual(result["score_estimate"], "9.992/10")
             self.assertGreater(result["requirements_blocking"], 0)
+            self.assertEqual(len(result["blocker_economics"]), result["requirements_blocking"])
 
     def test_blocks_only_real_remaining_gaps_when_incomplete(self):
         result = audit.build_audit()
         blockers = set(result["blocking_summary"])
+        blocker_ids = {item["blocker_id"] for item in result["blocker_economics"]}
 
         self.assertIn("production_product_face", blockers)
+        self.assertIn("completion:production_product_face", blocker_ids)
         self.assertIn("production_quasar_auditor", blockers)
         if result["status"] == "COMPLETE":
             self.assertEqual(blockers, set())

--- a/tests/test_prepilot_master_task_readiness.py
+++ b/tests/test_prepilot_master_task_readiness.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import subprocess
 import unittest
+import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from scripts import factory_production_readiness
 
@@ -53,6 +55,28 @@ class PrepilotMasterTaskReadinessTest(unittest.TestCase):
 
         self.assertEqual(receipt["result"], "BLOCKED")
         self.assertTrue(all(ref.startswith(".tmp/factory-runs/") for ref in receipt["evidence_refs"]))
+        self.assertTrue(receipt["blocker_economics"])
+        self.assertTrue(all("smallest_safe_next_action" in item for item in receipt["blocker_economics"]))
+
+    def test_production_readiness_can_consume_evidence_graph_component(self) -> None:
+        with TemporaryDirectory() as tmp:
+            graph_path = Path(tmp) / "evidence-graph.json"
+            graph_path.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://overkill-factory.dev/schemas/evidence-graph.schema.json",
+                        "record_type": "evidence_graph",
+                        "result": "BLOCKED",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            receipt = factory_production_readiness.build_readiness(evidence_graph_path=graph_path)
+
+        by_id = {item["id"]: item for item in receipt["components"]}
+        self.assertIn("evidence_graph", by_id)
+        self.assertEqual(by_id["evidence_graph"]["status"], "BLOCKED")
 
     def test_public_readme_rejects_narrative_history_as_onboarding(self) -> None:
         readme = (ROOT / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

This PR adds the Evidence/status/recomposition layer for the factory:

- Adds a machine-readable Evidence Graph across source card, gate report, worker results, receipts, artifacts and sanitized Hermes evidence.
- Adds a readiness truth ledger that separates contract existence, runtime enforcement, bounded public proof, live Hermes proof, product-specific proof and production readiness.
- Adds a sanitized local Hermes evidence exporter that records public-safe summaries and fail-closes private or untrusted references.
- Adds `factoryctl truth` as a one-command JSON status packet across repo state, optional GitHub status, optional Hermes evidence, evidence graph, readiness ledger and blockers.
- Adds blocker economics to gate reports, production readiness, completion audit and status snapshots.
- Adds a pre-pilot loose-end checklist that aggregates evidence gaps instead of inventing completion proof.

## Scope

Closes #92
Closes #93
Closes #94
Closes #95
Closes #97
Closes #98

## Public boundary

This PR does not add raw runtime logs, screenshots, private proof dumps, local workspace paths, conversation history or operator-owned evidence to the public repository. The Hermes exporter emits sanitized package references and redacts private/untrusted runtime refs.

## Validation

- `python -m unittest tests.test_evidence_graph_truth -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_public_json_artifacts.py`
- `git diff --check`
