### PR TITLE
[codex] Require design reference comparison gate

### DIFF
--- a/examples/cards/v35_valid_product_face.md
+++ b/examples/cards/v35_valid_product_face.md
@@ -141,47 +141,276 @@
     "reference_research": {
       "registry_refs": [
         "templates/reference-source-registry.json#21st-dev",
-        "templates/reference-source-registry.json#refero-styles"
+        "templates/reference-source-registry.json#refero-styles",
+        "templates/reference-source-registry.json#mobbin",
+        "templates/reference-source-registry.json#pageflows"
       ],
-      "selection_rationale": "Use professional product-tool references to avoid generic generated UI.",
+      "selection_rationale": "Search professional component libraries, product-flow libraries and public product references before implementation; select and reject candidates explicitly, synthesize reusable patterns, and copy no code, text, screenshots or assets without license review.",
       "sources": [
         {
           "source_id": "radix-ui-themes",
           "source_url_or_ref": "https://www.radix-ui.com/themes",
           "use_type": "accessibility-reference",
-          "what_to_learn": ["semantic tokens", "accessible controls"],
+          "what_to_learn": [
+            "semantic tokens",
+            "accessible controls"
+          ],
           "extracted_patterns": [
             "Use state semantics over decoration.",
             "Keep controls compact and named."
           ],
           "copy_policy": "do_not_copy",
-          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied"
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "source_type": "design_system",
+          "library_source": "Radix Themes",
+          "candidate_reason": "Selected for accessibility, semantic token and component density discipline.",
+          "selected_patterns": [
+            "Semantic color roles must drive product states instead of decorative palettes.",
+            "Composable, named controls should replace oversized explanatory blocks."
+          ],
+          "visual_dimensions_covered": [
+            "visual_language",
+            "density_spacing",
+            "interaction_model"
+          ],
+          "public_safety_notes": "Reference only; no code, text or assets copied."
         },
         {
           "source_id": "shadcn-data-table",
           "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
           "use_type": "dense-data-reference",
-          "what_to_learn": ["row scanning", "filters"],
+          "what_to_learn": [
+            "row scanning",
+            "filters"
+          ],
           "extracted_patterns": [
             "Dense lists need stable row focus.",
             "Controls should stay near affected data."
           ],
           "copy_policy": "do_not_copy",
-          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied"
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "source_type": "component_registry",
+          "library_source": "shadcn/ui",
+          "candidate_reason": "Selected for dense data-table ergonomics, filtering, sorting and row action patterns.",
+          "selected_patterns": [
+            "Dense operational data needs search, filters, sort and visible row focus.",
+            "Controls belong close to the data or state they affect."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "density_spacing"
+          ],
+          "public_safety_notes": "Reference only; no code, text or assets copied."
         },
         {
           "source_id": "linear-product-workflow",
           "source_url_or_ref": "https://linear.app",
           "use_type": "workflow-reference",
-          "what_to_learn": ["state-first workflow", "quiet product-tool hierarchy"],
+          "what_to_learn": [
+            "state-first workflow",
+            "quiet product-tool hierarchy"
+          ],
           "extracted_patterns": [
             "Work context should be visible without a hero.",
             "Status hierarchy should be compact and scannable."
           ],
           "copy_policy": "do_not_copy",
-          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied"
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "source_type": "product_reference",
+          "library_source": "Linear public product reference",
+          "candidate_reason": "Selected for compact work management hierarchy, state clarity and low-friction navigation.",
+          "selected_patterns": [
+            "Operational product tools should be compact, scannable and state-first.",
+            "Primary work context should be visible without a marketing-style hero."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "state_coverage",
+            "density_spacing"
+          ],
+          "public_safety_notes": "Reference only; no code, text or assets copied."
+        },
+        {
+          "source_id": "21st-dev-components",
+          "source_url_or_ref": "https://21st.dev/",
+          "source_type": "component_registry",
+          "library_source": "21st.dev",
+          "use_type": "component-library-and-craft-benchmark",
+          "candidate_reason": "Selected to compare component polish, hierarchy, spacing and interaction finish against modern React/Tailwind component references.",
+          "what_to_learn": [
+            "How modern component libraries compose dense command surfaces without looking generic.",
+            "How spacing, state affordances and micro-interactions make controls feel deliberate."
+          ],
+          "extracted_patterns": [
+            "Reusable components need explicit state, focus, hover and disabled behavior before visual approval.",
+            "Component density should be tuned to the operator task instead of stretched into marketing cards."
+          ],
+          "selected_patterns": [
+            "Require explicit states for controls and rows before Product Face PASS.",
+            "Use compact component groups with clear hierarchy instead of decorative dashboard blocks."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "visual_language",
+            "density_spacing"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied."
+        },
+        {
+          "source_id": "mobbin-workflow-patterns",
+          "source_url_or_ref": "https://mobbin.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Mobbin",
+          "use_type": "real-product-flow-and-screen-benchmark",
+          "candidate_reason": "Selected because real product flows expose navigation, density and state decisions that isolated mockups hide.",
+          "what_to_learn": [
+            "How professional products sequence navigation, detail inspection and recovery states.",
+            "How repeated-use workflows avoid decorative elements that slow scanning."
+          ],
+          "extracted_patterns": [
+            "A serious workflow needs visible current state, selected object, next action and recovery path.",
+            "Reference study must cover multiple screens or states, not a single attractive screenshot."
+          ],
+          "selected_patterns": [
+            "Require current object, state and next action to be visible together.",
+            "Reject single-screen inspiration that does not explain workflow behavior."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "state_coverage"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use synthesized observations only; do not commit screenshots or private captures."
+        },
+        {
+          "source_id": "pageflows-review-approval",
+          "source_url_or_ref": "https://pageflows.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Page Flows",
+          "use_type": "journey-state-and-approval-flow-benchmark",
+          "candidate_reason": "Selected to force journey-level coverage for approval, error, review and onboarding states.",
+          "what_to_learn": [
+            "How professional products communicate progress, blocking states and fallback paths across a journey.",
+            "How approval and review flows preserve confidence without hiding consequences."
+          ],
+          "extracted_patterns": [
+            "Approval surfaces need consequence, evidence and rollback context before the action.",
+            "Error and blocked states should preserve orientation and show the next safe action."
+          ],
+          "selected_patterns": [
+            "Require consequence, evidence and fallback context for approval surfaces.",
+            "Treat blocked/error states as first-class Product Face screenshots."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "state_coverage",
+            "layout_hierarchy"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use journey-level learning only; no copied videos, screenshots or private material."
         }
-      ]
+      ],
+      "library_searches": [
+        {
+          "library": "21st.dev",
+          "library_url": "https://21st.dev/",
+          "query_or_category": "operations dashboard, command surface, data table and review components",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "component craft supports dense repeated operator use",
+            "states and controls can be adapted without copying code or assets"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "21st-dev-components",
+            "shadcn-data-table"
+          ],
+          "rejected_candidate_ids": [
+            "decorative-dashboard-template",
+            "oversized-hero-block"
+          ]
+        },
+        {
+          "library": "Mobbin",
+          "library_url": "https://mobbin.com/",
+          "query_or_category": "workflow, status, review, incident and project operations flows",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "real product flow exposes navigation and state transitions",
+            "patterns improve operator speed instead of presentation aesthetics"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "mobbin-workflow-patterns",
+            "linear-product-workflow"
+          ],
+          "rejected_candidate_ids": [
+            "marketing-dashboard-gallery",
+            "single-screenshot-flow"
+          ]
+        },
+        {
+          "library": "Page Flows",
+          "library_url": "https://pageflows.com/",
+          "query_or_category": "approval, review, onboarding, error and blocked-state journeys",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "journey shows consequences and recovery states",
+            "flow can be compared dimension-by-dimension against the product task model"
+          ],
+          "candidate_count": 5,
+          "selected_source_ids": [
+            "pageflows-review-approval"
+          ],
+          "rejected_candidate_ids": [
+            "happy-path-only-flow"
+          ]
+        }
+      ],
+      "rejected_references": [
+        {
+          "source_id": "decorative-dashboard-template",
+          "source_url_or_ref": "external:generic-dashboard-gallery",
+          "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
+        },
+        {
+          "source_id": "marketing-dashboard-gallery",
+          "source_url_or_ref": "external:marketing-dashboard-gallery",
+          "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "happy-path-only-flow",
+          "source_url_or_ref": "external:single-happy-path-flow",
+          "rejection_reason": "Rejected because it does not show blocked, error, review or approval consequences."
+        }
+      ],
+      "pattern_synthesis": {
+        "layout_hierarchy": "Lead with source freshness, current state, blocker/next action and selected object before secondary metrics or explanation.",
+        "interaction_model": "Use command strips, segmented state filters, searchable lists, adjacent inspectors and explicit approval/recovery actions.",
+        "state_coverage": "Design and capture loading, empty, success, blocked, stale, contradictory, private-unavailable and visual-quality-fail states before PASS.",
+        "visual_language": "Use a restrained professional product-tool language with semantic status color, crisp typography and no generic AI-dashboard decoration.",
+        "density_spacing": "Keep dense but readable rows, fixed tool dimensions and compact panels so repeated operation is fast and stable.",
+        "anti_patterns": [
+          "single attractive screenshot without workflow proof",
+          "decorative KPI cards disconnected from factory objects",
+          "hero layout or marketing composition inside an operational cockpit"
+        ]
+      },
+      "reference_evidence_policy": {
+        "capture_required_before_implementation": true,
+        "side_by_side_comparison_required_before_pass": true,
+        "public_refs_only": true,
+        "no_private_screenshots_in_repo": true,
+        "public_safe_evidence_refs": [
+          "professional_design_process.reference_research.sources"
+        ]
+      }
     },
     "ux_architecture": {
       "information_hierarchy": ["status", "evidence", "review", "next action"],
@@ -222,17 +451,32 @@
     },
     "comparative_review_gate": {
       "status": "PASS",
-      "reviewer_role": "product-face",
+      "reviewer_role": "independent-product-face-reviewer",
       "must_compare_to_reference_packet": true,
-      "basis": "Product Face reviewer compares result to packet and reference quality bar.",
+      "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
       "block_when": [
         "Generic dashboard visual quality appears.",
-        "Evidence hierarchy is unclear."
+        "Evidence hierarchy is unclear.",
+        "Reference research lacks real library searches, selected candidates and rejected candidates.",
+        "The result cannot explain, dimension by dimension, how it matches or deliberately differs from the chosen references."
       ]
     },
     "handoff_requirements": {
-      "required_before_implementation": ["reference research", "wireframe gate", "prototype gate", "design QA plan"],
-      "product_face_result_must_include": ["professional_design_process_ref", "professional_design_process_comparison.status=pass"]
+      "required_before_implementation": [
+        "reference research",
+        "wireframe gate",
+        "prototype gate",
+        "design QA plan",
+        "library searches",
+        "rejected references",
+        "pattern synthesis",
+        "reference evidence policy"
+      ],
+      "product_face_result_must_include": [
+        "professional_design_process_ref",
+        "professional_design_process_comparison.status=pass",
+        "reference_quality_comparison.status=pass"
+      ]
     }
   }
 }

--- a/examples/local-web-cockpit-factory-slice/card.md
+++ b/examples/local-web-cockpit-factory-slice/card.md
@@ -572,50 +572,276 @@
       "registry_refs": [
         "templates/reference-source-registry.json#21st-dev",
         "templates/reference-source-registry.json#refero-styles",
-        "templates/reference-source-registry.json#motionsites"
+        "templates/reference-source-registry.json#motionsites",
+        "templates/reference-source-registry.json#mobbin",
+        "templates/reference-source-registry.json#pageflows"
       ],
