### PR TITLE
[codex] harden factory validation gears

### DIFF
--- a/.github/workflows/release-cli-smoke.yml
+++ b/.github/workflows/release-cli-smoke.yml
@@ -5,9 +5,14 @@ on:
     paths:
       - "README.md"
       - "pyproject.toml"
+      - "adapters/**"
+      - "agents/**"
+      - "docs/**"
+      - "examples/**"
+      - "schemas/**"
       - "scripts/**"
-      - "docs/getting-started/**"
-      - "docs/reference/cli.md"
+      - "skills/**"
+      - "templates/**"
       - ".github/workflows/release-cli-smoke.yml"
   push:
     branches:

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -18,6 +18,7 @@ from transition_hook import ACTION_BLOCK_TRANSITION, build_hook_result, write_js
 ROOT = Path(__file__).resolve().parents[2]
 TASK_ID_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
 LIVE_ADAPTER_SCHEMA = "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json"
+ROUTE_READINESS_SCHEMA = "https://overkill-factory.dev/schemas/hermes-worker-route-readiness.schema.json"
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 
 
@@ -71,7 +72,20 @@ def route_readiness_blockers(path: Path | None, required_worker_ids: list[str]) 
     if path is None:
         return ["route readiness manifest is required before live Hermes dispatch"]
     data = load_json(path)
