### PR TITLE
[codex] Guard Hermes runtime boundary and recovery plans

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -146,6 +146,9 @@ def record_live_binding(
     ledger = load_json(ledger_path)
     bindings = ledger.setdefault("live_bindings", {})
     bindings[card_id] = {
+        "binding_role": "hermes_ref_projection",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
         "board": board,
         "main_task_id": main_task_id,
         "worker_task_ids": worker_task_ids,

--- a/adapters/hermes/transition_hook.py
+++ b/adapters/hermes/transition_hook.py
@@ -69,11 +69,17 @@ def load_ledger(path: Path) -> dict[str, Any]:
         return {
             "$schema": "https://overkill-factory.dev/schemas/hermes-worker-ledger.schema.json",
             "ledger_type": "overkill_factory_hermes_worker_ledger",
+            "ledger_scope": "projection_idempotency_only",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
             "tasks": {},
         }
     data = load_json(path)
     data.setdefault("$schema", "https://overkill-factory.dev/schemas/hermes-worker-ledger.schema.json")
     data.setdefault("ledger_type", "overkill_factory_hermes_worker_ledger")
+    data.setdefault("ledger_scope", "projection_idempotency_only")
+    data.setdefault("runtime_authority", "hermes_kanban")
+    data.setdefault("local_state_authority", False)
     if not isinstance(data.get("tasks"), dict):
         data["tasks"] = {}
     return data
@@ -94,6 +100,13 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
         ident = task_id(card_id, worker_id)
         payload = {
             "task_id": ident,
+            "materialization_state": "pending_hermes_materialization",
+            "runtime_refs": {
+                "hermes_board_ref": "external:pending-hermes-board",
+                "hermes_task_ref": f"external:pending-hermes-task:{ident}",
+                "hermes_run_ref": "external:pending-hermes-run",
+            },
+            "local_record_role": "idempotency_projection",
             "card_id": card_id,
             "worker_id": worker_id,
             "title": task.get("title"),

--- a/agents/hermes-profile-bindings.public.json
+++ b/agents/hermes-profile-bindings.public.json
@@ -15,8 +15,10 @@
       "receipt_field": "orchestration_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; state mutation is owned by the adapter.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -48,8 +50,10 @@
       "receipt_field": "source_ledger_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Raw source refs stay private; public refs must be redacted or repo-relative.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -76,8 +80,10 @@
       "receipt_field": "product_sot_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use Product SOT artifact refs; do not publish raw private paper extracts.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -104,8 +110,10 @@
       "receipt_field": "architecture_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Architecture evidence must reference packets, tradeoffs and review requirements.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -133,8 +141,10 @@
       "receipt_field": "product_face_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Screenshots, console notes and state matrices must be redacted and repo-relative.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -163,8 +173,10 @@
       "receipt_field": "auditor_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Auditor evidence must include scope and coverage; no keys, funds or authority-bearing refs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -194,8 +206,10 @@
       "receipt_field": "security_scan_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Security findings must be scoped and redacted before public use.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -225,8 +239,10 @@
       "receipt_field": "appsec_owasp_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use generic endpoint refs and redact exploit-ready detail.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -255,8 +271,10 @@
       "receipt_field": "agentic_ai_security_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Tool-boundary and memory-trust refs must be public-safe and non-secret.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -286,8 +304,10 @@
       "receipt_field": "autoreview_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Review reports must name diff scope and finding status without private paths.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -315,8 +335,10 @@
       "receipt_field": "remote_proof_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Remote proof artifacts require transcript, cleanup and public-safe artifact refs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -344,8 +366,10 @@
       "receipt_field": "handoff_packet_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Handoff refs must be replayable and never depend on chat memory alone.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "advisory-review",
         "allowed_effective_queues": [
           "blocking-before-done",
@@ -375,8 +399,10 @@
       "receipt_field": "independent_review_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Review evidence must identify executor, reviewer and inspected refs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -404,8 +430,10 @@
       "receipt_field": "receipt_five_reconciliation_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Reconciliation indexes must use repo-relative refs and record superseded stale results explicitly.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -435,8 +463,10 @@
       "receipt_field": "human_gate_record",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Human records must use role names, explicit scope and public-safe evidence refs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready",
@@ -467,8 +497,10 @@
       "receipt_field": "documentation_os_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Docs refs must trace to SOT and architecture without private source dumps.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -496,8 +528,10 @@
       "receipt_field": "decomposition_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Card graph evidence must include worker packets, dependencies and gate mapping.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -525,8 +559,10 @@
       "receipt_field": "implementation_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Fallback implementation must include fallback rationale plus repo-relative diff/test refs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -554,8 +590,10 @@
       "receipt_field": "qa_verification_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Verification refs must include commands, outputs and artifacts.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -583,8 +621,10 @@
       "receipt_field": "security_orchestration_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Specialist matrix evidence must be scoped and public-safe.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -615,8 +655,10 @@
       "receipt_field": "cloud_infra_security_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Cloud evidence must omit account ids, tokens and private endpoints.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -645,8 +687,10 @@
       "receipt_field": "crypto_key_management_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Key and custody evidence must never contain real key material.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -675,8 +719,10 @@
       "receipt_field": "release_ops_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Release evidence must include smoke, rollback and monitoring refs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -704,8 +750,10 @@
       "receipt_field": "memory_steward_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Memory evidence must include trust tier and source refs, never raw private memory.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready",
@@ -735,8 +783,10 @@
       "receipt_field": "skill_eval_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Skill eval refs must include held-out evals and before/after evidence.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "advisory-review",
         "allowed_effective_queues": [
           "advisory-review"
@@ -764,8 +814,10 @@
       "receipt_field": "public_safety_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Public safety evidence must include scan commands and redaction notes.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -793,8 +845,10 @@
       "receipt_field": "supply_chain_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Supply-chain refs must include scans without exposing secrets.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready"
@@ -825,8 +879,10 @@
       "receipt_field": "detection_monitoring_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Monitoring refs must avoid private dashboard URLs and raw logs.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -856,8 +912,10 @@
       "receipt_field": "frontend_build_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -886,8 +944,10 @@
       "receipt_field": "backend_api_build_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -916,8 +976,10 @@
       "receipt_field": "data_persistence_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -947,8 +1009,10 @@
       "receipt_field": "solana_quasar_build_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -978,8 +1042,10 @@
       "receipt_field": "solana_quasar_qa_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -1009,8 +1075,10 @@
       "receipt_field": "wallet_transaction_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -1040,8 +1108,10 @@
       "receipt_field": "integration_build_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -1070,8 +1140,10 @@
       "receipt_field": "test_automation_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -1100,8 +1172,10 @@
       "receipt_field": "infra_devops_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -1130,8 +1204,10 @@
       "receipt_field": "agent_runtime_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Use repo-relative refs or explicit external refs; never include private paths, secrets or raw source extraction.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-done",
         "allowed_effective_queues": [
           "blocking-before-done"
@@ -1159,8 +1235,10 @@
       "receipt_field": "project_projection_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Projection evidence must use repo-relative or redacted refs; raw runtime and Discord identifiers stay private.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready",
@@ -1190,8 +1268,10 @@
       "receipt_field": "control_tower_bridge_result",
       "can_mutate_card_state": false,
       "evidence_path_policy": "Bridge evidence must use redacted or external refs; raw Discord ids, URLs, tokens, logs and runtime ids stay private.",
-      "dispatch_queue_policy": {
-        "source_of_truth": "factoryctl.worker_queue_class",
+      "factory_gate_timing_policy": {
+        "policy_kind": "factory_gate_timing_policy",
+        "policy_basis": "factoryctl.worker_gate_timing_class",
+        "runtime_authority": "hermes_kanban",
         "default_queue": "blocking-before-ready",
         "allowed_effective_queues": [
           "blocking-before-ready",

--- a/agents/worker-contract.schema.json
+++ b/agents/worker-contract.schema.json
@@ -14,7 +14,7 @@
     "authority_max",
     "veto_conditions",
     "evidence_required",
-    "kanban_transition_rules",
+    "factory_gate_transition_policy",
     "promotion_rule",
     "public_safety_notes"
   ],
@@ -52,7 +52,7 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 3 }
     },
-    "kanban_transition_rules": {
+    "factory_gate_transition_policy": {
       "type": "array",
       "items": { "type": "string", "minLength": 3 }
     },

--- a/agents/worker-registry.public.json
+++ b/agents/worker-registry.public.json
@@ -63,7 +63,7 @@
         "autonomy readiness packet",
         "ready gate verdict"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "never unblock R3/R4 without required gates"
       ],
       "promotion_rule": "hybrid worker remains supervised; closed subflows only after repeated success",
@@ -111,7 +111,7 @@
         "promoted claims",
         "rejected claims"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "Product SOT waits for source resolution"
       ],
       "promotion_rule": "stays open while source shapes remain unpredictable",
@@ -159,7 +159,7 @@
         "discovery notes",
         "assumption ledger"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "architecture waits for SOT candidate and open risk list"
       ],
       "promotion_rule": "closed only for repeatable SOT normalization after evals",
@@ -207,7 +207,7 @@
         "security architecture route",
         "architecture decision record"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "no decomposition before architecture gate"
       ],
       "promotion_rule": "stays open for judgment-heavy design",
@@ -251,7 +251,7 @@
         "a11y notes",
         "journey proof"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "product-facing done waits for Product Face evidence"
       ],
       "promotion_rule": "closed for repeatable screenshot/a11y runner after fixture coverage",
@@ -294,7 +294,7 @@
         "PDA/signers/CPI/CU checks",
         "waiver if not run"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "R3/R4 onchain waits for Auditor evidence or structured waiver"
       ],
       "promotion_rule": "hybrid until real Quasar implementation pilots pass",
@@ -339,7 +339,7 @@
         "findings",
         "evidence refs"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "done waits for security_scan_result when scan is required"
       ],
       "promotion_rule": "closed only for repeatable scan execution, not risk judgment",