-      "selection_rationale": "Use professional product-tool and component references to define compact state-first hierarchy, not to copy assets or brand.",
+      "selection_rationale": "Search professional component libraries, product-flow libraries and public product references before implementation; select and reject candidates explicitly, synthesize reusable patterns, and copy no code, text, screenshots or assets without license review.",
       "sources": [
         {
           "source_id": "radix-ui-themes",
           "source_url_or_ref": "https://www.radix-ui.com/themes",
           "use_type": "token-and-accessibility-reference",
-          "what_to_learn": ["semantic color tokens", "accessible component primitives"],
+          "what_to_learn": [
+            "semantic color tokens",
+            "accessible component primitives"
+          ],
           "extracted_patterns": [
             "Use semantic state colors rather than a one-note decorative palette.",
             "Keep controls compact and named by function."
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no code or assets copied."
+          "public_safety_notes": "Reference only; no code or assets copied.",
+          "source_type": "design_system",
+          "library_source": "Radix Themes",
+          "visual_dimensions_covered": [
+            "visual_language",
+            "density_spacing",
+            "interaction_model"
+          ],
+          "candidate_reason": "Selected for Radix Themes patterns relevant to professional Product Face quality.",
+          "selected_patterns": [
+            "Use semantic state colors rather than a one-note decorative palette.",
+            "Keep controls compact and named by function."
+          ]
         },
         {
           "source_id": "shadcn-data-table",
           "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
           "use_type": "dense-data-interaction-reference",
-          "what_to_learn": ["filtering and sorting patterns", "row action ergonomics"],
+          "what_to_learn": [
+            "filtering and sorting patterns",
+            "row action ergonomics"
+          ],
           "extracted_patterns": [
             "Dense operational views need search, filters and stable row focus.",
             "Detail inspection should stay adjacent to the selected row context."
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no code or assets copied."
+          "public_safety_notes": "Reference only; no code or assets copied.",
+          "source_type": "component_registry",
+          "library_source": "shadcn/ui",
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "density_spacing"
+          ],
+          "candidate_reason": "Selected for shadcn/ui patterns relevant to professional Product Face quality.",
+          "selected_patterns": [
+            "Dense operational views need search, filters and stable row focus.",
+            "Detail inspection should stay adjacent to the selected row context."
+          ]
         },
         {
           "source_id": "linear-product-workflow",
           "source_url_or_ref": "https://linear.app",
           "use_type": "product-workflow-reference",
-          "what_to_learn": ["state-first product work navigation", "low-friction worklist scanning"],
+          "what_to_learn": [
+            "state-first product work navigation",
+            "low-friction worklist scanning"
+          ],
           "extracted_patterns": [
             "Work status, owner and next action should be visible without a marketing hero.",
             "Focused work lists should be fast to scan and keep hierarchy quiet."
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no code or assets copied."
+          "public_safety_notes": "Reference only; no code or assets copied.",
+          "source_type": "product_reference",
+          "library_source": "Linear public product reference",
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "state_coverage",
+            "density_spacing"
+          ],
+          "candidate_reason": "Selected for Linear public product reference patterns relevant to professional Product Face quality.",
+          "selected_patterns": [
+            "Work status, owner and next action should be visible without a marketing hero.",
+            "Focused work lists should be fast to scan and keep hierarchy quiet."
+          ]
+        },
+        {
+          "source_id": "21st-dev-components",
+          "source_url_or_ref": "https://21st.dev/",
+          "source_type": "component_registry",
+          "library_source": "21st.dev",
+          "use_type": "component-library-and-craft-benchmark",
+          "candidate_reason": "Selected to compare component polish, hierarchy, spacing and interaction finish against modern React/Tailwind component references.",
+          "what_to_learn": [
+            "How modern component libraries compose dense command surfaces without looking generic.",
+            "How spacing, state affordances and micro-interactions make controls feel deliberate."
+          ],
+          "extracted_patterns": [
+            "Reusable components need explicit state, focus, hover and disabled behavior before visual approval.",
+            "Component density should be tuned to the operator task instead of stretched into marketing cards."
+          ],
+          "selected_patterns": [
+            "Require explicit states for controls and rows before Product Face PASS.",
+            "Use compact component groups with clear hierarchy instead of decorative dashboard blocks."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "visual_language",
+            "density_spacing"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied."
+        },
+        {
+          "source_id": "mobbin-workflow-patterns",
+          "source_url_or_ref": "https://mobbin.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Mobbin",
+          "use_type": "real-product-flow-and-screen-benchmark",
+          "candidate_reason": "Selected because real product flows expose navigation, density and state decisions that isolated mockups hide.",
+          "what_to_learn": [
+            "How professional products sequence navigation, detail inspection and recovery states.",
+            "How repeated-use workflows avoid decorative elements that slow scanning."
+          ],
+          "extracted_patterns": [
+            "A serious workflow needs visible current state, selected object, next action and recovery path.",
+            "Reference study must cover multiple screens or states, not a single attractive screenshot."
+          ],
+          "selected_patterns": [
+            "Require current object, state and next action to be visible together.",
+            "Reject single-screen inspiration that does not explain workflow behavior."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "state_coverage"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use synthesized observations only; do not commit screenshots or private captures."
+        },
+        {
+          "source_id": "pageflows-review-approval",
+          "source_url_or_ref": "https://pageflows.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Page Flows",
+          "use_type": "journey-state-and-approval-flow-benchmark",
+          "candidate_reason": "Selected to force journey-level coverage for approval, error, review and onboarding states.",
+          "what_to_learn": [
+            "How professional products communicate progress, blocking states and fallback paths across a journey.",
+            "How approval and review flows preserve confidence without hiding consequences."
+          ],
+          "extracted_patterns": [
+            "Approval surfaces need consequence, evidence and rollback context before the action.",
+            "Error and blocked states should preserve orientation and show the next safe action."
+          ],
+          "selected_patterns": [
+            "Require consequence, evidence and fallback context for approval surfaces.",
+            "Treat blocked/error states as first-class Product Face screenshots."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "state_coverage",
+            "layout_hierarchy"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use journey-level learning only; no copied videos, screenshots or private material."
         }
-      ]
+      ],
+      "library_searches": [
+        {
+          "library": "21st.dev",
+          "library_url": "https://21st.dev/",
+          "query_or_category": "operations dashboard, command surface, data table and review components",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "component craft supports dense repeated operator use",
+            "states and controls can be adapted without copying code or assets"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "21st-dev-components",
+            "shadcn-data-table"
+          ],
+          "rejected_candidate_ids": [
+            "decorative-dashboard-template",
+            "oversized-hero-block"
+          ]
+        },
+        {
+          "library": "Mobbin",
+          "library_url": "https://mobbin.com/",
+          "query_or_category": "workflow, status, review, incident and project operations flows",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "real product flow exposes navigation and state transitions",
+            "patterns improve operator speed instead of presentation aesthetics"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "mobbin-workflow-patterns",
+            "linear-product-workflow"
+          ],
+          "rejected_candidate_ids": [
+            "marketing-dashboard-gallery",
+            "single-screenshot-flow"
+          ]
+        },
+        {
+          "library": "Page Flows",
+          "library_url": "https://pageflows.com/",
+          "query_or_category": "approval, review, onboarding, error and blocked-state journeys",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "journey shows consequences and recovery states",
+            "flow can be compared dimension-by-dimension against the product task model"
+          ],
+          "candidate_count": 5,
+          "selected_source_ids": [
+            "pageflows-review-approval"
+          ],
+          "rejected_candidate_ids": [
+            "happy-path-only-flow"
+          ]
+        }
+      ],
+      "rejected_references": [
+        {
+          "source_id": "decorative-dashboard-template",
+          "source_url_or_ref": "external:generic-dashboard-gallery",
+          "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
+        },
+        {
+          "source_id": "marketing-dashboard-gallery",
+          "source_url_or_ref": "external:marketing-dashboard-gallery",
+          "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "happy-path-only-flow",
+          "source_url_or_ref": "external:single-happy-path-flow",
+          "rejection_reason": "Rejected because it does not show blocked, error, review or approval consequences."
+        }
+      ],
+      "pattern_synthesis": {
+        "layout_hierarchy": "Lead with source freshness, current state, blocker/next action and selected object before secondary metrics or explanation.",
+        "interaction_model": "Use command strips, segmented state filters, searchable lists, adjacent inspectors and explicit approval/recovery actions.",
+        "state_coverage": "Design and capture loading, empty, success, blocked, stale, contradictory, private-unavailable and visual-quality-fail states before PASS.",
+        "visual_language": "Use a restrained professional product-tool language with semantic status color, crisp typography and no generic AI-dashboard decoration.",
+        "density_spacing": "Keep dense but readable rows, fixed tool dimensions and compact panels so repeated operation is fast and stable.",
+        "anti_patterns": [
+          "single attractive screenshot without workflow proof",
+          "decorative KPI cards disconnected from factory objects",
+          "hero layout or marketing composition inside an operational cockpit"
+        ]
+      },
+      "reference_evidence_policy": {
+        "capture_required_before_implementation": true,
+        "side_by_side_comparison_required_before_pass": true,
+        "public_refs_only": true,
+        "no_private_screenshots_in_repo": true,
+        "public_safe_evidence_refs": [
+          "professional_design_process.reference_research.sources"
+        ]
+      }
     },
     "ux_architecture": {
       "information_hierarchy": [
@@ -680,13 +906,15 @@
     },
     "comparative_review_gate": {
       "status": "PASS",
-      "reviewer_role": "product-face",
+      "reviewer_role": "independent-product-face-reviewer",
       "must_compare_to_reference_packet": true,
-      "basis": "The cockpit must compare against the reference quality packet and block generic AI-dashboard symptoms.",
+      "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
       "block_when": [
         "The result resembles a generic dashboard.",
         "State, source and next safe action are not first-class.",
-        "Reference research does not affect layout, hierarchy, controls or state treatment."
+        "Reference research does not affect layout, hierarchy, controls or state treatment.",
+        "Reference research lacks real library searches, selected candidates and rejected candidates.",
+        "The result cannot explain, dimension by dimension, how it matches or deliberately differs from the chosen references."
       ]
     },
     "handoff_requirements": {
@@ -694,6 +922,10 @@
         "design brief",
         "task map",
         "reference research",
+        "library searches",
+        "rejected references",
+        "pattern synthesis",
+        "reference evidence policy",
         "UX architecture",
         "wireframe gate",
         "visual direction",
@@ -703,7 +935,8 @@
       ],
       "product_face_result_must_include": [
         "professional_design_process_ref",
-        "professional_design_process_comparison.status=pass"
+        "professional_design_process_comparison.status=pass",
+        "reference_quality_comparison.status=pass"
       ]
     }
   },

--- a/examples/minimal-hermes-project/card.md
+++ b/examples/minimal-hermes-project/card.md
@@ -237,9 +237,11 @@
     "reference_research": {
       "registry_refs": [
         "templates/reference-source-registry.json#21st-dev",
-        "templates/reference-source-registry.json#refero-styles"
+        "templates/reference-source-registry.json#refero-styles",
+        "templates/reference-source-registry.json#mobbin",
+        "templates/reference-source-registry.json#pageflows"
       ],
-      "selection_rationale": "Use public component and product-tool references for structure and density only; no copied code, copy, or assets.",
+      "selection_rationale": "Search professional component libraries, product-flow libraries and public product references before implementation; select and reject candidates explicitly, synthesize reusable patterns, and copy no code, text, screenshots or assets without license review.",
       "sources": [
         {
           "source_id": "radix-ui-themes",
@@ -255,7 +257,19 @@
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no source code, text, or assets copied."
+          "public_safety_notes": "Reference only; no source code, text, or assets copied.",
+          "source_type": "design_system",
+          "library_source": "Radix Themes",
+          "visual_dimensions_covered": [
+            "visual_language",
+            "density_spacing",
+            "interaction_model"
+          ],
+          "candidate_reason": "Selected for Radix Themes patterns relevant to professional Product Face quality.",
+          "selected_patterns": [
+            "Use semantic state colors instead of decorative gradients.",
+            "Keep controls compact and predictable."
+          ]
         },
         {
           "source_id": "shadcn-data-table",
@@ -271,7 +285,19 @@
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no source code, text, or assets copied."
+          "public_safety_notes": "Reference only; no source code, text, or assets copied.",
+          "source_type": "component_registry",
+          "library_source": "shadcn/ui",
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "density_spacing"
+          ],
+          "candidate_reason": "Selected for shadcn/ui patterns relevant to professional Product Face quality.",
+          "selected_patterns": [
+            "Use rows and status chips when the user needs comparison.",
+            "Avoid large isolated metric cards for small operational examples."
+          ]
         },
         {
           "source_id": "linear-product-workflow",
@@ -287,9 +313,200 @@
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no source code, text, or assets copied."
+          "public_safety_notes": "Reference only; no source code, text, or assets copied.",
+          "source_type": "product_reference",
+          "library_source": "Linear public product reference",
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "state_coverage",
+            "density_spacing"
+          ],
+          "candidate_reason": "Selected for Linear public product reference patterns relevant to professional Product Face quality.",
+          "selected_patterns": [
+            "Operational tools should be state-first and compact.",
+            "Important blockers should be visible without a hero section."
+          ]
+        },
+        {
+          "source_id": "21st-dev-components",
+          "source_url_or_ref": "https://21st.dev/",
+          "source_type": "component_registry",
+          "library_source": "21st.dev",
+          "use_type": "component-library-and-craft-benchmark",
+          "candidate_reason": "Selected to compare component polish, hierarchy, spacing and interaction finish against modern React/Tailwind component references.",
+          "what_to_learn": [
+            "How modern component libraries compose dense command surfaces without looking generic.",
+            "How spacing, state affordances and micro-interactions make controls feel deliberate."
+          ],
+          "extracted_patterns": [
+            "Reusable components need explicit state, focus, hover and disabled behavior before visual approval.",
+            "Component density should be tuned to the operator task instead of stretched into marketing cards."
+          ],
+          "selected_patterns": [
+            "Require explicit states for controls and rows before Product Face PASS.",
+            "Use compact component groups with clear hierarchy instead of decorative dashboard blocks."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "visual_language",
+            "density_spacing"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied."
+        },
+        {
+          "source_id": "mobbin-workflow-patterns",
+          "source_url_or_ref": "https://mobbin.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Mobbin",
+          "use_type": "real-product-flow-and-screen-benchmark",
+          "candidate_reason": "Selected because real product flows expose navigation, density and state decisions that isolated mockups hide.",
+          "what_to_learn": [
+            "How professional products sequence navigation, detail inspection and recovery states.",
+            "How repeated-use workflows avoid decorative elements that slow scanning."
+          ],
+          "extracted_patterns": [
+            "A serious workflow needs visible current state, selected object, next action and recovery path.",
+            "Reference study must cover multiple screens or states, not a single attractive screenshot."
+          ],
+          "selected_patterns": [
+            "Require current object, state and next action to be visible together.",
+            "Reject single-screen inspiration that does not explain workflow behavior."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "state_coverage"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use synthesized observations only; do not commit screenshots or private captures."
+        },
+        {
+          "source_id": "pageflows-review-approval",
+          "source_url_or_ref": "https://pageflows.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Page Flows",
+          "use_type": "journey-state-and-approval-flow-benchmark",
+          "candidate_reason": "Selected to force journey-level coverage for approval, error, review and onboarding states.",
+          "what_to_learn": [
+            "How professional products communicate progress, blocking states and fallback paths across a journey.",
+            "How approval and review flows preserve confidence without hiding consequences."
+          ],
+          "extracted_patterns": [
+            "Approval surfaces need consequence, evidence and rollback context before the action.",
+            "Error and blocked states should preserve orientation and show the next safe action."
+          ],
+          "selected_patterns": [
+            "Require consequence, evidence and fallback context for approval surfaces.",
+            "Treat blocked/error states as first-class Product Face screenshots."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "state_coverage",
+            "layout_hierarchy"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use journey-level learning only; no copied videos, screenshots or private material."
         }
-      ]
+      ],
+      "library_searches": [
+        {
+          "library": "21st.dev",
+          "library_url": "https://21st.dev/",
+          "query_or_category": "operations dashboard, command surface, data table and review components",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "component craft supports dense repeated operator use",
+            "states and controls can be adapted without copying code or assets"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "21st-dev-components",
+            "shadcn-data-table"
+          ],
+          "rejected_candidate_ids": [
+            "decorative-dashboard-template",
+            "oversized-hero-block"
+          ]
+        },
+        {
+          "library": "Mobbin",
+          "library_url": "https://mobbin.com/",
+          "query_or_category": "workflow, status, review, incident and project operations flows",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "real product flow exposes navigation and state transitions",
+            "patterns improve operator speed instead of presentation aesthetics"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "mobbin-workflow-patterns",
+            "linear-product-workflow"
+          ],
+          "rejected_candidate_ids": [
+            "marketing-dashboard-gallery",
+            "single-screenshot-flow"
+          ]
+        },
+        {
+          "library": "Page Flows",
+          "library_url": "https://pageflows.com/",
+          "query_or_category": "approval, review, onboarding, error and blocked-state journeys",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "journey shows consequences and recovery states",
+            "flow can be compared dimension-by-dimension against the product task model"
+          ],
+          "candidate_count": 5,
+          "selected_source_ids": [
+            "pageflows-review-approval"
+          ],
+          "rejected_candidate_ids": [
+            "happy-path-only-flow"
+          ]
+        }
+      ],
+      "rejected_references": [
+        {
+          "source_id": "decorative-dashboard-template",
+          "source_url_or_ref": "external:generic-dashboard-gallery",
+          "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
+        },
+        {
+          "source_id": "marketing-dashboard-gallery",
+          "source_url_or_ref": "external:marketing-dashboard-gallery",
+          "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "happy-path-only-flow",
+          "source_url_or_ref": "external:single-happy-path-flow",
+          "rejection_reason": "Rejected because it does not show blocked, error, review or approval consequences."
+        }
+      ],
+      "pattern_synthesis": {
+        "layout_hierarchy": "Lead with source freshness, current state, blocker/next action and selected object before secondary metrics or explanation.",
+        "interaction_model": "Use command strips, segmented state filters, searchable lists, adjacent inspectors and explicit approval/recovery actions.",
+        "state_coverage": "Design and capture loading, empty, success, blocked, stale, contradictory, private-unavailable and visual-quality-fail states before PASS.",
+        "visual_language": "Use a restrained professional product-tool language with semantic status color, crisp typography and no generic AI-dashboard decoration.",
+        "density_spacing": "Keep dense but readable rows, fixed tool dimensions and compact panels so repeated operation is fast and stable.",
+        "anti_patterns": [
+          "single attractive screenshot without workflow proof",
+          "decorative KPI cards disconnected from factory objects",
+          "hero layout or marketing composition inside an operational cockpit"
+        ]
+      },
+      "reference_evidence_policy": {
+        "capture_required_before_implementation": true,
+        "side_by_side_comparison_required_before_pass": true,
+        "public_refs_only": true,
+        "no_private_screenshots_in_repo": true,
+        "public_safe_evidence_refs": [
+          "professional_design_process.reference_research.sources"
+        ]
+      }
     },
     "ux_architecture": {
       "information_hierarchy": [
@@ -368,13 +585,37 @@
     },
     "comparative_review_gate": {
       "status": "PASS",
-      "reviewer_role": "product-face",
+      "reviewer_role": "independent-product-face-reviewer",
       "must_compare_to_reference_packet": true,
-      "basis": "The minimal Product Face reviewer must compare the surface against the design packet and block generic dashboard symptoms.",
+      "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
       "block_when": [
         "The result hides receipt state or evidence requirements.",
         "Reference research does not affect hierarchy, controls, or state treatment.",
-        "Mechanical screenshots pass while the surface remains generic or misleading."
+        "Mechanical screenshots pass while the surface remains generic or misleading.",
+        "Reference research lacks real library searches, selected candidates and rejected candidates.",
+        "The result cannot explain, dimension by dimension, how it matches or deliberately differs from the chosen references."
+      ]
+    },
+    "handoff_requirements": {
+      "required_before_implementation": [
+        "design brief",
+        "task map",
+        "reference research",
+        "library searches",
+        "rejected references",
+        "pattern synthesis",
+        "reference evidence policy",
+        "UX architecture",
+        "wireframe gate",
+        "visual direction",
+        "prototype gate",
+        "design QA plan",
+        "comparative review gate"
+      ],
+      "product_face_result_must_include": [
+        "professional_design_process_ref",
+        "professional_design_process_comparison.status=pass",
+        "reference_quality_comparison.status=pass"
       ]
     }
   }

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -19,6 +19,7 @@
     "design_fit_review",
     "professional_design_process_ref",
     "professional_design_process_comparison",