-    raw_routes = data.get("routes") or data.get("workers") or {}
+    blockers: list[str] = []
+    official_manifest = data.get("$schema") == ROUTE_READINESS_SCHEMA or "checks" in data
+    if official_manifest:
+        if data.get("$schema") != ROUTE_READINESS_SCHEMA:
+            blockers.append("route readiness manifest must declare the official hermes-worker-route-readiness schema")
+        if data.get("result") != "PASS":
+            blockers.append(f"route readiness result is {data.get('result')!r}, expected PASS")
+        if data.get("blocked_worker_count") not in {0, None}:
+            blockers.append(f"route readiness has {data.get('blocked_worker_count')} blocked worker(s)")
+        for worker_id in data.get("blocked_workers") or []:
+            blockers.append(f"{worker_id}: route readiness reports worker blocked")
+        raw_routes = data.get("checks") or []
+    else:
+        raw_routes = data.get("routes") or data.get("workers") or {}
     if isinstance(raw_routes, list):
         routes = {
             str(route.get("worker_id") or route.get("worker") or ""): route
@@ -82,19 +96,22 @@ def route_readiness_blockers(path: Path | None, required_worker_ids: list[str]) 
         routes = {str(worker_id): route for worker_id, route in raw_routes.items() if isinstance(route, dict)}
     else:
         routes = {}
-    blockers: list[str] = []
     for worker_id in sorted(set(required_worker_ids)):
         route = routes.get(worker_id)
         if not route:
             blockers.append(f"{worker_id}: missing route readiness record")
             continue
         checks = {
+            "status_ready": str(route.get("status") or "ready").strip().lower() == "ready",
             "profile_exists": route.get("profile_exists") is True,
             "provider_configured": route.get("provider_configured", route.get("provider_status")) in {True, "pass", "PASS"},
             "model_configured": route.get("model_configured", route.get("model_status")) in {True, "pass", "PASS"},
             "credential_status": str(route.get("credential_status") or "").strip().lower() == "pass",
-            "capability_manifest": route.get("capability_manifest_ok", route.get("capability_status")) in {True, "pass", "PASS"},
         }
+        if not official_manifest:
+            checks["capability_manifest"] = route.get("capability_manifest_ok", route.get("capability_status")) in {True, "pass", "PASS"}
+        if route.get("blocked_reasons"):
+            checks["blocked_reasons_empty"] = False
         failed = [name for name, ok in checks.items() if not ok]
         if failed:
             blockers.append(f"{worker_id}: route readiness failed ({', '.join(failed)})")
@@ -144,6 +161,21 @@ def record_live_binding(
     worker_task_ids: dict[str, str],
 ) -> None:
     ledger = load_json(ledger_path)
+    tasks = ledger.setdefault("tasks", {})
+    for task in tasks.values():
+        if not isinstance(task, dict):
+            continue
+        worker_id = str(task.get("worker_id") or "")
+        hermes_task_id = worker_task_ids.get(worker_id)
+        if str(task.get("card_id") or "") != card_id or not hermes_task_id:
+            continue
+        task["materialization_state"] = "materialized_in_hermes"
+        task["runtime_refs"] = {
+            "hermes_board_ref": f"hermes:{board}",
+            "hermes_task_ref": hermes_task_id,
+            "hermes_run_ref": "external:pending-hermes-run",
+        }
+        task["local_record_role"] = "idempotency_projection"
     bindings = ledger.setdefault("live_bindings", {})
     bindings[card_id] = {
         "binding_role": "hermes_ref_projection",
@@ -158,9 +190,15 @@ def record_live_binding(
 
 def validate_live_binding(*, ledger_path: Path, card_id: str, board: str, main_task_id: str) -> None:
     ledger = load_json(ledger_path)
+    if ledger.get("runtime_authority") != "hermes_kanban" or ledger.get("local_state_authority") is not False:
+        raise RuntimeError("ledger is not a Hermes-authoritative projection; refuse to complete arbitrary Hermes task")
     binding = (ledger.get("live_bindings") or {}).get(card_id)
     if not isinstance(binding, dict):
         raise RuntimeError(f"missing live binding for card {card_id}; refuse to complete arbitrary Hermes task")
+    if binding.get("runtime_authority") != "hermes_kanban" or binding.get("local_state_authority") is not False:
+        raise RuntimeError("live binding is not a Hermes-authoritative projection; refuse to complete arbitrary Hermes task")
+    if binding.get("binding_role") != "hermes_ref_projection":
+        raise RuntimeError("live binding must be a Hermes ref projection")
     if binding.get("board") != board or binding.get("main_task_id") != main_task_id:
         raise RuntimeError("main task id does not match the live binding for this card and board")
 

--- a/schemas/project-projection.schema.json
+++ b/schemas/project-projection.schema.json
@@ -208,5 +208,44 @@
       "additionalProperties": false
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "enum": ["executing", "review", "release_candidate", "production", "closed"]
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "execution_started": { "const": true }
+        },
+        "required": ["execution_started"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "projection_freshness": { "const": "runtime_fresh" }
+        },
+        "required": ["projection_freshness"]
+      },
+      "then": {
+        "properties": {
+          "truth_source_available": { "const": true },
+          "source_of_truth": {
+            "type": "object",
+            "properties": {
+              "freshness": { "const": "runtime_fresh" }
+            },
+            "required": ["freshness"]
+          }
+        },
+        "required": ["truth_source_available", "source_of_truth"]
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/scripts/release_integration_preflight.py
+++ b/scripts/release_integration_preflight.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -45,6 +46,43 @@ def load_json(path: Path) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def materialize_preflight_inputs(
+    *,
+    inventory_path: Path = DEFAULT_INVENTORY,
+    public_worktree_path: Path = DEFAULT_PUBLIC_WORKTREE,
+    public_head_path: Path = DEFAULT_PUBLIC_HEAD,
+    public_origin_path: Path = DEFAULT_PUBLIC_ORIGIN,
+    runner: Callable[..., subprocess.CompletedProcess[Any]] = subprocess.run,
+) -> list[Path]:
+    commands = [
+        [sys.executable, "scripts/worktree_release_inventory.py", "--out", str(inventory_path)],
+        [sys.executable, "scripts/public_safety_scan.py", "--summary-json", str(public_worktree_path)],
+        [
+            sys.executable,
+            "scripts/public_safety_scan.py",
+            "--git-ref",
+            "HEAD",
+            "--summary-json",
+            str(public_head_path),
+        ],
+        [
+            sys.executable,
+            "scripts/public_safety_scan.py",
+            "--git-ref",
+            "origin/main",
+            "--summary-json",
+            str(public_origin_path),
+        ],
+    ]
+    for command in commands:
+        runner(command, cwd=ROOT, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return [
+        path
+        for path in (inventory_path, public_worktree_path, public_head_path, public_origin_path)
+        if not path.is_file()
+    ]
 
 
 def git_text(*args: str) -> str:
@@ -102,6 +140,9 @@ def build_preflight(
     public_worktree = load_json(public_worktree_path)
     public_head = load_json(public_head_path)
     public_origin = load_json(public_origin_path)
+    evidence_paths = [inventory_path, public_worktree_path, public_head_path, public_origin_path]
+    missing_evidence_refs = [repo_ref(path) for path in evidence_paths if not path.is_file()]
+    evidence_refs = [repo_ref(path) for path in evidence_paths if path.is_file()]
 
     branch = branch_name if branch_name is not None else git_text("branch", "--show-current")
     actual_status_entries = actual_generated_entries = 0
@@ -122,6 +163,7 @@ def build_preflight(
         "worktree_public_safety_passed": public_worktree.get("result") == "PASS",
         "head_public_safety_passed": public_head.get("result") == "PASS",
         "origin_main_public_safety_passed": public_origin.get("result") == "PASS",
+        "preflight_evidence_refs_exist": not missing_evidence_refs,
         "worktree_inventory_has_no_unknown_entries": needs_human_review_entries == 0,
         "worktree_inventory_has_no_cleanup_candidates": safe_cleanup_candidates == 0,
         "worktree_has_release_candidate_material": release_candidate_entries > 0,
@@ -152,6 +194,8 @@ def build_preflight(
         next_required_actions.append("move release-candidate work off dirty main or commit through an explicit release branch")
     if not checks["release_ref_has_no_unintegrated_worktree_entries"]:
         next_required_actions.append("integrate the public-safe worktree into the target release ref")
+    if not checks["preflight_evidence_refs_exist"]:
+        next_required_actions.append("materialize missing preflight evidence summaries before release review")
     if not checks["head_public_safety_passed"] or not checks["origin_main_public_safety_passed"]:
         next_required_actions.append("rerun exact public-safety scans after the release ref is updated")
     if not next_required_actions:
@@ -199,12 +243,8 @@ def build_preflight(
         },
         "blocking_items": sorted(blocking_items),
         "attention_items": sorted(attention_items),
-        "evidence_refs": [
-            repo_ref(inventory_path),
-            repo_ref(public_worktree_path),
-            repo_ref(public_head_path),
-            repo_ref(public_origin_path),
-        ],
+        "evidence_refs": evidence_refs,
+        "missing_evidence_refs": missing_evidence_refs,
         "next_required_actions": next_required_actions,
         "limits": [
             "This preflight is public-safe and intentionally omits raw file paths.",
@@ -222,6 +262,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    materialize_preflight_inputs()
     receipt = build_preflight()
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")

--- a/scripts/secret_safety_scan.py
+++ b/scripts/secret_safety_scan.py
@@ -14,6 +14,7 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Iterator
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -70,6 +71,35 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
+def iter_scan_paths(root: Path) -> Iterator[Path]:
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return
+
+    for entry in entries:
+        try:
+            if any(part in SKIP_PARTS for part in entry.parts):
+                continue
+            if entry.is_dir():
+                yield from iter_scan_paths(entry)
+            else:
+                yield entry
+        except OSError:
+            continue
+
+
+def read_scannable_text(path: Path) -> tuple[str, str] | None:
+    try:
+        if not path.is_file() or not should_scan(path):
+            return None
+        rel = path.relative_to(ROOT).as_posix()
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return rel, text
+
+
 def build_summary(findings: list[str]) -> dict[str, object]:
     return {
         "$schema": "https://overkill-factory.dev/schemas/secret-safety-scan-summary.schema.json",
@@ -87,11 +117,11 @@ def build_summary(findings: list[str]) -> dict[str, object]:
 
 def scan() -> list[str]:
     findings: list[str] = []
-    for path in ROOT.rglob("*"):
-        if not path.is_file() or not should_scan(path):
+    for path in iter_scan_paths(ROOT):
+        scannable = read_scannable_text(path)
+        if scannable is None:
             continue
-        rel = path.relative_to(ROOT).as_posix()
-        text = path.read_text(encoding="utf-8", errors="replace")
+        rel, text = scannable
         for lineno, line in enumerate(text.splitlines(), start=1):
             for pattern in SECRET_PATTERNS:
                 if pattern.search(line):

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -25,6 +25,7 @@ SCAN_DIRS = [
     ROOT / "templates",
     ROOT / "docs",
     ROOT / "planning-bundles",
+    ROOT / "products",
 ]
 
 SCHEMA_OPTIONAL = {
@@ -126,8 +127,76 @@ def type_matches(expected: str | list[str], value: Any) -> bool:
     return False
 
 
-def validate_node(schema: dict[str, Any], value: Any, at: str) -> list[str]:
+def resolve_json_pointer(document: dict[str, Any], pointer: str) -> dict[str, Any] | None:
+    if not pointer.startswith("#/"):
+        return None
+    current: Any = document
+    for raw_part in pointer[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current if isinstance(current, dict) else None
+
+
+def resolve_ref(ref: str, schemas: dict[str, dict[str, Any]] | None, root_schema: dict[str, Any]) -> dict[str, Any] | None:
+    if ref.startswith("#/"):
+        return resolve_json_pointer(root_schema, ref)
+    if "#" in ref:
+        schema_ref, pointer = ref.split("#", 1)
+        target = schemas.get(schema_name(schema_ref)) if schemas else None
+        if target is not None and pointer.startswith("/"):
+            return resolve_json_pointer(target, f"#{pointer}")
+        return target
+    return schemas.get(schema_name(ref)) if schemas else None
+
+
+def schema_matches(
+    schema: dict[str, Any],
+    value: Any,
+    at: str,
+    schemas: dict[str, dict[str, Any]] | None = None,
+    root_schema: dict[str, Any] | None = None,
+    seen_refs: set[str] | None = None,
+) -> bool:
+    return not validate_node(schema, value, at, schemas=schemas, root_schema=root_schema, seen_refs=seen_refs)
+
+
+def validate_node(
+    schema: dict[str, Any],
+    value: Any,
+    at: str,
+    *,
+    schemas: dict[str, dict[str, Any]] | None = None,
+    root_schema: dict[str, Any] | None = None,
+    seen_refs: set[str] | None = None,
+) -> list[str]:
     errors: list[str] = []
+    root = root_schema or schema
+    seen = seen_refs or set()
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        if ref in seen:
+            errors.append(f"{at}: recursive $ref {ref!r} is not supported")
+            return errors
+        target = resolve_ref(ref, schemas, root)
+        if target is None:
+            errors.append(f"{at}: unresolved $ref {ref!r}")
+            return errors
+        errors.extend(validate_node(target, value, at, schemas=schemas, root_schema=target, seen_refs=seen | {ref}))
+    if isinstance(schema.get("allOf"), list):
+        for index, subschema in enumerate(schema["allOf"]):
+            if isinstance(subschema, dict):
+                errors.extend(validate_node(subschema, value, f"{at}.allOf[{index}]", schemas=schemas, root_schema=root, seen_refs=seen))
+    if "if" in schema and isinstance(schema["if"], dict):
+        if schema_matches(schema["if"], value, at, schemas=schemas, root_schema=root, seen_refs=seen):
+            then_schema = schema.get("then")
+            if isinstance(then_schema, dict):
+                errors.extend(validate_node(then_schema, value, at, schemas=schemas, root_schema=root, seen_refs=seen))
+        else:
+            else_schema = schema.get("else")
+            if isinstance(else_schema, dict):
+                errors.extend(validate_node(else_schema, value, at, schemas=schemas, root_schema=root, seen_refs=seen))
     if "type" in schema and not type_matches(schema["type"], value):
         errors.append(f"{at}: expected type {schema['type']}")
         return errors
@@ -137,8 +206,26 @@ def validate_node(schema: dict[str, Any], value: Any, at: str) -> list[str]:
         errors.append(f"{at}: value {value!r} not in enum")
     if isinstance(value, str) and "minLength" in schema and len(value) < int(schema["minLength"]):
         errors.append(f"{at}: string shorter than minLength {schema['minLength']}")
+    if isinstance(value, str) and "maxLength" in schema and len(value) > int(schema["maxLength"]):
+        errors.append(f"{at}: string longer than maxLength {schema['maxLength']}")
+    if isinstance(value, str) and "pattern" in schema and not re.search(str(schema["pattern"]), value):
+        errors.append(f"{at}: string does not match pattern {schema['pattern']!r}")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if "minimum" in schema and value < schema["minimum"]:
+            errors.append(f"{at}: number below minimum {schema['minimum']}")
+        if "maximum" in schema and value > schema["maximum"]:
+            errors.append(f"{at}: number above maximum {schema['maximum']}")
     if isinstance(value, list) and "minItems" in schema and len(value) < int(schema["minItems"]):
         errors.append(f"{at}: array shorter than minItems {schema['minItems']}")
+    if isinstance(value, list) and "maxItems" in schema and len(value) > int(schema["maxItems"]):
+        errors.append(f"{at}: array longer than maxItems {schema['maxItems']}")
+    if isinstance(value, list) and schema.get("uniqueItems") is True:
+        seen: set[str] = set()
+        for index, item in enumerate(value):
+            key = json.dumps(item, sort_keys=True)
+            if key in seen:
+                errors.append(f"{at}[{index}]: duplicate item violates uniqueItems")
+            seen.add(key)
     if isinstance(value, dict) and "minProperties" in schema and len(value) < int(schema["minProperties"]):
         errors.append(f"{at}: object has fewer properties than minProperties {schema['minProperties']}")
 
@@ -150,7 +237,9 @@ def validate_node(schema: dict[str, Any], value: Any, at: str) -> list[str]:
         if isinstance(properties, dict):
             for field, subschema in properties.items():
                 if field in value and isinstance(subschema, dict):
-                    errors.extend(validate_node(subschema, value[field], f"{at}.{field}"))
+                    errors.extend(
+                        validate_node(subschema, value[field], f"{at}.{field}", schemas=schemas, root_schema=root, seen_refs=seen)
+                    )
         additional = schema.get("additionalProperties", True)
         if additional is False and isinstance(properties, dict):
             for field in value:
@@ -159,11 +248,11 @@ def validate_node(schema: dict[str, Any], value: Any, at: str) -> list[str]:
         if isinstance(additional, dict):
             for field, item in value.items():
                 if field not in properties:
-                    errors.extend(validate_node(additional, item, f"{at}.{field}"))
+                    errors.extend(validate_node(additional, item, f"{at}.{field}", schemas=schemas, root_schema=root, seen_refs=seen))
 
     if isinstance(value, list) and isinstance(schema.get("items"), dict):
         for index, item in enumerate(value):
-            errors.extend(validate_node(schema["items"], item, f"{at}[{index}]"))
+            errors.extend(validate_node(schema["items"], item, f"{at}[{index}]", schemas=schemas, root_schema=root, seen_refs=seen))
 
     return errors
 
@@ -391,7 +480,7 @@ def main() -> int:
         if not schema:
             findings.append(f"{path.relative_to(ROOT).as_posix()}: schema not found for {ref}")
             continue
-        for error in validate_node(schema, data, "$"):
+        for error in validate_node(schema, data, "$", schemas=schemas, root_schema=schema):
             findings.append(f"{path.relative_to(ROOT).as_posix()}: {error}")
         for error in validate_domain_rules(data, "$"):
             findings.append(f"{path.relative_to(ROOT).as_posix()}: {error}")

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -833,8 +833,8 @@
   },
   "product_face_packet": {
     "$schema": "https://overkill-factory.dev/schemas/product-face-packet.schema.json",
-    "surface": "software_product",
-    "mode": "planning",
+    "surface": "web_app",
+    "mode": "greenfield",
     "user": "target user or operator",
     "job_to_be_done": "Use the produced surface or workflow with clear status, states and evidence.",
     "main_flows": ["primary product flow"],

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -70,16 +70,31 @@ def write_route_readiness(path: Path) -> None:
     path.write_text(
         json.dumps(
             {
-                "routes": {
-                    worker: {
+                "$schema": "https://overkill-factory.dev/schemas/hermes-worker-route-readiness.schema.json",
+                "schema": "overkill_factory_hermes_worker_route_readiness.v1",
+                "ledger_ref": "external:test-route-ledger",
+                "hermes_home_ref": "redacted-hermes-home",
+                "result": "PASS",
+                "worker_count": len(workers),
+                "blocked_worker_count": 0,
+                "blocked_workers": [],
+                "checks": [
+                    {
+                        "worker_id": worker,
+                        "task_id": f"route:{worker}",
+                        "required_before": "done",
+                        "queue_class": "blocking-before-done",
+                        "status": "ready",
                         "profile_exists": True,
                         "provider_configured": True,
                         "model_configured": True,
                         "credential_status": "pass",
-                        "capability_manifest_ok": True,
+                        "credential_evidence": ["external:test-credential-evidence"],
+                        "blocked_reasons": [],
                     }
                     for worker in workers
-                }
+                ],
+                "production_rule": "Do not dispatch unless every required worker route is ready.",
             }
         ),
         encoding="utf-8",
@@ -117,6 +132,13 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(binding["binding_role"], "hermes_ref_projection")
         self.assertEqual(binding["runtime_authority"], "hermes_kanban")
         self.assertFalse(binding["local_state_authority"])
+        materialized_tasks = [
+            task for task in ledger_data["tasks"].values()
+            if task["worker_id"] == "codex-security" and task["materialization_state"] == "materialized_in_hermes"
+        ]
+        self.assertEqual(len(materialized_tasks), 1)
+        self.assertEqual(materialized_tasks[0]["runtime_refs"]["hermes_board_ref"], f"hermes:{TEST_BOARD}")
+        self.assertTrue(materialized_tasks[0]["runtime_refs"]["hermes_task_ref"].startswith("t_"))
         link_calls = [call for call in fake.calls if len(call) >= 7 and call[4] == "link"]
         self.assertTrue(link_calls)
         for call in link_calls:
@@ -189,14 +211,59 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
     def test_complete_main_requires_materialized_live_binding(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             ledger = Path(tmp) / "ledger.json"
-            ledger.write_text(json.dumps({"tasks": {}}), encoding="utf-8")
+            ledger.write_text(
+                json.dumps(
+                    {
+                        "ledger_type": "overkill_factory_hermes_worker_ledger",
+                        "ledger_scope": "projection_idempotency_only",
+                        "runtime_authority": "hermes_kanban",
+                        "local_state_authority": False,
+                        "tasks": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
 
             with self.assertRaisesRegex(RuntimeError, "missing live binding"):
                 adapter.validate_live_binding(
                     ledger_path=ledger,
                     card_id="CARD-001",
                     board=TEST_BOARD,
-                    main_task_id="t_" + "deadbeef",
+                    main_task_id="fixture-main-task",
+                )
+
+    def test_complete_main_rejects_local_authority_live_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / "ledger.json"
+            ledger.write_text(
+                json.dumps(
+                    {
+                        "ledger_type": "overkill_factory_hermes_worker_ledger",
+                        "ledger_scope": "projection_idempotency_only",
+                        "runtime_authority": "hermes_kanban",
+                        "local_state_authority": False,
+                        "tasks": {},
+                        "live_bindings": {
+                            "CARD-001": {
+                                "binding_role": "local_state",
+                                "runtime_authority": "local-file",
+                                "local_state_authority": True,
+                                "board": TEST_BOARD,
+                                "main_task_id": "fixture-main-task",
+                                "worker_task_ids": {},
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "not a Hermes-authoritative projection"):
+                adapter.validate_live_binding(
+                    ledger_path=ledger,
+                    card_id="CARD-001",
+                    board=TEST_BOARD,
+                    main_task_id="fixture-main-task",
                 )
 
 

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import subprocess
 import sys
+import tomllib
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_JSON_VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
 
 
 def read_text(rel: str) -> str:
     return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def load_public_json_validator():
+    spec = importlib.util.spec_from_file_location("validate_public_json_artifacts", PUBLIC_JSON_VALIDATOR_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 class OpenSourceDocsTest(unittest.TestCase):
@@ -239,6 +251,12 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("not production approval", products)
         self.assertIn("No private product material", products)
 
+    def test_public_json_validator_scans_public_product_artifacts(self) -> None:
+        validator = load_public_json_validator()
+        scan_dirs = {path.relative_to(ROOT).as_posix() for path in validator.SCAN_DIRS}
+
+        self.assertIn("products", scan_dirs)
+
     def test_public_codex_skill_covers_open_source_stewardship(self) -> None:
         skill = read_text("skills/codex/overkill-factory/SKILL.md")
         open_source_ref = ROOT / "skills" / "codex" / "overkill-factory" / "references" / "open-source-github.md"
@@ -427,6 +445,21 @@ class OpenSourceDocsTest(unittest.TestCase):
         ]:
             with self.subTest(expected=expected):
                 self.assertIn(expected, workflow)
+
+    def test_release_cli_smoke_runs_for_packaged_asset_changes(self) -> None:
+        pyproject = tomllib.loads(read_text("pyproject.toml"))
+        workflow = read_text(".github/workflows/release-cli-smoke.yml")
+        data_files = pyproject["tool"]["setuptools"]["data-files"]
+        packaged_roots = {
+            pattern.split("/", 1)[0]
+            for patterns in data_files.values()
+            for pattern in patterns
+            if "/" in pattern
+        }
+
+        for root in sorted(packaged_roots):
+            with self.subTest(root=root):
+                self.assertIn(f'- "{root}/**"', workflow)
 
     def test_package_metadata_includes_cli_runtime_assets(self) -> None:
         pyproject = read_text("pyproject.toml")

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["validate_public_json_artifacts"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class PublicJsonArtifactValidatorTest(unittest.TestCase):
+    def test_enforces_numeric_bounds_used_by_public_schemas(self) -> None:
+        validator = load_validator()
+        schema = {"type": "integer", "minimum": 1, "maximum": 3}
+
+        self.assertEqual(validator.validate_node(schema, 2, "$"), [])
+        self.assertTrue(any("below minimum" in error for error in validator.validate_node(schema, 0, "$")))
+        self.assertTrue(any("above maximum" in error for error in validator.validate_node(schema, 4, "$")))
+
+    def test_enforces_string_pattern_used_by_public_schemas(self) -> None:
+        validator = load_validator()
+        schema = {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+
+        self.assertEqual(validator.validate_node(schema, "a" * 64, "$"), [])
+        self.assertTrue(any("does not match pattern" in error for error in validator.validate_node(schema, "not-a-sha", "$")))
+
+    def test_enforces_conditional_required_fields_used_by_worker_result_schema(self) -> None:
+        validator = load_validator()
+        schema = {
+            "allOf": [
+                {
+                    "if": {"properties": {"result": {"const": "BLOCKED"}}, "required": ["result"]},
+                    "then": {"required": ["recovery_recommendation"]},
+                }
+            ]
+        }
+
+        self.assertEqual(validator.validate_node(schema, {"result": "PASS"}, "$"), [])
+        errors = validator.validate_node(schema, {"result": "BLOCKED"}, "$")
+        self.assertTrue(any("recovery_recommendation" in error for error in errors))
+
+    def test_resolves_schema_file_refs_used_by_factory_card(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = {"$ref": "product-face-packet.schema.json"}
+        valid_packet = {
+            "$schema": "https://overkill-factory.dev/schemas/product-face-packet.schema.json",
+            "surface": "web_app",
+            "mode": "greenfield",
+            "user": "operator",
+            "job_to_be_done": "understand current state",
+            "main_flows": ["inspect status"],
+            "required_states": ["ready"],
+            "design_direction": {
+                "visual_tone": "clear",
+                "product_fit": "operator workflow",
+                "density": "compact",
+                "interaction_style": "direct",
+            },
+            "visual_quality_bar": {
+                "reference_quality_bar": "operator-grade surface",
+                "anti_generic_criteria": ["not generic"],
+                "professional_review_required": True,
+                "block_when": ["generic UI"],
+            },
+            "proof_required": ["screenshot"],
+            "reviewers_required": ["independent-reviewer"],
+            "done_definition": ["review passes"],
+            "human_gate": {"required": False, "reason": "not material"},
+        }
+        invalid_packet = dict(valid_packet, surface="software_product")
+
+        self.assertEqual(validator.validate_node(schema, valid_packet, "$", schemas=schemas), [])
+        errors = validator.validate_node(schema, invalid_packet, "$", schemas=schemas)
+        self.assertTrue(any("$.surface" in error and "not in enum" in error for error in errors))
+
+    def test_resolves_internal_defs_refs(self) -> None:
+        validator = load_validator()
+        schema = {
+            "$defs": {
+                "non_empty_text": {"type": "string", "minLength": 3}
+            },
+            "type": "object",
+            "properties": {
+                "summary": {"$ref": "#/$defs/non_empty_text"}
+            },
+        }
+
+        self.assertEqual(validator.validate_node(schema, {"summary": "ready"}, "$"), [])
+        errors = validator.validate_node(schema, {"summary": ""}, "$")
+        self.assertTrue(any("$.summary" in error and "shorter than minLength" in error for error in errors))
+
+    def test_project_projection_blocks_impossible_runtime_fresh_state(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["project-projection.schema.json"]
+        projection = json.loads((ROOT / "templates" / "project-projection.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, projection, "$", schemas=schemas, root_schema=schema), [])
+
+        impossible = dict(projection)
+        impossible["status"] = "production"
+        impossible["execution_started"] = False
+        impossible["truth_source_available"] = False
+        impossible["source_of_truth"] = dict(projection["source_of_truth"], freshness="stale")
+        errors = validator.validate_node(schema, impossible, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("execution_started" in error and "expected const True" in error for error in errors))
+        self.assertTrue(any("truth_source_available" in error and "expected const True" in error for error in errors))
+        self.assertTrue(any("source_of_truth.freshness" in error and "expected const 'runtime_fresh'" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_integration_preflight.py
+++ b/tests/test_release_integration_preflight.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -104,6 +105,69 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
         self.assertEqual(receipt["counts"]["generated_status_entries"], 4)
         self.assertEqual(receipt["counts"]["unintegrated_release_entries"], 0)
         self.assertEqual(receipt["attention_items"], [])
+
+    def test_missing_preflight_evidence_is_not_reported_as_existing_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = {
+                "inventory": root / "missing-inventory.json",
+                "worktree": root / "missing-worktree.json",
+                "head": root / "missing-head.json",
+                "origin": root / "missing-origin.json",
+            }
+
+            receipt = preflight.build_preflight(
+                inventory_path=paths["inventory"],
+                public_worktree_path=paths["worktree"],
+                public_head_path=paths["head"],
+                public_origin_path=paths["origin"],
+                branch_name="codex/release",
+                status_entries=0,
+                generated_status_entries=0,
+                created_at="2026-06-10T00:00:00Z",
+            )
+
+        self.assertEqual(receipt["evidence_refs"], [])
+        self.assertEqual(len(receipt["missing_evidence_refs"]), 4)
+        self.assertIn("preflight_evidence_refs_exist", receipt["blocking_items"])
+        self.assertIn(
+            "materialize missing preflight evidence summaries before release review",
+            receipt["next_required_actions"],
+        )
+
+    def test_materializer_creates_all_preflight_input_receipts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = {
+                "inventory": root / "inventory.json",
+                "worktree": root / "worktree.json",
+                "head": root / "head.json",
+                "origin": root / "origin.json",
+            }
+
+            def fake_runner(command, **_kwargs):
+                if "--out" in command:
+                    out = Path(command[command.index("--out") + 1])
+                    payload = {"result": "ATTENTION", "cleanup_policy": {}}
+                else:
+                    out = Path(command[command.index("--summary-json") + 1])
+                    payload = {"result": "PASS"}
+                out.parent.mkdir(parents=True, exist_ok=True)
+                out.write_text(json.dumps(payload), encoding="utf-8")
+                return subprocess.CompletedProcess(command, 0)
+
+            missing = preflight.materialize_preflight_inputs(
+                inventory_path=paths["inventory"],
+                public_worktree_path=paths["worktree"],
+                public_head_path=paths["head"],
+                public_origin_path=paths["origin"],
+                runner=fake_runner,
+            )
+
+            self.assertEqual(missing, [])
+            for path in paths.values():
+                with self.subTest(path=path.name):
+                    self.assertTrue(path.is_file())
 
     def _fixtures(
         self,

--- a/tests/test_secret_safety_scan.py
+++ b/tests/test_secret_safety_scan.py
@@ -1,5 +1,6 @@
 import importlib.util
 from pathlib import Path
+import tempfile
 import unittest
 
 
@@ -28,6 +29,27 @@ class SecretSafetyScanTest(unittest.TestCase):
 
         self.assertTrue(any(pattern.search(line) for pattern in scanner.SECRET_PATTERNS))
         self.assertIsNotNone(scanner.ASSIGNMENT_RE.search(line))
+
+    def test_disappeared_scan_path_does_not_crash(self):
+        scanner = load_scanner()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            clean = root / "clean.txt"
+            clean.write_text("public docs only\n", encoding="utf-8")
+            vanished = root / "vanished.txt"
+
+            original_root = scanner.ROOT
+            original_iter_scan_paths = scanner.iter_scan_paths
+            scanner.ROOT = root
+            scanner.iter_scan_paths = lambda _root: iter([vanished, clean])
+            try:
+                findings = scanner.scan()
+            finally:
+                scanner.ROOT = original_root
+                scanner.iter_scan_paths = original_iter_scan_paths
+
+        self.assertEqual([], findings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

This PR hardens the factory's operational gears across validation, Hermes live dispatch, release preflight, packaging smoke coverage, and safety scanning.

## Fixes

- Extends public JSON artifact validation to scan `products/`, resolve schema `$ref`s, and enforce the schema keywords already used by public contracts.
- Aligns the Hermes live kanban adapter with the official route-readiness contract and rejects local-authority live bindings.
- Records materialized Hermes task refs back into the projection ledger instead of leaving worker tasks pending after live dispatch.
- Blocks impossible project projection states such as `production` without execution and `runtime_fresh` without a fresh truth source.
- Makes `secret_safety_scan.py` robust when volatile filesystem entries disappear during traversal.
- Makes `release_integration_preflight.py` materialize and verify its own evidence summaries instead of referencing missing receipts.
- Expands release CLI smoke path filters to every packaged public asset root.
- Fixes the vFinal factory card template so embedded Product Face packet data satisfies its referenced schema.

## Root cause

Several gates were present as contracts but not fully enforced at the executable boundary. The factory could therefore report green on incomplete validation, accept ad-hoc runtime state as live truth, or require hidden pre-steps before a release preflight had real evidence behind it.

## Validation

- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_surface_sync.py`
- `python -B scripts\validate_worker_profiles.py`
- `python -B scripts\validate_planning_bundles.py`
- `python -B scripts\validate_document_governance.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `python -B scripts\release_integration_preflight.py`
- `git diff --check`

## Scope notes

This PR does not touch issue #84. It also does not publish audit history or private evidence into the public repo. Issues #140, #142, and #143 remain intentionally open for the next cycles.

Closes #137
Closes #138
Closes #139
Closes #141
Closes #144
Closes #145
Closes #146
Closes #147
Refs #140
Refs #142
Refs #143
Refs #134
