### PR TITLE
Add public planning bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: python adapters/hermes/compatibility-check.py
       - name: Public JSON artifact validation
         run: python scripts/validate_public_json_artifacts.py
+      - name: Planning bundle validation
+        run: python scripts/validate_planning_bundles.py
       - name: Public surface sync
         run: python scripts/validate_public_surface_sync.py
       - name: Worker profile validation

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ as a place to add files.
 | `agents/` | Public worker registry, profiles, permissions and Hermes bindings. See `agents/README.md`. |
 | `docs/` | Human guides for getting started, concepts, operations, agents and integrations. See `docs/README.md`. |
 | `examples/` | Small source examples and fixtures that teach or test the factory path. See `examples/README.md`. |
+| `planning-bundles/` | Public-safe planning protocols for creating candidate artifacts in web LLMs before factory validation. See `planning-bundles/README.md`. |
 | `products/` | Public validation products used by product-like and production-lane checks. See `products/README.md`. |
 | `schemas/` | Machine contracts for cards, receipts, worker outputs and gates. See `schemas/README.md`. |
 | `scripts/` | CLI entrypoints, validation tools, proof helpers and maintainer checks. See `scripts/README.md`. |
@@ -221,6 +222,8 @@ adapter rule or receipt contract.
 - `docs/visuals/README.md`: public visual-map boundary and validation rules.
 - Public visual map:
   `https://storage.googleapis.com/overkill-factory-public-assets-20apy/overkill-factory-map-v0.1.0.html`.
+- `planning-bundles/README.md`: public-safe planning protocols for candidate
+  artifacts that must be imported and validated before execution.
 - `docs/agents/worker-profiles.md`: worker roles, inputs, outputs, limits and
   evidence.
 - `agents/README.md`: human entrypoint for the agent contract directory.
@@ -257,6 +260,7 @@ Run these before publishing:
 python scripts/validate_document_governance.py
 python scripts/secret_safety_scan.py
 python scripts/public_safety_scan.py