@@ -383,7 +383,7 @@
         "test refs",
         "risk residuals"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "AppSec-sensitive done waits for AppSec result or waiver"
       ],
       "promotion_rule": "hybrid; checklists can become closed after repeated fixtures",
@@ -427,7 +427,7 @@
         "tool allowlist",
         "memory trust tier"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "agentic surfaces wait for tool-boundary evidence"
       ],
       "promotion_rule": "hybrid because judgment and adversarial reasoning remain necessary",
@@ -466,7 +466,7 @@
         "finding status",
         "follow-up action"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "pre-landing code work waits for AutoReview when required"
       ],
       "promotion_rule": "closed because input and output are repeatable",
@@ -511,7 +511,7 @@
         "cleanup",
         "cost note"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "remote proof evidence attaches before promotion"
       ],
       "promotion_rule": "closed because command/proof shape is repeatable",
@@ -552,7 +552,7 @@
         "artifact refs",
         "next action"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "handoff required for R2+ worker transfer"
       ],
       "promotion_rule": "closed because packet shape is repeatable",
@@ -593,7 +593,7 @@
         "residual risk",
         "reviewer-selection ref"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "R2+ waits for independent review before done"
       ],
       "promotion_rule": "hybrid; closed only for narrow repeatable review checklists",
@@ -652,7 +652,7 @@
         "closure summary",
         "completion audit verdict"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "runs after required worker artifacts exist",
         "runs before QA, AutoReview and done promotion",
         "blocks done when current evidence cannot satisfy Receipt Five"
@@ -708,7 +708,7 @@
         "decision actor role",
         "durable runtime event"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "architecture and R4 promotion wait for real human decision"
       ],
       "promotion_rule": "always human-controlled",
@@ -747,7 +747,7 @@
         "contract refs",
         "doc-shape routing"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "decomposition waits for durable docs"
       ],
       "promotion_rule": "hybrid; templated docs can become closed after evals",
@@ -799,7 +799,7 @@
         "Loop Plan",
         "lane/worktree isolation notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "cards without required contracts are rejected"
       ],
       "promotion_rule": "closed for narrow card normalization after regression suite",
@@ -839,7 +839,7 @@
         "tests",
         "receipt"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "use specialist builders first; fallback only for unknown or legacy code surfaces"
       ],
       "promotion_rule": "demote by default when a surface-specific builder exists",
@@ -883,7 +883,7 @@
         "component/test refs",
         "desktop/mobile evidence request"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "frontend work waits for Product Face packet and later Product Face validation"
       ],
       "promotion_rule": "closed only for repeatable component implementation with visual regression fixtures",
@@ -926,7 +926,7 @@
         "API test refs",
         "contract refs"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "API/auth work waits for AppSec and security evidence when sensitive"
       ],
       "promotion_rule": "closed only for repeatable endpoint/service patterns with contract tests",
@@ -970,7 +970,7 @@
         "schema test refs",
         "rollback notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "data work waits for rollback and security review when sensitive"
       ],
       "promotion_rule": "closed only for repeatable schema changes with rollback fixtures",
@@ -1014,7 +1014,7 @@
         "Quasar build/test refs",
         "PDA/signer map"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "onchain work waits for Solana QA, Auditor, security and human gates when required"
       ],
       "promotion_rule": "closed only after repeated Quasar fixtures and Auditor-reviewed patterns",
@@ -1057,7 +1057,7 @@
         "devnet/local refs",
         "negative test matrix"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "onchain done waits for QA, Auditor and security evidence"
       ],
       "promotion_rule": "closed only for stable Quasar test harnesses and replayable fixtures",
@@ -1100,7 +1100,7 @@
         "transaction-state tests",
         "signer boundary notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "wallet/funds work waits for crypto/key, AppSec and Product Face evidence"
       ],
       "promotion_rule": "closed only for repeated wallet-state components with safe fixtures",
@@ -1143,7 +1143,7 @@
         "runtime refs",
         "handoff gaps"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "integration waits for builder outputs and feeds QA verification"
       ],
       "promotion_rule": "closed only for repeatable glue patterns with stable E2E fixtures",
@@ -1188,7 +1188,7 @@
         "run logs",
         "coverage/gap notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "high-repeat work should become tests or evals before learning loop"
       ],
       "promotion_rule": "closed only when fixtures are stable and held-out cases pass",
@@ -1233,7 +1233,7 @@
         "smoke refs",
         "rollback notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "infra work waits for cloud/security/release gates when promotion-like"
       ],
       "promotion_rule": "closed only for repeatable environment setup with rollback fixtures",
@@ -1280,7 +1280,7 @@
         "safety review handoff",
         "agent eval plan"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "agent runtime work waits for agentic AI security, public safety and profile validation"
       ],
       "promotion_rule": "closed only for repeatable adapter/profile changes with regression tests",
@@ -1325,7 +1325,7 @@
         "pass/fail",
         "QA mode coverage"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "done waits for objective verification"
       ],
       "promotion_rule": "hybrid; closed only for deterministic fixtures",
@@ -1379,7 +1379,7 @@
         "specialist routing rationale",
         "required security gates"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "security-sensitive done waits for routed controls"
       ],
       "promotion_rule": "hybrid because security judgment stays adversarial",
@@ -1423,7 +1423,7 @@
         "rollback proof",
         "logs/monitoring plan"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "infra/release waits for cloud security evidence"
       ],
       "promotion_rule": "hybrid; closed only for deterministic policy checks",
@@ -1467,7 +1467,7 @@
         "custody model",
         "waivers"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "key/funds surfaces wait for crypto/key review"
       ],
       "promotion_rule": "hybrid because custody risk needs human oversight",
@@ -1520,7 +1520,7 @@
         "rollback proof",
         "production smoke"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "R4 release waits for human gate and rollback evidence"
       ],
       "promotion_rule": "hybrid; dry-run substeps can become closed",
@@ -1562,7 +1562,7 @@
         "source refs",
         "poisoning controls"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "memory updates wait for source and trust tier"
       ],
       "promotion_rule": "hybrid because memory quality depends on context",
@@ -1616,7 +1616,7 @@
         "factory maturity scorecard",
         "missing coverage register"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "closed specialists need eval-backed promotion"
       ],
       "promotion_rule": "closed only after repeated predictable success",
@@ -1658,7 +1658,7 @@
         "result",
         "redaction notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "public artifacts wait for public-safety pass"
       ],
       "promotion_rule": "closed because scan shape is deterministic",
@@ -1705,7 +1705,7 @@
         "workflow permissions",
         "SBOM or waiver"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "code/release work waits for supply-chain gate"
       ],
       "promotion_rule": "hybrid; scanners closed, risk judgment supervised",
@@ -1763,7 +1763,7 @@
         "dashboard or health evidence",
         "privacy visibility notes"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "production promotion waits for monitoring evidence"
       ],
       "promotion_rule": "hybrid because runtime signals are product-specific",
@@ -1805,7 +1805,7 @@
         "runtime state ref",
         "staleness note"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "when the owner Control Tower is active, material execution waits for a fresh projection"
       ],
       "promotion_rule": "closed because projection rendering is deterministic from runtime state once the mapping contract exists",
@@ -1849,7 +1849,7 @@
         "bridge health proof",
         "negative approval test"
       ],
