### PR TITLE
Require professional design process for Product Face

### DIFF
--- a/examples/cards/v35_valid_product_face.md
+++ b/examples/cards/v35_valid_product_face.md
@@ -99,6 +99,141 @@
       ]
     },
     "visual_evidence_plan": ["desktop screenshot", "mobile screenshot"]
+  },
+  "professional_design_process": {
+    "$schema": "https://overkill-factory.dev/schemas/professional-design-process.schema.json",
+    "record_type": "professional_design_process",
+    "surface_type": "operator validation surface",
+    "mode": "greenfield",
+    "design_brief": {
+      "user": "factory operator",
+      "job_to_be_done": "Review pilot status and evidence with clear next action.",
+      "decision_surface": "Pilot status and review evidence screens.",
+      "success_signal": "State, evidence and review outcome are visible without generic dashboard filler.",
+      "failure_risks": [
+        "The UI looks like a generated dashboard.",
+        "Review evidence and status hierarchy are unclear."
+      ]
+    },
+    "task_map": [
+      {
+        "task_id": "T1",
+        "user_goal": "Read pilot status.",
+        "trigger": "Operator opens the status screen.",
+        "success_signal": "Status and evidence are visible.",
+        "failure_state": "Status is hidden behind decorative metrics."
+      },
+      {
+        "task_id": "T2",
+        "user_goal": "Inspect review evidence.",
+        "trigger": "Operator opens evidence screen.",
+        "success_signal": "Evidence refs and review state are clear.",
+        "failure_state": "Evidence is ambiguous or missing."
+      },
+      {
+        "task_id": "T3",
+        "user_goal": "Confirm visual quality.",
+        "trigger": "Product Face review runs.",
+        "success_signal": "Reviewer compares result to reference quality bar.",
+        "failure_state": "Mechanical screenshot proof hides generic visual quality."
+      }
+    ],
+    "reference_research": {
+      "registry_refs": [
+        "templates/reference-source-registry.json#21st-dev",
+        "templates/reference-source-registry.json#refero-styles"
+      ],
+      "selection_rationale": "Use professional product-tool references to avoid generic generated UI.",
+      "sources": [
+        {
+          "source_id": "radix-ui-themes",
+          "source_url_or_ref": "https://www.radix-ui.com/themes",
+          "use_type": "accessibility-reference",
+          "what_to_learn": ["semantic tokens", "accessible controls"],
+          "extracted_patterns": [
+            "Use state semantics over decoration.",
+            "Keep controls compact and named."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied"
+        },
+        {
+          "source_id": "shadcn-data-table",
+          "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
+          "use_type": "dense-data-reference",
+          "what_to_learn": ["row scanning", "filters"],
+          "extracted_patterns": [
+            "Dense lists need stable row focus.",
+            "Controls should stay near affected data."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied"
+        },
+        {
+          "source_id": "linear-product-workflow",
+          "source_url_or_ref": "https://linear.app",
+          "use_type": "workflow-reference",
+          "what_to_learn": ["state-first workflow", "quiet product-tool hierarchy"],
+          "extracted_patterns": [
+            "Work context should be visible without a hero.",
+            "Status hierarchy should be compact and scannable."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied"
+        }
+      ]
+    },
+    "ux_architecture": {
+      "information_hierarchy": ["status", "evidence", "review", "next action"],
+      "navigation_model": "Two-screen operator flow with status overview and evidence detail.",
+      "state_model": ["loading", "pending", "success", "error"],
+      "density_rationale": "Operational review surface should be compact and state-first."
+    },
+    "wireframe_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": ["examples/cards/v35_valid_product_face.md#product_face_packet"],
+      "basis": "Wireframe separates status, evidence and review before styling."
+    },
+    "visual_direction": {
+      "typography": "Compact system UI.",
+      "spacing": "Stable rows and evidence groups.",
+      "color_semantics": "Distinct state colors for pending, success and error.",
+      "component_model": "Status summary, evidence list, review state and next action.",
+      "anti_generic_commitments": [
+        "No generic dashboard composition.",
+        "No decorative metrics detached from evidence."
+      ]
+    },
+    "prototype_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": ["examples/cards/v35_valid_product_face.md#product_face_packet"],
+      "basis": "Prototype scope covers status, evidence and review states.",
+      "real_data_states": ["loading", "pending", "success", "error"]
+    },
+    "design_qa_plan": {
+      "viewports": ["desktop 1440x900", "mobile 390x844"],
+      "accessibility_checks": ["keyboard", "labels", "contrast"],
+      "performance_checks": ["static render responsiveness"],
+      "screenshot_requirements": ["desktop", "mobile"],
+      "console_check_required": true,
+      "overlap_check_required": true
+    },
+    "comparative_review_gate": {
+      "status": "PASS",
+      "reviewer_role": "product-face",
+      "must_compare_to_reference_packet": true,
+      "basis": "Product Face reviewer compares result to packet and reference quality bar.",
+      "block_when": [
+        "Generic dashboard visual quality appears.",
+        "Evidence hierarchy is unclear."
+      ]
+    },
+    "handoff_requirements": {
+      "required_before_implementation": ["reference research", "wireframe gate", "prototype gate", "design QA plan"],
+      "product_face_result_must_include": ["professional_design_process_ref", "professional_design_process_comparison.status=pass"]
+    }
   }
 }
 ```

--- a/examples/local-web-cockpit-factory-slice/card.md
+++ b/examples/local-web-cockpit-factory-slice/card.md
@@ -530,6 +530,183 @@
       "proof_required"
     ]
   },
+  "professional_design_process": {
+    "$schema": "https://overkill-factory.dev/schemas/professional-design-process.schema.json",
+    "record_type": "professional_design_process",
+    "surface_type": "local web operations cockpit",
+    "mode": "greenfield",
+    "design_brief": {
+      "user": "external open-source factory operator",
+      "job_to_be_done": "Supervise factory state, blockers, evidence and next safe action from local structured snapshots.",
+      "decision_surface": "Local web cockpit current-state view and selected snapshot inspector.",
+      "success_signal": "Operator can distinguish state, freshness, blockers, review status and next action without private context.",
+      "failure_risks": [
+        "The UI looks like a generic generated dashboard instead of an operations cockpit.",
+        "The UI blurs request, approval, done, release, stale and blocked states."
+      ]
+    },
+    "task_map": [
+      {
+        "task_id": "T1",
+        "user_goal": "Understand the current projection.",
+        "trigger": "Operator opens the local cockpit.",
+        "success_signal": "Current state, source kind, freshness and risk are visible in one scan.",
+        "failure_state": "Decorative metrics imply success without evidence."
+      },
+      {
+        "task_id": "T2",
+        "user_goal": "Find and inspect blockers.",
+        "trigger": "A gate, review or evidence dependency is blocked.",
+        "success_signal": "Blocker owner, unblock condition and source refs are visible in the inspector.",
+        "failure_state": "The operator must read raw JSON or infer blockers from generic cards."
+      },
+      {
+        "task_id": "T3",
+        "user_goal": "Verify whether the surface is safe to trust.",
+        "trigger": "Product Face review evaluates the cockpit.",
+        "success_signal": "Screenshots, states, evidence refs and visual quality verdict compare against this process.",
+        "failure_state": "Mechanical browser proof passes while visual/product quality is unacceptable."
+      }
+    ],
+    "reference_research": {
+      "registry_refs": [
+        "templates/reference-source-registry.json#21st-dev",
+        "templates/reference-source-registry.json#refero-styles",
+        "templates/reference-source-registry.json#motionsites"
+      ],
+      "selection_rationale": "Use professional product-tool and component references to define compact state-first hierarchy, not to copy assets or brand.",
+      "sources": [
+        {
+          "source_id": "radix-ui-themes",
+          "source_url_or_ref": "https://www.radix-ui.com/themes",
+          "use_type": "token-and-accessibility-reference",
+          "what_to_learn": ["semantic color tokens", "accessible component primitives"],
+          "extracted_patterns": [
+            "Use semantic state colors rather than a one-note decorative palette.",
+            "Keep controls compact and named by function."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no code or assets copied."
+        },
+        {
+          "source_id": "shadcn-data-table",
+          "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
+          "use_type": "dense-data-interaction-reference",
+          "what_to_learn": ["filtering and sorting patterns", "row action ergonomics"],
+          "extracted_patterns": [
+            "Dense operational views need search, filters and stable row focus.",
+            "Detail inspection should stay adjacent to the selected row context."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no code or assets copied."
+        },
+        {
+          "source_id": "linear-product-workflow",
+          "source_url_or_ref": "https://linear.app",
+          "use_type": "product-workflow-reference",
+          "what_to_learn": ["state-first product work navigation", "low-friction worklist scanning"],
+          "extracted_patterns": [
+            "Work status, owner and next action should be visible without a marketing hero.",
+            "Focused work lists should be fast to scan and keep hierarchy quiet."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no code or assets copied."
+        }
+      ]
+    },
+    "ux_architecture": {
+      "information_hierarchy": [
+        "source and freshness",
+        "current state",
+        "blockers and gates",
+        "next safe action",
+        "evidence refs",
+        "timeline"
+      ],
+      "navigation_model": "Local app shell with command strip, state rail, searchable snapshot list, selected snapshot inspector and product face panel.",
+      "state_model": [
+        "loading",
+        "empty",
+        "success",
+        "error",
+        "blocked",
+        "stale",
+        "contradictory",
+        "private_unavailable"
+      ],
+      "density_rationale": "This is a repeated-use operator tool, so dense state-first layout is required; hero or decorative dashboard layout is blocked."
+    },
+    "wireframe_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": ["examples/local-web-cockpit-factory-slice/card.md#professional_design_process"],
+      "basis": "The wireframe model separates state rail, work queue and inspector before visual styling."
+    },
+    "visual_direction": {
+      "typography": "Compact system UI scale; no hero type inside the tool.",
+      "spacing": "Stable rows, toolbar and inspector spacing with no layout shift on state changes.",
+      "color_semantics": "Neutral app base with separate semantic colors for pass, warn, blocked, fail, stale and private-unavailable states.",
+      "component_model": "Segmented controls, search, state rail, row list, inspector, evidence chips and timeline rows.",
+      "anti_generic_commitments": [
+        "No decorative KPI cards detached from factory objects.",
+        "No generic dashboard visuals or fake charts.",
+        "No excessive explanatory copy where structure should carry meaning."
+      ]
+    },
+    "prototype_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": ["examples/local-web-cockpit-factory-slice/card.md#product_face_packet"],
+      "basis": "The prototype scope covers the required state matrix and the FX18 visual-quality-failure case.",
+      "real_data_states": [
+        "success current snapshot",
+        "blocked gate",
+        "stale snapshot",
+        "contradictory state",
+        "private evidence unavailable",
+        "mechanical pass but visual quality fail"
+      ]
+    },
+    "design_qa_plan": {
+      "viewports": ["desktop 1440x900", "laptop 1280x800", "mobile 390x844"],
+      "accessibility_checks": ["keyboard focus names", "semantic headings", "contrast", "aria-live load/error states"],
+      "performance_checks": ["local JSON render remains responsive", "no remote fetch", "no heavy decorative effects"],
+      "screenshot_requirements": ["desktop current state", "mobile current state", "blocked state"],
+      "console_check_required": true,
+      "overlap_check_required": true
+    },
+    "comparative_review_gate": {
+      "status": "PASS",
+      "reviewer_role": "product-face",
+      "must_compare_to_reference_packet": true,
+      "basis": "The cockpit must compare against the reference quality packet and block generic AI-dashboard symptoms.",
+      "block_when": [
+        "The result resembles a generic dashboard.",
+        "State, source and next safe action are not first-class.",
+        "Reference research does not affect layout, hierarchy, controls or state treatment."
+      ]
+    },
+    "handoff_requirements": {
+      "required_before_implementation": [
+        "design brief",
+        "task map",
+        "reference research",
+        "UX architecture",
+        "wireframe gate",
+        "visual direction",
+        "prototype gate",
+        "design QA plan",
+        "comparative review gate"
+      ],
+      "product_face_result_must_include": [
+        "professional_design_process_ref",
+        "professional_design_process_comparison.status=pass"
+      ]
+    }
+  },
   "software_development_plan": {
     "$schema": "https://overkill-factory.dev/schemas/software-development-plan.schema.json",
     "work_units": [

--- a/examples/minimal-hermes-project/card.md
+++ b/examples/minimal-hermes-project/card.md
@@ -196,6 +196,187 @@
       "mobile screenshot",
       "state matrix"
     ]
+  },
+  "professional_design_process": {
+    "record_type": "professional_design_process",
+    "surface_type": "web_app",
+    "mode": "greenfield",
+    "design_brief": {
+      "user": "External operator trying the public minimal factory example.",
+      "job_to_be_done": "Understand whether a tiny Product Face/Receipt Five run is ready, blocked, or still missing evidence.",
+      "decision_surface": "Receipt status screen for the minimal local example.",
+      "success_signal": "A first-time operator can see state, missing evidence, and next safe action without private context.",
+      "failure_risks": [
+        "The example looks like a generic dashboard rather than a receipt/status walkthrough.",
+        "The UI implies completion before Product Face evidence and Receipt Five exist."
+      ]
+    },
+    "task_map": [
+      {
+        "task_id": "T1",
+        "user_goal": "Confirm the current example state.",
+        "trigger": "Operator opens the minimal receipt/status surface.",
+        "success_signal": "State, source paper, and evidence requirement are visible immediately.",
+        "failure_state": "The operator confuses a generated packet with completed evidence."
+      },
+      {
+        "task_id": "T2",
+        "user_goal": "Find the next safe action.",
+        "trigger": "Receipt Five or Product Face proof is missing.",
+        "success_signal": "The surface points to the exact missing proof without suggesting release.",
+        "failure_state": "The UI offers a vague continue action or hides the blocker."
+      },
+      {
+        "task_id": "T3",
+        "user_goal": "Review whether the visual result fits the example.",
+        "trigger": "Product Face validation runs before done.",
+        "success_signal": "Reviewer compares screenshots, state coverage, and receipt clarity to the design packet.",
+        "failure_state": "Browser checks pass while the example still looks template-like or misleading."
+      }
+    ],
+    "reference_research": {
+      "registry_refs": [
+        "templates/reference-source-registry.json#21st-dev",
+        "templates/reference-source-registry.json#refero-styles"
+      ],
+      "selection_rationale": "Use public component and product-tool references for structure and density only; no copied code, copy, or assets.",
+      "sources": [
+        {
+          "source_id": "radix-ui-themes",
+          "source_url_or_ref": "https://www.radix-ui.com/themes",
+          "use_type": "accessibility-and-token-reference",
+          "what_to_learn": [
+            "Accessible primitive behavior",
+            "Neutral token systems for dense tools"
+          ],
+          "extracted_patterns": [
+            "Use semantic state colors instead of decorative gradients.",
+            "Keep controls compact and predictable."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text, or assets copied."
+        },
+        {
+          "source_id": "shadcn-data-table",
+          "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
+          "use_type": "structured-status-reference",
+          "what_to_learn": [
+            "Dense rows for inspectable operational data",
+            "Search and filtering close to the data they affect"
+          ],
+          "extracted_patterns": [
+            "Use rows and status chips when the user needs comparison.",
+            "Avoid large isolated metric cards for small operational examples."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text, or assets copied."
+        },
+        {
+          "source_id": "linear-product-workflow",
+          "source_url_or_ref": "https://linear.app",
+          "use_type": "workflow-state-reference",
+          "what_to_learn": [
+            "Fast state scanning",
+            "Clear distinction between issue status, owner, and next action"
+          ],
+          "extracted_patterns": [
+            "Operational tools should be state-first and compact.",
+            "Important blockers should be visible without a hero section."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text, or assets copied."
+        }
+      ]
+    },
+    "ux_architecture": {
+      "information_hierarchy": [
+        "example state",
+        "missing Product Face or Receipt Five evidence",
+        "next safe action",
+        "source and validation refs",
+        "review status"
+      ],
+      "navigation_model": "Single local status view with state summary, evidence checklist, and receipt detail.",
+      "state_model": [
+        "loading",
+        "empty",
+        "success",
+        "blocked",
+        "error"
+      ],
+      "density_rationale": "Keep the minimal example compact so first-run users see the factory rule without navigating a large dashboard."
+    },
+    "wireframe_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": [
+        "examples/minimal-hermes-project/expected-flow.md"
+      ],
+      "basis": "The public example flow separates generated packets, evidence requirements, and completion status before implementation."
+    },
+    "visual_direction": {
+      "typography": "Compact system UI with clear status labels and no hero-scale display type.",
+      "spacing": "Small, stable status rows and checklist spacing.",
+      "color_semantics": "Neutral base with distinct blocked, success, and warning states.",
+      "component_model": "Status summary, evidence checklist, receipt details, and validation command list.",
+      "anti_generic_commitments": [
+        "No decorative KPI dashboard for a tiny receipt example.",
+        "No generic AI-product wording in place of exact evidence state.",
+        "No completion styling while required proof is missing."
+      ]
+    },
+    "prototype_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": [
+        "examples/minimal-hermes-project/expected-flow.md"
+      ],
+      "basis": "The prototype path covers ready, blocked, and missing-evidence states before Product Face proof.",
+      "real_data_states": [
+        "ready for worker execution",
+        "missing Product Face result",
+        "missing Receipt Five",
+        "blocked completion"
+      ]
+    },
+    "design_qa_plan": {
+      "viewports": [
+        "desktop 1440x900",
+        "mobile 390x844"
+      ],
+      "accessibility_checks": [
+        "keyboard focus names",
+        "semantic headings",
+        "contrast",
+        "clear evidence labels"
+      ],
+      "performance_checks": [
+        "local static render remains responsive",
+        "no remote fetch",
+        "no decorative payload"
+      ],
+      "screenshot_requirements": [
+        "desktop status view",
+        "mobile status view",
+        "blocked evidence state"
+      ],
+      "console_check_required": true,
+      "overlap_check_required": true
+    },
+    "comparative_review_gate": {
+      "status": "PASS",
+      "reviewer_role": "product-face",
+      "must_compare_to_reference_packet": true,
+      "basis": "The minimal Product Face reviewer must compare the surface against the design packet and block generic dashboard symptoms.",
+      "block_when": [
+        "The result hides receipt state or evidence requirements.",
+        "Reference research does not affect hierarchy, controls, or state treatment.",
+        "Mechanical screenshots pass while the surface remains generic or misleading."
+      ]
+    }
   }
 }
 ```