+python scripts/validate_planning_bundles.py
 python scripts/validate_public_json_artifacts.py
 ```
 

--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -13,6 +13,7 @@ factoryctl run minimal
 python -m unittest discover -s tests
 python scripts/validate_document_governance.py
 python scripts/validate_public_json_artifacts.py
+python scripts/validate_planning_bundles.py
 python scripts/validate_public_surface_sync.py
 python scripts/validate_worker_profiles.py
 python scripts/secret_safety_scan.py
@@ -68,6 +69,7 @@ python scripts/factory_battery.py
 python scripts/validate_document_governance.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_public_json_artifacts.py
+python scripts/validate_planning_bundles.py
 python scripts/validate_public_surface_sync.py
 python scripts/public_safety_scan.py
 python scripts/secret_safety_scan.py

--- a/docs/public-surface.manifest.json
+++ b/docs/public-surface.manifest.json
@@ -11,6 +11,7 @@
     "docs/concepts/factory-flow.md",
     "docs/concepts/operator-journey.md",
     "docs/concepts/overkill-factory-method.md",
+    "planning-bundles/manifest.json",
     "schemas/",
     "scripts/factoryctl.py"
   ],
@@ -175,6 +176,26 @@
       "required_phrases": [
         "Hermes remains the runtime source of truth",
         "only the operator"
+      ]
+    },
+    {
+      "surface_id": "planning-bundles-index",
+      "path": "planning-bundles/README.md",
+      "surface_type": "public_planning_bundle_index",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "planning-bundles/manifest.json",
+        "schemas/planning-bundle-manifest.schema.json",
+        "scripts/validate_planning_bundles.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "Every bundle output is a candidate artifact",
+        "They do not replace the factory runtime"
       ]
     },
     {

--- a/planning-bundles/README.md
+++ b/planning-bundles/README.md
@@ -1,0 +1,46 @@
+# Planning Bundles
+
+Planning bundles are public-safe protocol packs for early factory work in a web
+LLM environment. They are useful when conversation, summarization and research
+are cheaper outside the local runtime.
+
+They do not replace the factory runtime, schemas, gates, receipts or evidence.
+Every bundle output is a candidate artifact until it is brought back into the
+repo or runtime and validated by the canonical factory process.
+
+## When To Use
+
+Use a planning bundle for:
+
+- source intake and clarification;
+- Product SOT drafting;
+- Specialist Research Plan drafting;
+- Product Face Packet planning;
+- Product Creation Plan drafting;
+- checklist review before local implementation begins.
+
+Do not use a planning bundle for:
+
+- worker execution;
+- runtime proof;
+- approval recording;
+- secret handling;
+- release or production readiness claims.
+
+## Public-Safe Rule
+
+Do not paste secrets, credentials, private keys, payment data, raw private logs,
+customer data or private source dumps into a web LLM. Use public-safe excerpts,
+redacted summaries or operator-approved synthetic examples.
+
+## Import Path
+
+1. Run the bundle in the chosen web LLM.
+2. Export the result as a candidate artifact.
+3. Bring the candidate back into the repo or runtime.
+4. Validate it against schemas, `factoryctl` gates and public safety scans.
+5. Continue only when the factory accepts the candidate as part of the gated
+   process.
+
+The bundle helps create a better draft. The factory decides whether the draft is
+usable.

--- a/planning-bundles/manifest.json
+++ b/planning-bundles/manifest.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/planning-bundle-manifest.schema.json",
+  "record_type": "planning_bundle_manifest",
+  "manifest_version": "v1",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "bundles": [
+    {
+      "bundle_id": "product-sot-drafting-v1",
+      "bundle_kind": "planning_protocol",
+      "version": "v1",
+      "status": "prototype_public_safe",
+      "target_platforms": [
+        "chatgpt-custom-gpt",
+        "gemini-gem",
+        "web-llm"
+      ],
+      "entrypoint": "planning-bundles/product-sot-drafting/INSTRUCTIONS.md",
+      "included_files": [
+        "planning-bundles/product-sot-drafting/INSTRUCTIONS.md",
+        "planning-bundles/product-sot-drafting/SKILL.md",
+        "planning-bundles/product-sot-drafting/templates/product-sot-candidate.md",
+        "planning-bundles/product-sot-drafting/checklists/pre-import-checklist.md"
+      ],
+      "compatible_factory_method_versions": [
+        "OVERKILL_VFINAL"
+      ],
+      "compatible_schema_refs": [
+        "schemas/product-sot.schema.json",
+        "schemas/full-product-sot-scope-coverage.schema.json",
+        "schemas/product-creation-plan.schema.json",
+        "schemas/product-implementation-readiness.schema.json"
+      ],
+      "expected_outputs": [
+        {
+          "output_id": "product_sot_candidate",
+          "output_type": "Product SOT candidate",
+          "candidate_schema_ref": "schemas/product-sot.schema.json",
+          "authority": "candidate_only"
+        },
+        {
+          "output_id": "open_decision_list",
+          "output_type": "Open decision list",
+          "candidate_schema_ref": "schemas/open-decision-list.schema.json",
+          "authority": "candidate_only"
+        }
+      ],
+      "import_validation": {
+        "handoff_rule": "Bring output back as a candidate artifact. These commands validate bundle definitions only; the imported candidate must be validated against its candidate_schema_ref and factory gates before execution.",
+        "commands": [
+          "python scripts/validate_planning_bundles.py",
+          "python scripts/validate_public_json_artifacts.py"
+        ]
+      },
+      "safety_rules": [
+        "Do not paste secrets, credentials, private keys, payment data or raw private logs into web LLMs.",
+        "Use redacted summaries or public-safe excerpts when source material is sensitive.",
+        "Mark every generated artifact as candidate_only until validated by the factory."
+      ],
+      "non_authority_rules": [
+        "A planning bundle is not runtime proof.",
+        "A planning bundle is not human approval.",
+        "A planning bundle is not production readiness.",
+        "A planning bundle is not a capability pack."
+      ]
+    }
+  ]
+}

--- a/planning-bundles/product-sot-drafting/INSTRUCTIONS.md
+++ b/planning-bundles/product-sot-drafting/INSTRUCTIONS.md
@@ -1,0 +1,39 @@
+# Product SOT Drafting Bundle
+
+Use this bundle in a web LLM to turn public-safe product input into a Product
+SOT candidate.
+
+## Setup
+
+Load these files into the web LLM:
+
+- `SKILL.md`
+- `templates/product-sot-candidate.md`
+- `checklists/pre-import-checklist.md`
+
+The operator may add public-safe source material, redacted notes or a short
+product brief. Do not paste secrets, credentials, private keys, payment data,
+raw private logs, customer data or private source dumps.
+
+## Expected Output
+
+The output must be marked `candidate_only` and shaped for
+`schemas/product-sot.schema.json`.
+
+The output must separate:
+
+- source facts;
+- assumptions;
+- open decisions;
+- scope in;
+- scope out;
+- risks;
+- access or authority gaps;
+- success criteria;
+- evidence refs that are public-safe.
+
+## Handoff
+
+Bring the candidate back into the factory repo or runtime and validate it before
+execution. The bundle output is not runtime proof, human approval, production
+readiness or a final Product SOT by itself.

--- a/planning-bundles/product-sot-drafting/SKILL.md
+++ b/planning-bundles/product-sot-drafting/SKILL.md
@@ -1,0 +1,36 @@
+# Product SOT Drafting
+
+You are helping draft a Product SOT candidate for Overkill Factory.
+
+## Boundaries
+
+- Treat all output as `candidate_only`.
+- Do not claim runtime proof.
+- Do not record human approval.
+- Do not claim production readiness.
+- Do not request or process secrets, credentials, private keys, payment data or
+  raw private logs.
+- Do not silently shrink the requested product into an MVP.
+
+## Workflow
+
+1. Restate the product intent in plain language.
+2. Separate source facts from assumptions.
+3. Identify missing decisions before planning execution.
+4. Draft the Product SOT candidate using the template.
+5. Mark every uncertain item as an open decision or research need.
+6. Produce a short pre-import checklist result.
+
+## Output Contract
+
+Return:
+
+- `candidate_status: candidate_only`;
+- Product SOT candidate sections;
+- open decisions;
+- research needs;
+- public-safe evidence refs;
+- import notes for factory validation.
+
+The next step is always local or runtime validation through factory schemas,
+gates and receipts.

--- a/planning-bundles/product-sot-drafting/checklists/pre-import-checklist.md
+++ b/planning-bundles/product-sot-drafting/checklists/pre-import-checklist.md
@@ -1,0 +1,13 @@
+# Pre-Import Checklist
+
+Before bringing the candidate into the factory, confirm:
+
+- [ ] The output is marked `candidate_only`.
+- [ ] No secrets, credentials, private keys, payment data or raw private logs are present.
+- [ ] Source facts and assumptions are separated.
+- [ ] Open decisions are explicit.
+- [ ] Scope in and scope out are both present.
+- [ ] Success criteria are testable.
+- [ ] Access, authority and risk gaps are listed.
+- [ ] The result does not claim runtime proof, human approval or production readiness.
+- [ ] The next step is factory validation, not execution.

--- a/planning-bundles/product-sot-drafting/templates/product-sot-candidate.md
+++ b/planning-bundles/product-sot-drafting/templates/product-sot-candidate.md
@@ -1,0 +1,87 @@
+# Product SOT Candidate
+
+`candidate_status: candidate_only`
+
+This draft is not runtime proof, human approval, production readiness or final
+Product SOT. It must be validated by the factory before execution.
+
+## Source Facts
+
+- 
+
+## Assumptions
+
+- 
+
+## What It Is
+
+
+## Target Users
+
+- 
+
+## Why It Matters
+
+
+## Outcome
+
+
+## Scope In
+
+- 
+
+## Scope Out
+
+- 
+
+## Risks
+
+- 
+
+## Authority
+
+
+## Data And Metrics
+
+- 
+
+## Dependencies
+
+- 
+
+## Access And Capabilities
+
+- 
+
+## Compliance And Privacy
+
+- 
+
+## Cost Relevance
+
+
+## Operations Expected
+
+- 
+
+## Success Criteria
+
+- 
+
+## Open Decisions
+
+- 
+
+## Research Needs
+
+- 
+
+## Public-Safe Evidence Refs
+
+- 
+
+## Import Notes
+
+- Validate against `schemas/product-sot.schema.json`.
+- Create or attach full Product SOT scope coverage.
+- Continue through method, readiness and worker gates before execution.

--- a/schemas/open-decision-list.schema.json
+++ b/schemas/open-decision-list.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/open-decision-list.schema.json",
+  "title": "Overkill Factory Open Decision List",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "candidate_status",
+    "decisions"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/open-decision-list.schema.json" },
+    "record_type": { "const": "open_decision_list" },
+    "candidate_status": { "const": "candidate_only" },
+    "decisions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "decision_id",
+          "question",
+          "why_it_matters",
+          "owner_or_authority",
+          "blocking_for",
+          "status"
+        ],
+        "properties": {
+          "decision_id": { "type": "string", "minLength": 3 },
+          "question": { "type": "string", "minLength": 3 },
+          "why_it_matters": { "type": "string", "minLength": 3 },
+          "owner_or_authority": { "type": "string", "minLength": 3 },
+          "blocking_for": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "status": {
+            "enum": [
+              "open",
+              "answered",
+              "deferred"
+            ]
+          },
+          "candidate_answer": { "type": "string" },
+          "public_safe_evidence_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "import_notes": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/planning-bundle-manifest.schema.json
+++ b/schemas/planning-bundle-manifest.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/planning-bundle-manifest.schema.json",
+  "title": "Overkill Factory Planning Bundle Manifest",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "manifest_version",
+    "factory_method_version",
+    "bundles"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/planning-bundle-manifest.schema.json" },
+    "record_type": { "const": "planning_bundle_manifest" },
+    "manifest_version": { "type": "string", "minLength": 2 },
+    "factory_method_version": { "type": "string", "minLength": 3 },
+    "bundles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "bundle_id",
+          "bundle_kind",
+          "version",
+          "status",
+          "target_platforms",
+          "entrypoint",
+          "included_files",
+          "compatible_factory_method_versions",
+          "compatible_schema_refs",
+          "expected_outputs",
+          "import_validation",
+          "safety_rules",
+          "non_authority_rules"
+        ],
+        "properties": {
+          "bundle_id": { "type": "string", "minLength": 3 },
+          "bundle_kind": { "const": "planning_protocol" },
+          "version": { "type": "string", "minLength": 1 },
+          "status": {
+            "enum": [
+              "prototype_public_safe",
+              "active_public_safe",
+              "deprecated",
+              "blocked"
+            ]
+          },
+          "target_platforms": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "entrypoint": { "type": "string", "minLength": 3 },
+          "included_files": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "compatible_factory_method_versions": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "compatible_schema_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "expected_outputs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "output_id",
+                "output_type",
+                "candidate_schema_ref",
+                "authority"
+              ],
+              "properties": {
+                "output_id": { "type": "string", "minLength": 3 },
+                "output_type": { "type": "string", "minLength": 3 },
+                "candidate_schema_ref": { "type": "string", "minLength": 3 },
+                "authority": { "const": "candidate_only" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "import_validation": {
+            "type": "object",
+            "required": [
+              "handoff_rule",
+              "commands"
+            ],
+            "properties": {
+              "handoff_rule": { "type": "string", "minLength": 12 },
+              "commands": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 3 }
+              }
+            },
+            "additionalProperties": false
+          },
+          "safety_rules": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 8 }
+          },
+          "non_authority_rules": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 8 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/public-surface-manifest.schema.json
+++ b/schemas/public-surface-manifest.schema.json
@@ -61,7 +61,8 @@
               "static_visual_preview",
               "concept_doc",
               "root_readme",
-              "public_visual_index"
+              "public_visual_index",
+              "public_planning_bundle_index"
             ]
           },
           "authority_level": {

--- a/scripts/validate_planning_bundles.py
+++ b/scripts/validate_planning_bundles.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Validate public planning bundles without treating them as runtime proof."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "planning-bundles" / "manifest.json"
+
+REQUIRED_TEXT_MARKERS = (
+    "candidate_only",
+    "not runtime proof",
+    "not human approval",
+    "not production readiness",
+    "Do not paste secrets",
+)
+INCLUDED_FILE_SUFFIXES = {".md"}
+FORBIDDEN_REF_FRAGMENTS = (
+    "capability",
+    "control-tower",
+    "operator",
+    "runtime",
+    "worker-packet",
+    "worker-result",
+)
+FORBIDDEN_COMMAND_FRAGMENTS = (
+    ".tmp/",
+    "adapters/",
+    "examples/",
+    "gate-report",
+    "templates/",
+    "transition-plan",
+    "worker-packet",
+)
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def repo_path(root: Path, rel: str) -> Path:
+    path = root / rel
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise ValueError(f"planning bundle path escapes repository: {rel}")
+    return path
+
+
+def normalized_ref(value: str) -> str:
+    return value.replace("\\", "/").replace("_", "-").lower()
+
+
+def contains_forbidden_fragment(value: str, fragments: tuple[str, ...]) -> str | None:
+    normalized = normalized_ref(value)
+    for fragment in fragments:
+        if fragment in normalized:
+            return fragment
+    return None
+
+
+def validate_manifest_data(manifest: dict[str, Any], *, root: Path = ROOT) -> list[str]:
+    findings: list[str] = []
+    bundles = manifest.get("bundles", [])
+    if not isinstance(bundles, list) or not bundles:
+        return ["planning-bundles/manifest.json: bundles must be a non-empty array"]
+
+    seen_ids: set[str] = set()
+    for bundle in bundles:
+        if not isinstance(bundle, dict):
+            findings.append("planning-bundles/manifest.json: bundle entry must be an object")
+            continue
+        bundle_id = str(bundle.get("bundle_id") or "")
+        if not bundle_id:
+            findings.append("planning-bundles/manifest.json: bundle missing bundle_id")
+            continue
+        if bundle_id in seen_ids:
+            findings.append(f"{bundle_id}: duplicate bundle_id")
+        seen_ids.add(bundle_id)
+
+        if bundle.get("bundle_kind") != "planning_protocol":
+            findings.append(f"{bundle_id}: bundle_kind must be planning_protocol")
+        if "capability" in bundle_id.lower():
+            findings.append(f"{bundle_id}: planning bundles must not duplicate capability packs")
+        if "OVERKILL_VFINAL" not in bundle.get("compatible_factory_method_versions", []):
+            findings.append(f"{bundle_id}: missing OVERKILL_VFINAL compatibility")
+
+        entrypoint = str(bundle.get("entrypoint") or "")
+        bundle_root = repo_path(root, entrypoint).parent if entrypoint else root / "planning-bundles" / bundle_id
+        if entrypoint and entrypoint not in bundle.get("included_files", []):
+            findings.append(f"{bundle_id}: entrypoint must be listed in included_files")
+        if not entrypoint.startswith("planning-bundles/"):
+            findings.append(f"{bundle_id}: entrypoint must live under planning-bundles/")
+
+        included_text = ""
+        for rel in bundle.get("included_files", []):
+            path = repo_path(root, str(rel))
+            if not normalized_ref(str(rel)).startswith("planning-bundles/"):
+                findings.append(f"{bundle_id}: included file must live under planning-bundles/: {rel}")
+            if not path.resolve().is_relative_to(bundle_root.resolve()):
+                findings.append(f"{bundle_id}: included file must stay under the bundle entrypoint directory: {rel}")
+            if path.suffix not in INCLUDED_FILE_SUFFIXES:
+                findings.append(f"{bundle_id}: included file must be markdown: {rel}")
+            forbidden = contains_forbidden_fragment(str(rel), FORBIDDEN_REF_FRAGMENTS)
+            if forbidden:
+                findings.append(f"{bundle_id}: included file crosses into non-planning surface {forbidden!r}: {rel}")
+            if not path.exists():
+                findings.append(f"{bundle_id}: included file does not exist: {rel}")
+                continue
+            included_text += "\n" + path.read_text(encoding="utf-8")
+
+        for ref in bundle.get("compatible_schema_refs", []):
+            forbidden = contains_forbidden_fragment(str(ref), FORBIDDEN_REF_FRAGMENTS)
+            if forbidden:
+                findings.append(f"{bundle_id}: compatible schema crosses into execution surface {forbidden!r}: {ref}")
+            if not repo_path(root, str(ref)).exists():
+                findings.append(f"{bundle_id}: compatible schema does not exist: {ref}")
+
+        for output in bundle.get("expected_outputs", []):
+            if not isinstance(output, dict):
+                findings.append(f"{bundle_id}: expected output entry must be an object")
+                continue
+            if output.get("authority") != "candidate_only":
+                findings.append(f"{bundle_id}: expected output {output.get('output_id')} must be candidate_only")
+            schema_ref = str(output.get("candidate_schema_ref") or "")
+            forbidden = contains_forbidden_fragment(schema_ref, FORBIDDEN_REF_FRAGMENTS)
+            if forbidden:
+                findings.append(f"{bundle_id}: candidate schema crosses into execution surface {forbidden!r}: {schema_ref}")
+            if schema_ref and not repo_path(root, schema_ref).exists():
+                findings.append(f"{bundle_id}: candidate schema does not exist: {schema_ref}")
+
+        import_validation = bundle.get("import_validation")
+        if not isinstance(import_validation, dict) or not import_validation.get("commands"):
+            findings.append(f"{bundle_id}: import_validation.commands is required")
+        elif isinstance(import_validation.get("commands"), list):
+            for command in import_validation["commands"]:
+                forbidden = contains_forbidden_fragment(str(command), FORBIDDEN_COMMAND_FRAGMENTS)
+                if forbidden:
+                    findings.append(f"{bundle_id}: import validation command must not target fixed runtime/example artifacts {forbidden!r}: {command}")
+
+        combined_policy = "\n".join(
+            [included_text, *[str(item) for item in bundle.get("safety_rules", [])], *[str(item) for item in bundle.get("non_authority_rules", [])]]
+        )
+        for marker in REQUIRED_TEXT_MARKERS:
+            if marker not in combined_policy:
+                findings.append(f"{bundle_id}: missing required safety marker {marker!r}")
+
+    return findings
+
+
+def validate(path: Path = MANIFEST_PATH) -> list[str]:
+    return validate_manifest_data(load_manifest(path))
+
+
+def main() -> int:
+    findings = validate()
+    if findings:
+        for finding in findings:
+            print(finding, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -18,7 +18,14 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_DIR = ROOT / "schemas"
-SCAN_DIRS = [ROOT / "examples", ROOT / ".tmp" / "factory-runs", ROOT / "agents", ROOT / "templates", ROOT / "docs"]
+SCAN_DIRS = [
+    ROOT / "examples",
+    ROOT / ".tmp" / "factory-runs",
+    ROOT / "agents",
+    ROOT / "templates",
+    ROOT / "docs",
+    ROOT / "planning-bundles",
+]
 
 SCHEMA_OPTIONAL = {
     ".tmp/factory-runs/product-face/console.json",

--- a/tests/test_planning_bundles.py
+++ b/tests/test_planning_bundles.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+planning_bundles = load_module("validate_planning_bundles", ROOT / "scripts" / "validate_planning_bundles.py")
+
+
+class PlanningBundleValidationTest(unittest.TestCase):
+    def manifest(self) -> dict:
+        return json.loads((ROOT / "planning-bundles" / "manifest.json").read_text(encoding="utf-8"))
+
+    def test_current_manifest_passes(self) -> None:
+        self.assertEqual(planning_bundles.validate(), [])
+
+    def test_missing_included_file_is_detected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        bundle = mutated["bundles"][0]
+        bundle["included_files"].append("planning-bundles/product-sot-drafting/missing.md")
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "product-sot-drafting-v1: included file does not exist: planning-bundles/product-sot-drafting/missing.md",
+            findings,
+        )
+
+    def test_output_authority_must_remain_candidate_only(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["bundles"][0]["expected_outputs"][0]["authority"] = "approved"
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "product-sot-drafting-v1: expected output product_sot_candidate must be candidate_only",
+            findings,
+        )
+
+    def test_missing_secret_boundary_marker_is_detected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        bundle = mutated["bundles"][0]
+        bundle["safety_rules"] = ["Use public-safe excerpts."]
+        bundle["included_files"] = [
+            "planning-bundles/product-sot-drafting/templates/product-sot-candidate.md",
+        ]
+        bundle["entrypoint"] = bundle["included_files"][0]
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn("product-sot-drafting-v1: missing required safety marker 'Do not paste secrets'", findings)
+
+    def test_bundle_kind_cannot_be_capability_pack(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["bundles"][0]["bundle_kind"] = "capability_pack"
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn("product-sot-drafting-v1: bundle_kind must be planning_protocol", findings)
+
+    def test_included_files_must_stay_inside_bundle_directory(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["bundles"][0]["included_files"].append("docs/concepts/operator-journey.md")
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "product-sot-drafting-v1: included file must live under planning-bundles/: docs/concepts/operator-journey.md",
+            findings,
+        )
+        self.assertIn(
+            "product-sot-drafting-v1: included file must stay under the bundle entrypoint directory: docs/concepts/operator-journey.md",
+            findings,
+        )
+
+    def test_execution_schema_refs_are_rejected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["bundles"][0]["compatible_schema_refs"].append("schemas/worker-packet.schema.json")
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "product-sot-drafting-v1: compatible schema crosses into execution surface 'worker-packet': schemas/worker-packet.schema.json",
+            findings,
+        )
+
+    def test_import_validation_cannot_target_static_runtime_examples(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["bundles"][0]["import_validation"]["commands"].append(
+            "python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json"
+        )
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "product-sot-drafting-v1: import validation command must not target fixed runtime/example artifacts 'templates/': python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json",
+            findings,
+        )
+
+    def test_open_decision_list_has_its_own_candidate_schema(self) -> None:
+        manifest = self.manifest()
+        output_refs = {output["output_id"]: output["candidate_schema_ref"] for output in manifest["bundles"][0]["expected_outputs"]}
+
+        self.assertEqual(output_refs["open_decision_list"], "schemas/open-decision-list.schema.json")
+
+    def test_public_surface_knows_planning_bundle_index(self) -> None:
+        surface_manifest = json.loads((ROOT / "docs" / "public-surface.manifest.json").read_text(encoding="utf-8"))
+
+        paths = {surface["path"] for surface in surface_manifest["surfaces"]}
+
+        self.assertIn("planning-bundles/README.md", paths)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add public-safe planning bundle contracts for web LLM drafting before factory validation.
- Add Product SOT drafting bundle, open decision list schema, and a validator that keeps outputs `candidate_only`.
- Wire planning-bundle validation into CI, public JSON validation, public-surface sync, README, and release checklist.

## Guardrails
- Bundle files must stay under their own planning-bundle directory.
- Bundle refs and commands cannot pull execution, worker, capability, or fixed example/template artifacts into planning authority.
- Bundle outputs remain candidates until imported and validated by factory schemas, gates, receipts, and scans.

## Validation
- `python -m unittest tests.test_planning_bundles -q`
- `python scripts\validate_planning_bundles.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\validate_public_surface_sync.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_document_governance.py`
- `python scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `git diff --check`

Closes #120.