### PR TITLE
Add Public Surface Sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: python adapters/hermes/compatibility-check.py
       - name: Public JSON artifact validation
         run: python scripts/validate_public_json_artifacts.py
+      - name: Public surface sync
+        run: python scripts/validate_public_surface_sync.py
       - name: Worker profile validation
         run: python scripts/validate_worker_profiles.py
       - name: Supply-chain proof

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ adapter rule or receipt contract.
 - `docs/concepts/factory-flow.md`: core concepts and phase flow.
 - `docs/concepts/overkill-factory-method.md`: human-readable method guide.
 - `docs/concepts/operator-journey.md`: step-by-step operator journey.
+- `docs/visuals/README.md`: public visual-map boundary and validation rules.
+- Public visual map:
+  `https://storage.googleapis.com/overkill-factory-public-assets-20apy/overkill-factory-map-v0.1.0.html`.
 - `docs/agents/worker-profiles.md`: worker roles, inputs, outputs, limits and
   evidence.
 - `agents/README.md`: human entrypoint for the agent contract directory.

--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -13,6 +13,7 @@ factoryctl run minimal
 python -m unittest discover -s tests
 python scripts/validate_document_governance.py
 python scripts/validate_public_json_artifacts.py
+python scripts/validate_public_surface_sync.py
 python scripts/validate_worker_profiles.py
 python scripts/secret_safety_scan.py
 python scripts/public_safety_scan.py
@@ -45,10 +46,16 @@ Run this before a public branch, release tag or pull request:
 python scripts/release_integration_preflight.py --out .tmp/release-check.json
 python scripts/factory_production_readiness.py --out .tmp/readiness-check.json
 python scripts/worktree_release_inventory.py --out .tmp/inventory-check.json