+    "reference_quality_comparison",
     "visual_quality_result",
     "blocking_findings",
     "evidence_refs",
@@ -127,6 +128,46 @@
       },
       "additionalProperties": true
     },
+    "reference_quality_comparison": {
+      "type": "object",
+      "required": [
+        "status",
+        "basis",
+        "reference_set_ref",
+        "compared_source_ids",
+        "dimensions",
+        "reviewer_independent_from_implementation"
+      ],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail", "pending"] },
+        "basis": { "type": "string", "minLength": 3 },
+        "reference_set_ref": { "type": "string", "minLength": 3 },
+        "compared_source_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "reviewer_independent_from_implementation": { "type": "boolean" },
+        "dimensions": {
+          "type": "object",
+          "required": [
+            "layout_hierarchy",
+            "interaction_model",
+            "state_coverage",
+            "visual_language",
+            "density_spacing"
+          ],
+          "properties": {
+            "layout_hierarchy": { "$ref": "#/$defs/reference_dimension_verdict" },
+            "interaction_model": { "$ref": "#/$defs/reference_dimension_verdict" },
+            "state_coverage": { "$ref": "#/$defs/reference_dimension_verdict" },
+            "visual_language": { "$ref": "#/$defs/reference_dimension_verdict" },
+            "density_spacing": { "$ref": "#/$defs/reference_dimension_verdict" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
     "visual_quality_result": {
       "type": "object",
       "required": ["status", "reviewer", "basis", "reference_quality_bar_checked", "ai_generic_symptoms"],
@@ -162,6 +203,17 @@
     },
     "next_action": {
       "type": "string"
+    }
+  },
+  "$defs": {
+    "reference_dimension_verdict": {
+      "type": "object",
+      "required": ["status", "basis"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail", "pending"] },
+        "basis": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
     }
   },
   "additionalProperties": true

--- a/schemas/professional-design-process.schema.json
+++ b/schemas/professional-design-process.schema.json
@@ -66,7 +66,15 @@
     },
     "reference_research": {
       "type": "object",
-      "required": ["registry_refs", "selection_rationale", "sources"],
+      "required": [
+        "registry_refs",
+        "selection_rationale",
+        "library_searches",
+        "sources",
+        "rejected_references",
+        "pattern_synthesis",
+        "reference_evidence_policy"
+      ],
       "properties": {
         "registry_refs": {
           "type": "array",
@@ -74,6 +82,46 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "selection_rationale": { "type": "string", "minLength": 3 },
+        "library_searches": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "object",
+            "required": [
+              "library",
+              "library_url",
+              "query_or_category",
+              "searched_at",
+              "selection_criteria",
+              "candidate_count",
+              "selected_source_ids",
+              "rejected_candidate_ids"
+            ],
+            "properties": {
+              "library": { "type": "string", "minLength": 2 },
+              "library_url": { "type": "string", "minLength": 3 },
+              "query_or_category": { "type": "string", "minLength": 2 },
+              "searched_at": { "type": "string", "minLength": 3 },
+              "selection_criteria": {
+                "type": "array",
+                "minItems": 2,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "candidate_count": { "type": "integer", "minimum": 3 },
+              "selected_source_ids": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "rejected_candidate_ids": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              }
+            },
+            "additionalProperties": true
+          }
+        },
         "sources": {
           "type": "array",
           "minItems": 3,
@@ -82,16 +130,33 @@
             "required": [
               "source_id",
               "source_url_or_ref",
+              "source_type",
+              "library_source",
               "use_type",
+              "candidate_reason",
               "what_to_learn",
               "extracted_patterns",
+              "selected_patterns",
+              "visual_dimensions_covered",
               "copy_policy",
               "license_or_terms_ref"
             ],
             "properties": {
               "source_id": { "type": "string", "minLength": 1 },
               "source_url_or_ref": { "type": "string", "minLength": 3 },
+              "source_type": {
+                "enum": [
+                  "component_registry",
+                  "design_library",
+                  "design_system",
+                  "product_reference",
+                  "site_gallery",
+                  "user_flow_library"
+                ]
+              },
+              "library_source": { "type": "string", "minLength": 2 },
               "use_type": { "type": "string", "minLength": 3 },
+              "candidate_reason": { "type": "string", "minLength": 3 },
               "what_to_learn": {
                 "type": "array",
                 "minItems": 2,
@@ -102,12 +167,78 @@
                 "minItems": 2,
                 "items": { "type": "string", "minLength": 1 }
               },
+              "selected_patterns": {
+                "type": "array",
+                "minItems": 2,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "visual_dimensions_covered": {
+                "type": "array",
+                "minItems": 3,
+                "items": { "type": "string", "minLength": 1 }
+              },
               "copy_policy": { "type": "string", "minLength": 3 },
               "license_or_terms_ref": { "type": "string", "minLength": 3 },
               "public_safety_notes": { "type": "string" }
             },
             "additionalProperties": true
           }
+        },
+        "rejected_references": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "object",
+            "required": ["source_id", "source_url_or_ref", "rejection_reason"],
+            "properties": {
+              "source_id": { "type": "string", "minLength": 1 },
+              "source_url_or_ref": { "type": "string", "minLength": 3 },
+              "rejection_reason": { "type": "string", "minLength": 3 }
+            },
+            "additionalProperties": true
+          }
+        },
+        "pattern_synthesis": {
+          "type": "object",
+          "required": [
+            "layout_hierarchy",
+            "interaction_model",
+            "state_coverage",
+            "visual_language",
+            "density_spacing"
+          ],
+          "properties": {
+            "layout_hierarchy": { "type": "string", "minLength": 3 },
+            "interaction_model": { "type": "string", "minLength": 3 },
+            "state_coverage": { "type": "string", "minLength": 3 },
+            "visual_language": { "type": "string", "minLength": 3 },
+            "density_spacing": { "type": "string", "minLength": 3 },
+            "anti_patterns": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          },
+          "additionalProperties": true
+        },
+        "reference_evidence_policy": {
+          "type": "object",
+          "required": [
+            "capture_required_before_implementation",
+            "side_by_side_comparison_required_before_pass",
+            "public_refs_only",
+            "no_private_screenshots_in_repo"
+          ],
+          "properties": {
+            "capture_required_before_implementation": { "const": true },
+            "side_by_side_comparison_required_before_pass": { "const": true },
+            "public_refs_only": { "const": true },
+            "no_private_screenshots_in_repo": { "const": true },
+            "public_safe_evidence_refs": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          },
+          "additionalProperties": true
         }
       },
       "additionalProperties": true

--- a/scripts/factory_completion_audit.py
+++ b/scripts/factory_completion_audit.py
@@ -271,7 +271,13 @@ def reusable_product_scope_is_valid(data: dict[str, Any], *, record_type: str | 
             return False
         if not str(data.get("professional_design_process_ref") or "").strip():
             return False
-        for field in ("packet_comparison", "source_promise_coverage", "design_fit_review", "professional_design_process_comparison"):
+        for field in (
+            "packet_comparison",
+            "source_promise_coverage",
+            "design_fit_review",
+            "professional_design_process_comparison",
+            "reference_quality_comparison",
+        ):
             value = data.get(field)
             if not isinstance(value, dict) or value.get("status") != "pass":
                 return False

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -385,8 +385,30 @@ PRODUCT_FACE_RESULT_ALIGNMENT_FIELDS = (
     "source_promise_coverage",
     "design_fit_review",
     "professional_design_process_comparison",
+    "reference_quality_comparison",
 )
 VISUAL_QUALITY_ALLOWED_RESULTS = {"PASS", "PASS_WITH_RESIDUALS", "BLOCK"}
+REFERENCE_RESEARCH_SOURCE_TYPES = {
+    "component_registry",
+    "design_library",
+    "design_system",
+    "product_reference",
+    "site_gallery",
+    "user_flow_library",
+}
+REFERENCE_RESEARCH_LIBRARY_TYPES = {
+    "component_registry",
+    "design_library",
+    "site_gallery",
+    "user_flow_library",
+}
+REFERENCE_COMPARISON_DIMENSIONS = (
+    "layout_hierarchy",
+    "interaction_model",
+    "state_coverage",
+    "visual_language",
+    "density_spacing",
+)
 
 
 @dataclass(frozen=True)
@@ -2194,25 +2216,112 @@ def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
 
     research = process.get("reference_research") if isinstance(process.get("reference_research"), dict) else {}
     sources = research.get("sources") if isinstance(research.get("sources"), list) else []
+    library_searches = research.get("library_searches") if isinstance(research.get("library_searches"), list) else []
+    rejected_references = (
+        research.get("rejected_references") if isinstance(research.get("rejected_references"), list) else []
+    )
     if len(sources) < 3:
         errors.append("professional_design_process.reference_research.sources requires at least 3 sources")
     if len(_list_items(research.get("registry_refs"))) < 2:
         errors.append("professional_design_process.reference_research.registry_refs requires at least 2 registry refs")
     if not _non_empty_text(research.get("selection_rationale")):
         errors.append("professional_design_process.reference_research.selection_rationale is required")
+    if len(library_searches) < 2:
+        errors.append("professional_design_process.reference_research.library_searches requires at least 2 library searches")
+    for index, search in enumerate(library_searches):
+        if not isinstance(search, dict):
+            errors.append(f"professional_design_process.reference_research.library_searches[{index}] must be an object")
+            continue
+        for field in ("library", "library_url", "query_or_category", "searched_at"):
+            if not _non_empty_text(search.get(field)):
+                errors.append(f"professional_design_process.reference_research.library_searches[{index}].{field} is required")
+        if len(_list_items(search.get("selection_criteria"))) < 2:
+            errors.append(
+                f"professional_design_process.reference_research.library_searches[{index}].selection_criteria requires at least 2 items"
+            )
+        candidate_count = search.get("candidate_count")
+        if not isinstance(candidate_count, int) or candidate_count < 3:
+            errors.append(
+                f"professional_design_process.reference_research.library_searches[{index}].candidate_count must be at least 3"
+            )
+        if not _list_items(search.get("selected_source_ids")):
+            errors.append(
+                f"professional_design_process.reference_research.library_searches[{index}].selected_source_ids is required"
+            )
+        if not _list_items(search.get("rejected_candidate_ids")):
+            errors.append(
+                f"professional_design_process.reference_research.library_searches[{index}].rejected_candidate_ids is required"
+            )
+
+    source_types: set[str] = set()
     for index, source in enumerate(sources):
         if not isinstance(source, dict):
             errors.append(f"professional_design_process.reference_research.sources[{index}] must be an object")
             continue
-        for field in ("source_id", "source_url_or_ref", "use_type", "copy_policy", "license_or_terms_ref"):
+        for field in (
+            "source_id",
+            "source_url_or_ref",
+            "source_type",
+            "library_source",
+            "use_type",
+            "candidate_reason",
+            "copy_policy",
+            "license_or_terms_ref",
+        ):
             if not _non_empty_text(source.get(field)):
                 errors.append(f"professional_design_process.reference_research.sources[{index}].{field} is required")
+        source_type = str(source.get("source_type") or "").strip()
+        if source_type:
+            source_types.add(source_type)
+            if source_type not in REFERENCE_RESEARCH_SOURCE_TYPES:
+                errors.append(
+                    f"professional_design_process.reference_research.sources[{index}].source_type must be a known design reference type"
+                )
         if len(_list_items(source.get("what_to_learn"))) < 2:
             errors.append(f"professional_design_process.reference_research.sources[{index}].what_to_learn requires at least 2 items")
         if len(_list_items(source.get("extracted_patterns"))) < 2:
             errors.append(f"professional_design_process.reference_research.sources[{index}].extracted_patterns requires at least 2 items")
+        if len(_list_items(source.get("selected_patterns"))) < 2:
+            errors.append(
+                f"professional_design_process.reference_research.sources[{index}].selected_patterns requires at least 2 items"
+            )
+        if len(_list_items(source.get("visual_dimensions_covered"))) < 3:
+            errors.append(
+                f"professional_design_process.reference_research.sources[{index}].visual_dimensions_covered requires at least 3 items"
+            )
         if str(source.get("copy_policy") or "").strip().lower() in {"copy", "blind_copy"}:
             errors.append(f"professional_design_process.reference_research.sources[{index}].copy_policy must not allow blind copying")
+    if not source_types & REFERENCE_RESEARCH_LIBRARY_TYPES:
+        errors.append("professional_design_process.reference_research.sources requires at least one design library, component registry, site gallery or user-flow library source")
+    if len(source_types) < 2:
+        errors.append("professional_design_process.reference_research.sources requires at least 2 distinct source types")
+
+    if len(rejected_references) < 2:
+        errors.append("professional_design_process.reference_research.rejected_references requires at least 2 rejected candidates")
+    for index, rejected in enumerate(rejected_references):
+        if not isinstance(rejected, dict):
+            errors.append(f"professional_design_process.reference_research.rejected_references[{index}] must be an object")
+            continue
+        for field in ("source_id", "source_url_or_ref", "rejection_reason"):
+            if not _non_empty_text(rejected.get(field)):
+                errors.append(f"professional_design_process.reference_research.rejected_references[{index}].{field} is required")
+
+    synthesis = research.get("pattern_synthesis") if isinstance(research.get("pattern_synthesis"), dict) else {}
+    for field in REFERENCE_COMPARISON_DIMENSIONS:
+        if not _non_empty_text(synthesis.get(field)):
+            errors.append(f"professional_design_process.reference_research.pattern_synthesis.{field} is required")
+
+    evidence_policy = (
+        research.get("reference_evidence_policy") if isinstance(research.get("reference_evidence_policy"), dict) else {}
+    )
+    for field in (
+        "capture_required_before_implementation",
+        "side_by_side_comparison_required_before_pass",
+        "public_refs_only",
+        "no_private_screenshots_in_repo",
+    ):
+        if evidence_policy.get(field) is not True:
+            errors.append(f"professional_design_process.reference_research.reference_evidence_policy.{field} must be true")
 
     architecture = process.get("ux_architecture") if isinstance(process.get("ux_architecture"), dict) else {}
     for field in ("information_hierarchy", "navigation_model", "state_model", "density_rationale"):
@@ -2258,6 +2367,8 @@ def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
         errors.append("professional_design_process.comparative_review_gate.must_compare_to_reference_packet must be true")
     if not _non_empty_text(comparative.get("reviewer_role")):
         errors.append("professional_design_process.comparative_review_gate.reviewer_role is required")
+    elif "independent" not in str(comparative.get("reviewer_role") or "").strip().lower():
+        errors.append("professional_design_process.comparative_review_gate.reviewer_role must identify an independent design/Product Face reviewer")
     if not _non_empty_text(comparative.get("basis")):
         errors.append("professional_design_process.comparative_review_gate.basis is required")
     if not _list_items(comparative.get("block_when")):
@@ -2448,6 +2559,35 @@ def validate_card(data: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_reference_quality_comparison(comparison: Any, *, is_pass: bool) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(comparison, dict) or not comparison:
+        if is_pass:
+            errors.append("product_face_result.reference_quality_comparison is required for PASS")
+        return errors
+    if is_pass and _status_value(comparison) != "pass":
+        errors.append("product_face_result.reference_quality_comparison.status must be pass")
+    if not _non_empty_text(comparison.get("basis")):
+        errors.append("product_face_result.reference_quality_comparison.basis is required")
+    if not _non_empty_text(comparison.get("reference_set_ref")):
+        errors.append("product_face_result.reference_quality_comparison.reference_set_ref is required")
+    if is_pass and len(_list_items(comparison.get("compared_source_ids"))) < 3:
+        errors.append("product_face_result.reference_quality_comparison.compared_source_ids requires at least 3 references")
+    if is_pass and comparison.get("reviewer_independent_from_implementation") is not True:
+        errors.append("product_face_result.reference_quality_comparison.reviewer_independent_from_implementation must be true")
+    dimensions = comparison.get("dimensions") if isinstance(comparison.get("dimensions"), dict) else {}
+    for dimension in REFERENCE_COMPARISON_DIMENSIONS:
+        verdict = dimensions.get(dimension)
+        if not isinstance(verdict, dict):
+            errors.append(f"product_face_result.reference_quality_comparison.dimensions.{dimension} is required")
+            continue
+        if is_pass and _status_value(verdict) != "pass":
+            errors.append(f"product_face_result.reference_quality_comparison.dimensions.{dimension}.status must be pass")
+        if not _non_empty_text(verdict.get("basis")):
+            errors.append(f"product_face_result.reference_quality_comparison.dimensions.{dimension}.basis is required")
+    return errors
+
+
 def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     required_string = ["result", "tool_or_profile", "executed_by", "performance_note", "next_action"]
@@ -2486,6 +2626,8 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
             errors.append("product_face_result.visual_quality_result.status must be PASS, PASS_WITH_RESIDUALS or BLOCK")
         if not _non_empty_text(visual_quality.get("reviewer")):
             errors.append("product_face_result.visual_quality_result.reviewer is required")
+        elif is_pass and str(visual_quality.get("reviewer") or "").strip() == str(result.get("executed_by") or "").strip():
+            errors.append("product_face_result.visual_quality_result.reviewer must differ from executed_by")
         if not _non_empty_text(visual_quality.get("basis")):
             errors.append("product_face_result.visual_quality_result.basis is required")
         if visual_status in {"PASS", "PASS_WITH_RESIDUALS"} and visual_quality.get("reference_quality_bar_checked") is not True:
@@ -2506,6 +2648,7 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
             errors.append("product_face_result.professional_design_process_comparison.status must be pass")
         elif not _non_empty_text(professional_comparison.get("basis")):
             errors.append("product_face_result.professional_design_process_comparison.basis is required")
+    errors.extend(validate_reference_quality_comparison(result.get("reference_quality_comparison"), is_pass=is_pass))
     return errors
 
 
@@ -4031,9 +4174,23 @@ def build_worker_result(
                     "status": "pass" if not blocking_findings else "fail",
                     "basis": "Product Face evidence is explicitly compared to the professional design process.",
                 },
+                "reference_quality_comparison": {
+                    "status": "pass" if not blocking_findings else "fail",
+                    "basis": "Product Face evidence is compared against the selected design/reference library packet.",
+                    "reference_set_ref": "card.professional_design_process.reference_research",
+                    "compared_source_ids": ["design-library-reference", "component-registry-reference", "product-flow-reference"],
+                    "reviewer_independent_from_implementation": not blocking_findings,
+                    "dimensions": {
+                        dimension: {
+                            "status": "pass" if not blocking_findings else "fail",
+                            "basis": f"{dimension} compared against selected reference patterns.",
+                        }
+                        for dimension in REFERENCE_COMPARISON_DIMENSIONS
+                    },
+                },
                 "visual_quality_result": {
                     "status": "PASS" if not blocking_findings else "BLOCK",
-                    "reviewer": "product-face-validator",
+                    "reviewer": "independent-product-face-reviewer",
                     "basis": (
                         "Professional visual quality bar reviewed for this bounded card."
                         if not blocking_findings

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -27,8 +27,16 @@ PRODUCT_ALIGNMENT_FIELDS = (
     "source_promise_coverage",
     "design_fit_review",
     "professional_design_process_comparison",
+    "reference_quality_comparison",
 )
 VISUAL_QUALITY_PASS_RESULTS = {"PASS", "PASS_WITH_RESIDUALS"}
+REFERENCE_COMPARISON_DIMENSIONS = (
+    "layout_hierarchy",
+    "interaction_model",
+    "state_coverage",
+    "visual_language",
+    "density_spacing",
+)
 
 
 class PlaywrightUnavailable(RuntimeError):
@@ -105,6 +113,20 @@ def parse_viewport(raw: str) -> Viewport:
     if width < 1 or height < 1:
         raise ValueError(f"viewport dimensions must be positive, got {raw!r}")
     return Viewport(name=name.strip() or f"{width}x{height}", width=width, height=height)
+
+
+def parse_reference_dimension(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise ValueError("--reference-comparison-dimension must be DIMENSION=BASIS")
+    dimension, basis = raw.split("=", 1)
+    dimension = dimension.strip()
+    basis = basis.strip()
+    if dimension not in REFERENCE_COMPARISON_DIMENSIONS:
+        allowed = ", ".join(REFERENCE_COMPARISON_DIMENSIONS)
+        raise ValueError(f"--reference-comparison-dimension dimension must be one of: {allowed}")
+    if not basis:
+        raise ValueError("--reference-comparison-dimension basis must be non-empty")
+    return dimension, basis
 
 
 def resolve_target(target: str, *, allow_external_file: bool = False) -> tuple[str, Path | None]:
@@ -356,6 +378,20 @@ def base_result(
             "status": "pending",
             "basis": "Product Face proof must compare the result against the professional design process before promotion.",
         },
+        "reference_quality_comparison": {
+            "status": "pending",
+            "basis": "Product Face proof must compare the implemented surface against selected design-library references before promotion.",
+            "reference_set_ref": "",
+            "compared_source_ids": [],
+            "reviewer_independent_from_implementation": False,
+            "dimensions": {
+                dimension: {
+                    "status": "pending",
+                    "basis": "Reference comparison not recorded.",
+                }
+                for dimension in REFERENCE_COMPARISON_DIMENSIONS
+            },
+        },
         "visual_quality_result": {
             "status": "BLOCK",
             "reviewer": "product-face-proof-runner",
@@ -397,11 +433,13 @@ def validate_reusable_product_scope(
         raise ValueError(
             "--reusable-for-product requires Product Face alignment: packet_ref, "
             "packet_comparison=pass, source_promise_coverage=pass, design_fit_review=pass and "
-            "professional_design_process_comparison=pass"
+            "professional_design_process_comparison=pass, reference_quality_comparison=pass"
         )
     visual_quality = result.get("visual_quality_result") if isinstance(result.get("visual_quality_result"), dict) else {}
     if visual_quality.get("status") not in VISUAL_QUALITY_PASS_RESULTS or visual_quality.get("reference_quality_bar_checked") is not True:
         raise ValueError("reusable Product Face evidence requires visual_quality_result PASS or PASS_WITH_RESIDUALS")
+    if not reference_quality_passes(result):
+        raise ValueError("reusable Product Face evidence requires dimensioned reference_quality_comparison PASS")
 
 
 def product_alignment_passes(result: dict[str, Any]) -> bool:
@@ -433,6 +471,34 @@ def visual_quality_passes(result: dict[str, Any]) -> bool:
     return True
 
 
+def reference_quality_passes(result: dict[str, Any]) -> bool:
+    comparison = result.get("reference_quality_comparison")
+    if not isinstance(comparison, dict):
+        return False
+    if comparison.get("status") != "pass":
+        return False
+    if not str(comparison.get("basis") or "").strip():
+        return False
+    if not str(comparison.get("reference_set_ref") or "").strip():
+        return False
+    if len([item for item in comparison.get("compared_source_ids") or [] if str(item).strip()]) < 3:
+        return False
+    if comparison.get("reviewer_independent_from_implementation") is not True:
+        return False
+    dimensions = comparison.get("dimensions")
+    if not isinstance(dimensions, dict):
+        return False
+    for dimension in REFERENCE_COMPARISON_DIMENSIONS:
+        verdict = dimensions.get(dimension)
+        if not isinstance(verdict, dict):
+            return False
+        if verdict.get("status") != "pass":
+            return False
+        if not str(verdict.get("basis") or "").strip():
+            return False
+    return True
+
+
 def apply_product_alignment(
     *,
     result: dict[str, Any],
@@ -442,6 +508,10 @@ def apply_product_alignment(
     design_fit_review_basis: str | None,
     professional_design_process_ref: str | None,
     professional_design_process_comparison_basis: str | None,
+    reference_quality_ref: str | None,
+    reference_quality_comparison_basis: str | None,
+    compared_reference_ids: list[str] | None,
+    reference_quality_dimensions: dict[str, str] | None,
 ) -> None:
     values = {
         "packet_ref": packet_ref,
@@ -450,11 +520,26 @@ def apply_product_alignment(
         "design_fit_review": design_fit_review_basis,
         "professional_design_process_ref": professional_design_process_ref,
         "professional_design_process_comparison": professional_design_process_comparison_basis,
+        "reference_quality_ref": reference_quality_ref,
+        "reference_quality_comparison": reference_quality_comparison_basis,
     }
     supplied = {field for field, value in values.items() if str(value or "").strip()}
+    if compared_reference_ids:
+        supplied.add("compared_reference_ids")
+    if reference_quality_dimensions:
+        supplied.add("reference_quality_dimensions")
     if not supplied:
         return
     missing = [field for field, value in values.items() if not str(value or "").strip()]
+    if not compared_reference_ids or len([item for item in compared_reference_ids if str(item).strip()]) < 3:
+        missing.append("compared_reference_ids")
+    missing_dimensions = [
+        dimension
+        for dimension in REFERENCE_COMPARISON_DIMENSIONS
+        if not str((reference_quality_dimensions or {}).get(dimension) or "").strip()
+    ]
+    if missing_dimensions:
+        missing.extend(f"reference_comparison_dimension:{dimension}" for dimension in missing_dimensions)
     if missing:
         raise ValueError("Product Face alignment is incomplete: missing " + ", ".join(missing))
     result["packet_ref"] = str(packet_ref).strip()
@@ -474,6 +559,20 @@ def apply_product_alignment(
     result["professional_design_process_comparison"] = {
         "status": "pass",
         "basis": str(professional_design_process_comparison_basis).strip(),
+    }
+    result["reference_quality_comparison"] = {
+        "status": "pass",
+        "basis": str(reference_quality_comparison_basis).strip(),
+        "reference_set_ref": str(reference_quality_ref).strip(),
+        "compared_source_ids": [str(item).strip() for item in compared_reference_ids or [] if str(item).strip()],
+        "reviewer_independent_from_implementation": True,
+        "dimensions": {
+            dimension: {
+                "status": "pass",
+                "basis": str((reference_quality_dimensions or {}).get(dimension)).strip(),
+            }
+            for dimension in REFERENCE_COMPARISON_DIMENSIONS
+        },
     }
 
 
@@ -511,14 +610,14 @@ def apply_visual_quality_review(
 
 
 def enforce_visual_quality_gate(result: dict[str, Any]) -> None:
-    if result.get("result") == "PASS" and not visual_quality_passes(result):
+    if result.get("result") == "PASS" and (not visual_quality_passes(result) or not reference_quality_passes(result)):
         result["result"] = "WAIVED"
         result["blocking_findings"] = True
         result["findings_summary"] = (
-            "Mechanical Product Face proof ran, but professional visual quality approval is missing or blocked."
+            "Mechanical Product Face proof ran, but professional visual/reference quality approval is missing or blocked."
         )
         result["next_action"] = (
-            "Record visual_quality_result PASS or PASS_WITH_RESIDUALS from an empowered Product Face reviewer before promotion."
+            "Record visual_quality_result and dimensioned reference_quality_comparison PASS from an independent Product Face reviewer before promotion."
         )
 
 
@@ -838,6 +937,10 @@ def build_product_face_proof(
     design_fit_review_basis: str | None = None,
     professional_design_process_ref: str | None = None,
     professional_design_process_comparison_basis: str | None = None,
+    reference_quality_ref: str | None = None,
+    reference_quality_comparison_basis: str | None = None,
+    compared_reference_ids: list[str] | None = None,
+    reference_quality_dimensions: dict[str, str] | None = None,
     visual_quality_status: str | None = None,
     visual_quality_reviewer: str | None = None,
     visual_quality_basis: str | None = None,
@@ -902,6 +1005,10 @@ def build_product_face_proof(
         design_fit_review_basis=design_fit_review_basis,
         professional_design_process_ref=professional_design_process_ref,
         professional_design_process_comparison_basis=professional_design_process_comparison_basis,
+        reference_quality_ref=reference_quality_ref,
+        reference_quality_comparison_basis=reference_quality_comparison_basis,
+        compared_reference_ids=compared_reference_ids,
+        reference_quality_dimensions=reference_quality_dimensions,
     )
     apply_visual_quality_review(
         result=result,
@@ -953,6 +1060,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--design-fit-review-basis", help="Why this proof fits the intended product/design direction.")
     parser.add_argument("--professional-design-process-ref", help="Professional Design Process packet used for Product Face approval.")
     parser.add_argument("--professional-design-process-comparison-basis", help="Why this proof satisfies the professional design process.")
+    parser.add_argument("--reference-quality-ref", help="Reference research packet/set used for dimensioned Product Face comparison.")
+    parser.add_argument("--reference-quality-comparison-basis", help="Why this proof matches the selected professional references.")
+    parser.add_argument("--compared-reference-id", action="append", help="Reference source id used in the side-by-side comparison. Repeat at least 3 times.")
+    parser.add_argument(
+        "--reference-comparison-dimension",
+        action="append",
+        help="Dimension comparison as DIMENSION=BASIS. Required dimensions: layout_hierarchy, interaction_model, state_coverage, visual_language, density_spacing.",
+    )
     parser.add_argument("--visual-quality-status", choices=["PASS", "BLOCK", "PASS_WITH_RESIDUALS"], help="Professional visual quality verdict.")
     parser.add_argument("--visual-quality-reviewer", help="Reviewer empowered to block visually unacceptable UI.")
     parser.add_argument("--visual-quality-basis", help="Why the surface meets or fails the product-specific quality bar.")
@@ -964,6 +1079,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
         viewports = [parse_viewport(raw) for raw in args.viewport] if args.viewport else None
+        reference_dimensions = {
+            dimension: basis
+            for dimension, basis in (
+                parse_reference_dimension(raw) for raw in args.reference_comparison_dimension or []
+            )
+        }
         result = build_product_face_proof(
             target=args.target,
             out=Path(args.out),
@@ -984,6 +1105,10 @@ def main(argv: list[str] | None = None) -> int:
             design_fit_review_basis=args.design_fit_review_basis,
             professional_design_process_ref=args.professional_design_process_ref,
             professional_design_process_comparison_basis=args.professional_design_process_comparison_basis,
+            reference_quality_ref=args.reference_quality_ref,
+            reference_quality_comparison_basis=args.reference_quality_comparison_basis,
+            compared_reference_ids=args.compared_reference_id,
+            reference_quality_dimensions=reference_dimensions,
             visual_quality_status=args.visual_quality_status,
             visual_quality_reviewer=args.visual_quality_reviewer,
             visual_quality_basis=args.visual_quality_basis,

--- a/scripts/production_full_product_worker_graph.py
+++ b/scripts/production_full_product_worker_graph.py
@@ -155,7 +155,13 @@ def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
         if lane.get("reusable_policy") == "strict" and data.get("reusable_for_product") is not True:
             errors.append("strict lane must be reusable_for_product=true")
         if lane.get("record_type") == "product_face_result" and lane.get("reusable_policy") == "strict":
-            for field in ("packet_comparison", "source_promise_coverage", "design_fit_review", "professional_design_process_comparison"):
+            for field in (
+                "packet_comparison",
+                "source_promise_coverage",
+                "design_fit_review",
+                "professional_design_process_comparison",
+                "reference_quality_comparison",
+            ):
                 value = data.get(field)
                 if not isinstance(value, dict) or value.get("status") != "pass":
                     errors.append(f"strict Product Face lane requires {field}.status=pass")

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -39,6 +39,28 @@ PRODUCT_FACE_ALIGNMENT_FIELDS = (
     "source_promise_coverage",
     "design_fit_review",
     "professional_design_process_comparison",
+    "reference_quality_comparison",
+)
+REFERENCE_RESEARCH_SOURCE_TYPES = {
+    "component_registry",
+    "design_library",
+    "design_system",
+    "product_reference",
+    "site_gallery",
+    "user_flow_library",
+}
+REFERENCE_RESEARCH_LIBRARY_TYPES = {
+    "component_registry",
+    "design_library",
+    "site_gallery",
+    "user_flow_library",
+}
+REFERENCE_COMPARISON_DIMENSIONS = (
+    "layout_hierarchy",
+    "interaction_model",
+    "state_coverage",
+    "visual_language",
+    "density_spacing",
 )
 PRIVATE_USERS_PATH = "C:" + r"[\\/]+" + "Users"
 PRIVATE_SYNC_ROOT = "One" + "Drive"
@@ -189,24 +211,98 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             value = data.get(field)
             if not isinstance(value, dict) or value.get("status") != "pass":
                 errors.append(f"{at}: reusable product_face_result requires {field}.status=pass")
+        comparison = data.get("reference_quality_comparison")
+        if isinstance(comparison, dict) and comparison.get("status") == "pass":
+            if len([item for item in comparison.get("compared_source_ids") or [] if str(item).strip()]) < 3:
+                errors.append(f"{at}: reusable product_face_result requires at least 3 compared reference ids")
+            if comparison.get("reviewer_independent_from_implementation") is not True:
+                errors.append(f"{at}: reference_quality_comparison requires independent reviewer proof")
+            dimensions = comparison.get("dimensions") if isinstance(comparison.get("dimensions"), dict) else {}
+            for dimension in REFERENCE_COMPARISON_DIMENSIONS:
+                verdict = dimensions.get(dimension)
+                if not isinstance(verdict, dict) or verdict.get("status") != "pass" or not str(verdict.get("basis") or "").strip():
+                    errors.append(f"{at}: reference_quality_comparison.dimensions.{dimension} requires status=pass and basis")
     if data.get("record_type") == "professional_design_process":
         research = data.get("reference_research") if isinstance(data.get("reference_research"), dict) else {}
         sources = research.get("sources") if isinstance(research.get("sources"), list) else []
+        library_searches = research.get("library_searches") if isinstance(research.get("library_searches"), list) else []
+        rejected_references = research.get("rejected_references") if isinstance(research.get("rejected_references"), list) else []
+        pattern_synthesis = research.get("pattern_synthesis") if isinstance(research.get("pattern_synthesis"), dict) else {}
+        evidence_policy = research.get("reference_evidence_policy") if isinstance(research.get("reference_evidence_policy"), dict) else {}
+        source_types: set[str] = set()
         if len(sources) < 3:
             errors.append(f"{at}: professional_design_process requires at least 3 reference sources")
+        if len(library_searches) < 2:
+            errors.append(f"{at}: professional_design_process requires at least 2 library searches")
+        for index, search in enumerate(library_searches):
+            if not isinstance(search, dict):
+                errors.append(f"{at}.reference_research.library_searches[{index}]: expected object")
+                continue
+            for field in ("library", "library_url", "query_or_category", "searched_at"):
+                if not str(search.get(field) or "").strip():
+                    errors.append(f"{at}.reference_research.library_searches[{index}]: missing {field}")
+            if len(search.get("selection_criteria") or []) < 2:
+                errors.append(f"{at}.reference_research.library_searches[{index}]: requires at least 2 selection_criteria")
+            if int(search.get("candidate_count") or 0) < 3:
+                errors.append(f"{at}.reference_research.library_searches[{index}]: candidate_count must be at least 3")
+            if not search.get("selected_source_ids"):
+                errors.append(f"{at}.reference_research.library_searches[{index}]: selected_source_ids is required")
+            if not search.get("rejected_candidate_ids"):
+                errors.append(f"{at}.reference_research.library_searches[{index}]: rejected_candidate_ids is required")
         for index, source in enumerate(sources):
             if not isinstance(source, dict):
                 errors.append(f"{at}.reference_research.sources[{index}]: expected object")
                 continue
+            source_type = str(source.get("source_type") or "").strip()
+            if source_type not in REFERENCE_RESEARCH_SOURCE_TYPES:
+                errors.append(f"{at}.reference_research.sources[{index}]: source_type must be a known reference type")
+            else:
+                source_types.add(source_type)
+            for field in ("library_source", "candidate_reason", "license_or_terms_ref"):
+                if not str(source.get(field) or "").strip():
+                    errors.append(f"{at}.reference_research.sources[{index}]: missing {field}")
+            if len(source.get("what_to_learn") or []) < 2:
+                errors.append(f"{at}.reference_research.sources[{index}]: requires at least 2 what_to_learn items")
             if len(source.get("extracted_patterns") or []) < 2:
                 errors.append(f"{at}.reference_research.sources[{index}]: requires at least 2 extracted_patterns")
+            if len(source.get("selected_patterns") or []) < 2:
+                errors.append(f"{at}.reference_research.sources[{index}]: requires at least 2 selected_patterns")
+            if len(source.get("visual_dimensions_covered") or []) < 3:
+                errors.append(f"{at}.reference_research.sources[{index}]: requires at least 3 visual_dimensions_covered")
             copy_policy = str(source.get("copy_policy") or "").lower()
             if copy_policy in {"copy", "blind_copy"}:
                 errors.append(f"{at}.reference_research.sources[{index}]: copy_policy must not allow blind copying")
+        if not (source_types & REFERENCE_RESEARCH_LIBRARY_TYPES):
+            errors.append(f"{at}: professional_design_process requires a design library, component registry, site gallery or user-flow library source")
+        if len(source_types) < 2:
+            errors.append(f"{at}: professional_design_process requires at least 2 distinct source types")
+        if len(rejected_references) < 2:
+            errors.append(f"{at}: professional_design_process requires at least 2 rejected references")
+        for index, rejected in enumerate(rejected_references):
+            if not isinstance(rejected, dict):
+                errors.append(f"{at}.reference_research.rejected_references[{index}]: expected object")
+                continue
+            for field in ("source_id", "source_url_or_ref", "rejection_reason"):
+                if not str(rejected.get(field) or "").strip():
+                    errors.append(f"{at}.reference_research.rejected_references[{index}]: missing {field}")
+        for dimension in REFERENCE_COMPARISON_DIMENSIONS:
+            if not str(pattern_synthesis.get(dimension) or "").strip():
+                errors.append(f"{at}.reference_research.pattern_synthesis.{dimension}: required")
+        for field in (
+            "capture_required_before_implementation",
+            "side_by_side_comparison_required_before_pass",
+            "public_refs_only",
+            "no_private_screenshots_in_repo",
+        ):
+            if evidence_policy.get(field) is not True:
+                errors.append(f"{at}.reference_research.reference_evidence_policy.{field}: must be true")
         for gate_name in ("wireframe_gate", "prototype_gate", "comparative_review_gate"):
             gate = data.get(gate_name) if isinstance(data.get(gate_name), dict) else {}
             if gate.get("status") != "PASS":
                 errors.append(f"{at}: professional_design_process {gate_name}.status must be PASS")
+        reviewer_role = str((data.get("comparative_review_gate") or {}).get("reviewer_role") or "").lower()
+        if "independent" not in reviewer_role:
+            errors.append(f"{at}: professional_design_process comparative_review_gate requires an independent reviewer")
     if data.get("record_type") == "factory_learning_proposal":
         serialized_refs = "\n".join(str(ref) for ref in data.get("source_evidence_refs", []))
         if PRIVATE_MARKERS.search(serialized_refs):

--- a/templates/professional-design-process.json
+++ b/templates/professional-design-process.json
@@ -40,9 +40,11 @@
     "registry_refs": [
       "templates/reference-source-registry.json#21st-dev",
       "templates/reference-source-registry.json#refero-styles",
-      "templates/reference-source-registry.json#motionsites"
+      "templates/reference-source-registry.json#motionsites",
+      "templates/reference-source-registry.json#mobbin",
+      "templates/reference-source-registry.json#pageflows"
     ],
-    "selection_rationale": "Use component/reference libraries for interaction and visual craft, but copy no code or assets without license review.",
+    "selection_rationale": "Search professional component libraries, product-flow libraries and public product references before implementation; select and reject candidates explicitly, synthesize reusable patterns, and copy no code, text, screenshots or assets without license review.",
     "sources": [
       {
         "source_id": "radix-ui-themes",
@@ -58,7 +60,19 @@
         ],
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-        "public_safety_notes": "Reference only; no source code, text or assets copied."
+        "public_safety_notes": "Reference only; no source code, text or assets copied.",
+        "source_type": "design_system",
+        "library_source": "Radix Themes",
+        "candidate_reason": "Selected for accessibility, semantic token and component density discipline.",
+        "selected_patterns": [
+          "Semantic color roles must drive product states instead of decorative palettes.",
+          "Composable, named controls should replace oversized explanatory blocks."
+        ],
+        "visual_dimensions_covered": [
+          "visual_language",
+          "density_spacing",
+          "interaction_model"
+        ]
       },
       {
         "source_id": "shadcn-data-table",
@@ -74,7 +88,19 @@
         ],
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-        "public_safety_notes": "Reference only; no source code, text or assets copied."
+        "public_safety_notes": "Reference only; no source code, text or assets copied.",
+        "source_type": "component_registry",
+        "library_source": "shadcn/ui",
+        "candidate_reason": "Selected for dense data-table ergonomics, filtering, sorting and row action patterns.",
+        "selected_patterns": [
+          "Dense operational data needs search, filters, sort and visible row focus.",
+          "Controls belong close to the data or state they affect."
+        ],
+        "visual_dimensions_covered": [
+          "layout_hierarchy",
+          "interaction_model",
+          "density_spacing"
+        ]
       },
       {
         "source_id": "linear-product-workflow",
@@ -90,9 +116,200 @@
         ],
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no source code, text or assets copied.",
+        "source_type": "product_reference",
+        "library_source": "Linear public product reference",
+        "candidate_reason": "Selected for compact work management hierarchy, state clarity and low-friction navigation.",
+        "selected_patterns": [
+          "Operational product tools should be compact, scannable and state-first.",
+          "Primary work context should be visible without a marketing-style hero."
+        ],
+        "visual_dimensions_covered": [
+          "layout_hierarchy",
+          "state_coverage",
+          "density_spacing"
+        ]
+      },
+      {
+        "source_id": "21st-dev-components",
+        "source_url_or_ref": "https://21st.dev/",
+        "source_type": "component_registry",
+        "library_source": "21st.dev",
+        "use_type": "component-library-and-craft-benchmark",
+        "candidate_reason": "Selected to compare component polish, hierarchy, spacing and interaction finish against modern React/Tailwind component references.",
+        "what_to_learn": [
+          "How modern component libraries compose dense command surfaces without looking generic.",
+          "How spacing, state affordances and micro-interactions make controls feel deliberate."
+        ],
+        "extracted_patterns": [
+          "Reusable components need explicit state, focus, hover and disabled behavior before visual approval.",
+          "Component density should be tuned to the operator task instead of stretched into marketing cards."
+        ],
+        "selected_patterns": [
+          "Require explicit states for controls and rows before Product Face PASS.",
+          "Use compact component groups with clear hierarchy instead of decorative dashboard blocks."
+        ],
+        "visual_dimensions_covered": [
+          "interaction_model",
+          "visual_language",
+          "density_spacing"
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
         "public_safety_notes": "Reference only; no source code, text or assets copied."
+      },
+      {
+        "source_id": "mobbin-workflow-patterns",
+        "source_url_or_ref": "https://mobbin.com/",
+        "source_type": "user_flow_library",
+        "library_source": "Mobbin",
+        "use_type": "real-product-flow-and-screen-benchmark",
+        "candidate_reason": "Selected because real product flows expose navigation, density and state decisions that isolated mockups hide.",
+        "what_to_learn": [
+          "How professional products sequence navigation, detail inspection and recovery states.",
+          "How repeated-use workflows avoid decorative elements that slow scanning."
+        ],
+        "extracted_patterns": [
+          "A serious workflow needs visible current state, selected object, next action and recovery path.",
+          "Reference study must cover multiple screens or states, not a single attractive screenshot."
+        ],
+        "selected_patterns": [
+          "Require current object, state and next action to be visible together.",
+          "Reject single-screen inspiration that does not explain workflow behavior."
+        ],
+        "visual_dimensions_covered": [
+          "layout_hierarchy",
+          "interaction_model",
+          "state_coverage"
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Use synthesized observations only; do not commit screenshots or private captures."
+      },
+      {
+        "source_id": "pageflows-review-approval",
+        "source_url_or_ref": "https://pageflows.com/",
+        "source_type": "user_flow_library",
+        "library_source": "Page Flows",
+        "use_type": "journey-state-and-approval-flow-benchmark",
+        "candidate_reason": "Selected to force journey-level coverage for approval, error, review and onboarding states.",
+        "what_to_learn": [
+          "How professional products communicate progress, blocking states and fallback paths across a journey.",
+          "How approval and review flows preserve confidence without hiding consequences."
+        ],
+        "extracted_patterns": [
+          "Approval surfaces need consequence, evidence and rollback context before the action.",
+          "Error and blocked states should preserve orientation and show the next safe action."
+        ],
+        "selected_patterns": [
+          "Require consequence, evidence and fallback context for approval surfaces.",
+          "Treat blocked/error states as first-class Product Face screenshots."
+        ],
+        "visual_dimensions_covered": [
+          "interaction_model",
+          "state_coverage",
+          "layout_hierarchy"
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Use journey-level learning only; no copied videos, screenshots or private material."
       }
-    ]
+    ],
+    "library_searches": [
+      {
+        "library": "21st.dev",
+        "library_url": "https://21st.dev/",
+        "query_or_category": "operations dashboard, command surface, data table and review components",
+        "searched_at": "2026-06-14",
+        "selection_criteria": [
+          "component craft supports dense repeated operator use",
+          "states and controls can be adapted without copying code or assets"
+        ],
+        "candidate_count": 6,
+        "selected_source_ids": [
+          "21st-dev-components",
+          "shadcn-data-table"
+        ],
+        "rejected_candidate_ids": [
+          "decorative-dashboard-template",
+          "oversized-hero-block"
+        ]
+      },
+      {
+        "library": "Mobbin",
+        "library_url": "https://mobbin.com/",
+        "query_or_category": "workflow, status, review, incident and project operations flows",
+        "searched_at": "2026-06-14",
+        "selection_criteria": [
+          "real product flow exposes navigation and state transitions",
+          "patterns improve operator speed instead of presentation aesthetics"
+        ],
+        "candidate_count": 6,
+        "selected_source_ids": [
+          "mobbin-workflow-patterns",
+          "linear-product-workflow"
+        ],
+        "rejected_candidate_ids": [
+          "marketing-dashboard-gallery",
+          "single-screenshot-flow"
+        ]
+      },
+      {
+        "library": "Page Flows",
+        "library_url": "https://pageflows.com/",
+        "query_or_category": "approval, review, onboarding, error and blocked-state journeys",
+        "searched_at": "2026-06-14",
+        "selection_criteria": [
+          "journey shows consequences and recovery states",
+          "flow can be compared dimension-by-dimension against the product task model"
+        ],
+        "candidate_count": 5,
+        "selected_source_ids": [
+          "pageflows-review-approval"
+        ],
+        "rejected_candidate_ids": [
+          "happy-path-only-flow"
+        ]
+      }
+    ],
+    "rejected_references": [
+      {
+        "source_id": "decorative-dashboard-template",
+        "source_url_or_ref": "external:generic-dashboard-gallery",
+        "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
+      },
+      {
+        "source_id": "marketing-dashboard-gallery",
+        "source_url_or_ref": "external:marketing-dashboard-gallery",
+        "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+      },
+      {
+        "source_id": "happy-path-only-flow",
+        "source_url_or_ref": "external:single-happy-path-flow",
+        "rejection_reason": "Rejected because it does not show blocked, error, review or approval consequences."
+      }
+    ],
+    "pattern_synthesis": {
+      "layout_hierarchy": "Lead with source freshness, current state, blocker/next action and selected object before secondary metrics or explanation.",
+      "interaction_model": "Use command strips, segmented state filters, searchable lists, adjacent inspectors and explicit approval/recovery actions.",
+      "state_coverage": "Design and capture loading, empty, success, blocked, stale, contradictory, private-unavailable and visual-quality-fail states before PASS.",
+      "visual_language": "Use a restrained professional product-tool language with semantic status color, crisp typography and no generic AI-dashboard decoration.",
+      "density_spacing": "Keep dense but readable rows, fixed tool dimensions and compact panels so repeated operation is fast and stable.",
+      "anti_patterns": [
+        "single attractive screenshot without workflow proof",
+        "decorative KPI cards disconnected from factory objects",
+        "hero layout or marketing composition inside an operational cockpit"
+      ]
+    },
+    "reference_evidence_policy": {
+      "capture_required_before_implementation": true,
+      "side_by_side_comparison_required_before_pass": true,
+      "public_refs_only": true,
+      "no_private_screenshots_in_repo": true,
+      "public_safe_evidence_refs": [
+        "professional_design_process.reference_research.sources"
+      ]
+    }
   },
   "ux_architecture": {
     "information_hierarchy": [
@@ -176,13 +393,15 @@
   },
   "comparative_review_gate": {
     "status": "PASS",
-    "reviewer_role": "product-face",
+    "reviewer_role": "independent-product-face-reviewer",
     "must_compare_to_reference_packet": true,
-    "basis": "Product Face reviewer must compare the implemented surface to the reference research and block generic AI-dashboard symptoms.",
+    "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
     "block_when": [
       "The result resembles a generic dashboard rather than the product's task model.",
       "Reference research exists but did not affect layout, hierarchy, controls or state treatment.",
-      "Mechanical screenshots pass while the visual hierarchy is not credible for a professional product."
+      "Mechanical screenshots pass while the visual hierarchy is not credible for a professional product.",
+      "Reference research lacks real library searches, selected candidates and rejected candidates.",
+      "The result cannot explain, dimension by dimension, how it matches or deliberately differs from the chosen references."
     ]
   },
   "handoff_requirements": {
@@ -195,11 +414,16 @@
       "visual direction",
       "prototype gate",
       "design QA plan",
-      "comparative review gate"
+      "comparative review gate",
+      "library searches",
+      "rejected references",
+      "pattern synthesis",
+      "reference evidence policy"
     ],
     "product_face_result_must_include": [
       "professional_design_process_ref",
-      "professional_design_process_comparison.status=pass"
+      "professional_design_process_comparison.status=pass",
+      "reference_quality_comparison.status=pass"
     ]
   }
 }

--- a/templates/reference-source-registry.json
+++ b/templates/reference-source-registry.json
@@ -33,6 +33,26 @@
       "informs_product_experience_fields": ["design_direction", "component expectations"]
     },
     {
+      "source_id": "mobbin",
+      "name": "Mobbin",
+      "url": "https://mobbin.com/",
+      "allowed_use": ["real product flow benchmark", "mobile and web UX pattern study"],
+      "forbidden_use": ["copying product screenshots into the repo", "copying brand-specific layouts or assets"],
+      "license_terms_status": "operator must verify current terms before reuse; default to reference-only study",
+      "public_safety_notes": "Record synthesized patterns and public URLs only; do not commit private screenshots.",
+      "informs_product_experience_fields": ["interaction_model", "state_coverage", "workflow ergonomics"]
+    },
+    {
+      "source_id": "pageflows",
+      "name": "Page Flows",
+      "url": "https://pageflows.com/",
+      "allowed_use": ["user journey benchmark", "state and transition coverage study"],
+      "forbidden_use": ["copying videos/screenshots into the repo", "treating a single screen as full UX proof"],
+      "license_terms_status": "operator must verify current terms before reuse; default to reference-only study",
+      "public_safety_notes": "Use as journey evidence source; publish only synthesized observations unless licensed.",
+      "informs_product_experience_fields": ["task_model", "interaction_model", "state_coverage"]
+    },
+    {
       "source_id": "sceneai",
       "name": "SceneAI",
       "url": "https://sceneai.art/",

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -363,50 +363,276 @@
       "registry_refs": [
         "templates/reference-source-registry.json#21st-dev",
         "templates/reference-source-registry.json#refero-styles",
-        "templates/reference-source-registry.json#motionsites"
+        "templates/reference-source-registry.json#motionsites",
+        "templates/reference-source-registry.json#mobbin",
+        "templates/reference-source-registry.json#pageflows"
       ],
-      "selection_rationale": "Use references to define craft, density, interaction and state treatment before implementation; copy no code or assets without license review.",
+      "selection_rationale": "Search professional component libraries, product-flow libraries and public product references before implementation; select and reject candidates explicitly, synthesize reusable patterns, and copy no code, text, screenshots or assets without license review.",
       "sources": [
         {
           "source_id": "radix-ui-themes",
           "source_url_or_ref": "https://www.radix-ui.com/themes",
           "use_type": "accessibility-and-token-system-reference",
-          "what_to_learn": ["accessible primitives", "color and density token discipline"],
+          "what_to_learn": [
+            "accessible primitives",
+            "color and density token discipline"
+          ],
           "extracted_patterns": [
             "Use semantic tokens and states instead of one decorative palette.",
             "Prefer composable controls over oversized text blocks."
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no source code, text or assets copied."
+          "public_safety_notes": "Reference only; no source code, text or assets copied.",
+          "source_type": "design_system",
+          "library_source": "Radix Themes",
+          "candidate_reason": "Selected for accessibility, semantic token and component density discipline.",
+          "selected_patterns": [
+            "Semantic color roles must drive product states instead of decorative palettes.",
+            "Composable, named controls should replace oversized explanatory blocks."
+          ],
+          "visual_dimensions_covered": [
+            "visual_language",
+            "density_spacing",
+            "interaction_model"
+          ]
         },
         {
           "source_id": "shadcn-data-table",
           "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
           "use_type": "structured-data-interaction-reference",
-          "what_to_learn": ["filtering and row focus", "data table interaction ergonomics"],
+          "what_to_learn": [
+            "filtering and row focus",
+            "data table interaction ergonomics"
+          ],
           "extracted_patterns": [
             "Dense operational data needs search, filters and clear row state.",
             "Controls should stay close to the data they affect."
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-          "public_safety_notes": "Reference only; no source code, text or assets copied."
+          "public_safety_notes": "Reference only; no source code, text or assets copied.",
+          "source_type": "component_registry",
+          "library_source": "shadcn/ui",
+          "candidate_reason": "Selected for dense data-table ergonomics, filtering, sorting and row action patterns.",
+          "selected_patterns": [
+            "Dense operational data needs search, filters, sort and visible row focus.",
+            "Controls belong close to the data or state they affect."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "density_spacing"
+          ]
         },
         {
           "source_id": "linear-product-workflow",
           "source_url_or_ref": "https://linear.app",
           "use_type": "product-workflow-and-state-reference",
-          "what_to_learn": ["fast product-work navigation", "state and ownership clarity"],
+          "what_to_learn": [
+            "fast product-work navigation",
+            "state and ownership clarity"
+          ],
           "extracted_patterns": [
             "Product tools should be compact, scannable and state-first.",
             "Primary work context should be visible without a marketing-style hero."
           ],
           "copy_policy": "do_not_copy",
           "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Reference only; no source code, text or assets copied.",
+          "source_type": "product_reference",
+          "library_source": "Linear public product reference",
+          "candidate_reason": "Selected for compact work management hierarchy, state clarity and low-friction navigation.",
+          "selected_patterns": [
+            "Operational product tools should be compact, scannable and state-first.",
+            "Primary work context should be visible without a marketing-style hero."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "state_coverage",
+            "density_spacing"
+          ]
+        },
+        {
+          "source_id": "21st-dev-components",
+          "source_url_or_ref": "https://21st.dev/",
+          "source_type": "component_registry",
+          "library_source": "21st.dev",
+          "use_type": "component-library-and-craft-benchmark",
+          "candidate_reason": "Selected to compare component polish, hierarchy, spacing and interaction finish against modern React/Tailwind component references.",
+          "what_to_learn": [
+            "How modern component libraries compose dense command surfaces without looking generic.",
+            "How spacing, state affordances and micro-interactions make controls feel deliberate."
+          ],
+          "extracted_patterns": [
+            "Reusable components need explicit state, focus, hover and disabled behavior before visual approval.",
+            "Component density should be tuned to the operator task instead of stretched into marketing cards."
+          ],
+          "selected_patterns": [
+            "Require explicit states for controls and rows before Product Face PASS.",
+            "Use compact component groups with clear hierarchy instead of decorative dashboard blocks."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "visual_language",
+            "density_spacing"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
           "public_safety_notes": "Reference only; no source code, text or assets copied."
+        },
+        {
+          "source_id": "mobbin-workflow-patterns",
+          "source_url_or_ref": "https://mobbin.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Mobbin",
+          "use_type": "real-product-flow-and-screen-benchmark",
+          "candidate_reason": "Selected because real product flows expose navigation, density and state decisions that isolated mockups hide.",
+          "what_to_learn": [
+            "How professional products sequence navigation, detail inspection and recovery states.",
+            "How repeated-use workflows avoid decorative elements that slow scanning."
+          ],
+          "extracted_patterns": [
+            "A serious workflow needs visible current state, selected object, next action and recovery path.",
+            "Reference study must cover multiple screens or states, not a single attractive screenshot."
+          ],
+          "selected_patterns": [
+            "Require current object, state and next action to be visible together.",
+            "Reject single-screen inspiration that does not explain workflow behavior."
+          ],
+          "visual_dimensions_covered": [
+            "layout_hierarchy",
+            "interaction_model",
+            "state_coverage"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use synthesized observations only; do not commit screenshots or private captures."
+        },
+        {
+          "source_id": "pageflows-review-approval",
+          "source_url_or_ref": "https://pageflows.com/",
+          "source_type": "user_flow_library",
+          "library_source": "Page Flows",
+          "use_type": "journey-state-and-approval-flow-benchmark",
+          "candidate_reason": "Selected to force journey-level coverage for approval, error, review and onboarding states.",
+          "what_to_learn": [
+            "How professional products communicate progress, blocking states and fallback paths across a journey.",
+            "How approval and review flows preserve confidence without hiding consequences."
+          ],
+          "extracted_patterns": [
+            "Approval surfaces need consequence, evidence and rollback context before the action.",
+            "Error and blocked states should preserve orientation and show the next safe action."
+          ],
+          "selected_patterns": [
+            "Require consequence, evidence and fallback context for approval surfaces.",
+            "Treat blocked/error states as first-class Product Face screenshots."
+          ],
+          "visual_dimensions_covered": [
+            "interaction_model",
+            "state_coverage",
+            "layout_hierarchy"
+          ],
+          "copy_policy": "do_not_copy",
+          "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+          "public_safety_notes": "Use journey-level learning only; no copied videos, screenshots or private material."
         }
-      ]
+      ],
+      "library_searches": [
+        {
+          "library": "21st.dev",
+          "library_url": "https://21st.dev/",
+          "query_or_category": "operations dashboard, command surface, data table and review components",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "component craft supports dense repeated operator use",
+            "states and controls can be adapted without copying code or assets"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "21st-dev-components",
+            "shadcn-data-table"
+          ],
+          "rejected_candidate_ids": [
+            "decorative-dashboard-template",
+            "oversized-hero-block"
+          ]
+        },
+        {
+          "library": "Mobbin",
+          "library_url": "https://mobbin.com/",
+          "query_or_category": "workflow, status, review, incident and project operations flows",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "real product flow exposes navigation and state transitions",
+            "patterns improve operator speed instead of presentation aesthetics"
+          ],
+          "candidate_count": 6,
+          "selected_source_ids": [
+            "mobbin-workflow-patterns",
+            "linear-product-workflow"
+          ],
+          "rejected_candidate_ids": [
+            "marketing-dashboard-gallery",
+            "single-screenshot-flow"
+          ]
+        },
+        {
+          "library": "Page Flows",
+          "library_url": "https://pageflows.com/",
+          "query_or_category": "approval, review, onboarding, error and blocked-state journeys",
+          "searched_at": "2026-06-14",
+          "selection_criteria": [
+            "journey shows consequences and recovery states",
+            "flow can be compared dimension-by-dimension against the product task model"
+          ],
+          "candidate_count": 5,
+          "selected_source_ids": [
+            "pageflows-review-approval"
+          ],
+          "rejected_candidate_ids": [
+            "happy-path-only-flow"
+          ]
+        }
+      ],
+      "rejected_references": [
+        {
+          "source_id": "decorative-dashboard-template",
+          "source_url_or_ref": "external:generic-dashboard-gallery",
+          "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
+        },
+        {
+          "source_id": "marketing-dashboard-gallery",
+          "source_url_or_ref": "external:marketing-dashboard-gallery",
+          "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "happy-path-only-flow",
+          "source_url_or_ref": "external:single-happy-path-flow",
+          "rejection_reason": "Rejected because it does not show blocked, error, review or approval consequences."
+        }
+      ],
+      "pattern_synthesis": {
+        "layout_hierarchy": "Lead with source freshness, current state, blocker/next action and selected object before secondary metrics or explanation.",
+        "interaction_model": "Use command strips, segmented state filters, searchable lists, adjacent inspectors and explicit approval/recovery actions.",
+        "state_coverage": "Design and capture loading, empty, success, blocked, stale, contradictory, private-unavailable and visual-quality-fail states before PASS.",
+        "visual_language": "Use a restrained professional product-tool language with semantic status color, crisp typography and no generic AI-dashboard decoration.",
+        "density_spacing": "Keep dense but readable rows, fixed tool dimensions and compact panels so repeated operation is fast and stable.",
+        "anti_patterns": [
+          "single attractive screenshot without workflow proof",
+          "decorative KPI cards disconnected from factory objects",
+          "hero layout or marketing composition inside an operational cockpit"
+        ]
+      },
+      "reference_evidence_policy": {
+        "capture_required_before_implementation": true,
+        "side_by_side_comparison_required_before_pass": true,
+        "public_refs_only": true,
+        "no_private_screenshots_in_repo": true,
+        "public_safe_evidence_refs": [
+          "professional_design_process.reference_research.sources"
+        ]
+      }
     },
     "ux_architecture": {
       "information_hierarchy": ["source and freshness", "state and blockers", "next safe action", "evidence and review", "detail drill-down"],
@@ -448,13 +674,15 @@
     },
     "comparative_review_gate": {
       "status": "PASS",
-      "reviewer_role": "product-face",
+      "reviewer_role": "independent-product-face-reviewer",
       "must_compare_to_reference_packet": true,
-      "basis": "Product Face reviewer must compare implemented surface to research, task model and Product Face packet.",
+      "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
       "block_when": [
         "The result resembles a generic dashboard rather than the product task model.",
         "Reference research did not affect layout, hierarchy, controls or state treatment.",
-        "Mechanical screenshots pass while visual hierarchy is not credible for a professional product."
+        "Mechanical screenshots pass while visual hierarchy is not credible for a professional product.",
+        "Reference research lacks real library searches, selected candidates and rejected candidates.",
+        "The result cannot explain, dimension by dimension, how it matches or deliberately differs from the chosen references."
       ]
     },
     "handoff_requirements": {
@@ -467,11 +695,16 @@
         "visual direction",
         "prototype gate",
         "design QA plan",
-        "comparative review gate"
+        "comparative review gate",
+        "library searches",
+        "rejected references",
+        "pattern synthesis",
+        "reference evidence policy"
       ],
       "product_face_result_must_include": [
         "professional_design_process_ref",
-        "professional_design_process_comparison.status=pass"
+        "professional_design_process_comparison.status=pass",
+        "reference_quality_comparison.status=pass"
       ]
     }
   },

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -75,6 +75,33 @@ class FactorySelfImprovementTest(unittest.TestCase):
             errors,
         )
 
+    def test_professional_design_process_requires_real_library_research(self) -> None:
+        process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
+        process["reference_research"].pop("library_searches")
+        process["reference_research"].pop("rejected_references")
+        process["reference_research"].pop("pattern_synthesis")
+        process["reference_research"]["reference_evidence_policy"] = {
+            "capture_required_before_implementation": False,
+            "side_by_side_comparison_required_before_pass": False,
+            "public_refs_only": True,
+            "no_private_screenshots_in_repo": True,
+        }
+        process["comparative_review_gate"]["reviewer_role"] = "product-face"
+
+        errors = factoryctl.validate_professional_design_process(process)
+
+        self.assertIn("professional_design_process.reference_research.library_searches requires at least 2 library searches", errors)
+        self.assertIn("professional_design_process.reference_research.rejected_references requires at least 2 rejected candidates", errors)
+        self.assertIn("professional_design_process.reference_research.pattern_synthesis.layout_hierarchy is required", errors)
+        self.assertIn(
+            "professional_design_process.reference_research.reference_evidence_policy.capture_required_before_implementation must be true",
+            errors,
+        )
+        self.assertIn(
+            "professional_design_process.comparative_review_gate.reviewer_role must identify an independent design/Product Face reviewer",
+            errors,
+        )
+
     def test_reference_quality_rejects_copy_without_license_ref(self) -> None:
         packet = dict(vfinal_card()["reference_quality_packet"])
         packet["references"] = [
@@ -109,6 +136,8 @@ class FactorySelfImprovementTest(unittest.TestCase):
         self.assertIn("motionsites", source_ids)
         self.assertIn("uiverse", source_ids)
         self.assertIn("21st-dev", source_ids)
+        self.assertIn("mobbin", source_ids)
+        self.assertIn("pageflows", source_ids)
         self.assertIn("sceneai", source_ids)
         self.assertIn("refero-styles", source_ids)
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -134,6 +134,27 @@ def human_gate_record(source_card: dict | None = None) -> dict:
     }
 
 
+def reference_quality_comparison_fixture() -> dict:
+    return {
+        "status": "pass",
+        "basis": "Independent reviewer compared the Product Face result against selected professional references.",
+        "reference_set_ref": "examples/cards/v35_valid_product_face.md#professional_design_process.reference_research",
+        "compared_source_ids": [
+            "21st-dev-components",
+            "mobbin-workflow-patterns",
+            "pageflows-review-approval",
+        ],
+        "reviewer_independent_from_implementation": True,
+        "dimensions": {
+            dimension: {
+                "status": "pass",
+                "basis": f"The result satisfies the {dimension} bar from the selected references.",
+            }
+            for dimension in factoryctl.REFERENCE_COMPARISON_DIMENSIONS
+        },
+    }
+
+
 PRIVATE_NAME = "KA" + "XIS"
 PRIVATE_ENV = "V" + "M"
 PRIVATE_USERS_PATH = "C:" + "\\\\" + "Users"
@@ -444,6 +465,7 @@ class FactoryCtlTest(unittest.TestCase):
                     "status": "pass",
                     "basis": "The validator confirmed the result satisfies the professional design process gates."
                 },
+                "reference_quality_comparison": reference_quality_comparison_fixture(),
                 "visual_quality_result": {
                     "status": "PASS",
                     "reviewer": "product-face-reviewer",
@@ -504,6 +526,7 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_result.source_promise_coverage is required for product-facing completion", errors)
         self.assertIn("product_face_result.design_fit_review is required for product-facing completion", errors)
         self.assertIn("product_face_result.professional_design_process_comparison is required for product-facing completion", errors)
+        self.assertIn("product_face_result.reference_quality_comparison is required for product-facing completion", errors)
         self.assertIn("product_face_result.professional_design_process_ref is required for PASS", errors)
         self.assertIn("product_face_result.visual_quality_result is required", errors)
 
@@ -558,6 +581,7 @@ class FactoryCtlTest(unittest.TestCase):
                     "status": "pass",
                     "basis": "Mechanical proof claims the process was followed, but visual quality review blocks it."
                 },
+                "reference_quality_comparison": reference_quality_comparison_fixture(),
                 "visual_quality_result": {
                     "status": "BLOCK",
                     "reviewer": "product-face-reviewer",
@@ -600,6 +624,60 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_result PASS requires a11y.status=pass", errors)
         self.assertIn("product_face_result PASS requires overlap_check.status=pass", errors)
         self.assertIn("product_face_result.visual_quality_result is required", errors)
+
+    def test_product_face_waived_allows_pending_reference_quality(self) -> None:
+        result = {
+            "result": "WAIVED",
+            "tool_or_profile": "browser-proof-runner",
+            "executed_by": "product-face-validator",
+            "screenshots": ["not-captured: fallback"],
+            "viewports": ["1440x900"],
+            "checked_states": ["initial-render"],
+            "user_journeys_checked": ["open target"],
+            "a11y": {"status": "fail"},
+            "overlap_check": {"status": "fail"},
+            "performance_note": "fallback validation only",
+            "packet_comparison": {"status": "pending", "basis": "Pending proof."},
+            "source_promise_coverage": {"status": "pending", "basis": "Pending proof."},
+            "design_fit_review": {"status": "pending", "basis": "Pending proof."},
+            "professional_design_process_ref": "",
+            "professional_design_process_comparison": {"status": "pending", "basis": "Pending proof."},
+            "reference_quality_comparison": {
+                "status": "pending",
+                "basis": "Reference comparison not recorded yet.",
+                "reference_set_ref": "pending-reference-set",
+                "compared_source_ids": [],
+                "reviewer_independent_from_implementation": False,
+                "dimensions": {
+                    dimension: {
+                        "status": "pending",
+                        "basis": "Reference comparison not recorded yet.",
+                    }
+                    for dimension in factoryctl.REFERENCE_COMPARISON_DIMENSIONS
+                },
+            },
+            "visual_quality_result": {
+                "status": "BLOCK",
+                "reviewer": "product-face-reviewer",
+                "basis": "Visual quality not approved.",
+                "reference_quality_bar_checked": False,
+                "ai_generic_symptoms": ["missing independent visual review"],
+            },
+            "blocking_findings": True,
+            "evidence_refs": ["reports/product-face.md"],
+            "next_action": "rerun proof",
+        }
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertNotIn(
+            "product_face_result.reference_quality_comparison.compared_source_ids requires at least 3 references",
+            errors,
+        )
+        self.assertNotIn(
+            "product_face_result.reference_quality_comparison.reviewer_independent_from_implementation must be true",
+            errors,
+        )
 
     def test_auditor_preflight_cannot_claim_pass(self) -> None:
         bad = {

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -18,6 +18,13 @@ sys.modules["product_face_proof"] = product_face_proof
 SPEC.loader.exec_module(product_face_proof)
 
 
+def reference_dimension_basis() -> dict[str, str]:
+    return {
+        dimension: f"Unit proof compares {dimension} against selected professional references."
+        for dimension in product_face_proof.REFERENCE_COMPARISON_DIMENSIONS
+    }
+
+
 class ProductFaceProofTest(unittest.TestCase):
     def test_parse_viewport_accepts_named_size(self) -> None:
         viewport = product_face_proof.parse_viewport("tablet=768x1024")
@@ -101,6 +108,7 @@ class ProductFaceProofTest(unittest.TestCase):
             "design_fit_review",
             "professional_design_process_ref",
             "professional_design_process_comparison",
+            "reference_quality_comparison",
             "visual_quality_result",
             "blocking_findings",
             "evidence_refs",
@@ -188,6 +196,14 @@ class ProductFaceProofTest(unittest.TestCase):
                 design_fit_review_basis="Unit proof includes an explicit design-fit review.",
                 professional_design_process_ref="templates/professional-design-process.json",
                 professional_design_process_comparison_basis="Unit proof satisfies the professional design process gates.",
+                reference_quality_ref="templates/professional-design-process.json#reference_research",
+                reference_quality_comparison_basis="Unit proof compares against selected professional design references.",
+                compared_reference_ids=[
+                    "21st-dev-components",
+                    "mobbin-workflow-patterns",
+                    "pageflows-review-approval",
+                ],
+                reference_quality_dimensions=reference_dimension_basis(),
             )
             product_face_proof.apply_visual_quality_review(
                 result=result,

--- a/ui/issue-84-local-cockpit/professional-design-process.json
+++ b/ui/issue-84-local-cockpit/professional-design-process.json
@@ -40,50 +40,276 @@
     "registry_refs": [
       "templates/reference-source-registry.json#21st-dev",
       "templates/reference-source-registry.json#refero-styles",
-      "templates/reference-source-registry.json#motionsites"
+      "templates/reference-source-registry.json#motionsites",
+      "templates/reference-source-registry.json#mobbin",
+      "templates/reference-source-registry.json#pageflows"
     ],
-    "selection_rationale": "Use professional product-tool and component references to define compact state-first hierarchy, not to copy assets or brand.",
+    "selection_rationale": "Search professional component libraries, product-flow libraries and public product references before implementation; select and reject candidates explicitly, synthesize reusable patterns, and copy no code, text, screenshots or assets without license review.",
     "sources": [
       {
         "source_id": "radix-ui-themes",
         "source_url_or_ref": "https://www.radix-ui.com/themes",
         "use_type": "token-and-accessibility-reference",
-        "what_to_learn": ["semantic color tokens", "accessible component primitives"],
+        "what_to_learn": [
+          "semantic color tokens",
+          "accessible component primitives"
+        ],
         "extracted_patterns": [
           "Use semantic state colors rather than a one-note decorative palette.",
           "Keep controls compact and named by function."
         ],
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-        "public_safety_notes": "Reference only; no code or assets copied."
+        "public_safety_notes": "Reference only; no code or assets copied.",
+        "source_type": "design_system",
+        "library_source": "Radix Themes",
+        "candidate_reason": "Selected for accessibility, semantic token and component density discipline.",
+        "selected_patterns": [
+          "Semantic color roles must drive product states instead of decorative palettes.",
+          "Composable, named controls should replace oversized explanatory blocks."
+        ],
+        "visual_dimensions_covered": [
+          "visual_language",
+          "density_spacing",
+          "interaction_model"
+        ]
       },
       {
         "source_id": "shadcn-data-table",
         "source_url_or_ref": "https://ui.shadcn.com/docs/components/data-table",
         "use_type": "dense-data-interaction-reference",
-        "what_to_learn": ["filtering and sorting patterns", "row action ergonomics"],
+        "what_to_learn": [
+          "filtering and sorting patterns",
+          "row action ergonomics"
+        ],
         "extracted_patterns": [
           "Dense operational views need search, filters and stable row focus.",
           "Detail inspection should stay adjacent to the selected row context."
         ],
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-        "public_safety_notes": "Reference only; no code or assets copied."
+        "public_safety_notes": "Reference only; no code or assets copied.",
+        "source_type": "component_registry",
+        "library_source": "shadcn/ui",
+        "candidate_reason": "Selected for dense data-table ergonomics, filtering, sorting and row action patterns.",
+        "selected_patterns": [
+          "Dense operational data needs search, filters, sort and visible row focus.",
+          "Controls belong close to the data or state they affect."
+        ],
+        "visual_dimensions_covered": [
+          "layout_hierarchy",
+          "interaction_model",
+          "density_spacing"
+        ]
       },
       {
         "source_id": "linear-product-workflow",
         "source_url_or_ref": "https://linear.app",
         "use_type": "product-workflow-reference",
-        "what_to_learn": ["state-first product work navigation", "low-friction worklist scanning"],
+        "what_to_learn": [
+          "state-first product work navigation",
+          "low-friction worklist scanning"
+        ],
         "extracted_patterns": [
           "Work status, owner and next action should be visible without a marketing hero.",
           "Focused work lists should be fast to scan and keep hierarchy quiet."
         ],
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
-        "public_safety_notes": "Reference only; no code or assets copied."
+        "public_safety_notes": "Reference only; no code or assets copied.",
+        "source_type": "product_reference",
+        "library_source": "Linear public product reference",
+        "candidate_reason": "Selected for compact work management hierarchy, state clarity and low-friction navigation.",
+        "selected_patterns": [
+          "Operational product tools should be compact, scannable and state-first.",
+          "Primary work context should be visible without a marketing-style hero."
+        ],
+        "visual_dimensions_covered": [
+          "layout_hierarchy",
+          "state_coverage",
+          "density_spacing"
+        ]
+      },
+      {
+        "source_id": "21st-dev-components",
+        "source_url_or_ref": "https://21st.dev/",
+        "source_type": "component_registry",
+        "library_source": "21st.dev",
+        "use_type": "component-library-and-craft-benchmark",
+        "candidate_reason": "Selected to compare component polish, hierarchy, spacing and interaction finish against modern React/Tailwind component references.",
+        "what_to_learn": [
+          "How modern component libraries compose dense command surfaces without looking generic.",
+          "How spacing, state affordances and micro-interactions make controls feel deliberate."
+        ],
+        "extracted_patterns": [
+          "Reusable components need explicit state, focus, hover and disabled behavior before visual approval.",
+          "Component density should be tuned to the operator task instead of stretched into marketing cards."
+        ],
+        "selected_patterns": [
+          "Require explicit states for controls and rows before Product Face PASS.",
+          "Use compact component groups with clear hierarchy instead of decorative dashboard blocks."
+        ],
+        "visual_dimensions_covered": [
+          "interaction_model",
+          "visual_language",
+          "density_spacing"
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Reference only; no source code, text or assets copied."
+      },
+      {
+        "source_id": "mobbin-workflow-patterns",
+        "source_url_or_ref": "https://mobbin.com/",
+        "source_type": "user_flow_library",
+        "library_source": "Mobbin",
+        "use_type": "real-product-flow-and-screen-benchmark",
+        "candidate_reason": "Selected because real product flows expose navigation, density and state decisions that isolated mockups hide.",
+        "what_to_learn": [
+          "How professional products sequence navigation, detail inspection and recovery states.",
+          "How repeated-use workflows avoid decorative elements that slow scanning."
+        ],
+        "extracted_patterns": [
+          "A serious workflow needs visible current state, selected object, next action and recovery path.",
+          "Reference study must cover multiple screens or states, not a single attractive screenshot."
+        ],
+        "selected_patterns": [
+          "Require current object, state and next action to be visible together.",
+          "Reject single-screen inspiration that does not explain workflow behavior."
+        ],
+        "visual_dimensions_covered": [
+          "layout_hierarchy",
+          "interaction_model",
+          "state_coverage"
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Use synthesized observations only; do not commit screenshots or private captures."
+      },
+      {
+        "source_id": "pageflows-review-approval",
+        "source_url_or_ref": "https://pageflows.com/",
+        "source_type": "user_flow_library",
+        "library_source": "Page Flows",
+        "use_type": "journey-state-and-approval-flow-benchmark",
+        "candidate_reason": "Selected to force journey-level coverage for approval, error, review and onboarding states.",
+        "what_to_learn": [
+          "How professional products communicate progress, blocking states and fallback paths across a journey.",
+          "How approval and review flows preserve confidence without hiding consequences."
+        ],
+        "extracted_patterns": [
+          "Approval surfaces need consequence, evidence and rollback context before the action.",
+          "Error and blocked states should preserve orientation and show the next safe action."
+        ],
+        "selected_patterns": [
+          "Require consequence, evidence and fallback context for approval surfaces.",
+          "Treat blocked/error states as first-class Product Face screenshots."
+        ],
+        "visual_dimensions_covered": [
+          "interaction_model",
+          "state_coverage",
+          "layout_hierarchy"
+        ],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "benchmark_only_no_code_or_assets_copied",
+        "public_safety_notes": "Use journey-level learning only; no copied videos, screenshots or private material."
       }
-    ]
+    ],
+    "library_searches": [
+      {
+        "library": "21st.dev",
+        "library_url": "https://21st.dev/",
+        "query_or_category": "operations dashboard, command surface, data table and review components",
+        "searched_at": "2026-06-14",
+        "selection_criteria": [
+          "component craft supports dense repeated operator use",
+          "states and controls can be adapted without copying code or assets"
+        ],
+        "candidate_count": 6,
+        "selected_source_ids": [
+          "21st-dev-components",
+          "shadcn-data-table"
+        ],
+        "rejected_candidate_ids": [
+          "decorative-dashboard-template",
+          "oversized-hero-block"
+        ]
+      },
+      {
+        "library": "Mobbin",
+        "library_url": "https://mobbin.com/",
+        "query_or_category": "workflow, status, review, incident and project operations flows",
+        "searched_at": "2026-06-14",
+        "selection_criteria": [
+          "real product flow exposes navigation and state transitions",
+          "patterns improve operator speed instead of presentation aesthetics"
+        ],
+        "candidate_count": 6,
+        "selected_source_ids": [
+          "mobbin-workflow-patterns",
+          "linear-product-workflow"
+        ],
+        "rejected_candidate_ids": [
+          "marketing-dashboard-gallery",
+          "single-screenshot-flow"
+        ]
+      },
+      {
+        "library": "Page Flows",
+        "library_url": "https://pageflows.com/",
+        "query_or_category": "approval, review, onboarding, error and blocked-state journeys",
+        "searched_at": "2026-06-14",
+        "selection_criteria": [
+          "journey shows consequences and recovery states",
+          "flow can be compared dimension-by-dimension against the product task model"
+        ],
+        "candidate_count": 5,
+        "selected_source_ids": [
+          "pageflows-review-approval"
+        ],
+        "rejected_candidate_ids": [
+          "happy-path-only-flow"
+        ]
+      }
+    ],
+    "rejected_references": [
+      {
+        "source_id": "decorative-dashboard-template",
+        "source_url_or_ref": "external:generic-dashboard-gallery",
+        "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
+      },
+      {
+        "source_id": "marketing-dashboard-gallery",
+        "source_url_or_ref": "external:marketing-dashboard-gallery",
+        "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+      },
+      {
+        "source_id": "happy-path-only-flow",
+        "source_url_or_ref": "external:single-happy-path-flow",
+        "rejection_reason": "Rejected because it does not show blocked, error, review or approval consequences."
+      }
+    ],
+    "pattern_synthesis": {
+      "layout_hierarchy": "Lead with source freshness, current state, blocker/next action and selected object before secondary metrics or explanation.",
+      "interaction_model": "Use command strips, segmented state filters, searchable lists, adjacent inspectors and explicit approval/recovery actions.",
+      "state_coverage": "Design and capture loading, empty, success, blocked, stale, contradictory, private-unavailable and visual-quality-fail states before PASS.",
+      "visual_language": "Use a restrained professional product-tool language with semantic status color, crisp typography and no generic AI-dashboard decoration.",
+      "density_spacing": "Keep dense but readable rows, fixed tool dimensions and compact panels so repeated operation is fast and stable.",
+      "anti_patterns": [
+        "single attractive screenshot without workflow proof",
+        "decorative KPI cards disconnected from factory objects",
+        "hero layout or marketing composition inside an operational cockpit"
+      ]
+    },
+    "reference_evidence_policy": {
+      "capture_required_before_implementation": true,
+      "side_by_side_comparison_required_before_pass": true,
+      "public_refs_only": true,
+      "no_private_screenshots_in_repo": true,
+      "public_safe_evidence_refs": [
+        "professional_design_process.reference_research.sources"
+      ]
+    }
   },
   "ux_architecture": {
     "information_hierarchy": [
@@ -154,13 +380,15 @@
   },
   "comparative_review_gate": {
     "status": "PASS",
-    "reviewer_role": "product-face",
+    "reviewer_role": "independent-product-face-reviewer",
     "must_compare_to_reference_packet": true,
-    "basis": "The cockpit uses a state-first app shell and blocks the previous generic dashboard failure mode.",
+    "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
     "block_when": [
       "The result resembles a generic dashboard.",
       "State, source and next safe action are not first-class.",
-      "Reference research does not affect layout, hierarchy, controls or state treatment."
+      "Reference research does not affect layout, hierarchy, controls or state treatment.",
+      "Reference research lacks real library searches, selected candidates and rejected candidates.",
+      "The result cannot explain, dimension by dimension, how it matches or deliberately differs from the chosen references."
     ]
   },
   "handoff_requirements": {
@@ -173,11 +401,16 @@
       "visual direction",
       "prototype gate",
       "design QA plan",
-      "comparative review gate"
+      "comparative review gate",
+      "library searches",
+      "rejected references",
+      "pattern synthesis",
+      "reference evidence policy"
     ],
     "product_face_result_must_include": [
       "professional_design_process_ref",
-      "professional_design_process_comparison.status=pass"
+      "professional_design_process_comparison.status=pass",
+      "reference_quality_comparison.status=pass"
     ]
   }
 }


### PR DESCRIPTION
## What changed
- Requires professional design reference research before Product Face approval: library searches, selected and rejected candidates, pattern synthesis, evidence policy and independent comparative review.
- Adds `reference_quality_comparison` to Product Face results and strict completion checks.
- Extends `product_face_proof.py` CLI so PASS/reusable proofs must provide compared reference ids and dimension-by-dimension basis.
- Updates public templates/examples and regression tests for the stricter process.

## Why
The factory was able to produce visually weak UI while treating design references as loose notes. This change makes reference research and side-by-side comparison a machine-checkable gate.

## Validation
- `python -m unittest discover -s tests` -> 364 tests OK
- `python scripts/validate_public_json_artifacts.py` -> OK
- `python scripts/public_safety_scan.py` -> OK
- `python scripts/secret_safety_scan.py` -> OK
- `python scripts/supply_chain_proof.py --check --no-write` -> PASS