--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -80,6 +80,7 @@
     "human_gate_packet": { "type": "object" },
     "reasoning_policy": { "$ref": "reasoning-policy.schema.json" },
     "reference_quality_packet": { "$ref": "reference-quality-packet.schema.json" },
+    "professional_design_process": { "$ref": "professional-design-process.schema.json" },
     "r4_gate": { "type": "object" },
     "outcome_contract": { "type": "object" },
     "discovery_brief": { "type": "object" },

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -17,6 +17,8 @@
     "packet_comparison",
     "source_promise_coverage",
     "design_fit_review",
+    "professional_design_process_ref",
+    "professional_design_process_comparison",
     "visual_quality_result",
     "blocking_findings",
     "evidence_refs",
@@ -105,6 +107,18 @@
       "additionalProperties": true
     },
     "design_fit_review": {
+      "type": "object",
+      "required": ["status", "basis"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail", "pending"] },
+        "basis": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "professional_design_process_ref": {
+      "type": "string"
+    },
+    "professional_design_process_comparison": {
       "type": "object",
       "required": ["status", "basis"],
       "properties": {

--- a/schemas/professional-design-process.schema.json
+++ b/schemas/professional-design-process.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/professional-design-process.schema.json",
+  "title": "Overkill Factory Professional Design Process",
+  "type": "object",
+  "required": [
+    "record_type",
+    "surface_type",
+    "mode",
+    "design_brief",
+    "task_map",
+    "reference_research",
+    "ux_architecture",
+    "wireframe_gate",
+    "visual_direction",
+    "prototype_gate",
+    "design_qa_plan",
+    "comparative_review_gate",
+    "handoff_requirements"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/professional-design-process.schema.json"
+    },
+    "record_type": {
+      "const": "professional_design_process"
+    },
+    "surface_type": {
+      "type": "string",
+      "minLength": 3
+    },
+    "mode": {
+      "enum": ["greenfield", "redesign", "brownfield", "qa_only", "migration"]
+    },
+    "design_brief": {
+      "type": "object",
+      "required": ["user", "job_to_be_done", "decision_surface", "success_signal", "failure_risks"],
+      "properties": {
+        "user": { "type": "string", "minLength": 3 },
+        "job_to_be_done": { "type": "string", "minLength": 3 },
+        "decision_surface": { "type": "string", "minLength": 3 },
+        "success_signal": { "type": "string", "minLength": 3 },
+        "failure_risks": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "task_map": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["task_id", "user_goal", "trigger", "success_signal", "failure_state"],
+        "properties": {
+          "task_id": { "type": "string", "minLength": 1 },
+          "user_goal": { "type": "string", "minLength": 3 },
+          "trigger": { "type": "string", "minLength": 3 },
+          "success_signal": { "type": "string", "minLength": 3 },
+          "failure_state": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "reference_research": {
+      "type": "object",
+      "required": ["registry_refs", "selection_rationale", "sources"],
+      "properties": {
+        "registry_refs": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "selection_rationale": { "type": "string", "minLength": 3 },
+        "sources": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "source_id",
+              "source_url_or_ref",
+              "use_type",
+              "what_to_learn",
+              "extracted_patterns",
+              "copy_policy",
+              "license_or_terms_ref"
+            ],
+            "properties": {
+              "source_id": { "type": "string", "minLength": 1 },
+              "source_url_or_ref": { "type": "string", "minLength": 3 },
+              "use_type": { "type": "string", "minLength": 3 },
+              "what_to_learn": {
+                "type": "array",
+                "minItems": 2,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "extracted_patterns": {
+                "type": "array",
+                "minItems": 2,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "copy_policy": { "type": "string", "minLength": 3 },
+              "license_or_terms_ref": { "type": "string", "minLength": 3 },
+              "public_safety_notes": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "ux_architecture": {
+      "type": "object",
+      "required": ["information_hierarchy", "navigation_model", "state_model", "density_rationale"],
+      "properties": {
+        "information_hierarchy": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "navigation_model": { "type": "string", "minLength": 3 },
+        "state_model": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "density_rationale": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "wireframe_gate": {
+      "type": "object",
+      "required": ["status", "reviewer", "artifact_refs", "basis"],
+      "properties": {
+        "status": { "const": "PASS" },
+        "reviewer": { "type": "string", "minLength": 3 },
+        "artifact_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "basis": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "visual_direction": {
+      "type": "object",
+      "required": ["typography", "spacing", "color_semantics", "component_model", "anti_generic_commitments"],
+      "properties": {
+        "typography": { "type": "string", "minLength": 3 },
+        "spacing": { "type": "string", "minLength": 3 },
+        "color_semantics": { "type": "string", "minLength": 3 },
+        "component_model": { "type": "string", "minLength": 3 },
+        "anti_generic_commitments": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "prototype_gate": {
+      "type": "object",
+      "required": ["status", "reviewer", "artifact_refs", "basis", "real_data_states"],
+      "properties": {
+        "status": { "const": "PASS" },
+        "reviewer": { "type": "string", "minLength": 3 },
+        "artifact_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "basis": { "type": "string", "minLength": 3 },
+        "real_data_states": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "design_qa_plan": {
+      "type": "object",
+      "required": [
+        "viewports",
+        "accessibility_checks",
+        "performance_checks",
+        "screenshot_requirements",
+        "console_check_required",
+        "overlap_check_required"
+      ],
+      "properties": {
+        "viewports": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "accessibility_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "performance_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "screenshot_requirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "console_check_required": { "const": true },
+        "overlap_check_required": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "comparative_review_gate": {
+      "type": "object",
+      "required": ["status", "reviewer_role", "must_compare_to_reference_packet", "basis", "block_when"],
+      "properties": {
+        "status": { "const": "PASS" },
+        "reviewer_role": { "type": "string", "minLength": 3 },
+        "must_compare_to_reference_packet": { "const": true },
+        "basis": { "type": "string", "minLength": 3 },
+        "block_when": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "handoff_requirements": {
+      "type": "object",
+      "minProperties": 1
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/factory_completion_audit.py
+++ b/scripts/factory_completion_audit.py
@@ -269,7 +269,9 @@ def reusable_product_scope_is_valid(data: dict[str, Any], *, record_type: str | 
             return False
         if not str(data.get("packet_ref") or "").strip():
             return False
-        for field in ("packet_comparison", "source_promise_coverage", "design_fit_review"):
+        if not str(data.get("professional_design_process_ref") or "").strip():
+            return False
+        for field in ("packet_comparison", "source_promise_coverage", "design_fit_review", "professional_design_process_comparison"):
             value = data.get(field)
             if not isinstance(value, dict) or value.get("status") != "pass":
                 return False

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -354,6 +354,21 @@ REFERENCE_QUALITY_REQUIRED_FIELDS = (
     "performance_constraints",
     "acceptance_criteria",
 )
+PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS = (
+    "record_type",
+    "surface_type",
+    "mode",
+    "design_brief",
+    "task_map",
+    "reference_research",
+    "ux_architecture",
+    "wireframe_gate",
+    "visual_direction",
+    "prototype_gate",
+    "design_qa_plan",
+    "comparative_review_gate",
+    "handoff_requirements",
+)
 REASONING_POLICY_REQUIRED_FIELDS = (
     "record_type",
     "reasoning_class",
@@ -369,6 +384,7 @@ PRODUCT_FACE_RESULT_ALIGNMENT_FIELDS = (
     "packet_comparison",
     "source_promise_coverage",
     "design_fit_review",
+    "professional_design_process_comparison",
 )
 VISUAL_QUALITY_ALLOWED_RESULTS = {"PASS", "PASS_WITH_RESIDUALS", "BLOCK"}
 
@@ -418,12 +434,12 @@ WORKERS: dict[str, WorkerDefinition] = {
         factory_phase="F5/F13",
         output_field="product_face_result",
         tool_required="browser screenshot/a11y/mobile validation runner",
-        timing="after product_face_packet and before product-facing done",
+        timing="after product_face_packet and professional_design_process, before product-facing done",
         blocking_policy=(
             "Frontend, UX, mobile, wallet UI, or visible product work cannot be "
             "declared complete without screen/state/mobile/a11y evidence."
         ),
-        required_inputs=("product_face_packet", "target_repo_paths", "acceptance_criteria"),
+        required_inputs=("product_face_packet", "professional_design_process", "target_repo_paths", "acceptance_criteria"),
     ),
     "independent-reviewer": WorkerDefinition(
         worker_id="independent-reviewer",
@@ -552,7 +568,7 @@ WORKERS: dict[str, WorkerDefinition] = {
         tool_required="frontend runtime, browser, component tests and visual proof handoff",
         timing="during scoped visible-product implementation, before Product Face validation",
         blocking_policy="Frontend work cannot be treated as generic code when visible product surfaces are in scope.",
-        required_inputs=("product_face_packet", "scope_in", "scope_out", "done_definition"),
+        required_inputs=("product_face_packet", "professional_design_process", "scope_in", "scope_out", "done_definition"),
     ),
     "backend-api-builder": WorkerDefinition(
         worker_id="backend-api-builder",
@@ -2142,6 +2158,114 @@ def validate_reference_quality_packet(packet: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS:
+        value = process.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"professional_design_process.{field} must be a non-empty array")
+        elif isinstance(value, dict):
+            if not value:
+                errors.append(f"professional_design_process.{field} must be a non-empty object")
+        elif not _non_empty_text(value):
+            errors.append(f"professional_design_process.{field} is required")
+
+    if process.get("record_type") not in (None, "professional_design_process"):
+        errors.append("professional_design_process.record_type must be professional_design_process")
+
+    brief = process.get("design_brief") if isinstance(process.get("design_brief"), dict) else {}
+    for field in ("user", "job_to_be_done", "decision_surface", "success_signal"):
+        if not _non_empty_text(brief.get(field)):
+            errors.append(f"professional_design_process.design_brief.{field} is required")
+    if len(_list_items(brief.get("failure_risks"))) < 2:
+        errors.append("professional_design_process.design_brief.failure_risks requires at least 2 risks")
+
+    tasks = process.get("task_map") if isinstance(process.get("task_map"), list) else []
+    if len(tasks) < 3:
+        errors.append("professional_design_process.task_map requires at least 3 user/system tasks")
+    for index, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            errors.append(f"professional_design_process.task_map[{index}] must be an object")
+            continue
+        for field in ("task_id", "user_goal", "trigger", "success_signal", "failure_state"):
+            if not _non_empty_text(task.get(field)):
+                errors.append(f"professional_design_process.task_map[{index}].{field} is required")
+
+    research = process.get("reference_research") if isinstance(process.get("reference_research"), dict) else {}
+    sources = research.get("sources") if isinstance(research.get("sources"), list) else []
+    if len(sources) < 3:
+        errors.append("professional_design_process.reference_research.sources requires at least 3 sources")
+    if len(_list_items(research.get("registry_refs"))) < 2:
+        errors.append("professional_design_process.reference_research.registry_refs requires at least 2 registry refs")
+    if not _non_empty_text(research.get("selection_rationale")):
+        errors.append("professional_design_process.reference_research.selection_rationale is required")
+    for index, source in enumerate(sources):
+        if not isinstance(source, dict):
+            errors.append(f"professional_design_process.reference_research.sources[{index}] must be an object")
+            continue
+        for field in ("source_id", "source_url_or_ref", "use_type", "copy_policy", "license_or_terms_ref"):
+            if not _non_empty_text(source.get(field)):
+                errors.append(f"professional_design_process.reference_research.sources[{index}].{field} is required")
+        if len(_list_items(source.get("what_to_learn"))) < 2:
+            errors.append(f"professional_design_process.reference_research.sources[{index}].what_to_learn requires at least 2 items")
+        if len(_list_items(source.get("extracted_patterns"))) < 2:
+            errors.append(f"professional_design_process.reference_research.sources[{index}].extracted_patterns requires at least 2 items")
+        if str(source.get("copy_policy") or "").strip().lower() in {"copy", "blind_copy"}:
+            errors.append(f"professional_design_process.reference_research.sources[{index}].copy_policy must not allow blind copying")
+
+    architecture = process.get("ux_architecture") if isinstance(process.get("ux_architecture"), dict) else {}
+    for field in ("information_hierarchy", "navigation_model", "state_model", "density_rationale"):
+        value = architecture.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"professional_design_process.ux_architecture.{field} must be a non-empty array")
+        elif not _non_empty_text(value):
+            errors.append(f"professional_design_process.ux_architecture.{field} is required")
+
+    for field in ("wireframe_gate", "prototype_gate"):
+        gate = process.get(field) if isinstance(process.get(field), dict) else {}
+        if gate.get("status") != "PASS":
+            errors.append(f"professional_design_process.{field}.status must be PASS before product-facing implementation")
+        if not _non_empty_text(gate.get("reviewer")):
+            errors.append(f"professional_design_process.{field}.reviewer is required")
+        if not _list_items(gate.get("artifact_refs")):
+            errors.append(f"professional_design_process.{field}.artifact_refs must be a non-empty array")
+        if not _non_empty_text(gate.get("basis")):
+            errors.append(f"professional_design_process.{field}.basis is required")
+
+    visual_direction = process.get("visual_direction") if isinstance(process.get("visual_direction"), dict) else {}
+    for field in ("typography", "spacing", "color_semantics", "component_model", "anti_generic_commitments"):
+        value = visual_direction.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"professional_design_process.visual_direction.{field} must be a non-empty array")
+        elif not _non_empty_text(value):
+            errors.append(f"professional_design_process.visual_direction.{field} is required")
+
+    qa_plan = process.get("design_qa_plan") if isinstance(process.get("design_qa_plan"), dict) else {}
+    for field in ("viewports", "accessibility_checks", "performance_checks", "screenshot_requirements"):
+        if not _list_items(qa_plan.get(field)):
+            errors.append(f"professional_design_process.design_qa_plan.{field} must be a non-empty array")
+    for field in ("console_check_required", "overlap_check_required"):
+        if qa_plan.get(field) is not True:
+            errors.append(f"professional_design_process.design_qa_plan.{field} must be true")
+
+    comparative = process.get("comparative_review_gate") if isinstance(process.get("comparative_review_gate"), dict) else {}
+    if comparative.get("status") != "PASS":
+        errors.append("professional_design_process.comparative_review_gate.status must be PASS")
+    if comparative.get("must_compare_to_reference_packet") is not True:
+        errors.append("professional_design_process.comparative_review_gate.must_compare_to_reference_packet must be true")
+    if not _non_empty_text(comparative.get("reviewer_role")):
+        errors.append("professional_design_process.comparative_review_gate.reviewer_role is required")
+    if not _non_empty_text(comparative.get("basis")):
+        errors.append("professional_design_process.comparative_review_gate.basis is required")
+    if not _list_items(comparative.get("block_when")):
+        errors.append("professional_design_process.comparative_review_gate.block_when must be a non-empty array")
+
+    return errors
+
+
 def validate_reasoning_policy(policy: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     for field in REASONING_POLICY_REQUIRED_FIELDS:
@@ -2285,6 +2409,10 @@ def validate_card(data: dict[str, Any]) -> list[str]:
                     errors.append("product_experience_plan.reference_quality_waiver requires owner and reason")
             else:
                 errors.extend(validate_reference_quality_packet(data["reference_quality_packet"]))
+            if not isinstance(data.get("professional_design_process"), dict):
+                errors.append("professional_design_process required for vFinal product-facing surfaces")
+            else:
+                errors.extend(validate_professional_design_process(data["professional_design_process"]))
     phase = str(data.get("phase", "")).upper()
     if surfaces & PRODUCT_FACE_SURFACES and phase in {"F11", "F16", "F17"}:
         if not isinstance(data.get("product_face_result"), dict) and not str(data.get("product_face_result_ref") or "").strip():
@@ -2368,6 +2496,16 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
             errors.append("product_face_result PASS requires visual_quality_result.status PASS or PASS_WITH_RESIDUALS")
         if is_pass and visual_status == "PASS_WITH_RESIDUALS" and not _list_items(visual_quality.get("residuals")):
             errors.append("product_face_result PASS_WITH_RESIDUALS requires residuals")
+    professional_comparison = result.get("professional_design_process_comparison")
+    if is_pass:
+        if not _non_empty_text(result.get("professional_design_process_ref")):
+            errors.append("product_face_result.professional_design_process_ref is required for PASS")
+        if not isinstance(professional_comparison, dict) or not professional_comparison:
+            errors.append("product_face_result.professional_design_process_comparison is required for PASS")
+        elif _status_value(professional_comparison) != "pass":
+            errors.append("product_face_result.professional_design_process_comparison.status must be pass")
+        elif not _non_empty_text(professional_comparison.get("basis")):
+            errors.append("product_face_result.professional_design_process_comparison.basis is required")
     return errors
 
 
@@ -2419,6 +2557,9 @@ def validate_product_face_result_against_card(result: dict[str, Any], card: dict
     packet_ref = str(result.get("packet_ref") or "").strip()
     if strict_product_experience_required(card) and not packet_ref:
         errors.append("product_face_result.packet_ref is required for vFinal product-facing completion")
+    professional_ref = str(result.get("professional_design_process_ref") or "").strip()
+    if strict_product_experience_required(card) and not professional_ref:
+        errors.append("product_face_result.professional_design_process_ref is required for vFinal product-facing completion")
 
     return errors
 
@@ -3085,6 +3226,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "parallel_lane_contracts": lane_contracts,
             "reasoning_policy": card.get("reasoning_policy"),
             "reference_quality_packet": card.get("reference_quality_packet"),
+            "professional_design_process": card.get("professional_design_process"),
             "learning_proposal_refs": card.get("learning_proposal_refs", []),
             "canonical_product_sot_ref": card.get("canonical_product_sot_ref") or "card.product_sot",
             "product_creation_plan_ref": card.get("product_creation_plan_ref")
@@ -3883,6 +4025,11 @@ def build_worker_result(
                 "design_fit_review": {
                     "status": "pass" if not blocking_findings else "fail",
                     "basis": "Design fit reviewed by Product Face validator for this bounded card.",
+                },
+                "professional_design_process_ref": "card.professional_design_process",
+                "professional_design_process_comparison": {
+                    "status": "pass" if not blocking_findings else "fail",
+                    "basis": "Product Face evidence is explicitly compared to the professional design process.",
                 },
                 "visual_quality_result": {
                     "status": "PASS" if not blocking_findings else "BLOCK",

--- a/scripts/full_product_worker_graph.py
+++ b/scripts/full_product_worker_graph.py
@@ -234,7 +234,8 @@ def build_graph() -> dict[str, Any]:
         "policy_decision": (
             "This proves product-specific worker-graph reconciliation for the public QVG validation product, "
             "including reusable Quasar Auditor and CU/SVM/economic lanes. The Product Face lane is not reusable until "
-            "packet comparison, source-promise coverage and design-fit review are recorded as pass."
+            "packet comparison, source-promise coverage, design-fit review and professional-design-process comparison "
+            "are recorded as pass."
         ),
         "next_action": "Add managed remote proof, product-specific release/human evidence and a fully reusable graph before practical 10/10 completion.",
     }

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -26,6 +26,7 @@ PRODUCT_ALIGNMENT_FIELDS = (
     "packet_comparison",
     "source_promise_coverage",
     "design_fit_review",
+    "professional_design_process_comparison",
 )
 VISUAL_QUALITY_PASS_RESULTS = {"PASS", "PASS_WITH_RESIDUALS"}
 
@@ -350,6 +351,11 @@ def base_result(
             "status": "pending",
             "basis": "Visual/product-fit review must be recorded by Product Face reviewer before promotion.",
         },
+        "professional_design_process_ref": "",
+        "professional_design_process_comparison": {
+            "status": "pending",
+            "basis": "Product Face proof must compare the result against the professional design process before promotion.",
+        },
         "visual_quality_result": {
             "status": "BLOCK",
             "reviewer": "product-face-proof-runner",
@@ -390,7 +396,8 @@ def validate_reusable_product_scope(
     if not product_alignment_passes(result):
         raise ValueError(
             "--reusable-for-product requires Product Face alignment: packet_ref, "
-            "packet_comparison=pass, source_promise_coverage=pass and design_fit_review=pass"
+            "packet_comparison=pass, source_promise_coverage=pass, design_fit_review=pass and "
+            "professional_design_process_comparison=pass"
         )
     visual_quality = result.get("visual_quality_result") if isinstance(result.get("visual_quality_result"), dict) else {}
     if visual_quality.get("status") not in VISUAL_QUALITY_PASS_RESULTS or visual_quality.get("reference_quality_bar_checked") is not True:
@@ -433,12 +440,16 @@ def apply_product_alignment(
     packet_comparison_basis: str | None,
     source_promise_coverage_basis: str | None,
     design_fit_review_basis: str | None,
+    professional_design_process_ref: str | None,
+    professional_design_process_comparison_basis: str | None,
 ) -> None:
     values = {
         "packet_ref": packet_ref,
         "packet_comparison": packet_comparison_basis,
         "source_promise_coverage": source_promise_coverage_basis,
         "design_fit_review": design_fit_review_basis,
+        "professional_design_process_ref": professional_design_process_ref,
+        "professional_design_process_comparison": professional_design_process_comparison_basis,
     }
     supplied = {field for field, value in values.items() if str(value or "").strip()}
     if not supplied:
@@ -458,6 +469,11 @@ def apply_product_alignment(
     result["design_fit_review"] = {
         "status": "pass",
         "basis": str(design_fit_review_basis).strip(),
+    }
+    result["professional_design_process_ref"] = str(professional_design_process_ref).strip()
+    result["professional_design_process_comparison"] = {
+        "status": "pass",
+        "basis": str(professional_design_process_comparison_basis).strip(),
     }
 
 
@@ -820,6 +836,8 @@ def build_product_face_proof(
     packet_comparison_basis: str | None = None,
     source_promise_coverage_basis: str | None = None,
     design_fit_review_basis: str | None = None,
+    professional_design_process_ref: str | None = None,
+    professional_design_process_comparison_basis: str | None = None,
     visual_quality_status: str | None = None,
     visual_quality_reviewer: str | None = None,
     visual_quality_basis: str | None = None,
@@ -882,6 +900,8 @@ def build_product_face_proof(
         packet_comparison_basis=packet_comparison_basis,
         source_promise_coverage_basis=source_promise_coverage_basis,
         design_fit_review_basis=design_fit_review_basis,
+        professional_design_process_ref=professional_design_process_ref,
+        professional_design_process_comparison_basis=professional_design_process_comparison_basis,
     )
     apply_visual_quality_review(
         result=result,
@@ -931,6 +951,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--packet-comparison-basis", help="Why this proof matches the Product Face Packet.")
     parser.add_argument("--source-promise-coverage-basis", help="Why this proof covers the source/product promise.")
     parser.add_argument("--design-fit-review-basis", help="Why this proof fits the intended product/design direction.")
+    parser.add_argument("--professional-design-process-ref", help="Professional Design Process packet used for Product Face approval.")
+    parser.add_argument("--professional-design-process-comparison-basis", help="Why this proof satisfies the professional design process.")
     parser.add_argument("--visual-quality-status", choices=["PASS", "BLOCK", "PASS_WITH_RESIDUALS"], help="Professional visual quality verdict.")
     parser.add_argument("--visual-quality-reviewer", help="Reviewer empowered to block visually unacceptable UI.")
     parser.add_argument("--visual-quality-basis", help="Why the surface meets or fails the product-specific quality bar.")
@@ -960,6 +982,8 @@ def main(argv: list[str] | None = None) -> int:
             packet_comparison_basis=args.packet_comparison_basis,
             source_promise_coverage_basis=args.source_promise_coverage_basis,
             design_fit_review_basis=args.design_fit_review_basis,
+            professional_design_process_ref=args.professional_design_process_ref,
+            professional_design_process_comparison_basis=args.professional_design_process_comparison_basis,
             visual_quality_status=args.visual_quality_status,
             visual_quality_reviewer=args.visual_quality_reviewer,
             visual_quality_basis=args.visual_quality_basis,

--- a/scripts/production_full_product_worker_graph.py
+++ b/scripts/production_full_product_worker_graph.py
@@ -155,12 +155,14 @@ def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
         if lane.get("reusable_policy") == "strict" and data.get("reusable_for_product") is not True:
             errors.append("strict lane must be reusable_for_product=true")
         if lane.get("record_type") == "product_face_result" and lane.get("reusable_policy") == "strict":
-            for field in ("packet_comparison", "source_promise_coverage", "design_fit_review"):
+            for field in ("packet_comparison", "source_promise_coverage", "design_fit_review", "professional_design_process_comparison"):
                 value = data.get(field)
                 if not isinstance(value, dict) or value.get("status") != "pass":
                     errors.append(f"strict Product Face lane requires {field}.status=pass")
             if not str(data.get("packet_ref") or "").strip():
                 errors.append("strict Product Face lane requires packet_ref")
+            if not str(data.get("professional_design_process_ref") or "").strip():
+                errors.append("strict Product Face lane requires professional_design_process_ref")
         target = data.get("product_target")
         if lane.get("reusable_policy") == "strict":
             if not isinstance(target, dict):

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -38,6 +38,7 @@ PRODUCT_FACE_ALIGNMENT_FIELDS = (
     "packet_comparison",
     "source_promise_coverage",
     "design_fit_review",
+    "professional_design_process_comparison",
 )
 PRIVATE_USERS_PATH = "C:" + r"[\\/]+" + "Users"
 PRIVATE_SYNC_ROOT = "One" + "Drive"
@@ -182,10 +183,30 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
     if data.get("record_type") == "product_face_result" and data.get("reusable_for_product") is True:
         if not str(data.get("packet_ref") or "").strip():
             errors.append(f"{at}: reusable product_face_result requires packet_ref")
+        if not str(data.get("professional_design_process_ref") or "").strip():
+            errors.append(f"{at}: reusable product_face_result requires professional_design_process_ref")
         for field in PRODUCT_FACE_ALIGNMENT_FIELDS:
             value = data.get(field)
             if not isinstance(value, dict) or value.get("status") != "pass":
                 errors.append(f"{at}: reusable product_face_result requires {field}.status=pass")
+    if data.get("record_type") == "professional_design_process":
+        research = data.get("reference_research") if isinstance(data.get("reference_research"), dict) else {}
+        sources = research.get("sources") if isinstance(research.get("sources"), list) else []
+        if len(sources) < 3:
+            errors.append(f"{at}: professional_design_process requires at least 3 reference sources")
+        for index, source in enumerate(sources):
+            if not isinstance(source, dict):
+                errors.append(f"{at}.reference_research.sources[{index}]: expected object")
+                continue
+            if len(source.get("extracted_patterns") or []) < 2:
+                errors.append(f"{at}.reference_research.sources[{index}]: requires at least 2 extracted_patterns")
+            copy_policy = str(source.get("copy_policy") or "").lower()
+            if copy_policy in {"copy", "blind_copy"}:
+                errors.append(f"{at}.reference_research.sources[{index}]: copy_policy must not allow blind copying")
+        for gate_name in ("wireframe_gate", "prototype_gate", "comparative_review_gate"):
+            gate = data.get(gate_name) if isinstance(data.get(gate_name), dict) else {}
+            if gate.get("status") != "PASS":
+                errors.append(f"{at}: professional_design_process {gate_name}.status must be PASS")
     if data.get("record_type") == "factory_learning_proposal":
         serialized_refs = "\n".join(str(ref) for ref in data.get("source_evidence_refs", []))
         if PRIVATE_MARKERS.search(serialized_refs):

--- a/templates/product-experience-plan.json
+++ b/templates/product-experience-plan.json
@@ -48,7 +48,9 @@
   ],
   "done_definition": [
     "Product Face Packet exists before implementation",
+    "Professional Design Process exists before implementation",
     "Product Face Result compares screenshots/states/flows against the packet",
+    "Product Face Result compares screenshots/states/flows against the professional design process",
     "review confirms evidence matches the original product promise",
     "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"
   ],
@@ -58,6 +60,7 @@
     "reason": "Set required=true when visual/product direction is not already approved or affects external user promise."
   },
   "prototype_decision": "prototype_not_required because flow is known; update when uncertainty exists",
+  "professional_design_process_ref": "templates/professional-design-process.json",
   "device_or_viewport_scope": [
     "desktop 1440x900",
     "mobile 390x844 when mobile is in scope"

--- a/templates/product-face-packet.json
+++ b/templates/product-face-packet.json
@@ -47,11 +47,13 @@
     "mobile 390x844 when mobile is in scope"
   ],
   "prototype_needed": "no",
+  "professional_design_process_ref": "templates/professional-design-process.json",
   "proof_required": [
     "desktop screenshot",
     "mobile screenshot when mobile is in scope",
     "states evidence",
     "Product Face Result comparison to packet",
+    "Product Face Result comparison to professional_design_process",
     "visual_quality_result verdict"
   ],
   "reviewers_required": [
@@ -63,6 +65,7 @@
     "result covers required flows and states",
     "result includes evidence for required viewports",
     "review confirms result fits the product promise and visual direction",
+    "review confirms result satisfies the professional_design_process",
     "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"
   ],
   "human_gate": {

--- a/templates/professional-design-process.json
+++ b/templates/professional-design-process.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/professional-design-process.schema.json",
+  "record_type": "professional_design_process",
+  "surface_type": "web_app",
+  "mode": "greenfield",
+  "design_brief": {
+    "user": "Primary operator or product user for this surface.",
+    "job_to_be_done": "Complete the surface's main product job with clear state, evidence and next action.",
+    "decision_surface": "The screen or flow where the user makes the important product decision.",
+    "success_signal": "A reviewer can explain the surface hierarchy, state, action and evidence without private context.",
+    "failure_risks": [
+      "The surface looks like a generic AI dashboard instead of the product being built.",
+      "The surface hides blockers, stale state or evidence gaps behind successful-looking cards."
+    ]
+  },
+  "task_map": [
+    {
+      "task_id": "T1",
+      "user_goal": "Understand the current state.",
+      "trigger": "User opens the product surface.",
+      "success_signal": "Current state, source and freshness are visible without scanning decorative text.",
+      "failure_state": "The UI implies progress or success without durable evidence."
+    },
+    {
+      "task_id": "T2",
+      "user_goal": "Find the next safe action.",
+      "trigger": "User sees a blocked, stale or contradictory state.",
+      "success_signal": "The next action is specific, bounded and tied to a source ref.",
+      "failure_state": "The user sees a vague CTA or an unsafe action."
+    },
+    {
+      "task_id": "T3",
+      "user_goal": "Verify the visual result against the promised product job.",
+      "trigger": "Product Face review runs before done or release.",
+      "success_signal": "Reviewer compares screenshots, states and flows to the reference bar.",
+      "failure_state": "Mechanical browser proof passes but the surface still looks generic or audience-mismatched."
+    }
+  ],
+  "reference_research": {
+    "registry_refs": [
+      "templates/reference-source-registry.json#21st-dev",
+      "templates/reference-source-registry.json#refero-styles",
+      "templates/reference-source-registry.json#motionsites"
+    ],
+    "selection_rationale": "Use component/reference libraries for interaction and visual craft, but copy no code or assets without license review.",
+    "sources": [
+      {
+        "source_id": "radix-ui-themes",
+        "source_url_or_ref": "https://www.radix-ui.com/themes",
+        "use_type": "accessibility-and-token-system-reference",
+        "what_to_learn": [
+          "Accessible primitives and design tokens",
+          "Light/dark color scales and component density"
+        ],
+        "extracted_patterns": [
+          "Use semantic color roles instead of one-note decorative palettes.",
+          "Prefer small composable controls over oversized explanatory blocks."
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no source code, text or assets copied."
+      },
+      {
+        "source_id": "shadcn-data-table",
+        "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
+        "use_type": "structured-data-interaction-reference",
+        "what_to_learn": [
+          "Filtering, sorting and row actions for dense operational data",
+          "Reusable table composition without inventing custom controls"
+        ],
+        "extracted_patterns": [
+          "Dense data surfaces need search, filter, sort and row focus states.",
+          "Controls should stay close to the data they affect."
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no source code, text or assets copied."
+      },
+      {
+        "source_id": "linear-product-workflow",
+        "source_url_or_ref": "https://linear.app",
+        "use_type": "product-workflow-and-state-reference",
+        "what_to_learn": [
+          "Fast product work navigation",
+          "Clear distinction between issue state, owner, priority and next action"
+        ],
+        "extracted_patterns": [
+          "Operational product tools should be compact, scannable and state-first.",
+          "Primary work context should be visible without a marketing-style hero."
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no source code, text or assets copied."
+      }
+    ]
+  },
+  "ux_architecture": {
+    "information_hierarchy": [
+      "source and freshness",
+      "current state and blocker",
+      "next safe action",
+      "evidence and review status",
+      "detail drill-down"
+    ],
+    "navigation_model": "App-shell view with compact command bar, state lane, focused work list and detail inspector.",
+    "state_model": [
+      "loading",
+      "empty",
+      "success",
+      "error",
+      "blocked",
+      "stale",
+      "private_unavailable",
+      "contradictory"
+    ],
+    "density_rationale": "Use dense, quiet, repeatable product-tool layout for operators instead of a landing page or generic analytics dashboard."
+  },
+  "wireframe_gate": {
+    "status": "PASS",
+    "reviewer": "product-face",
+    "artifact_refs": [
+      "templates/professional-design-process.json#ux_architecture"
+    ],
+    "basis": "Layout separates source, state, work queue and inspector before visual styling."
+  },
+  "visual_direction": {
+    "typography": "Compact system UI scale; no hero-scale type inside product tools.",
+    "spacing": "Tight app-shell spacing with stable row, toolbar and inspector dimensions.",
+    "color_semantics": "Neutral base with distinct semantic states for success, warning, blocked, error and private/unavailable.",
+    "component_model": "Toolbar, segmented state controls, searchable work list, lane rows, data list, inspector and evidence chips.",
+    "anti_generic_commitments": [
+      "No decorative KPI cards detached from factory objects.",
+      "No oversized hero section for an operational tool.",
+      "No vague AI-dashboard copy in place of state and evidence."
+    ]
+  },
+  "prototype_gate": {
+    "status": "PASS",
+    "reviewer": "product-face",
+    "artifact_refs": [
+      "templates/professional-design-process.json"
+    ],
+    "basis": "Prototype must cover real state categories and unhappy paths before implementation.",
+    "real_data_states": [
+      "long dense data",
+      "blocked gate",
+      "stale snapshot",
+      "private evidence unavailable",
+      "contradictory state"
+    ]
+  },
+  "design_qa_plan": {
+    "viewports": [
+      "desktop 1440x900",
+      "laptop 1280x800",
+      "mobile 390x844"
+    ],
+    "accessibility_checks": [
+      "keyboard focus names",
+      "semantic headings",
+      "contrast",
+      "aria-live load and error states"
+    ],
+    "performance_checks": [
+      "local JSON render remains responsive",
+      "no remote fetch",
+      "no expensive decoration blocking first render"
+    ],
+    "screenshot_requirements": [
+      "desktop current state",
+      "mobile current state",
+      "blocked or error state"
+    ],
+    "console_check_required": true,
+    "overlap_check_required": true
+  },
+  "comparative_review_gate": {
+    "status": "PASS",
+    "reviewer_role": "product-face",
+    "must_compare_to_reference_packet": true,
+    "basis": "Product Face reviewer must compare the implemented surface to the reference research and block generic AI-dashboard symptoms.",
+    "block_when": [
+      "The result resembles a generic dashboard rather than the product's task model.",
+      "Reference research exists but did not affect layout, hierarchy, controls or state treatment.",
+      "Mechanical screenshots pass while the visual hierarchy is not credible for a professional product."
+    ]
+  },
+  "handoff_requirements": {
+    "required_before_implementation": [
+      "design brief",
+      "task map",
+      "reference research",
+      "UX architecture",
+      "wireframe gate",
+      "visual direction",
+      "prototype gate",
+      "design QA plan",
+      "comparative review gate"
+    ],
+    "product_face_result_must_include": [
+      "professional_design_process_ref",
+      "professional_design_process_comparison.status=pass"
+    ]
+  }
+}

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -321,6 +321,160 @@
     "acceptance_criteria": ["Product Face design-fit review passes"],
     "product_experience_fields_informed": ["experience_sot", "design_direction", "proof_required"]
   },
+  "professional_design_process": {
+    "$schema": "https://overkill-factory.dev/schemas/professional-design-process.schema.json",
+    "record_type": "professional_design_process",
+    "surface_type": "software product surface",
+    "mode": "greenfield",
+    "design_brief": {
+      "user": "target user or operator",
+      "job_to_be_done": "Use the produced surface or workflow with clear status, states and evidence.",
+      "decision_surface": "The product-facing screen, document, flow or tool surface where the user decides what is true and what to do next.",
+      "success_signal": "Reviewer can explain the hierarchy, state, evidence and next action without private context.",
+      "failure_risks": [
+        "The surface looks like a generic AI dashboard or demo.",
+        "The surface hides blockers, stale state or missing evidence behind successful-looking UI."
+      ]
+    },
+    "task_map": [
+      {
+        "task_id": "T1",
+        "user_goal": "Understand current state.",
+        "trigger": "User opens the surface.",
+        "success_signal": "State, source and freshness are visible.",
+        "failure_state": "The surface implies success without evidence."
+      },
+      {
+        "task_id": "T2",
+        "user_goal": "Find next safe action.",
+        "trigger": "User sees blocked, stale, empty or contradictory state.",
+        "success_signal": "Action is bounded, specific and tied to a source.",
+        "failure_state": "The user sees a vague or unsafe action."
+      },
+      {
+        "task_id": "T3",
+        "user_goal": "Verify product fit.",
+        "trigger": "Product Face review runs before done.",
+        "success_signal": "Reviewer compares output to references, task model and visual direction.",
+        "failure_state": "Mechanical proof passes while the product feels generic or audience-mismatched."
+      }
+    ],
+    "reference_research": {
+      "registry_refs": [
+        "templates/reference-source-registry.json#21st-dev",
+        "templates/reference-source-registry.json#refero-styles",
+        "templates/reference-source-registry.json#motionsites"
+      ],
+      "selection_rationale": "Use references to define craft, density, interaction and state treatment before implementation; copy no code or assets without license review.",
+      "sources": [
+        {
+          "source_id": "radix-ui-themes",
+          "source_url_or_ref": "https://www.radix-ui.com/themes",
+          "use_type": "accessibility-and-token-system-reference",
+          "what_to_learn": ["accessible primitives", "color and density token discipline"],
+          "extracted_patterns": [
+            "Use semantic tokens and states instead of one decorative palette.",
+            "Prefer composable controls over oversized text blocks."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied."
+        },
+        {
+          "source_id": "shadcn-data-table",
+          "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
+          "use_type": "structured-data-interaction-reference",
+          "what_to_learn": ["filtering and row focus", "data table interaction ergonomics"],
+          "extracted_patterns": [
+            "Dense operational data needs search, filters and clear row state.",
+            "Controls should stay close to the data they affect."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied."
+        },
+        {
+          "source_id": "linear-product-workflow",
+          "source_url_or_ref": "https://linear.app",
+          "use_type": "product-workflow-and-state-reference",
+          "what_to_learn": ["fast product-work navigation", "state and ownership clarity"],
+          "extracted_patterns": [
+            "Product tools should be compact, scannable and state-first.",
+            "Primary work context should be visible without a marketing-style hero."
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied."
+        }
+      ]
+    },
+    "ux_architecture": {
+      "information_hierarchy": ["source and freshness", "state and blockers", "next safe action", "evidence and review", "detail drill-down"],
+      "navigation_model": "Compact app-shell with command bar, state lane, work list and detail inspector.",
+      "state_model": ["loading", "empty", "success", "error", "blocked", "stale", "private_unavailable", "contradictory"],
+      "density_rationale": "Use dense, quiet product-tool layout for repeated operational use."
+    },
+    "wireframe_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": ["professional_design_process.ux_architecture"],
+      "basis": "Layout separates source, state, queue and inspector before visual styling."
+    },
+    "visual_direction": {
+      "typography": "Compact system UI scale; no hero type inside product tools.",
+      "spacing": "Tight app-shell spacing with stable row, toolbar and inspector dimensions.",
+      "color_semantics": "Neutral base with separate semantic colors for success, warning, blocked, error and private/unavailable.",
+      "component_model": "Toolbar, segmented controls, searchable list, lane rows, data list, inspector and evidence chips.",
+      "anti_generic_commitments": [
+        "No decorative KPI cards disconnected from product objects.",
+        "No landing-page hero for an operational tool.",
+        "No vague AI-dashboard copy in place of state and evidence."
+      ]
+    },
+    "prototype_gate": {
+      "status": "PASS",
+      "reviewer": "product-face",
+      "artifact_refs": ["professional_design_process.task_map"],
+      "basis": "Prototype must cover real state categories and unhappy paths before implementation.",
+      "real_data_states": ["long dense data", "blocked gate", "stale snapshot", "private evidence unavailable", "contradictory state"]
+    },
+    "design_qa_plan": {
+      "viewports": ["desktop 1440x900", "laptop 1280x800", "mobile 390x844"],
+      "accessibility_checks": ["keyboard focus names", "semantic headings", "contrast", "aria-live load and error states"],
+      "performance_checks": ["local render remains responsive", "no remote fetch", "no decorative work blocking first render"],
+      "screenshot_requirements": ["desktop current state", "mobile current state", "blocked or error state"],
+      "console_check_required": true,
+      "overlap_check_required": true
+    },
+    "comparative_review_gate": {
+      "status": "PASS",
+      "reviewer_role": "product-face",
+      "must_compare_to_reference_packet": true,
+      "basis": "Product Face reviewer must compare implemented surface to research, task model and Product Face packet.",
+      "block_when": [
+        "The result resembles a generic dashboard rather than the product task model.",
+        "Reference research did not affect layout, hierarchy, controls or state treatment.",
+        "Mechanical screenshots pass while visual hierarchy is not credible for a professional product."
+      ]
+    },
+    "handoff_requirements": {
+      "required_before_implementation": [
+        "design brief",
+        "task map",
+        "reference research",
+        "UX architecture",
+        "wireframe gate",
+        "visual direction",
+        "prototype gate",
+        "design QA plan",
+        "comparative review gate"
+      ],
+      "product_face_result_must_include": [
+        "professional_design_process_ref",
+        "professional_design_process_comparison.status=pass"
+      ]
+    }
+  },
   "learning_proposal_refs": [
     "templates/factory-learning-proposal.json"
   ],

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -48,6 +48,33 @@ class FactorySelfImprovementTest(unittest.TestCase):
 
         self.assertIn("reference_quality_packet required for vFinal product-facing surfaces", errors)
 
+    def test_vfinal_product_surface_requires_professional_design_process(self) -> None:
+        card = vfinal_card()
+        card["surfaces"] = ["frontend"]
+        card.pop("professional_design_process")
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("professional_design_process required for vFinal product-facing surfaces", errors)
+
+    def test_professional_design_process_rejects_nominal_reference_research(self) -> None:
+        process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
+        process["reference_research"]["sources"] = process["reference_research"]["sources"][:1]
+        process["reference_research"]["sources"][0]["extracted_patterns"] = ["single pattern is too weak"]
+        process["wireframe_gate"]["status"] = "BLOCK"
+
+        errors = factoryctl.validate_professional_design_process(process)
+
+        self.assertIn("professional_design_process.reference_research.sources requires at least 3 sources", errors)
+        self.assertIn(
+            "professional_design_process.reference_research.sources[0].extracted_patterns requires at least 2 items",
+            errors,
+        )
+        self.assertIn(
+            "professional_design_process.wireframe_gate.status must be PASS before product-facing implementation",
+            errors,
+        )
+
     def test_reference_quality_rejects_copy_without_license_ref(self) -> None:
         packet = dict(vfinal_card()["reference_quality_packet"])
         packet["references"] = [
@@ -72,6 +99,7 @@ class FactorySelfImprovementTest(unittest.TestCase):
 
         self.assertEqual(packet["input_contract"]["reasoning_policy"]["record_type"], "reasoning_policy")
         self.assertEqual(packet["input_contract"]["reference_quality_packet"]["record_type"], "reference_quality_packet")
+        self.assertEqual(packet["input_contract"]["professional_design_process"]["record_type"], "professional_design_process")
         self.assertEqual(packet["input_contract"]["learning_proposal_refs"], ["templates/factory-learning-proposal.json"])
 
     def test_default_reference_registry_contains_post_sources_as_catalog_entries(self) -> None:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -439,6 +439,11 @@ class FactoryCtlTest(unittest.TestCase):
                     "status": "pass",
                     "basis": "The validator confirmed this bounded SaaS surface matches the Product Face packet."
                 },
+                "professional_design_process_ref": "examples/cards/v35_valid_product_face.md#professional_design_process",
+                "professional_design_process_comparison": {
+                    "status": "pass",
+                    "basis": "The validator confirmed the result satisfies the professional design process gates."
+                },
                 "visual_quality_result": {
                     "status": "PASS",
                     "reviewer": "product-face-reviewer",
@@ -498,6 +503,8 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_result.packet_comparison is required for product-facing completion", errors)
         self.assertIn("product_face_result.source_promise_coverage is required for product-facing completion", errors)
         self.assertIn("product_face_result.design_fit_review is required for product-facing completion", errors)
+        self.assertIn("product_face_result.professional_design_process_comparison is required for product-facing completion", errors)
+        self.assertIn("product_face_result.professional_design_process_ref is required for PASS", errors)
         self.assertIn("product_face_result.visual_quality_result is required", errors)
 
     def test_product_face_completion_blocks_mechanically_ok_but_ai_generic_ui(self) -> None:
@@ -545,6 +552,11 @@ class FactoryCtlTest(unittest.TestCase):
                 "design_fit_review": {
                     "status": "pass",
                     "basis": "Mechanical layout and state checks passed."
+                },
+                "professional_design_process_ref": "examples/cards/v35_valid_product_face.md#professional_design_process",
+                "professional_design_process_comparison": {
+                    "status": "pass",
+                    "basis": "Mechanical proof claims the process was followed, but visual quality review blocks it."
                 },
                 "visual_quality_result": {
                     "status": "BLOCK",

--- a/tests/test_issue84_local_cockpit_ui.py
+++ b/tests/test_issue84_local_cockpit_ui.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DATA_BUILDER_PATH = ROOT / "scripts" / "issue84" / "build_local_cockpit_data.py"
+FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
 UI_DIR = ROOT / "ui" / "issue-84-local-cockpit"
 FIXTURES = ROOT / "fixtures" / "issue-84" / "status-snapshot-v0"
 
@@ -64,6 +65,16 @@ def load_data_builder():
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     sys.modules["issue84_build_local_cockpit_data"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_factoryctl():
+    spec = importlib.util.spec_from_file_location("factoryctl_for_issue84_ui", FACTORYCTL_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["factoryctl_for_issue84_ui"] = module
     spec.loader.exec_module(module)
     return module
 
@@ -171,6 +182,14 @@ class Issue84LocalCockpitUITest(unittest.TestCase):
         self.assertNotIn("innerHTML", script)
         self.assertIn("textContent", script)
         self.assertNotRegex(script, r"https?://")
+        self.assertIn("brand-lockup", html)
+        self.assertIn("state-rail", script)
+        self.assertIn("snapshot-head", script)
+        self.assertIn("inspector-stack", script)
+        self.assertNotIn("radial-gradient", styles)
+        self.assertNotIn("letter-spacing: -", styles)
+        self.assertNotRegex(styles, r"font-size:\s*clamp")
+        self.assertNotIn("999px", styles)
         self.assertNotIn("Approve gate", html + script)
         self.assertNotIn("Release now", html + script)
         self.assertNotIn("Complete issue", html + script)
@@ -215,6 +234,14 @@ class Issue84LocalCockpitUITest(unittest.TestCase):
         self.assertTrue(module.is_loopback_host("localhost"))
         self.assertFalse(module.is_loopback_host("0.0.0.0"))
         self.assertFalse(module.is_loopback_host("192.168.1.20"))
+
+    def test_local_cockpit_professional_design_process_is_valid(self) -> None:
+        factoryctl = load_factoryctl()
+        process = json.loads((UI_DIR / "professional-design-process.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(process["record_type"], "professional_design_process")
+        self.assertEqual(factoryctl.validate_professional_design_process(process), [])
+        self.assertGreaterEqual(len(process["reference_research"]["sources"]), 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -99,6 +99,8 @@ class ProductFaceProofTest(unittest.TestCase):
             "packet_comparison",
             "source_promise_coverage",
             "design_fit_review",
+            "professional_design_process_ref",
+            "professional_design_process_comparison",
             "visual_quality_result",
             "blocking_findings",
             "evidence_refs",
@@ -184,6 +186,8 @@ class ProductFaceProofTest(unittest.TestCase):
                 packet_comparison_basis="Unit proof is explicitly matched to the packet.",
                 source_promise_coverage_basis="Unit proof covers the named product promise.",
                 design_fit_review_basis="Unit proof includes an explicit design-fit review.",
+                professional_design_process_ref="templates/professional-design-process.json",
+                professional_design_process_comparison_basis="Unit proof satisfies the professional design process gates.",
             )
             product_face_proof.apply_visual_quality_review(
                 result=result,

--- a/ui/issue-84-local-cockpit/app.js
+++ b/ui/issue-84-local-cockpit/app.js
@@ -53,7 +53,7 @@ function sectionTitle(eyebrow, title, copy) {
   const children = [];
   if (eyebrow) children.push(node("p", { className: "eyebrow", text: eyebrow }));
   children.push(node("h2", { text: title }));
-  if (copy) children.push(node("p", { className: "subtle", text: copy }));
+  if (copy) children.push(node("p", { className: "section-meta", text: copy }));
   return children;
 }
 
@@ -116,10 +116,10 @@ function stateCountFor(stateId) {
 function renderCommandStrip() {
   const metrics = state.data.metrics;
   return node("section", { className: "command-strip", "aria-label": "Cockpit summary metrics" }, [
-    metric("Fixture projections", metrics.status_fixture_projections),
-    metric("Adapter report projections", metrics.adapter_report_projections),
-    metric("Blocked or review states", metrics.blocked_or_review_count),
-    metric("Raw private payloads shown", metrics.raw_private_payload_count),
+    metric("Fixture snapshots", metrics.status_fixture_projections),
+    metric("Adapter reports", metrics.adapter_report_projections),
+    metric("Blocked / review", metrics.blocked_or_review_count),
+    metric("Private payloads", metrics.raw_private_payload_count),
   ]);
 }
 
@@ -149,8 +149,8 @@ function renderStateFilters() {
     }, [node("strong", { text: entry.label }), node("br"), node("span", { className: "subtle", text: `${stateCountFor(entry.id)} matches · ${entry.demo_query}` })]));
   });
 
-  return node("section", { className: "panel", "aria-label": "State filters" }, [
-    ...sectionTitle("State semantics", "Required states", "Filter by the Product Face packet state matrix. Color is paired with text labels."),
+  return node("section", { className: "panel state-rail", "aria-label": "State filters" }, [
+    ...sectionTitle("State rail", "Required states"),
     node("div", { className: "state-filter-grid" }, buttons),
   ]);
 }
@@ -196,19 +196,30 @@ function renderSnapshotList() {
       renderApp();
     },
   }, [
-    node("strong", { text: snapshot.title }),
-    node("span", { className: "subtle", text: snapshot.input_ref }),
-    node("span", { className: "snapshot-meta" }, [
-      pill("state", snapshot.current_state, "state-pill current-pill"),
-      pill("ui", snapshot.state_ui, "state-pill"),
-      pill("review", snapshot.review.status),
+    node("span", { className: "snapshot-status" }, [
+      pill("", snapshot.current_state, "state-pill current-pill"),
+      pill("", snapshot.review.status, "pill"),
     ]),
+    node("span", { className: "snapshot-title-cell" }, [
+      node("strong", { text: snapshot.title }),
+      node("span", { className: "subtle", text: snapshot.input_ref }),
+    ]),
+    node("span", { className: "snapshot-phase", text: snapshot.phase }),
+    node("span", { className: "snapshot-action", text: snapshot.next_safe_action.action_type }),
   ]));
 
   return node("aside", { className: "panel", "aria-label": "Snapshot list" }, [
-    ...sectionTitle("Local sources", "Snapshots", "Fixture and adapter report projections only."),
+    ...sectionTitle("Local sources", "Snapshots & work queue"),
     node("div", { className: "search-row" }, [input]),
-    rows.length ? node("div", { className: "snapshot-list" }, rows) : node("p", { className: "subtle", text: "No snapshot matches the current filter." }),
+    rows.length ? node("div", { className: "snapshot-list" }, [
+      node("div", { className: "snapshot-head", "aria-hidden": "true" }, [
+        node("span", { text: "State" }),
+        node("span", { text: "Source" }),
+        node("span", { text: "Phase" }),
+        node("span", { text: "Action" }),
+      ]),
+      ...rows,
+    ]) : node("p", { className: "subtle", text: "No snapshot matches the current filter." }),
   ]);
 }
 
@@ -218,7 +229,7 @@ function kv(label, value) {
 
 function renderObjectList(title, items, formatter, emptyCopy) {
   const content = items && items.length
-    ? node("ul", { className: "object-list" }, items.map((item) => node("li", { className: "object-card" }, formatter(item))))
+    ? node("ul", { className: "object-list" }, items.map((item) => node("li", { className: "object-row" }, formatter(item))))
     : node("p", { className: "subtle", text: emptyCopy });
   return node("section", { className: "stack", "aria-label": title }, [node("h3", { text: title }), content]);
 }
@@ -237,9 +248,12 @@ function renderDetail() {
     "data-current-state": selected.current_state,
     "aria-label": "Selected snapshot detail",
   }, [
-    node("p", { className: "eyebrow", text: selected.phase }),
+    node("div", { className: "inspector-kicker" }, [
+      node("p", { className: "eyebrow", text: "Inspector" }),
+      node("span", { className: "subtle", text: selected.phase }),
+    ]),
     node("h2", { text: selected.title }),
-    node("p", { className: "subtle", text: selected.next_safe_action.label }),
+    node("p", { className: "next-action", text: selected.next_safe_action.label }),
     node("div", { className: "pill-row" }, [
       pill("current", selected.current_state, "state-pill current-pill"),
       pill("ui", selected.state_ui, "state-pill"),
@@ -278,7 +292,7 @@ function renderProductFacePanel() {
   const packet = state.data.product_face;
   const review = state.data.product_face_review;
   return node("aside", { className: "panel", "aria-label": "Product Face contract" }, [
-    ...sectionTitle("Product Face packet", packet.surface, packet.job_to_be_done),
+    ...sectionTitle("Product Face", packet.surface),
     node("div", { className: "pill-row" }, [
       pill("review", review.verdict),
       pill("consume", review.may_consume_product_face_packet ? "bounded yes" : "blocked"),
@@ -300,7 +314,7 @@ function renderStateCoverage() {
     pill("matches", stateCountFor(entry.id), "state-pill"),
   ]));
   return node("section", { className: "panel", "aria-label": "State coverage matrix" }, [
-    ...sectionTitle("State coverage", "Packet-required state matrix", "Each state is text-labeled and available through fixtures, adapter projections or explicit demo mode."),
+    ...sectionTitle("State coverage", "Packet-required state matrix"),
     node("div", { className: "state-coverage-grid" }, cards),
   ]);
 }
@@ -312,14 +326,14 @@ function renderTimeline() {
     node("p", { className: "subtle", text: `${item.current_state} · ${item.next_action} · ${item.source_ref}` }),
   ]));
   return node("section", { className: "panel", "aria-label": "Transition timeline" }, [
-    ...sectionTitle("Timeline", "Recent projections", "Replay is based on source refs, not chat memory."),
+    ...sectionTitle("Timeline", "Recent projections"),
     node("div", { className: "timeline" }, rows),
   ]);
 }
 
 function renderGuardrails() {
   return node("section", { className: "panel", "aria-label": "Forbidden actions" }, [
-    ...sectionTitle("Safety boundary", "Forbidden by this surface", "The cockpit makes boundaries visible instead of hiding them behind successful-looking cards."),
+    ...sectionTitle("Safety boundary", "Forbidden by this surface"),
     node("ul", { className: "guardrail-list" }, state.data.policy.forbidden_actions.map((item) => node("li", { text: item }))),
   ]);
 }
@@ -334,9 +348,9 @@ function renderApp() {
   if (!state.selectedId) state.selectedId = state.data.snapshots[0].id;
   root.appendChild(renderCommandStrip());
   root.appendChild(node("div", { className: "layout" }, [
-    node("div", { className: "stack" }, [renderStateFilters(), renderSnapshotList()]),
-    node("div", { className: "stack" }, [renderDetail(), renderStateCoverage(), renderTimeline(), renderGuardrails()]),
-    renderProductFacePanel(),
+    renderStateFilters(),
+    node("div", { className: "stack main-stack" }, [renderSnapshotList(), renderStateCoverage()]),
+    node("div", { className: "stack inspector-stack" }, [renderDetail(), renderProductFacePanel(), renderTimeline(), renderGuardrails()]),
   ]));
 }
 

--- a/ui/issue-84-local-cockpit/index.html
+++ b/ui/issue-84-local-cockpit/index.html
@@ -9,16 +9,17 @@
   <body>
     <a class="skip-link" href="#cockpit-main">Skip to cockpit</a>
     <header class="topbar" role="banner">
-      <div>
-        <p class="eyebrow">Overkill Factory · local-first projection</p>
-        <h1>Issue 84 Local Cockpit</h1>
-        <p class="lede">
-          Read-only factory state, gates, blockers, evidence refs and next safe action from local fixtures and reviewed adapter output.
-        </p>
+      <div class="brand-lockup">
+        <span class="brand-mark" aria-hidden="true">OF</span>
+        <div>
+          <h1>Issue 84 Local Cockpit</h1>
+          <p>Local-first factory projection</p>
+        </div>
       </div>
-      <div class="mode-card" aria-label="Safety mode">
-        <strong>Projection only</strong>
-        <span>No runtime mutation, no product-face approval, no release claim.</span>
+      <div class="top-actions" aria-label="Cockpit mode">
+        <span class="mode-chip">Projection only</span>
+        <span class="mode-chip">Loopback</span>
+        <span class="mode-chip">Public-safe refs</span>
       </div>
     </header>
 

--- a/ui/issue-84-local-cockpit/professional-design-process.json
+++ b/ui/issue-84-local-cockpit/professional-design-process.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/professional-design-process.schema.json",
+  "record_type": "professional_design_process",
+  "surface_type": "local web operations cockpit",
+  "mode": "redesign",
+  "design_brief": {
+    "user": "external open-source factory operator",
+    "job_to_be_done": "Supervise factory state, blockers, evidence and next safe action from local structured snapshots.",
+    "decision_surface": "Local web cockpit current-state view and selected snapshot inspector.",
+    "success_signal": "Operator can distinguish state, freshness, blockers, review status and next action without private context.",
+    "failure_risks": [
+      "The UI looks like a generic generated dashboard instead of an operations cockpit.",
+      "The UI blurs request, approval, done, release, stale and blocked states."
+    ]
+  },
+  "task_map": [
+    {
+      "task_id": "T1",
+      "user_goal": "Understand the current projection.",
+      "trigger": "Operator opens the local cockpit.",
+      "success_signal": "Current state, source kind, freshness and risk are visible in one scan.",
+      "failure_state": "Decorative metrics imply success without evidence."
+    },
+    {
+      "task_id": "T2",
+      "user_goal": "Find and inspect blockers.",
+      "trigger": "A gate, review or evidence dependency is blocked.",
+      "success_signal": "Blocker owner, unblock condition and source refs are visible in the inspector.",
+      "failure_state": "The operator must read raw JSON or infer blockers from generic cards."
+    },
+    {
+      "task_id": "T3",
+      "user_goal": "Verify whether the surface is safe to trust.",
+      "trigger": "Product Face review evaluates the cockpit.",
+      "success_signal": "Screenshots, states, evidence refs and visual quality verdict compare against this process.",
+      "failure_state": "Mechanical browser proof passes while visual/product quality is unacceptable."
+    }
+  ],
+  "reference_research": {
+    "registry_refs": [
+      "templates/reference-source-registry.json#21st-dev",
+      "templates/reference-source-registry.json#refero-styles",
+      "templates/reference-source-registry.json#motionsites"
+    ],
+    "selection_rationale": "Use professional product-tool and component references to define compact state-first hierarchy, not to copy assets or brand.",
+    "sources": [
+      {
+        "source_id": "radix-ui-themes",
+        "source_url_or_ref": "https://www.radix-ui.com/themes",
+        "use_type": "token-and-accessibility-reference",
+        "what_to_learn": ["semantic color tokens", "accessible component primitives"],
+        "extracted_patterns": [
+          "Use semantic state colors rather than a one-note decorative palette.",
+          "Keep controls compact and named by function."
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no code or assets copied."
+      },
+      {
+        "source_id": "shadcn-data-table",
+        "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
+        "use_type": "dense-data-interaction-reference",
+        "what_to_learn": ["filtering and sorting patterns", "row action ergonomics"],
+        "extracted_patterns": [
+          "Dense operational views need search, filters and stable row focus.",
+          "Detail inspection should stay adjacent to the selected row context."
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no code or assets copied."
+      },
+      {
+        "source_id": "linear-product-workflow",
+        "source_url_or_ref": "https://linear.app",
+        "use_type": "product-workflow-reference",
+        "what_to_learn": ["state-first product work navigation", "low-friction worklist scanning"],
+        "extracted_patterns": [
+          "Work status, owner and next action should be visible without a marketing hero.",
+          "Focused work lists should be fast to scan and keep hierarchy quiet."
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no code or assets copied."
+      }
+    ]
+  },
+  "ux_architecture": {
+    "information_hierarchy": [
+      "source and freshness",
+      "current state",
+      "blockers and gates",
+      "next safe action",
+      "evidence refs",
+      "timeline"
+    ],
+    "navigation_model": "Local app shell with command strip, state rail, searchable snapshot list, selected snapshot inspector and product face panel.",
+    "state_model": [
+      "loading",
+      "empty",
+      "success",
+      "error",
+      "blocked",
+      "stale",
+      "contradictory",
+      "private_unavailable"
+    ],
+    "density_rationale": "This is a repeated-use operator tool, so dense state-first layout is required; hero or decorative dashboard layout is blocked."
+  },
+  "wireframe_gate": {
+    "status": "PASS",
+    "reviewer": "product-face",
+    "artifact_refs": [
+      "ui/issue-84-local-cockpit/index.html",
+      "ui/issue-84-local-cockpit/app.js"
+    ],
+    "basis": "The implemented structure separates state rail, work queue and inspector before visual styling."
+  },
+  "visual_direction": {
+    "typography": "Compact system UI scale; no hero type inside the tool.",
+    "spacing": "Stable rows, toolbar and inspector spacing with no layout shift on state changes.",
+    "color_semantics": "Neutral app base with separate semantic colors for pass, warn, blocked, fail, stale and private-unavailable states.",
+    "component_model": "Segmented controls, search, state rail, row list, inspector, evidence chips and timeline rows.",
+    "anti_generic_commitments": [
+      "No decorative KPI cards detached from factory objects.",
+      "No generic dashboard visuals or fake charts.",
+      "No excessive explanatory copy where structure should carry meaning."
+    ]
+  },
+  "prototype_gate": {
+    "status": "PASS",
+    "reviewer": "product-face",
+    "artifact_refs": [
+      "ui/issue-84-local-cockpit/index.html",
+      "ui/issue-84-local-cockpit/styles.css"
+    ],
+    "basis": "The redesign covers the required state matrix and the FX18 visual-quality-failure case.",
+    "real_data_states": [
+      "success current snapshot",
+      "blocked gate",
+      "stale snapshot",
+      "contradictory state",
+      "private evidence unavailable",
+      "mechanical pass but visual quality fail"
+    ]
+  },
+  "design_qa_plan": {
+    "viewports": ["desktop 1440x900", "laptop 1280x800", "mobile 390x844"],
+    "accessibility_checks": ["keyboard focus names", "semantic headings", "contrast", "aria-live load/error states"],
+    "performance_checks": ["local JSON render remains responsive", "no remote fetch", "no heavy decorative effects"],
+    "screenshot_requirements": ["desktop current state", "mobile current state", "blocked state"],
+    "console_check_required": true,
+    "overlap_check_required": true
+  },
+  "comparative_review_gate": {
+    "status": "PASS",
+    "reviewer_role": "product-face",
+    "must_compare_to_reference_packet": true,
+    "basis": "The cockpit uses a state-first app shell and blocks the previous generic dashboard failure mode.",
+    "block_when": [
+      "The result resembles a generic dashboard.",
+      "State, source and next safe action are not first-class.",
+      "Reference research does not affect layout, hierarchy, controls or state treatment."
+    ]
+  },
+  "handoff_requirements": {
+    "required_before_implementation": [
+      "design brief",
+      "task map",
+      "reference research",
+      "UX architecture",
+      "wireframe gate",
+      "visual direction",
+      "prototype gate",
+      "design QA plan",
+      "comparative review gate"
+    ],
+    "product_face_result_must_include": [
+      "professional_design_process_ref",
+      "professional_design_process_comparison.status=pass"
+    ]
+  }
+}

--- a/ui/issue-84-local-cockpit/styles.css
+++ b/ui/issue-84-local-cockpit/styles.css
@@ -1,22 +1,24 @@
 :root {
-  color-scheme: dark;
-  --bg: #0b1118;
-  --panel: #101923;
-  --panel-2: #14202c;
-  --panel-3: #172737;
-  --ink: #eef6ff;
-  --muted: #9fb0c3;
-  --line: #2c3d50;
-  --line-strong: #49627a;
-  --accent: #91c7ff;
-  --good: #5de59c;
-  --warn: #ffd166;
-  --bad: #ff7b7b;
-  --blocked: #f59e0b;
-  --private: #c4a7ff;
-  --stale: #9ca3af;
-  --conflict: #fb7185;
-  --shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --surface-soft: #f0f3f7;
+  --surface-strong: #e7ecf2;
+  --ink: #121821;
+  --muted: #667485;
+  --subtle: #8a96a5;
+  --line: #d6dde6;
+  --line-strong: #aeb9c7;
+  --accent: #2563eb;
+  --good: #16814a;
+  --warn: #b77900;
+  --bad: #c93636;
+  --blocked: #9a5b00;
+  --private: #6b4bb4;
+  --stale: #6b7280;
+  --conflict: #b91c50;
+  --cyan: #047481;
+  --shadow: 0 14px 34px rgba(18, 24, 33, 0.08);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -27,9 +29,7 @@
 body {
   min-height: 100vh;
   margin: 0;
-  background:
-    radial-gradient(circle at top left, rgba(63, 124, 172, 0.22), transparent 28rem),
-    linear-gradient(180deg, #0a1017 0%, #0d141d 45%, #080d13 100%);
+  background: var(--bg);
   color: var(--ink);
 }
 
@@ -46,8 +46,8 @@ button:focus-visible,
 a:focus-visible,
 input:focus-visible,
 [tabindex]:focus-visible {
-  outline: 3px solid var(--accent);
-  outline-offset: 3px;
+  outline: 3px solid rgba(37, 99, 235, 0.38);
+  outline-offset: 2px;
 }
 
 .skip-link {
@@ -56,9 +56,9 @@ input:focus-visible,
   top: -4rem;
   z-index: 10;
   background: var(--ink);
-  color: var(--bg);
-  padding: 0.65rem 0.9rem;
-  border-radius: 0.5rem;
+  color: #fff;
+  padding: 0.65rem 0.85rem;
+  border-radius: 8px;
   text-decoration: none;
 }
 
@@ -67,11 +67,50 @@ input:focus-visible,
 }
 
 .topbar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(17rem, 24rem);
+  display: flex;
+  min-height: 4.5rem;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
-  align-items: end;
-  padding: 1.5rem clamp(1rem, 3vw, 2.25rem) 0;
+  padding: 0.85rem clamp(1rem, 3vw, 2rem);
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(14px);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.brand-lockup,
+.top-actions,
+.snapshot-status,
+.snapshot-meta,
+.pill-row,
+.detail-grid,
+.kv,
+.inspector-kicker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.brand-lockup {
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.brand-mark {
+  display: inline-grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  border: 1px solid #111827;
+  border-radius: 8px;
+  background: #111827;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
 }
 
 h1,
@@ -82,142 +121,137 @@ p {
 }
 
 h1 {
-  margin-bottom: 0.35rem;
-  font-size: clamp(2rem, 5vw, 4.5rem);
-  letter-spacing: -0.06em;
-  line-height: 0.92;
-}
-
-h2 {
-  font-size: clamp(1.35rem, 2.4vw, 2.1rem);
-  letter-spacing: -0.035em;
-}
-
-h3 {
-  font-size: 1rem;
-  letter-spacing: -0.01em;
-}
-
-.eyebrow {
-  margin-bottom: 0.45rem;
-  color: var(--accent);
-  font-size: 0.74rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.lede {
-  max-width: 72ch;
-  margin-bottom: 0;
-  color: var(--muted);
+  margin: 0 0 0.1rem;
   font-size: 1.02rem;
+  line-height: 1.2;
+  letter-spacing: 0;
 }
 
-.mode-card,
+.brand-lockup p,
+.section-meta,
+.subtle {
+  color: var(--muted);
+}
+
+.brand-lockup p {
+  margin: 0;
+  font-size: 0.82rem;
+}
+
+.top-actions {
+  justify-content: flex-end;
+}
+
+.mode-chip,
+.pill,
+.state-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 1.55rem;
+  padding: 0.2rem 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 650;
+}
+
+.cockpit {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.85rem clamp(1rem, 3vw, 2rem) 1.25rem;
+}
+
 .panel,
 .detail-card,
 .metric,
-.snapshot-row,
-.state-filter,
-.timeline-row,
 .loading-panel,
 .empty-panel,
 .error-panel,
 .noscript {
   border: 1px solid var(--line);
-  background: rgba(16, 25, 35, 0.86);
+  border-radius: 8px;
+  background: var(--surface);
   box-shadow: var(--shadow);
-}
-
-.mode-card {
-  display: grid;
-  gap: 0.35rem;
-  padding: 1rem;
-  border-radius: 1rem;
-  color: var(--muted);
-}
-
-.mode-card strong {
-  color: var(--ink);
-}
-
-.cockpit {
-  display: grid;
-  gap: 1rem;
-  padding: 1.25rem clamp(1rem, 3vw, 2.25rem) 2.25rem;
 }
 
 .loading-panel,
 .empty-panel,
 .error-panel,
 .noscript {
-  padding: 2rem;
-  border-radius: 1.15rem;
-}
-
-.loading-panel {
-  min-height: 16rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.loading-panel::after {
-  content: "";
-  position: absolute;
-  inset: auto 2rem 2rem 2rem;
-  height: 0.7rem;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(145, 199, 255, 0.12), rgba(145, 199, 255, 0.65), rgba(145, 199, 255, 0.12));
+  min-height: 14rem;
+  padding: 1.25rem;
 }
 
 .error-panel {
-  border-color: rgba(255, 123, 123, 0.7);
+  border-color: rgba(201, 54, 54, 0.55);
+}
+
+.eyebrow {
+  margin-bottom: 0.25rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h2 {
+  margin-bottom: 0.65rem;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin-bottom: 0.45rem;
+  font-size: 0.88rem;
+  line-height: 1.25;
+  letter-spacing: 0;
 }
 
 .command-strip {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .metric {
-  padding: 0.9rem;
-  border-radius: 0.9rem;
+  min-height: 4.4rem;
+  padding: 0.72rem 0.8rem;
+  box-shadow: none;
 }
 
 .metric span {
   display: block;
   color: var(--muted);
-  font-size: 0.74rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
 .metric strong {
   display: block;
-  margin-top: 0.35rem;
-  font-size: 1.75rem;
-  letter-spacing: -0.04em;
+  margin-top: 0.25rem;
+  font-size: 1.55rem;
+  line-height: 1.05;
+  letter-spacing: 0;
 }
 
 .layout {
   display: grid;
-  grid-template-columns: minmax(18rem, 26rem) minmax(0, 1fr) minmax(18rem, 24rem);
-  gap: 1rem;
+  grid-template-columns: minmax(14rem, 17rem) minmax(26rem, 1fr) minmax(22rem, 29rem);
+  gap: 0.85rem;
   align-items: start;
 }
 
 .panel,
 .detail-card {
   min-width: 0;
-  border-radius: 1.05rem;
-  padding: 1rem;
-}
-
-.panel h2,
-.detail-card h2 {
-  margin-bottom: 0.75rem;
+  padding: 0.85rem;
 }
 
 h1,
@@ -229,187 +263,246 @@ p,
 .snapshot-row,
 .timeline-row,
 .detail-card,
-.panel {
+.panel,
+.object-row,
+.state-filter {
   overflow-wrap: anywhere;
+}
+
+.stack {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.main-stack,
+.inspector-stack {
+  min-width: 0;
 }
 
 .search-row {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65rem;
 }
 
 .search-row input {
   width: 100%;
+  min-height: 2.25rem;
   border: 1px solid var(--line);
-  border-radius: 0.65rem;
-  background: #0b121a;
+  border-radius: 8px;
+  background: var(--surface-soft);
   color: var(--ink);
-  padding: 0.65rem 0.75rem;
+  padding: 0.52rem 0.65rem;
+  font-size: 0.86rem;
 }
 
 .state-filter-grid,
 .state-coverage-grid {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.42rem;
 }
 
 .state-filter {
   width: 100%;
-  padding: 0.7rem;
-  border-radius: 0.7rem;
+  min-height: 3.5rem;
+  padding: 0.58rem 0.62rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
   text-align: left;
   cursor: pointer;
 }
 
+.state-filter strong {
+  font-size: 0.82rem;
+}
+
 .state-filter[aria-pressed="true"] {
-  border-color: var(--accent);
-  background: rgba(145, 199, 255, 0.16);
+  border-color: var(--state-color, var(--accent));
+  background: color-mix(in srgb, var(--state-color, var(--accent)) 10%, #fff);
 }
 
 .snapshot-list {
   display: grid;
-  gap: 0.55rem;
-  max-height: 54rem;
-  overflow: auto;
-  padding-right: 0.2rem;
+  gap: 0.35rem;
+  padding-right: 0.15rem;
+}
+
+.snapshot-head,
+.snapshot-row {
+  display: grid;
+  grid-template-columns: minmax(7.4rem, 8rem) minmax(13rem, 1fr) minmax(7rem, 9rem) minmax(4.5rem, 5.5rem);
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.snapshot-head {
+  min-height: 2rem;
+  padding: 0 0.65rem;
+  color: var(--subtle);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
 .snapshot-row {
   width: 100%;
-  display: grid;
-  gap: 0.35rem;
-  padding: 0.8rem;
-  border-radius: 0.8rem;
+  min-height: 4.4rem;
+  padding: 0.62rem 0.65rem;
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--state-color, var(--line-strong));
+  border-radius: 8px;
+  background: var(--surface);
   cursor: pointer;
   text-align: left;
 }
 
+.snapshot-row:hover {
+  border-color: var(--line-strong);
+  background: #fbfcfe;
+}
+
 .snapshot-row[aria-current="true"] {
-  border-color: var(--accent);
-  background: rgba(145, 199, 255, 0.12);
+  border-color: var(--state-color, var(--accent));
+  background: color-mix(in srgb, var(--state-color, var(--accent)) 8%, #fff);
+}
+
+.snapshot-title-cell {
+  display: grid;
+  gap: 0.22rem;
+  min-width: 0;
 }
 
 .snapshot-row strong {
   line-height: 1.2;
+  font-size: 0.88rem;
 }
 
-.snapshot-meta,
-.pill-row,
-.detail-grid,
-.kv {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.pill,
-.state-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  min-height: 1.7rem;
-  padding: 0.25rem 0.55rem;
-  border: 1px solid var(--line-strong);
-  border-radius: 999px;
+.snapshot-phase,
+.snapshot-action {
   color: var(--muted);
   font-size: 0.78rem;
 }
 
 .state-pill {
   color: var(--ink);
-  font-weight: 750;
+}
+
+.pill-row,
+.detail-grid {
+  align-items: flex-start;
 }
 
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin: 1rem 0;
+  gap: 0.55rem;
+  margin: 0.8rem 0;
 }
 
 .kv {
   display: grid;
-  gap: 0.25rem;
-  padding: 0.75rem;
-  border: 1px solid var(--line);
-  border-radius: 0.8rem;
-  background: rgba(255, 255, 255, 0.02);
+  gap: 0.15rem;
+  min-height: 3.6rem;
+  padding: 0.55rem 0;
+  border-top: 1px solid var(--line);
 }
 
 .kv span {
-  color: var(--muted);
-  font-size: 0.75rem;
+  color: var(--subtle);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
-.stack {
-  display: grid;
-  gap: 0.75rem;
+.kv strong {
+  font-size: 0.84rem;
+  line-height: 1.25;
 }
 
 .object-list {
   display: grid;
-  gap: 0.55rem;
+  gap: 0;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.object-card {
-  padding: 0.7rem;
-  border: 1px solid var(--line);
-  border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.025);
+.object-row {
+  padding: 0.62rem 0;
+  border-top: 1px solid var(--line);
 }
 
-.object-card p {
-  margin-bottom: 0.35rem;
+.object-row p {
+  margin-bottom: 0.3rem;
   color: var(--muted);
 }
 
-.object-card code,
+.object-row code,
 .ref-code {
-  color: #dbeafe;
+  color: #1e3a8a;
   overflow-wrap: anywhere;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.78rem;
+  font-size: 0.76rem;
+}
+
+.state-coverage-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .state-coverage-card {
-  padding: 0.75rem;
-  border: 1px solid var(--line);
-  border-radius: 0.8rem;
-  background: rgba(255, 255, 255, 0.025);
+  min-height: 7rem;
+  padding: 0.62rem 0;
+  border-top: 3px solid var(--state-color, var(--line-strong));
 }
 
 .state-coverage-card h3 {
-  margin-bottom: 0.3rem;
+  margin-bottom: 0.25rem;
 }
 
 .state-coverage-card p {
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.35rem;
   color: var(--muted);
+  font-size: 0.82rem;
 }
 
 .timeline {
   display: grid;
-  gap: 0.55rem;
-  max-height: 25rem;
-  overflow: auto;
+  gap: 0;
 }
 
 .timeline-row {
-  padding: 0.7rem;
-  border-radius: 0.75rem;
+  padding: 0.62rem 0;
+  border-top: 1px solid var(--line);
 }
 
 .timeline-row time {
   display: block;
-  color: var(--muted);
-  font-size: 0.78rem;
+  color: var(--subtle);
+  font-size: 0.72rem;
+}
+
+.timeline-row p {
+  margin-bottom: 0;
+}
+
+.inspector-kicker {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.next-action {
+  margin-bottom: 0.7rem;
+  padding: 0.6rem 0.65rem;
+  border-left: 4px solid var(--state-color, var(--accent));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--state-color, var(--accent)) 8%, #fff);
+  color: var(--ink);
+  font-size: 0.86rem;
+  font-weight: 650;
 }
 
 [data-state-ui="loading_snapshot"] {
@@ -440,7 +533,7 @@ p,
   --state-color: var(--warn);
 }
 [data-state-ui="long_dense_data"] {
-  --state-color: #67e8f9;
+  --state-color: var(--cyan);
 }
 
 [data-current-state="success"] {
@@ -474,21 +567,17 @@ p,
   --current-color: var(--warn);
 }
 
-[data-state-ui] {
-  border-color: color-mix(in srgb, var(--state-color) 56%, var(--line));
-}
-
 [data-state-ui] .state-pill,
 [data-current-state] .current-pill {
-  border-color: color-mix(in srgb, var(--state-color, var(--current-color)) 70%, var(--line));
-  background: color-mix(in srgb, var(--state-color, var(--current-color)) 13%, transparent);
+  border-color: color-mix(in srgb, var(--state-color, var(--current-color)) 45%, var(--line));
+  background: color-mix(in srgb, var(--state-color, var(--current-color)) 9%, #fff);
 }
 
 [data-current-state] .current-pill::before,
 [data-state-ui] .state-pill::before {
   content: "";
-  width: 0.55rem;
-  height: 0.55rem;
+  width: 0.52rem;
+  height: 0.52rem;
   flex: 0 0 auto;
   border-radius: 50%;
   background: var(--state-color, var(--current-color));
@@ -497,36 +586,88 @@ p,
 .guardrail-list {
   columns: 2;
   column-gap: 1rem;
-  padding-left: 1.2rem;
+  padding-left: 1.1rem;
   color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.section-meta {
+  margin-top: -0.35rem;
+  margin-bottom: 0.7rem;
+  font-size: 0.82rem;
 }
 
 .subtle {
-  color: var(--muted);
+  font-size: 0.78rem;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1180px) {
+  .layout {
+    grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);
+  }
+
+  .inspector-stack {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 820px) {
   .topbar,
-  .layout,
-  .command-strip {
+  .top-actions {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  .topbar,
+  .layout {
     grid-template-columns: 1fr;
   }
 
-  .snapshot-list,
-  .timeline {
-    max-height: none;
-  }
-}
-
-@media (max-width: 700px) {
-  .topbar,
-  .cockpit {
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
+  .topbar {
+    display: grid;
   }
 
+  .command-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric {
+    min-height: 3.8rem;
+  }
+
+  .snapshot-head {
+    display: none;
+  }
+
+  .snapshot-row {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  .snapshot-status {
+    order: 2;
+  }
+
+  .snapshot-phase,
+  .snapshot-action {
+    order: 3;
+  }
+
+  .state-coverage-grid,
   .detail-grid {
     grid-template-columns: 1fr;
+  }
+
+  .guardrail-list {
+    columns: 1;
+  }
+}
+
+@media (max-width: 520px) {
+  .cockpit,
+  .topbar {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
   }
 
   .panel,
@@ -534,26 +675,6 @@ p,
   .loading-panel,
   .empty-panel,
   .error-panel {
-    border-radius: 0.85rem;
-    padding: 0.85rem;
-  }
-
-  .guardrail-list {
-    columns: 1;
-  }
-
-  h1 {
-    font-size: clamp(2.2rem, 18vw, 3.25rem);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .loading-panel::after {
-    animation: load-pulse 1.8s ease-in-out infinite;
-  }
-
-  @keyframes load-pulse {
-    0%, 100% { opacity: 0.25; transform: translateX(-0.6rem); }
-    50% { opacity: 0.9; transform: translateX(0.6rem); }
+    padding: 0.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- make `professional_design_process` a required Product Face/Product Experience contract for product-facing factory work
- require Product Face PASS evidence to compare against the professional design process
- redesign the Issue 84 local cockpit as a compact operations surface with state rail, searchable work queue, inspector, evidence refs, and real Product Face proof
- update the minimal public example so the new design gate does not break first-run onboarding

Closes #131

## Validation
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py`
- `python scripts\validate_public_json_artifacts.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `git diff --check`
- `python scripts\product_face_proof.py ...` against `http://127.0.0.1:8784/` with desktop/mobile screenshots, console, overlap, a11y basics, and professional design comparison