-      "kanban_transition_rules": [
+      "factory_gate_transition_policy": [
         "Discord responses are advisory until the runtime records a valid structured event",
         "the bridge never marks ready, done, released or approved by itself"
       ],

--- a/agents/worker-roster.md
+++ b/agents/worker-roster.md
@@ -54,7 +54,7 @@ needed.
 
 | Worker | Mode | Enters | What it does |
 |---|---|---|---|
-| `factory-orchestrator` | hybrid | F0-F18 | Maintains phase, risk, routing, Method Contract, capability coverage, readiness, blockers and Kanban state. It does not approve product, security or R3/R4 gates. |
+| `factory-orchestrator` | hybrid | F0-F18 | Maintains phase, risk, routing, Method Contract, capability coverage, readiness and blockers, then emits semantic transition/recovery intent for Hermes. It does not own Kanban runtime state or approve product, security or R3/R4 gates. |
 | `source-ledger-worker` | open | F0-F1 | Separates source, inference, decision, conflict, stale material and gap before any SOT claim is promoted. |
 | `product-sot-planner` | open | F2-F3 | Owns Outcome/Discovery and turns source ledger plus answers into a Product SOT candidate. Candidate is not approval. |
 | `product-architect` | open | F4-F6 | Creates architecture candidate, boundaries, tradeoffs, trust boundaries and risk map from the SOT. |

--- a/docs/agents/hermes-profile-manifest.md
+++ b/docs/agents/hermes-profile-manifest.md
@@ -27,14 +27,15 @@ and refusal boundaries for that builder's surface. A frontend builder without
 Product Face handoff, or a Solana builder without Quasar/Auditor boundaries, is
 not considered operable.
 
-## Source Of Truth
+## Gate Timing Boundary
 
-The runtime profile does not decide its own queue. Runtime queue is computed by
-`factoryctl.worker_queue_class` and exposed on `worker_task.queue_class`.
+The runtime profile does not decide its own execution queue. Factory gate timing
+is computed by `factoryctl.worker_gate_timing_class` and exposed on
+`worker_task.gate_timing_class`.
 
-The profile binding may describe queue policy, but it is not an execution
-source. This avoids split-brain behavior between Hermes routing and factory
-transition planning.
+The profile binding may describe gate timing policy, but it is not an execution
+source. Hermes Kanban remains responsible for dispatch, dependencies, worker
+lifecycle, block/unblock and durable audit history.
 
 ## Result Schema Rule
 

--- a/docs/agents/live-agent-configuration.md
+++ b/docs/agents/live-agent-configuration.md
@@ -134,14 +134,16 @@ Only a fresh sanitized ledger row with `readiness_state=current_profile_ready`,
 treated as current profile readiness. Stale, missing or wrong-profile rows stay
 blocked or degraded.
 
-## Queue Rule
+## Gate Timing Rule
 
-The binding carries `dispatch_queue_policy`, but it is not a second runtime
-queue source. The executable queue is computed by
-`factoryctl.worker_queue_class` and exposed as `worker_task.queue_class`.
+The binding carries `factory_gate_timing_policy`, but it is not a second
+runtime queue source. Gate timing is computed by
+`factoryctl.worker_gate_timing_class` and exposed as
+`worker_task.gate_timing_class` for semantic materialization.
 
-That is better for Hermes because phase/risk can change the queue. A static
-binding queue would let the adapter and transition plan disagree.
+That is better for Hermes because phase/risk can change the required timing.
+A static binding queue would let the adapter and transition plan disagree.
+Hermes still owns dispatch, dependencies, worker lifecycle and durable state.
 
 ## Result Schema Rule
 

--- a/docs/architecture/hermes-integration.md
+++ b/docs/architecture/hermes-integration.md
@@ -46,16 +46,17 @@ Before `done`, the adapter should:
 - enforce independent review and human gate requirements;
 - return an explicit block reason instead of silently closing.
 
-## Queue Classes
+## Gate Timing Classes
 
-| Queue | Meaning |
+| Gate timing | Meaning |
 | --- | --- |
 | `blocking-before-ready` | The main card should not become ready until this planning or gate input exists. |
 | `blocking-before-done` | The main card may be ready, but cannot close until the worker result exists. |
 | `advisory-review` | Useful review path that becomes blocking only when the card contract requires it. |
 
-The executable queue is computed by `factoryctl.worker_queue_class`; the binding
-records policy, not a second source of truth.
+Gate timing is computed by `factoryctl.worker_gate_timing_class`; the binding
+records semantic policy, not a second dispatch source of truth. Hermes Kanban
+owns runtime queueing, dependencies, worker lifecycle and durable state.
 
 ## Evidence Boundary
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,6 +41,7 @@ factoryctl init --out ../my-product-factory --project-name my-product
 factoryctl validate-card examples/minimal-hermes-project/card.md
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
+factoryctl recovery-plan --card examples/minimal-hermes-project/card.md
 factoryctl help-next --card examples/minimal-hermes-project/card.md --out .tmp/factory-help.json
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
@@ -55,6 +56,11 @@ or internal evidence machinery.
 `status-snapshot` projects card, gate, lane and evidence state for operators. It
 does not replace Hermes, card contracts, gate reports or Receipt Five as the
 source of truth.
+
+`recovery-plan` emits machine-readable recovery routes for blocked factory
+work. It does not execute workers or unblock cards. Recovery work must be
+materialized as native Hermes Kanban tasks, links, comments, runs and
+block/unblock events.
 
 ## Evidence And Truth Commands
 

--- a/schemas/factory-recovery-plan.schema.json
+++ b/schemas/factory-recovery-plan.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-recovery-plan.schema.json",
+  "title": "Overkill Factory Recovery Plan",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "card_id",
+    "gate_predicate_result",
+    "blocked_workers",
+    "recovery_routes",
+    "hermes_runtime_boundary",
+    "public_private_boundary",
+    "limits"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-recovery-plan.schema.json"
+    },
+    "record_type": { "const": "factory_recovery_plan" },
+    "created_at": { "type": "string", "minLength": 10 },
+    "card_id": { "type": ["string", "null"] },
+    "gate_predicate_result": { "enum": ["PASS", "BLOCK"] },
+    "blocked_workers": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "next_safe_actions": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "recovery_routes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "recovery_route_id",
+          "blocker_type",
+          "factory_owned_repair_allowed",
+          "human_gate_required",
+          "repair_owner_worker",
+          "repair_task_ref",
+          "repair_inputs",
+          "expected_repair_outputs",
+          "commands_or_worker_routes",
+          "invalidates_refs",
+          "supersedes_refs",
+          "dependency_edge_patch",
+          "downstream_freeze_scope",
+          "fresh_review_required",
+          "fresh_review_result_ref",
+          "unblock_authority_ref",
+          "retry_policy",
+          "audit_trail_refs",
+          "hermes_materialization"
+        ],
+        "properties": {
+          "recovery_route_id": { "type": "string", "minLength": 3 },
+          "blocker_type": {
+            "enum": [
+              "product",
+              "security",
+              "source",
+              "orchestration",
+              "runtime",
+              "capability",
+              "dependency",
+              "human_gate",
+              "must_not_proceed"
+            ]
+          },
+          "factory_owned_repair_allowed": { "type": "boolean" },
+          "human_gate_required": { "type": "boolean" },
+          "repair_owner_worker": { "type": "string", "minLength": 3 },
+          "repair_task_ref": { "type": "string", "minLength": 3 },
+          "repair_inputs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "expected_repair_outputs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "commands_or_worker_routes": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "invalidates_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "supersedes_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "dependency_edge_patch": {
+            "type": "object",
+            "required": ["old_edges", "new_edges", "patch_authority"],
+            "properties": {
+              "old_edges": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "new_edges": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "patch_authority": { "type": "string", "minLength": 3 }
+            },
+            "additionalProperties": true
+          },
+          "downstream_freeze_scope": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "fresh_review_required": { "type": "boolean" },
+          "fresh_review_result_ref": { "type": "string", "minLength": 3 },
+          "unblock_authority_ref": { "type": "string", "minLength": 3 },
+          "retry_policy": {
+            "type": "object",
+            "required": ["max_attempts", "attempt_number", "stop_classes"],
+            "properties": {
+              "max_attempts": { "type": "integer", "minimum": 1 },
+              "attempt_number": { "type": "integer", "minimum": 1 },
+              "stop_classes": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "escalation_reason": { "type": "string" }
+            },
+            "additionalProperties": true
+          },
+          "audit_trail_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "hermes_materialization": {
+            "type": "object",
+            "required": [
+              "runtime_authority",
+              "native_primitives",
+              "task_intent",
+              "parent_link_policy",
+              "comments_metadata_policy",
+              "local_state_authority"
+            ],
+            "properties": {
+              "runtime_authority": { "const": "hermes_kanban" },
+              "native_primitives": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "enum": [
+                    "kanban_task",
+                    "parent_link",
+                    "blocked_state",
+                    "comment_metadata",
+                    "run_history",
+                    "reclaim_reassign"
+                  ]
+                }
+              },
+              "task_intent": { "type": "string", "minLength": 3 },
+              "parent_link_policy": { "type": "string", "minLength": 3 },
+              "comments_metadata_policy": { "type": "string", "minLength": 3 },
+              "local_state_authority": { "const": false }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "hermes_runtime_boundary": {
+      "type": "object",
+      "required": [
+        "runtime_authority",
+        "factory_output",
+        "no_shadow_scheduler",
+        "no_shadow_dispatcher",
+        "no_shadow_dependency_engine",
+        "local_state_authority"
+      ],
+      "properties": {
+        "runtime_authority": { "const": "hermes_kanban" },
+        "factory_output": { "const": "semantic_recovery_contract" },
+        "no_shadow_scheduler": { "const": true },
+        "no_shadow_dispatcher": { "const": true },
+        "no_shadow_dependency_engine": { "const": true },
+        "local_state_authority": { "const": false }
+      },
+      "additionalProperties": true
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["no_raw_logs", "no_private_paths", "no_private_ids"],
+      "properties": {
+        "no_raw_logs": { "const": true },
+        "no_private_paths": { "const": true },
+        "no_private_ids": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/hermes-profile-binding.schema.json
+++ b/schemas/hermes-profile-binding.schema.json
@@ -21,7 +21,7 @@
           "worker_id",
           "profile_id",
           "hermes_profile_name",
-          "dispatch_queue_policy",
+          "factory_gate_timing_policy",
           "skill_refs",
           "result_schema",
           "receipt_field",
@@ -38,11 +38,19 @@
           "worker_id": { "type": "string", "minLength": 3 },
           "profile_id": { "type": "string", "minLength": 3 },
           "hermes_profile_name": { "type": "string", "minLength": 3 },
-          "dispatch_queue_policy": {
+          "factory_gate_timing_policy": {
             "type": "object",
-            "required": ["source_of_truth", "default_queue", "allowed_effective_queues"],
+            "required": [
+              "policy_kind",
+              "policy_basis",
+              "runtime_authority",
+              "default_queue",
+              "allowed_effective_queues"
+            ],
             "properties": {
-              "source_of_truth": { "const": "factoryctl.worker_queue_class" },
+              "policy_kind": { "const": "factory_gate_timing_policy" },
+              "policy_basis": { "const": "factoryctl.worker_gate_timing_class" },
+              "runtime_authority": { "const": "hermes_kanban" },
               "default_queue": {
                 "enum": [
                   "blocking-before-ready",

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -44,7 +44,10 @@
           "task_type",
           "worker_id",
           "title",
+          "gate_timing_class",
           "queue_class",
+          "runtime_authority",
+          "local_state_authority",
           "required_before",
           "packet",
           "expected_receipt_field",
@@ -52,6 +55,13 @@
         ],
         "properties": {
           "task_type": { "const": "worker_subtask" },
+          "gate_timing_class": {
+            "enum": [
+              "blocking-before-ready",
+              "blocking-before-done",
+              "advisory-review"
+            ]
+          },
           "queue_class": {
             "enum": [
               "blocking-before-ready",
@@ -62,6 +72,8 @@
           "required_before": {
             "enum": ["ready", "done"]
           },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false },
           "status": {
             "enum": [
               "requires_execution",

--- a/schemas/hermes-worker-ledger.schema.json
+++ b/schemas/hermes-worker-ledger.schema.json
@@ -3,15 +3,27 @@
   "$id": "https://overkill-factory.dev/schemas/hermes-worker-ledger.schema.json",
   "title": "Overkill Factory Hermes Worker Ledger",
   "type": "object",
-  "required": ["ledger_type", "tasks"],
+  "required": [
+    "ledger_type",
+    "ledger_scope",
+    "runtime_authority",
+    "local_state_authority",
+    "tasks"
+  ],
   "properties": {
     "ledger_type": { "const": "overkill_factory_hermes_worker_ledger" },
+    "ledger_scope": { "const": "projection_idempotency_only" },
+    "runtime_authority": { "const": "hermes_kanban" },
+    "local_state_authority": { "const": false },
     "tasks": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "required": [
           "task_id",
+          "materialization_state",
+          "runtime_refs",
+          "local_record_role",
           "card_id",
           "worker_id",
           "queue_class",
@@ -20,6 +32,30 @@
           "status",
           "packet"
         ],
+        "properties": {
+          "materialization_state": {
+            "enum": [
+              "pending_hermes_materialization",
+              "materialized_in_hermes",
+              "projection_only"
+            ]
+          },
+          "runtime_refs": {
+            "type": "object",
+            "required": [
+              "hermes_board_ref",
+              "hermes_task_ref",
+              "hermes_run_ref"
+            ],
+            "properties": {
+              "hermes_board_ref": { "type": "string", "minLength": 3 },
+              "hermes_task_ref": { "type": "string", "minLength": 3 },
+              "hermes_run_ref": { "type": "string", "minLength": 3 }
+            },
+            "additionalProperties": false
+          },
+          "local_record_role": { "const": "idempotency_projection" }
+        },
         "additionalProperties": true
       }
     },

--- a/schemas/parallel-lane-contract.schema.json
+++ b/schemas/parallel-lane-contract.schema.json
@@ -34,6 +34,7 @@
     "cleanup_status",
     "integration_owner",
     "residual_risks",
+    "runtime_boundary",
     "public_safety_boundary"
   ],
   "properties": {
@@ -145,6 +146,20 @@
     "residual_risks": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
+    },
+    "runtime_boundary": {
+      "type": "object",
+      "required": ["state_role", "runtime_authority", "local_state_authority"],
+      "properties": {
+        "state_role": { "enum": ["planning_only", "projection_only", "materialized_runtime_refs"] },
+        "runtime_authority": { "const": "hermes_kanban" },
+        "local_state_authority": { "const": false },
+        "materialized_hermes_task_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
     },
     "public_safety_boundary": {
       "type": "object",

--- a/schemas/product-creation-plan.schema.json
+++ b/schemas/product-creation-plan.schema.json
@@ -21,6 +21,7 @@
     "drift_check",
     "stop_conditions",
     "reconciliation_policy",
+    "runtime_boundary",
     "evidence_refs"
   ],
   "properties": {
@@ -80,6 +81,20 @@
     "drift_check": { "type": "string", "minLength": 8 },
     "stop_conditions": { "type": "array", "minItems": 1, "items": { "type": "string" } },
     "reconciliation_policy": { "type": "string", "minLength": 8 },
+    "runtime_boundary": {
+      "type": "object",
+      "required": ["state_role", "runtime_authority", "local_state_authority"],
+      "properties": {
+        "state_role": { "enum": ["planning_only", "materialized_runtime_refs"] },
+        "runtime_authority": { "const": "hermes_kanban" },
+        "local_state_authority": { "const": false },
+        "materialized_hermes_task_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
     "evidence_refs": {
       "type": "array",
       "minItems": 1,

--- a/schemas/work-unit-contract.schema.json
+++ b/schemas/work-unit-contract.schema.json
@@ -24,6 +24,7 @@
     "product_context_packet_ref",
     "reviewer_selection_ref",
     "rollback_or_recovery",
+    "runtime_boundary",
     "evidence_refs"
   ],
   "properties": {
@@ -97,6 +98,17 @@
     "product_context_packet_ref": { "type": "string", "minLength": 3 },
     "reviewer_selection_ref": { "type": "string", "minLength": 3 },
     "rollback_or_recovery": { "type": "string", "minLength": 3 },
+    "runtime_boundary": {
+      "type": "object",
+      "required": ["state_role", "runtime_authority", "local_state_authority"],
+      "properties": {
+        "state_role": { "enum": ["planning_only", "materialized_runtime_refs"] },
+        "runtime_authority": { "const": "hermes_kanban" },
+        "local_state_authority": { "const": false },
+        "materialized_hermes_task_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
     "evidence_refs": {
       "type": "array",
       "minItems": 1,

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -120,8 +120,8 @@
       "required": [
         "profile_id",
         "hermes_profile_name",
-        "dispatch_queue_policy",
-        "queue_class_source",
+        "factory_gate_timing_policy",
+        "gate_timing_source",
         "skill_refs",
         "result_schema",
         "receipt_field",
@@ -142,17 +142,19 @@
           "type": "string",
           "minLength": 3
         },
-        "dispatch_queue_policy": {
+        "factory_gate_timing_policy": {
           "type": "object",
           "required": [
-            "source_of_truth",
+            "policy_kind",
+            "policy_basis",
+            "runtime_authority",
             "default_queue",
             "allowed_effective_queues"
           ],
           "properties": {
-            "source_of_truth": {
-              "const": "factoryctl.worker_queue_class"
-            },
+            "policy_kind": { "const": "factory_gate_timing_policy" },
+            "policy_basis": { "const": "factoryctl.worker_gate_timing_class" },
+            "runtime_authority": { "const": "hermes_kanban" },
             "default_queue": {
               "enum": [
                 "blocking-before-ready",
@@ -176,8 +178,8 @@
           },
           "additionalProperties": false
         },
-        "queue_class_source": {
-          "const": "worker_task.queue_class"
+        "gate_timing_source": {
+          "const": "worker_task.gate_timing_class"
         },
         "skill_refs": {
           "type": "array",

--- a/schemas/worker-registry.schema.json
+++ b/schemas/worker-registry.schema.json
@@ -22,7 +22,7 @@
           "authority_max",
           "veto_conditions",
           "evidence_required",
-          "kanban_transition_rules",
+          "factory_gate_transition_policy",
           "promotion_rule",
           "public_safety_notes"
         ],

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -216,7 +216,95 @@
         }
       },
       "additionalProperties": false
+    },
+    "recovery_recommendation": {
+      "type": "object",
+      "required": [
+        "blocker_type",
+        "factory_owned_repair_allowed",
+        "human_gate_required",
+        "recovery_route_id",
+        "repair_owner_worker",
+        "invalidates_refs",
+        "supersedes_refs",
+        "fresh_review_required",
+        "unblock_authority_ref",
+        "retry_policy",
+        "hermes_runtime_boundary"
+      ],
+      "properties": {
+        "blocker_type": {
+          "enum": [
+            "product",
+            "security",
+            "source",
+            "orchestration",
+            "runtime",
+            "capability",
+            "dependency",
+            "human_gate",
+            "must_not_proceed"
+          ]
+        },
+        "factory_owned_repair_allowed": { "type": "boolean" },
+        "human_gate_required": { "type": "boolean" },
+        "recovery_route_id": { "type": "string", "minLength": 3 },
+        "repair_owner_worker": { "type": "string", "minLength": 3 },
+        "repair_task_ref": { "type": "string", "minLength": 3 },
+        "invalidates_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "supersedes_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "fresh_review_required": { "type": "boolean" },
+        "fresh_review_result_ref": { "type": "string", "minLength": 3 },
+        "unblock_authority_ref": { "type": "string", "minLength": 3 },
+        "retry_policy": {
+          "type": "object",
+          "required": ["max_attempts", "attempt_number", "stop_classes"],
+          "properties": {
+            "max_attempts": { "type": "integer", "minimum": 1 },
+            "attempt_number": { "type": "integer", "minimum": 1 },
+            "stop_classes": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "escalation_reason": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "hermes_runtime_boundary": {
+          "type": "object",
+          "required": [
+            "runtime_authority",
+            "uses_native_kanban_primitives",
+            "local_state_authority"
+          ],
+          "properties": {
+            "runtime_authority": { "const": "hermes_kanban" },
+            "uses_native_kanban_primitives": { "const": true },
+            "local_state_authority": { "const": false }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "result": { "const": "BLOCKED" } },
+        "required": ["result"]
+      },
+      "then": {
+        "required": ["recovery_recommendation"]
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -1239,6 +1239,96 @@ def worker_blocker_economics(worker_id: str, status: str, reason: str) -> dict[s
     )
 
 
+def blocker_type_for_worker(worker_id: str) -> str:
+    if worker_id == "human-gate-clerk":
+        return "human_gate"
+    if worker_id in {
+        "codex-security",
+        "solana-quasar-auditor",
+        "security-orchestrator",
+        "appsec-owasp-specialist",
+        "agentic-ai-security-specialist",
+        "cloud-infra-security-specialist",
+        "crypto-key-management-specialist",
+        "public-safety-gate",
+        "supply-chain-gate",
+        "detection-monitoring-worker",
+    }:
+        return "security"
+    if worker_id in {"source-ledger-worker", "product-sot-planner"}:
+        return "source"
+    if worker_id in {"factory-orchestrator", "evidence-reconciler", "independent-reviewer", "autoreview-gate"}:
+        return "orchestration"
+    if worker_id in {"agent-runtime-builder", "infra-devops-builder", "remote-proof-runner"}:
+        return "runtime"
+    return "dependency"
+
+
+def recovery_runtime_boundary() -> dict[str, Any]:
+    return {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": True,
+        "native_primitives": [
+            "kanban_task",
+            "parent_link",
+            "blocked_state",
+            "comment_metadata",
+            "run_history",
+            "reclaim_reassign",
+        ],
+        "local_state_authority": False,
+    }
+
+
+def recovery_recommendation_for_worker(
+    *,
+    worker_id: str,
+    card: dict[str, Any],
+    reason: str,
+    attempt_number: int = 1,
+) -> dict[str, Any]:
+    card_id = sanitize_slug(card.get("card_id") or "factory-card", fallback="factory-card")
+    blocker_type = blocker_type_for_worker(worker_id)
+    human_gate_required = blocker_type == "human_gate"
+    route_id = f"recovery:{card_id}:{sanitize_slug(worker_id, fallback='worker')}"
+    output_field = WORKERS.get(worker_id, WORKERS["factory-orchestrator"]).output_field
+    return {
+        "blocker_type": blocker_type,
+        "factory_owned_repair_allowed": not human_gate_required,
+        "human_gate_required": human_gate_required,
+        "recovery_route_id": route_id,
+        "repair_owner_worker": worker_id,
+        "repair_task_ref": f"hermes:intent:{route_id}",
+        "repair_inputs": [reason or f"{worker_id} blocked"],
+        "expected_repair_outputs": [output_field],
+        "commands_or_worker_routes": [f"route {worker_id} through Hermes Kanban"],
+        "invalidates_refs": [f"worker-result:{output_field}:blocking-or-stale"],
+        "supersedes_refs": [f"worker-result:{output_field}:fresh-pass-required"],
+        "dependency_edge_patch": {
+            "old_edges": [f"blocked:{output_field}"],
+            "new_edges": [f"fresh-review:{output_field}"],
+            "patch_authority": "fresh review PASS recorded in Hermes before unblock",
+        },
+        "downstream_freeze_scope": ["next worker", "done promotion", "Receipt Five closure"],
+        "fresh_review_required": not human_gate_required,
+        "fresh_review_result_ref": f"worker-result:{output_field}:fresh-review",
+        "unblock_authority_ref": "Hermes blocked event plus fresh review PASS" if not human_gate_required else "human_gate_record",
+        "retry_policy": {
+            "max_attempts": 10,
+            "attempt_number": attempt_number,
+            "stop_classes": [
+                "human_gate",
+                "secret_or_access_required",
+                "external_mutation_required",
+                "ambiguous_product_decision",
+                "repeated_failed_recovery",
+            ],
+            "escalation_reason": "Escalate only when the blocker leaves factory-owned safe repair scope.",
+        },
+        "hermes_runtime_boundary": recovery_runtime_boundary(),
+    }
+
+
 def scan_result_passed(value: Any) -> bool:
     if value is True:
         return True
@@ -3416,8 +3506,8 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
         packet["profile_binding"] = {
             "profile_id": profile_binding.get("profile_id"),
             "hermes_profile_name": profile_binding.get("hermes_profile_name"),
-            "dispatch_queue_policy": profile_binding.get("dispatch_queue_policy"),
-            "queue_class_source": "worker_task.queue_class",
+            "factory_gate_timing_policy": profile_binding.get("factory_gate_timing_policy"),
+            "gate_timing_source": "worker_task.gate_timing_class",
             "skill_refs": profile_binding.get("skill_refs", []),
             "result_schema": profile_binding.get("result_schema"),
             "receipt_field": profile_binding.get("receipt_field"),
@@ -3522,6 +3612,134 @@ def build_gate_report(card: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def recovery_route_from_action(card: dict[str, Any], action: dict[str, Any], index: int) -> dict[str, Any]:
+    worker_id = str(action.get("worker_id") or "factory-orchestrator").strip() or "factory-orchestrator"
+    worker = WORKERS.get(worker_id, WORKERS["factory-orchestrator"])
+    card_id = sanitize_slug(card.get("card_id") or "factory-card", fallback="factory-card")
+    blocker_type = blocker_type_for_worker(worker_id)
+    human_gate_required = blocker_type == "human_gate"
+    route_id = f"recovery:{card_id}:{index}:{sanitize_slug(worker_id, fallback='worker')}"
+    action_text = str(action.get("action") or "run required worker and attach evidence").strip()
+    field = str(action.get("field") or worker.output_field).strip()
+    return {
+        "recovery_route_id": route_id,
+        "blocker_type": blocker_type,
+        "factory_owned_repair_allowed": not human_gate_required,
+        "human_gate_required": human_gate_required,
+        "repair_owner_worker": worker_id,
+        "repair_task_ref": f"hermes:intent:{route_id}",
+        "repair_inputs": [
+            f"card:{card_id}",
+            f"blocked-field:{field}",
+            action_text,
+        ],
+        "expected_repair_outputs": [field],
+        "commands_or_worker_routes": [f"route {worker_id} through Hermes Kanban"],
+        "invalidates_refs": [f"worker-result:{field}:blocking-or-stale"],
+        "supersedes_refs": [f"worker-result:{field}:fresh-pass-required"],
+        "dependency_edge_patch": {
+            "old_edges": [f"blocked:{field}"],
+            "new_edges": [f"fresh-review:{field}"],
+            "patch_authority": "fresh review PASS recorded in Hermes before unblock",
+        },
+        "downstream_freeze_scope": [
+            "next worker",
+            "done promotion",
+            "Receipt Five closure",
+        ],
+        "fresh_review_required": not human_gate_required,
+        "fresh_review_result_ref": f"worker-result:{field}:fresh-review",
+        "unblock_authority_ref": "Hermes blocked event plus fresh review PASS" if not human_gate_required else "human_gate_record",
+        "retry_policy": {
+            "max_attempts": 10,
+            "attempt_number": 1,
+            "stop_classes": [
+                "human_gate",
+                "secret_or_access_required",
+                "external_mutation_required",
+                "ambiguous_product_decision",
+                "repeated_failed_recovery",
+            ],
+            "escalation_reason": "Escalate only when the blocker leaves factory-owned safe repair scope.",
+        },
+        "audit_trail_refs": [
+            "factoryctl:gate-report",
+            f"worker:{worker_id}",
+        ],
+        "hermes_materialization": {
+            "runtime_authority": "hermes_kanban",
+            "native_primitives": [
+                "kanban_task",
+                "parent_link",
+                "blocked_state",
+                "comment_metadata",
+                "run_history",
+                "reclaim_reassign",
+            ],
+            "task_intent": "Create or route a Hermes repair task; do not mutate a local task lifecycle.",
+            "parent_link_policy": "Repair task remains linked to the blocked parent and downstream work stays blocked until fresh review passes.",
+            "comments_metadata_policy": "Store blocker type, invalidation refs, retry attempt and unblock authority in Hermes comments/metadata.",
+            "local_state_authority": False,
+        },
+    }
+
+
+def recovery_route_from_validation_error(card: dict[str, Any], error: str, index: int) -> dict[str, Any]:
+    return recovery_route_from_action(
+        card,
+        {
+            "worker_id": "factory-orchestrator",
+            "field": "card_contract",
+            "action": error,
+            "authority": "factory-orchestrator emits a repaired card contract; Hermes records the repair task and review.",
+        },
+        index,
+    )
+
+
+def build_factory_recovery_plan(card: dict[str, Any]) -> dict[str, Any]:
+    report = build_gate_report(card)
+    routes: list[dict[str, Any]] = []
+    route_index = 1
+    if report.get("gate_predicate_result") == "BLOCK":
+        for error in report.get("card_validation_errors", []):
+            routes.append(recovery_route_from_validation_error(card, str(error), route_index))
+            route_index += 1
+        for action in report.get("next_safe_actions", []):
+            if not isinstance(action, dict):
+                continue
+            routes.append(recovery_route_from_action(card, action, route_index))
+            route_index += 1
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-recovery-plan.schema.json",
+        "record_type": "factory_recovery_plan",
+        "created_at": utc_now(),
+        "card_id": report.get("card_id"),
+        "gate_predicate_result": report.get("gate_predicate_result"),
+        "blocked_workers": report.get("blocked_workers", []),
+        "next_safe_actions": report.get("next_safe_actions", []),
+        "recovery_routes": routes,
+        "hermes_runtime_boundary": {
+            "runtime_authority": "hermes_kanban",
+            "factory_output": "semantic_recovery_contract",
+            "no_shadow_scheduler": True,
+            "no_shadow_dispatcher": True,
+            "no_shadow_dependency_engine": True,
+            "local_state_authority": False,
+        },
+        "public_private_boundary": {
+            "no_raw_logs": True,
+            "no_private_paths": True,
+            "no_private_ids": True,
+        },
+        "limits": [
+            "This plan does not execute workers, approve gates, unblock Hermes tasks, or bypass missing evidence.",
+            "Recovery routes are semantic contracts; Hermes Kanban remains the runtime authority for tasks, links, block/unblock, comments, runs and audit history.",
+            "Human/security/release/deployment/GitHub/funds/secrets/mainnet approval is never implied by a recovery route.",
+        ],
+    }
+
+
 BEFORE_READY_WORKERS = {
     "factory-orchestrator",
     "source-ledger-worker",
@@ -3566,7 +3784,7 @@ BEFORE_DONE_WORKERS = {
 }
 
 
-def worker_queue_class(worker_id: str, card: dict[str, Any]) -> str:
+def worker_gate_timing_class(worker_id: str, card: dict[str, Any]) -> str:
     phase = str(card.get("phase", "")).upper()
     effective_risk = risk(card)
     if worker_id == "human-gate-clerk" and phase in {"F4", "F9"}:
@@ -3580,6 +3798,11 @@ def worker_queue_class(worker_id: str, card: dict[str, Any]) -> str:
     if worker_id == "handoff-packer" and effective_risk in REVIEW_RISK:
         return "blocking-before-done"
     return "advisory-review"
+
+
+def worker_queue_class(worker_id: str, card: dict[str, Any]) -> str:
+    """Compatibility alias: this is gate timing policy, not runtime queue authority."""
+    return worker_gate_timing_class(worker_id, card)
 
 
 def string_list(value: Any) -> list[str]:
@@ -3756,6 +3979,20 @@ def validate_worker_result_record(
         result = str(data.get("result") or "").strip()
         if result not in {"PASS", "WAIVED"}:
             errors.append("result must be PASS or WAIVED to satisfy a required worker")
+        if result == "BLOCKED":
+            recovery = data.get("recovery_recommendation")
+            if not isinstance(recovery, dict):
+                errors.append("BLOCKED worker result requires recovery_recommendation")
+            else:
+                boundary = recovery.get("hermes_runtime_boundary") if isinstance(recovery.get("hermes_runtime_boundary"), dict) else {}
+                if boundary.get("runtime_authority") != "hermes_kanban":
+                    errors.append("recovery_recommendation.hermes_runtime_boundary.runtime_authority must be hermes_kanban")
+                if boundary.get("local_state_authority") is not False:
+                    errors.append("recovery_recommendation must not claim local runtime state authority")
+                if not str(recovery.get("recovery_route_id") or "").strip():
+                    errors.append("recovery_recommendation.recovery_route_id is required")
+                if not isinstance(recovery.get("retry_policy"), dict):
+                    errors.append("recovery_recommendation.retry_policy is required")
         if data.get("blocking_findings") is not False:
             errors.append("blocking_findings must be false")
         for field in ("worker", "card_ref", "findings_summary", "tool_or_profile", "executed_by", "next_action"):
@@ -3890,7 +4127,10 @@ def build_worker_task(worker_id: str, card: dict[str, Any], source_path: Path) -
         "task_type": "worker_subtask",
         "worker_id": worker_id,
         "title": f"{worker.worker_name}: {card.get('card_id') or 'factory-card'}",
+        "gate_timing_class": queue_class,
         "queue_class": queue_class,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
         "required_before": "ready" if queue_class == "blocking-before-ready" else "done",
         "packet": packet,
         "profile_binding": packet.get("profile_binding"),
@@ -4123,6 +4363,12 @@ def build_worker_result(
             "active": True,
         },
     }
+    if result == "BLOCKED":
+        payload["recovery_recommendation"] = recovery_recommendation_for_worker(
+            worker_id=worker_id,
+            card=card,
+            reason=findings_summary or next_action or "blocked worker result",
+        )
     if worker_id == "codex-security":
         scan_packet = card.get("security_scan_packet", {}) if isinstance(card.get("security_scan_packet"), dict) else {}
         scope = scan_packet.get("scan_scope") or card.get("surfaces", [])
@@ -5383,22 +5629,15 @@ def command_gate_report(args: argparse.Namespace) -> int:
 
 
 def command_unblock_plan(args: argparse.Namespace) -> int:
-    report = build_gate_report(load_json_like(args.card))
-    plan = {
-        "$schema": "https://overkill-factory.dev/schemas/unblock-plan.schema.json",
-        "record_type": "operator_unblock_plan",
-        "created_at": utc_now(),
-        "card_id": report.get("card_id"),
-        "gate_predicate_result": report.get("gate_predicate_result"),
-        "blocked_workers": report.get("blocked_workers", []),
-        "next_safe_actions": report.get("next_safe_actions", []),
-        "limits": [
-            "This plan does not execute workers, approve gates, or bypass missing evidence.",
-            "Human/security/review evidence must be produced by the assigned authority.",
-        ],
-    }
+    plan = build_factory_recovery_plan(load_json_like(args.card))
     write_json(args.out, plan)
-    return 1 if report.get("gate_predicate_result") == "BLOCK" else 0
+    return 1 if plan.get("gate_predicate_result") == "BLOCK" else 0
+
+
+def command_recovery_plan(args: argparse.Namespace) -> int:
+    plan = build_factory_recovery_plan(load_json_like(args.card))
+    write_json(args.out, plan)
+    return 1 if plan.get("gate_predicate_result") == "BLOCK" else 0
 
 
 def command_help_next(args: argparse.Namespace) -> int:
@@ -5668,6 +5907,11 @@ def build_parser() -> argparse.ArgumentParser:
     unblock_plan_parser.add_argument("--card", type=Path, required=True)
     unblock_plan_parser.add_argument("--out", type=Path)
     unblock_plan_parser.set_defaults(func=command_unblock_plan)
+
+    recovery_plan_parser = sub.add_parser("recovery-plan", help="Emit semantic recovery routes without replacing Hermes runtime state.")
+    recovery_plan_parser.add_argument("--card", type=Path, required=True)
+    recovery_plan_parser.add_argument("--out", type=Path)
+    recovery_plan_parser.set_defaults(func=command_recovery_plan)
 
     help_next_parser = sub.add_parser("help-next", help="Show the next safe action without making the user operate internal factory machinery.")
     help_next_parser.add_argument("--card", type=Path, required=True)

--- a/scripts/materialize_hermes_profiles.py
+++ b/scripts/materialize_hermes_profiles.py
@@ -62,7 +62,7 @@ def render_soul(worker: dict, binding: dict) -> str:
     understanding_contract = worker.get("understanding_contract", {})
     failure_contract = worker.get("failure_contract", {})
     promotion_contract = worker.get("promotion_contract", {})
-    dispatch_policy = binding.get("dispatch_queue_policy", {})
+    gate_timing_policy = binding.get("factory_gate_timing_policy", {})
 
     parts = [
         f"# {worker.get('display_name', worker['worker_id'])}",
@@ -117,12 +117,14 @@ def render_soul(worker: dict, binding: dict) -> str:
             "Hermes Binding",
             "\n".join(
                 [
-                    f"Queue source of truth: {dispatch_policy.get('source_of_truth', 'factoryctl.worker_queue_class')}",
+                    f"Gate timing policy basis: {gate_timing_policy.get('policy_basis', 'factoryctl.worker_gate_timing_class')}",
                     "",
-                    f"Default queue policy: {dispatch_policy.get('default_queue', 'blocking-before-done')}",
+                    f"Runtime authority: {gate_timing_policy.get('runtime_authority', 'hermes_kanban')}",
                     "",
-                    "Allowed effective queues:",
-                    bullets(dispatch_policy.get("allowed_effective_queues")),
+                    f"Default gate timing: {gate_timing_policy.get('default_queue', 'blocking-before-done')}",
+                    "",
+                    "Allowed effective gate timings:",
+                    bullets(gate_timing_policy.get("allowed_effective_queues")),
                     "",
                     f"Result schema: {binding.get('result_schema', 'schemas/worker-result.schema.json')}",
                     "",
@@ -133,7 +135,7 @@ def render_soul(worker: dict, binding: dict) -> str:
                     "",
                     f"Can mutate card state: {str(binding.get('can_mutate_card_state', False)).lower()}",
                     "",
-                    "Card state mutation: forbidden directly; adapter owns state mutation.",
+                    "Card state mutation: forbidden directly; Hermes Kanban owns runtime state and the adapter only materializes intent.",
                 ]
             ),
         ),

--- a/scripts/validate_worker_profiles.py
+++ b/scripts/validate_worker_profiles.py
@@ -275,16 +275,24 @@ def validate(
                 findings.append(f"{worker_id}: binding must include hermes-kanban skill")
             if binding.get("can_mutate_card_state") is not False:
                 findings.append(f"{worker_id}: worker profile must not directly mutate card state")
-            policy = binding.get("dispatch_queue_policy")
+            if "dispatch_queue_policy" in binding:
+                findings.append(f"{worker_id}: binding must use factory_gate_timing_policy, not dispatch_queue_policy")
+            policy = binding.get("factory_gate_timing_policy")
             if not isinstance(policy, dict):
-                findings.append(f"{worker_id}: binding missing dispatch_queue_policy")
+                findings.append(f"{worker_id}: binding missing factory_gate_timing_policy")
             else:
-                if policy.get("source_of_truth") != "factoryctl.worker_queue_class":
-                    findings.append(f"{worker_id}: dispatch queue source must be factoryctl.worker_queue_class")
+                if "source_of_truth" in policy:
+                    findings.append(f"{worker_id}: factory_gate_timing_policy must not claim source_of_truth")
+                if policy.get("policy_kind") != "factory_gate_timing_policy":
+                    findings.append(f"{worker_id}: factory_gate_timing_policy.policy_kind must be factory_gate_timing_policy")
+                if policy.get("policy_basis") != "factoryctl.worker_gate_timing_class":
+                    findings.append(f"{worker_id}: gate timing policy basis must be factoryctl.worker_gate_timing_class")
+                if policy.get("runtime_authority") != "hermes_kanban":
+                    findings.append(f"{worker_id}: gate timing runtime authority must be hermes_kanban")
                 if not policy.get("default_queue"):
-                    findings.append(f"{worker_id}: dispatch_queue_policy missing default_queue")
+                    findings.append(f"{worker_id}: factory_gate_timing_policy missing default_queue")
                 if not policy.get("allowed_effective_queues"):
-                    findings.append(f"{worker_id}: dispatch_queue_policy missing allowed_effective_queues")
+                    findings.append(f"{worker_id}: factory_gate_timing_policy missing allowed_effective_queues")
             for field in (
                 "profile_manifest_ref",
                 "profile_description_ref",

--- a/templates/parallel-lane-contract.json
+++ b/templates/parallel-lane-contract.json
@@ -66,6 +66,12 @@
   "residual_risks": [
     "No write lane was integrated from this example contract."
   ],
+  "runtime_boundary": {
+    "state_role": "projection_only",
+    "runtime_authority": "hermes_kanban",
+    "local_state_authority": false,
+    "materialized_hermes_task_refs": []
+  },
   "public_safety_boundary": {
     "no_private_product_names": true,
     "no_local_absolute_paths": true,

--- a/templates/product-creation-plan.json
+++ b/templates/product-creation-plan.json
@@ -47,5 +47,11 @@
   "drift_check": "Refresh this plan when Product SOT, method, architecture, capability packs or landed slices change.",
   "stop_conditions": ["missing Product SOT coverage", "missing promotion ladder for production intent", "stale product context"],
   "reconciliation_policy": "Mark work units todo, ready, blocked, done, rejected, superseded or needs_refresh; never treat a done slice as whole-product completion.",
+  "runtime_boundary": {
+    "state_role": "planning_only",
+    "runtime_authority": "hermes_kanban",
+    "local_state_authority": false,
+    "materialized_hermes_task_refs": []
+  },
   "evidence_refs": ["templates/full-product-sot-scope-coverage.json"]
 }

--- a/templates/work-unit-contract.json
+++ b/templates/work-unit-contract.json
@@ -21,5 +21,11 @@
   "product_context_packet_ref": "templates/product-context-packet.json",
   "reviewer_selection_ref": "templates/reviewer-selection-plan.json",
   "rollback_or_recovery": "Revert this slice without touching unrelated work.",
+  "runtime_boundary": {
+    "state_role": "planning_only",
+    "runtime_authority": "hermes_kanban",
+    "local_state_authority": false,
+    "materialized_hermes_task_ref": "external:not-materialized"
+  },
   "evidence_refs": ["work-unit-contract.md"]
 }

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -866,6 +866,36 @@ class FactoryCtlTest(unittest.TestCase):
                 next_action="fix",
             )
 
+    def test_blocked_worker_result_carries_recovery_recommendation_without_promotion_authority(self) -> None:
+        card = load_card("v35_valid_security_with_scan.md")
+
+        result = factoryctl.build_worker_result(
+            "codex-security",
+            card,
+            result="BLOCKED",
+            tool_or_profile="codex-security:security-scan",
+            executed_by="security-runner",
+            evidence_refs=["reports/security.md"],
+            blocking_findings=True,
+            findings_summary="Security finding blocks continuation.",
+            next_action="repair finding and rerun security scan",
+        )
+
+        recovery = result["recovery_recommendation"]
+        self.assertEqual(recovery["blocker_type"], "security")
+        self.assertTrue(recovery["factory_owned_repair_allowed"])
+        self.assertEqual(recovery["hermes_runtime_boundary"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(recovery["hermes_runtime_boundary"]["local_state_authority"])
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="security_scan_result",
+            expected_worker_id="codex-security",
+            card=card,
+            evidence_root=ROOT,
+        )
+        self.assertIn("result must be PASS or WAIVED to satisfy a required worker", errors)
+        self.assertNotIn("BLOCKED worker result requires recovery_recommendation", errors)
+
     def test_real_specialist_result_requires_domain_contract_fields(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md")
         result = worker_result("appsec_owasp_result")
@@ -1071,6 +1101,34 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(queues["supply-chain-gate"], "blocking-before-ready")
         self.assertEqual(queues["codex-security"], "blocking-before-done")
         self.assertEqual(queues["solana-quasar-auditor"], "blocking-before-done")
+
+    def test_recovery_plan_does_not_turn_normal_execution_into_recovery(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+
+        plan = factoryctl.build_factory_recovery_plan(card)
+
+        self.assertEqual(plan["gate_predicate_result"], "PASS")
+        self.assertEqual(plan["recovery_routes"], [])
+        self.assertEqual(plan["hermes_runtime_boundary"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(plan["hermes_runtime_boundary"]["local_state_authority"])
+
+    def test_recovery_plan_for_blocked_gate_uses_hermes_native_boundary(self) -> None:
+        card = load_card("v35_valid_product_face.md")
+        card.pop("security_scan_packet", None)
+
+        plan = factoryctl.build_factory_recovery_plan(card)
+
+        self.assertEqual(plan["gate_predicate_result"], "BLOCK")
+        self.assertGreater(len(plan["recovery_routes"]), 0)
+        route = plan["recovery_routes"][0]
+        self.assertIn("repair_task_ref", route)
+        self.assertIn("downstream_freeze_scope", route)
+        self.assertIn("unblock_authority_ref", route)
+        self.assertEqual(route["hermes_materialization"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(route["hermes_materialization"]["local_state_authority"])
+        self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_scheduler"])
+        self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_dispatcher"])
+        self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_dependency_engine"])
 
     def test_hermes_schemas_allow_before_ready_block_action(self) -> None:
         action = "block_and_create_before_ready_tasks"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -109,9 +109,14 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 ]
             )
             result = adapter.materialize(args, runner=fake)
+            ledger_data = json.loads((Path(tmp) / "ledger.json").read_text(encoding="utf-8"))
 
         self.assertEqual(result["main_task_id"], MAIN_TASK_ID)
         self.assertIn("codex-security", result["worker_task_ids"])
+        binding = ledger_data["live_bindings"]["KFP-V35-POS-ONCHAIN-AUDITOR"]
+        self.assertEqual(binding["binding_role"], "hermes_ref_projection")
+        self.assertEqual(binding["runtime_authority"], "hermes_kanban")
+        self.assertFalse(binding["local_state_authority"])
         link_calls = [call for call in fake.calls if len(call) >= 7 and call[4] == "link"]
         self.assertTrue(link_calls)
         for call in link_calls:

--- a/tests/test_hermes_transition_hook.py
+++ b/tests/test_hermes_transition_hook.py
@@ -46,7 +46,15 @@ class HermesTransitionHookTest(unittest.TestCase):
         self.assertGreater(first["ledger"]["created"], [])
         self.assertEqual(second["ledger"]["created"], [])
         self.assertEqual(first["ledger"]["task_count"], second["ledger"]["task_count"])
+        self.assertEqual(ledger_data["ledger_scope"], "projection_idempotency_only")
+        self.assertEqual(ledger_data["runtime_authority"], "hermes_kanban")
+        self.assertFalse(ledger_data["local_state_authority"])
         self.assertEqual(len(ledger_data["tasks"]), first["ledger"]["task_count"])
+        task = next(iter(ledger_data["tasks"].values()))
+        self.assertEqual(task["materialization_state"], "pending_hermes_materialization")
+        self.assertEqual(task["local_record_role"], "idempotency_projection")
+        self.assertIn("runtime_refs", task)
+        self.assertIn("hermes_task_ref", task["runtime_refs"])
 
     def test_done_hook_blocks_missing_worker_results(self) -> None:
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"

--- a/tests/test_materialize_hermes_profiles.py
+++ b/tests/test_materialize_hermes_profiles.py
@@ -4,14 +4,30 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import importlib.util
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "materialize_hermes_profiles.py"
+SPEC = importlib.util.spec_from_file_location("materialize_hermes_profiles", SCRIPT)
+assert SPEC is not None
+materialize = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(materialize)
 
 
 class MaterializeHermesProfilesTest(unittest.TestCase):
+    def test_rendered_profile_uses_gate_timing_not_queue_source_of_truth(self) -> None:
+        workers = materialize.load_json(ROOT / "agents" / "worker-profiles.public.json")["profiles"]
+        bindings = materialize.load_json(ROOT / "agents" / "hermes-profile-bindings.public.json")["bindings"]
+
+        soul = materialize.render_soul(workers["frontend-builder"], bindings["frontend-builder"])
+
+        self.assertIn("Gate timing policy basis: factoryctl.worker_gate_timing_class", soul)
+        self.assertIn("Runtime authority: hermes_kanban", soul)
+        self.assertNotIn("Queue source of truth", soul)
+
     def test_dry_run_does_not_require_existing_source_profile(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = subprocess.run(

--- a/tests/test_operator_experience.py
+++ b/tests/test_operator_experience.py
@@ -21,17 +21,36 @@ def run_factoryctl(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def run_factoryctl_blocking_ok(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "scripts/factoryctl.py", *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_card_without_security_packet(tmp: Path) -> Path:
+    source = (ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md").read_text(encoding="utf-8")
+    data = json.loads(source[source.find("{") : source.rfind("}") + 1])
+    data.pop("security_scan_packet", None)
+    path = tmp / "blocked-card.json"
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
 class OperatorExperienceTest(unittest.TestCase):
     def test_factoryctl_exposes_single_operator_entrypoint(self) -> None:
         help_text = run_factoryctl("--help").stdout
         run_help = run_factoryctl("run", "--help").stdout
 
-        for command in ["doctor", "init", "run", "unblock-plan", "help-next"]:
+        for command in ["doctor", "init", "run", "unblock-plan", "recovery-plan", "help-next"]:
             with self.subTest(command=command):
                 self.assertIn(command, help_text)
         self.assertIn("minimal", run_help)
 
-    def test_unblock_plan_is_read_only_operator_guidance(self) -> None:
+    def test_unblock_plan_emits_semantic_recovery_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / "unblock-plan.json"
             run_factoryctl(
@@ -43,9 +62,37 @@ class OperatorExperienceTest(unittest.TestCase):
             )
             payload = json.loads(out.read_text(encoding="utf-8"))
 
-        self.assertEqual(payload["record_type"], "operator_unblock_plan")
+        self.assertEqual(payload["record_type"], "factory_recovery_plan")
         self.assertIn("next_safe_actions", payload)
+        self.assertIn("recovery_routes", payload)
+        self.assertEqual(payload["gate_predicate_result"], "PASS")
+        self.assertEqual(payload["recovery_routes"], [])
+        self.assertEqual(payload["hermes_runtime_boundary"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(payload["hermes_runtime_boundary"]["local_state_authority"])
+        self.assertTrue(payload["hermes_runtime_boundary"]["no_shadow_dispatcher"])
         self.assertTrue(any("does not execute workers" in item for item in payload["limits"]))
+
+    def test_recovery_plan_names_hermes_native_materialization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            card = write_card_without_security_packet(tmp)
+            out = tmp / "recovery-plan.json"
+            result = run_factoryctl_blocking_ok(
+                "recovery-plan",
+                "--card",
+                str(card),
+                "--out",
+                str(out),
+            )
+            payload = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(payload["$schema"], "https://overkill-factory.dev/schemas/factory-recovery-plan.schema.json")
+        self.assertGreater(len(payload["recovery_routes"]), 0)
+        route = payload["recovery_routes"][0]
+        self.assertEqual(route["hermes_materialization"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(route["hermes_materialization"]["local_state_authority"])
+        self.assertIn("kanban_task", route["hermes_materialization"]["native_primitives"])
 
     def test_doctor_reports_public_install_health_without_real_hermes_e2e(self) -> None:
         result = run_factoryctl("doctor", "--json")

--- a/tests/test_worker_profiles.py
+++ b/tests/test_worker_profiles.py
@@ -159,8 +159,12 @@ class WorkerProfilesTest(unittest.TestCase):
 
         self.assertEqual(packet["profile_binding"]["profile_id"], "product-face.profile.v1")
         self.assertEqual(packet["profile_binding"]["hermes_profile_name"], "product-face")
-        self.assertEqual(packet["profile_binding"]["queue_class_source"], "worker_task.queue_class")
-        self.assertEqual(packet["profile_binding"]["dispatch_queue_policy"]["source_of_truth"], "factoryctl.worker_queue_class")
+        self.assertEqual(packet["profile_binding"]["gate_timing_source"], "worker_task.gate_timing_class")
+        timing_policy = packet["profile_binding"]["factory_gate_timing_policy"]
+        self.assertEqual(timing_policy["policy_kind"], "factory_gate_timing_policy")
+        self.assertEqual(timing_policy["policy_basis"], "factoryctl.worker_gate_timing_class")
+        self.assertEqual(timing_policy["runtime_authority"], "hermes_kanban")
+        self.assertNotIn("source_of_truth", timing_policy)
         self.assertIn("overkill-factory", packet["profile_binding"]["skill_refs"])
         self.assertIn("hermes-kanban", packet["profile_binding"]["skill_refs"])
         self.assertFalse(packet["profile_binding"]["can_mutate_card_state"])
@@ -184,8 +188,11 @@ class WorkerProfilesTest(unittest.TestCase):
 
         self.assertEqual(tasks["solana-quasar-auditor"]["profile_binding"]["profile_id"], "solana-quasar-auditor.profile.v1")
         self.assertEqual(tasks["codex-security"]["profile_binding"]["receipt_field"], "security_scan_result")
+        self.assertEqual(tasks["supply-chain-gate"]["gate_timing_class"], "blocking-before-ready")
         self.assertEqual(tasks["supply-chain-gate"]["queue_class"], "blocking-before-ready")
-        self.assertEqual(tasks["supply-chain-gate"]["profile_binding"]["queue_class_source"], "worker_task.queue_class")
+        self.assertEqual(tasks["supply-chain-gate"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(tasks["supply-chain-gate"]["local_state_authority"])
+        self.assertEqual(tasks["supply-chain-gate"]["profile_binding"]["gate_timing_source"], "worker_task.gate_timing_class")
 
     def test_profile_binding_queue_is_policy_not_second_runtime_source(self) -> None:
         card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
@@ -194,8 +201,13 @@ class WorkerProfilesTest(unittest.TestCase):
         task = factoryctl.build_worker_task("security-orchestrator", card, card_path)
 
         self.assertEqual(task["queue_class"], "blocking-before-ready")
+        self.assertEqual(task["gate_timing_class"], "blocking-before-ready")
         self.assertNotIn("dispatch_queue", task["profile_binding"])
-        self.assertEqual(task["profile_binding"]["dispatch_queue_policy"]["source_of_truth"], "factoryctl.worker_queue_class")
+        self.assertNotIn("dispatch_queue_policy", task["profile_binding"])
+        timing_policy = task["profile_binding"]["factory_gate_timing_policy"]
+        self.assertEqual(timing_policy["policy_basis"], "factoryctl.worker_gate_timing_class")
+        self.assertEqual(timing_policy["runtime_authority"], "hermes_kanban")
+        self.assertNotIn("source_of_truth", timing_policy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR implements the Hermes-native boundary needed to prevent Overkill Factory from becoming a shadow Hermes runtime, and adds the operational recovery contract for factory-owned BLOCK recovery.

- Replaces dispatch/queue authority language with Factory gate timing policy while keeping Hermes Kanban as runtime authority.
- Marks ledgers, live bindings, product plans, work units and parallel lanes as planning/projection/idempotency surfaces unless they carry Hermes runtime refs.
- Adds a `factory_recovery_plan` schema plus `factoryctl recovery-plan` and updates `unblock-plan` to emit bounded recovery routes for BLOCK cases.
- Adds machine-readable recovery recommendations to BLOCKED worker results without granting promotion or approval authority.
- Adds validators/tests so dangerous wording and local state authority cannot quietly come back.

## Issue Links

Refs #134.
Closes #135.

## Important Boundary

The #134 work in this PR is the recovery contract and guardrail layer: it classifies blockers, invalidates stale partial outputs, describes dependency repair, records Hermes-native materialization intent and keeps downstream continuation blocked until a fresh review authorizes it. It does not turn the Factory into a second scheduler or dispatcher; actual runtime state remains owned by Hermes Kanban.

## Validation

- `python -B scripts\validate_worker_profiles.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B -m unittest discover -s tests -p "test_*.py" -q` — 369 tests passing
- `git diff --check`
- Static grep confirmed no dangerous runtime-authority wording remains in public/operational surfaces outside guard tests/validators.

No public historical audit artifacts or private run evidence were added.