+python scripts/validate_public_surface_sync.py --check-published
 ```
 
 These commands write local summaries under `.tmp` when an output path is
 provided. Generated summaries must not be committed as release proof.
+
+`validate_public_surface_sync.py --check-published` compares the validated local
+map to the published public object. Run it only after the public object has been
+published or refreshed; before publication it may correctly report the remote
+map as out of sync.
 
 ## Full Validation Battery
 
@@ -61,6 +68,7 @@ python scripts/factory_battery.py
 python scripts/validate_document_governance.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_public_json_artifacts.py
+python scripts/validate_public_surface_sync.py
 python scripts/public_safety_scan.py
 python scripts/secret_safety_scan.py
 python scripts/supply_chain_proof.py --check --no-write

--- a/docs/public-surface.manifest.json
+++ b/docs/public-surface.manifest.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/public-surface-manifest.schema.json",
+  "record_type": "public_surface_manifest",
+  "manifest_version": "v1",
+  "created_at": "2026-06-14T00:00:00Z",
+  "canonical_sources": [
+    "agents/worker-registry.public.json",
+    "agents/worker-profiles.public.json",
+    "agents/hermes-profile-bindings.public.json",
+    "docs/agents/factory-stage-agent-map.md",
+    "docs/concepts/factory-flow.md",
+    "docs/concepts/operator-journey.md",
+    "docs/concepts/overkill-factory-method.md",
+    "schemas/",
+    "scripts/factoryctl.py"
+  ],
+  "published_check_policy": {
+    "default_status_without_network": "not_checked",
+    "comparison": "sha256"
+  },
+  "surfaces": [
+    {
+      "surface_id": "visual-map-v0.1.0-html",
+      "path": "docs/visuals/overkill-factory-map-v0.1.0.html",
+      "published_url": "https://storage.googleapis.com/overkill-factory-public-assets-20apy/overkill-factory-map-v0.1.0.html",
+      "surface_type": "conceptual_visual_map",
+      "authority_level": "conceptual_supporting_surface",
+      "source_refs": [
+        "agents/worker-registry.public.json",
+        "agents/worker-profiles.public.json",
+        "agents/hermes-profile-bindings.public.json",
+        "docs/agents/factory-stage-agent-map.md",
+        "scripts/factoryctl.py"
+      ],
+      "claim_checks": [
+        "metadata",
+        "source_refs_exist",
+        "worker_count",
+        "stage_count",
+        "risk_tiers",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "expected_worker_count": 40,
+      "expected_stage_count": 33,
+      "canonical_stage_count": 32,
+      "conceptual_exceptions": [
+        "The visual map includes two conceptual summary nodes for readiness and R4 rigor in addition to the canonical 32-stage agent map."
+      ],
+      "required_phrases": [
+        "Hermes segue como fonte da verdade",
+        "não provam entrega"
+      ]
+    },
+    {
+      "surface_id": "visual-map-v0.1.0-svg",
+      "path": "docs/visuals/overkill-factory-map-v0.1.0.svg",
+      "surface_type": "static_visual_preview",
+      "authority_level": "conceptual_supporting_surface",
+      "source_refs": [
+        "docs/visuals/README.md",
+        "docs/visuals/overkill-factory-map-v0.1.0.html",
+        "docs/agents/factory-stage-agent-map.md"
+      ],
+      "claim_checks": [
+        "metadata",
+        "source_refs_exist",
+        "risk_tiers",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "not runtime evidence",
+        "not a source of truth"
+      ]
+    },
+    {
+      "surface_id": "visuals-index",
+      "path": "docs/visuals/README.md",
+      "surface_type": "public_visual_index",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "docs/public-surface.manifest.json",
+        "docs/visuals/overkill-factory-map-v0.1.0.html",
+        "docs/visuals/overkill-factory-map-v0.1.0.svg"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "Executable contracts remain authoritative",
+        "they do not replace them"
+      ]
+    },
+    {
+      "surface_id": "factory-flow-concepts",
+      "path": "docs/concepts/factory-flow.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "docs/agents/factory-stage-agent-map.md",
+        "schemas/factory-card.schema.json",
+        "scripts/factoryctl.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "Hermes Kanban state plus repo-relative evidence and receipts are the source of truth",
+        "they do not close work by themselves"
+      ]
+    },
+    {
+      "surface_id": "operator-journey",
+      "path": "docs/concepts/operator-journey.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "docs/agents/factory-stage-agent-map.md",
+        "docs/factory-workflow.catalog.json",
+        "scripts/factoryctl.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "runtime state and receipts decide completion",
+        "Done without evidence is only a claim"
+      ]
+    },
+    {
+      "surface_id": "overkill-factory-method",
+      "path": "docs/concepts/overkill-factory-method.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "docs/factory-workflow.catalog.json",
+        "schemas/factory-card.schema.json",
+        "scripts/factoryctl.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "risk_tiers",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "executable gates and runtime receipts decide whether work can move",
+        "An agent saying \"finished\" is not enough"
+      ]
+    },
+    {
+      "surface_id": "stage-agent-map",
+      "path": "docs/agents/factory-stage-agent-map.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "agents/worker-registry.public.json",
+        "agents/worker-profiles.public.json",
+        "agents/hermes-profile-bindings.public.json"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "stage_count",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "canonical_stage_count": 32,
+      "required_phrases": [
+        "Hermes remains the runtime source of truth",
+        "only the operator"
+      ]
+    },
+    {
+      "surface_id": "root-readme",
+      "path": "README.md",
+      "surface_type": "root_readme",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "docs/visuals/README.md",
+        "docs/public-surface.manifest.json",
+        "docs/visuals/overkill-factory-map-v0.1.0.html"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "expected_links",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "Hermes and Receipt Five remain the source of truth"
+      ],
+      "expected_links": [
+        "https://storage.googleapis.com/overkill-factory-public-assets-20apy/overkill-factory-map-v0.1.0.html"
+      ]
+    }
+  ]
+}

--- a/docs/visuals/overkill-factory-map-v0.1.0.html
+++ b/docs/visuals/overkill-factory-map-v0.1.0.html
@@ -4,6 +4,21 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Overkill Factory</title>
+<script type="application/json" id="overkill-public-surface-metadata">
+{
+  "surface_id": "visual-map-v0.1.0-html",
+  "manifest_ref": "docs/public-surface.manifest.json",
+  "authority_level": "conceptual_supporting_surface",
+  "source_refs": [
+    "agents/worker-registry.public.json",
+    "agents/worker-profiles.public.json",
+    "agents/hermes-profile-bindings.public.json",
+    "docs/agents/factory-stage-agent-map.md",
+    "scripts/factoryctl.py"
+  ],
+  "claim_checks": ["worker_count", "stage_count", "risk_tiers", "source_of_truth_disclaimer", "no_runtime_proof_claim"]
+}
+</script>
 <style>
   :root {
     --bg: #151514;

--- a/docs/visuals/overkill-factory-map-v0.1.0.svg
+++ b/docs/visuals/overkill-factory-map-v0.1.0.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
   <title id="title">Overkill Factory visual map</title>
   <desc id="desc">Static preview of the Overkill Factory production line from source intake to Product SOT, gates, execution, proof, release and learnback.</desc>
+  <metadata id="overkill-public-surface-metadata">{"surface_id":"visual-map-v0.1.0-svg","manifest_ref":"docs/public-surface.manifest.json","authority_level":"conceptual_supporting_surface","source_refs":["docs/visuals/README.md","docs/visuals/overkill-factory-map-v0.1.0.html","docs/agents/factory-stage-agent-map.md"],"claim_checks":["risk_tiers","source_of_truth_disclaimer","no_runtime_proof_claim"]}</metadata>
   <defs>
     <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
       <stop offset="0" stop-color="#151514"/>

--- a/schemas/public-surface-manifest.schema.json
+++ b/schemas/public-surface-manifest.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/public-surface-manifest.schema.json",
+  "title": "Overkill Factory Public Surface Manifest",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "manifest_version",
+    "created_at",
+    "canonical_sources",
+    "published_check_policy",
+    "surfaces"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/public-surface-manifest.schema.json" },
+    "record_type": { "const": "public_surface_manifest" },
+    "manifest_version": { "type": "string", "minLength": 2 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "canonical_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "published_check_policy": {
+      "type": "object",
+      "required": [
+        "default_status_without_network",
+        "comparison"
+      ],
+      "properties": {
+        "default_status_without_network": {
+          "enum": ["not_checked"]
+        },
+        "comparison": {
+          "enum": ["sha256"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "surface_id",
+          "path",
+          "surface_type",
+          "authority_level",
+          "source_refs",
+          "claim_checks"
+        ],
+        "properties": {
+          "surface_id": { "type": "string", "minLength": 3 },
+          "path": { "type": "string", "minLength": 3 },
+          "published_url": { "type": "string", "minLength": 10 },
+          "surface_type": {
+            "enum": [
+              "conceptual_visual_map",
+              "static_visual_preview",
+              "concept_doc",
+              "root_readme",
+              "public_visual_index"
+            ]
+          },
+          "authority_level": {
+            "enum": [
+              "supporting_explanation_not_source_of_truth",
+              "conceptual_supporting_surface"
+            ]
+          },
+          "source_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "claim_checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "metadata",
+                "source_refs_exist",
+                "worker_count",
+                "stage_count",
+                "risk_tiers",
+                "source_of_truth_disclaimer",
+                "no_runtime_proof_claim",
+                "expected_links"
+              ]
+            }
+          },
+          "expected_worker_count": { "type": "integer" },
+          "expected_stage_count": { "type": "integer" },
+          "canonical_stage_count": { "type": "integer" },
+          "conceptual_exceptions": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "required_phrases": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "expected_links": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 10 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate_public_surface_sync.py
+++ b/scripts/validate_public_surface_sync.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Validate public docs and visual maps against canonical factory state."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "docs" / "public-surface.manifest.json"
+
+RISK_TIERS = {"R0", "R1", "R2", "R3", "R4"}
+OVERCLAIM_PATTERNS = [
+    re.compile(r"visual map\s+(is|becomes|acts as)\s+the\s+source\s+of\s+truth", re.IGNORECASE),
+    re.compile(r"public docs\s+(prove|guarantee)\s+runtime", re.IGNORECASE),
+    re.compile(r"conceptual map\s+(proves|guarantees)\s+production", re.IGNORECASE),
+    re.compile(r"map\s+(proves|guarantees)\s+runtime\s+readiness", re.IGNORECASE),
+]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def repo_path(root: Path, rel: str) -> Path:
+    path = root / rel
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise ValueError(f"public surface path escapes repository: {rel}")
+    return path
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical_worker_count(root: Path) -> int:
+    registry = load_json(root / "agents" / "worker-registry.public.json")
+    workers = registry.get("workers", [])
+    return len(workers) if isinstance(workers, list) else 0
+
+
+def stage_map_count(root: Path) -> int:
+    text = (root / "docs" / "agents" / "factory-stage-agent-map.md").read_text(encoding="utf-8")
+    return len(re.findall(r"^\| \d+\.", text, flags=re.MULTILINE))
+
+
+def html_worker_count(text: str) -> int | None:
+    match = re.search(r"expectedCount:\\s*(\\d+)", text)
+    return int(match.group(1)) if match else None
+
+
+def html_stage_count(text: str) -> int | None:
+    return len(re.findall(r"\\{ id: \"[^\"]+\", n:", text)) or None
+
+
+def missing_risk_tiers(text: str) -> set[str]:
+    if "R0-R4" in text:
+        return set()
+    return {tier for tier in RISK_TIERS if tier not in text}
+
+
+def public_doc_overclaim_findings(path: str, text: str) -> list[str]:
+    findings: list[str] = []
+    for pattern in OVERCLAIM_PATTERNS:
+        if pattern.search(text):
+            findings.append(f"{path}: public surface overclaims runtime authority")
+    return findings
+
+
+def has_surface_metadata(surface: dict[str, Any], text: str) -> bool:
+    surface_id = str(surface.get("surface_id") or "")
+    rel = str(surface.get("path") or "")
+    if rel.endswith(".html"):
+        return 'id="overkill-public-surface-metadata"' in text and surface_id in text
+    if rel.endswith(".svg"):
+        return "<metadata" in text and surface_id in text
+    return True
+
+
+def source_ref_exists(root: Path, ref: str) -> bool:
+    if ref.startswith(("http://", "https://", "external:", "factoryctl:")):
+        return True
+    return repo_path(root, ref).exists()
+
+
+def validate_surface(
+    manifest: dict[str, Any],
+    surface: dict[str, Any],
+    *,
+    root: Path,
+    check_published: bool,
+    fetcher: Callable[[str], bytes] | None,
+) -> list[str]:
+    findings: list[str] = []
+    rel = str(surface.get("path") or "")
+    path = repo_path(root, rel)
+    if not path.exists():
+        return [f"{rel}: public surface file is missing"]
+    text = path.read_text(encoding="utf-8")
+    checks = set(surface.get("claim_checks", []))
+
+    if "metadata" in checks and not has_surface_metadata(surface, text):
+        findings.append(f"{rel}: missing public surface metadata")
+
+    if "source_refs_exist" in checks:
+        for ref in surface.get("source_refs", []):
+            if not source_ref_exists(root, str(ref)):
+                findings.append(f"{rel}: source_ref does not exist: {ref}")
+
+    if "worker_count" in checks:
+        expected = int(surface.get("expected_worker_count") or canonical_worker_count(root))
+        actual = canonical_worker_count(root)
+        if expected != actual:
+            findings.append(f"{rel}: manifest worker count {expected} does not match registry count {actual}")
+        visual_count = html_worker_count(text)
+        if visual_count is not None and visual_count != actual:
+            findings.append(f"{rel}: visual worker count {visual_count} does not match registry count {actual}")
+
+    if "stage_count" in checks:
+        canonical = stage_map_count(root)
+        manifest_canonical = int(surface.get("canonical_stage_count") or canonical)
+        if manifest_canonical != canonical:
+            findings.append(f"{rel}: manifest canonical stage count {manifest_canonical} does not match stage map {canonical}")
+        visual = html_stage_count(text)
+        expected_stage_count = surface.get("expected_stage_count")
+        if visual is not None and expected_stage_count is not None and int(expected_stage_count) != visual:
+            findings.append(f"{rel}: visual stage count {visual} does not match manifest expected_stage_count {expected_stage_count}")
+        if visual is not None and visual != canonical and not surface.get("conceptual_exceptions"):
+            findings.append(f"{rel}: visual stage count differs from canonical stage map without conceptual_exceptions")
+
+    if "risk_tiers" in checks:
+        missing = missing_risk_tiers(text)
+        if missing:
+            findings.append(f"{rel}: missing risk tier labels {sorted(missing)}")
+
+    if "source_of_truth_disclaimer" in checks:
+        required = [str(item) for item in surface.get("required_phrases", [])]
+        lower = normalized(text)
+        for phrase in required:
+            if normalized(phrase) not in lower:
+                findings.append(f"{rel}: missing required public-boundary phrase {phrase!r}")
+
+    if "no_runtime_proof_claim" in checks:
+        findings.extend(public_doc_overclaim_findings(rel, text))
+
+    if "expected_links" in checks:
+        for link in surface.get("expected_links", []):
+            if str(link) not in text:
+                findings.append(f"{rel}: missing expected public link {link}")
+
+    published_url = surface.get("published_url")
+    if check_published and published_url:
+        remote = (fetcher or fetch_url)(str(published_url))
+        local_sha = sha256_bytes(path.read_bytes())
+        remote_sha = sha256_bytes(remote)
+        if local_sha != remote_sha:
+            findings.append(f"{rel}: published_out_of_sync for {published_url}")
+
+    return findings
+
+
+def fetch_url(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=30) as response:
+        return response.read()
+
+
+def validate_manifest_data(
+    manifest: dict[str, Any],
+    *,
+    root: Path = ROOT,
+    check_published: bool = False,
+    fetcher: Callable[[str], bytes] | None = None,
+) -> list[str]:
+    findings: list[str] = []
+    for ref in manifest.get("canonical_sources", []):
+        if not source_ref_exists(root, str(ref)):
+            findings.append(f"manifest: canonical source does not exist: {ref}")
+    surfaces = manifest.get("surfaces", [])
+    if not isinstance(surfaces, list) or not surfaces:
+        return ["manifest: surfaces must be a non-empty array"]
+    for surface in surfaces:
+        if isinstance(surface, dict):
+            findings.extend(
+                validate_surface(
+                    manifest,
+                    surface,
+                    root=root,
+                    check_published=check_published,
+                    fetcher=fetcher,
+                )
+            )
+        else:
+            findings.append("manifest: surface entry must be an object")
+    return findings
+
+
+def validate_manifest(
+    *,
+    manifest_path: Path = MANIFEST_PATH,
+    root: Path = ROOT,
+    check_published: bool = False,
+    fetcher: Callable[[str], bytes] | None = None,
+) -> list[str]:
+    manifest = load_json(manifest_path)
+    return validate_manifest_data(manifest, root=root, check_published=check_published, fetcher=fetcher)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
+    parser.add_argument("--check-published", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    findings = validate_manifest(manifest_path=args.manifest, check_published=args.check_published)
+    if findings:
+        for finding in findings:
+            print(finding, file=sys.stderr)
+        return 1
+    if args.check_published:
+        print("OK")
+    else:
+        print("OK (published map status: not_checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_public_surface_sync.py
+++ b/tests/test_public_surface_sync.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+surface_sync = load_module("validate_public_surface_sync", ROOT / "scripts" / "validate_public_surface_sync.py")
+
+
+class PublicSurfaceSyncTest(unittest.TestCase):
+    def manifest(self) -> dict:
+        return json.loads((ROOT / "docs" / "public-surface.manifest.json").read_text(encoding="utf-8"))
+
+    def test_public_surface_manifest_is_current(self) -> None:
+        self.assertEqual(surface_sync.validate_manifest(), [])
+
+    def test_worker_count_drift_is_detected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["surfaces"][0]["expected_worker_count"] = 999
+
+        findings = surface_sync.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "docs/visuals/overkill-factory-map-v0.1.0.html: manifest worker count 999 does not match registry count 40",
+            findings,
+        )
+
+    def test_missing_public_boundary_phrase_is_detected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["surfaces"][0]["required_phrases"] = ["this phrase is intentionally absent from the public map"]
+
+        findings = surface_sync.validate_manifest_data(mutated)
+
+        self.assertTrue(any("missing required public-boundary phrase" in finding for finding in findings))
+
+    def test_published_map_checksum_mismatch_is_detected(self) -> None:
+        manifest = self.manifest()
+
+        findings = surface_sync.validate_manifest_data(
+            manifest,
+            check_published=True,
+            fetcher=lambda _url: b"stale published map",
+        )
+
+        self.assertTrue(any("published_out_of_sync" in finding for finding in findings))
+
+    def test_runtime_overclaim_is_detected(self) -> None:
+        findings = surface_sync.public_doc_overclaim_findings(
+            "docs/visuals/overkill-factory-map-v0.1.0.html",
+            "The visual map is the source of truth and map proves runtime readiness.",
+        )
+
+        self.assertEqual(
+            findings,
+            [
+                "docs/visuals/overkill-factory-map-v0.1.0.html: public surface overclaims runtime authority",
+                "docs/visuals/overkill-factory-map-v0.1.0.html: public surface overclaims runtime authority",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #115.

This PR adds Public Surface Sync so public docs and visual maps cannot silently drift away from the executable factory contracts.

Key changes:
- adds `docs/public-surface.manifest.json` as the canonical manifest of public-facing surfaces;
- adds `scripts/validate_public_surface_sync.py` and CI coverage;
- validates docs, stage map, visual HTML/SVG, README map link, worker count, stage count, risk labels, disclaimers and runtime-overclaim patterns;
- embeds public-safe surface metadata in the HTML/SVG visual map;
- documents `--check-published` as the release/publication check for the GCS object.

## Boundary

This is stacked on #124. It does not implement or steer #84/cockpit. It adds no runtime logs, screenshots, private paths, private links, historical outputs or private evidence to the public repo.

## Validation

- `python -m unittest tests.test_public_surface_sync tests.test_open_source_docs tests.test_factory_stage_agent_map -q`
- `python scripts\validate_public_surface_sync.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `git diff --check`
- Added-line checks for #84/cockpit and private paths/artifacts passed.

## Published Object Check

`python scripts\validate_public_surface_sync.py --check-published` currently reports `published_out_of_sync` for the GCS HTML object, which is expected before this PR's updated local HTML is published. This is the intended release gate: publish/refresh the object, then rerun `--check-published` before claiming the public map is current.