### PR TITLE
[codex] sync public docs surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,14 @@ jobs:
         run: python scripts/secret_safety_scan.py
       - name: Public safety scan
         run: python scripts/public_safety_scan.py
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install docs dependencies
+        run: python -m pip install ".[docs]"
+      - name: MkDocs strict build
+        run: python -m mkdocs build --strict --site-dir "$RUNNER_TEMP/overkill-mkdocs-site"

--- a/.github/workflows/public-surface-published-sync.yml
+++ b/.github/workflows/public-surface-published-sync.yml
@@ -1,0 +1,20 @@
+name: public-surface-published-sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  check-published-surface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Published public surface sync
+        run: python -B scripts/validate_public_surface_sync.py --check-published

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+site/
 coverage/
 validation/
 pilots/

--- a/docs/public-surface.manifest.json
+++ b/docs/public-surface.manifest.json
@@ -11,6 +11,9 @@
     "docs/concepts/factory-flow.md",
     "docs/concepts/operator-journey.md",
     "docs/concepts/overkill-factory-method.md",
+    "docs/getting-started/quickstart-hermes.md",
+    "docs/operations/validation-and-release.md",
+    "docs/reference/cli.md",
     "planning-bundles/manifest.json",
     "schemas/",
     "scripts/factoryctl.py"
@@ -196,6 +199,76 @@
       "required_phrases": [
         "Every bundle output is a candidate artifact",
         "They do not replace the factory runtime"
+      ]
+    },
+    {
+      "surface_id": "quickstart-hermes",
+      "path": "docs/getting-started/quickstart-hermes.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "README.md",
+        "adapters/hermes/README.md",
+        "examples/minimal-hermes-project/card.md",
+        "scripts/factoryctl.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "expected_links",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "Discord is optional cockpit UI. It is not the source of truth.",
+        "Attach worker results and Receipt Five before any `done` transition."
+      ],
+      "expected_links": [
+        "adapters/hermes/README.md",
+        "examples/minimal-hermes-project/card.md"
+      ]
+    },
+    {
+      "surface_id": "cli-reference",
+      "path": "docs/reference/cli.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "README.md",
+        "scripts/factoryctl.py",
+        "tests/test_factoryctl.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "the runtime source of truth for real cards and transitions.",
+        "does not replace Hermes, card contracts, gate reports or Receipt Five as the source of truth."
+      ]
+    },
+    {
+      "surface_id": "validation-and-release",
+      "path": "docs/operations/validation-and-release.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "scripts/release_integration_preflight.py",
+        "scripts/worktree_release_inventory.py",
+        "scripts/validate_public_surface_sync.py",
+        "scripts/public_safety_scan.py",
+        "scripts/secret_safety_scan.py",
+        "scripts/supply_chain_proof.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "operator status can be projected without becoming the source of truth.",
+        "Generated summaries must not be committed as release proof.",
+        "No single chat answer, dashboard status or worker packet is a release proof."
       ]
     },
     {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,13 @@ site_name: Overkill Factory
 site_description: Gated production line for Hermes-powered agentic product work.
 repo_url: https://github.com/felipegermano17/overkill-factory
 docs_dir: docs
+exclude_docs: |
+  /README.md
+not_in_nav: |
+  operations/*local-cockpit-validation.md
 nav:
   - Operator Path: index.md
+  - Quickstart With Hermes: getting-started/quickstart-hermes.md
   - Install In Your Hermes: getting-started/install-in-hermes.md
   - First Operator Walkthrough: getting-started/first-external-operator-walkthrough.md
   - CLI Reference: reference/cli.md
@@ -16,6 +21,14 @@ nav:
       - Worker Profiles: agents/worker-profiles.md
       - Stage Map: agents/factory-stage-agent-map.md
       - Capability Packs: agents/capability-packs.md
+      - Hermes Profile Manifest: agents/hermes-profile-manifest.md
+      - Live Agent Configuration: agents/live-agent-configuration.md
+      - Permission Model: agents/permission-model.md
+      - Security Specialist Matrix: agents/security-specialist-matrix.md
+  - Architecture:
+      - Hermes Integration: architecture/hermes-integration.md
+  - Automation:
+      - Worker Automation v0: automation/worker-automation-v0.md
   - Security:
       - OSS Security: security/oss-security.md
       - Security Matrix: security/security-control-matrix.md
@@ -23,7 +36,20 @@ nav:
       - Validation And Release: operations/validation-and-release.md
       - Parallel Execution And Status: operations/parallel-execution-and-status.md
       - Release Policy: operations/release-policy.md
+      - Troubleshooting: operations/troubleshooting.md
   - Control Tower:
       - Discord UX Study Gate: control-tower/discord-cockpit-ux-study-gate.md
-  - Maintainer Internals: maintenance/repo-surface.md
-  - Factory Learning OS: maintenance/factory-learning-skill-evolution-os.md
+      - Discord Control Tower OS: control-tower/discord-control-tower-os.md
+      - Discord Control Tower Setup: control-tower/discord-control-tower-setup-pt-br.md
+      - Open Source Setup: control-tower/open-source-setup.md
+  - Governance:
+      - Document Governance: governance/document-governance.md
+  - Product Face:
+      - Proof Runner: product-face/proof-runner.md
+  - Visuals:
+      - Public Visual Surfaces: visuals/README.md
+  - Maintainer Internals:
+      - Repo Surface: maintenance/repo-surface.md
+      - Factory Learning OS: maintenance/factory-learning-skill-evolution-os.md
+      - Self Improvement Loop: maintenance/self-improvement-loop.md
+      - Context Spine: memory/context-spine.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ Issues = "https://github.com/felipegermano17/overkill-factory/issues"
 factoryctl = "scripts.factoryctl:main"
 overkill-quickstart = "scripts.quickstart_smoke:main"
 
+[project.optional-dependencies]
+docs = ["mkdocs>=1.6,<2"]
+
 [tool.setuptools]
 py-modules = []
 include-package-data = true

--- a/scripts/supply_chain_proof.py
+++ b/scripts/supply_chain_proof.py
@@ -25,6 +25,7 @@ USES_RE = re.compile(r"uses:\s*(\S+)")
 
 SKIP_PARTS = {".git", "__pycache__", ".mypy_cache", ".pytest_cache"}
 SKIP_OUTPUT_PARTS = {".tmp/factory-runs/supply-chain"}
+NON_RUNTIME_OPTIONAL_DEPENDENCY_GROUPS = {"ci", "dev", "doc", "docs", "test", "tests"}
 
 
 def now_iso() -> str:
@@ -172,7 +173,13 @@ def dependency_posture() -> dict[str, Any]:
     if "pyproject.toml" in runtime_dependency_manifests:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         project = pyproject.get("project", {}) if isinstance(pyproject, dict) else {}
-        has_runtime_dependencies = bool(project.get("dependencies") or project.get("optional-dependencies"))
+        optional_dependencies = project.get("optional-dependencies") or {}
+        runtime_optional_groups = [
+            name
+            for name, dependencies in optional_dependencies.items()
+            if dependencies and str(name).lower() not in NON_RUNTIME_OPTIONAL_DEPENDENCY_GROUPS
+        ]
+        has_runtime_dependencies = bool(project.get("dependencies") or runtime_optional_groups)
         if not has_runtime_dependencies:
             runtime_dependency_manifests.remove("pyproject.toml")
     return {
@@ -184,7 +191,8 @@ def dependency_posture() -> dict[str, Any]:
             "must add lockfile/audit evidence before release."
             if not present
             else (
-                "Only packaging metadata without runtime dependencies is present; no dependency audit follow-up is required."
+                "Only packaging metadata and non-runtime optional tooling dependencies are present; "
+                "no runtime dependency audit follow-up is required."
                 if not runtime_dependency_manifests
                 else "Dependency manifests with runtime dependencies are present and require the repository-specific audit path."
             )

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -305,6 +305,49 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Maintainer internals", repo_surface)
         self.assertIn("Generated output", repo_surface)
 
+    def test_public_surface_manifest_covers_core_operator_docs(self) -> None:
+        manifest = json.loads(read_text("docs/public-surface.manifest.json"))
+        by_path = {surface["path"]: surface for surface in manifest["surfaces"]}
+        core_docs = [
+            "docs/getting-started/quickstart-hermes.md",
+            "docs/reference/cli.md",
+            "docs/operations/validation-and-release.md",
+        ]
+
+        for rel in core_docs:
+            with self.subTest(rel=rel):
+                self.assertIn(rel, manifest["canonical_sources"])
+                self.assertIn(rel, by_path)
+                self.assertIn("source_refs_exist", by_path[rel]["claim_checks"])
+                self.assertIn("source_of_truth_disclaimer", by_path[rel]["claim_checks"])
+                self.assertIn("no_runtime_proof_claim", by_path[rel]["claim_checks"])
+
+    def test_mkdocs_public_surface_build_is_ci_covered(self) -> None:
+        pyproject = read_text("pyproject.toml")
+        ci = read_text(".github/workflows/ci.yml")
+        gitignore = read_text(".gitignore")
+        mkdocs = read_text("mkdocs.yml")
+
+        self.assertIn("[project.optional-dependencies]", pyproject)
+        self.assertIn('docs = ["mkdocs>=1.6,<2"]', pyproject)
+        self.assertIn('python -m pip install ".[docs]"', ci)
+        self.assertIn('python -m mkdocs build --strict --site-dir "$RUNNER_TEMP/overkill-mkdocs-site"', ci)
+        self.assertIn("site/", gitignore)
+        self.assertIn("exclude_docs:", mkdocs)
+        self.assertIn("not_in_nav:", mkdocs)
+
+    def test_published_surface_sync_has_manual_scheduled_workflow(self) -> None:
+        workflow = read_text(".github/workflows/public-surface-published-sync.yml")
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("schedule:", workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertNotIn("push:", workflow)
+        self.assertIn("permissions:", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertIn("python -B scripts/validate_public_surface_sync.py --check-published", workflow)
+        self.assertNotIn("upload-artifact", workflow)
+
     def test_release_security_and_example_gallery_are_professional_surfaces(self) -> None:
         changelog = read_text("CHANGELOG.md")
         release_policy = read_text("docs/operations/release-policy.md")

--- a/tests/test_supply_chain_proof.py
+++ b/tests/test_supply_chain_proof.py
@@ -106,6 +106,40 @@ class SupplyChainProofTests(unittest.TestCase):
         self.assertTrue(posture["requires_followup"])
         self.assertEqual(posture["detected_manifests"], ["requirements.txt"])
 
+    def test_docs_optional_dependency_does_not_count_as_runtime_dependency(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "fixture"\n'
+                "[project.optional-dependencies]\n"
+                'docs = ["mkdocs>=1.6,<2"]\n',
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(proof, "ROOT", root):
+                posture = proof.dependency_posture()
+
+        self.assertFalse(posture["requires_followup"])
+        self.assertEqual(posture["detected_manifests"], ["pyproject.toml"])
+
+    def test_runtime_optional_dependency_requires_followup(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "fixture"\n'
+                "[project.optional-dependencies]\n"
+                'postgres = ["psycopg[binary]>=3"]\n',
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(proof, "ROOT", root):
+                posture = proof.dependency_posture()
+
+        self.assertTrue(posture["requires_followup"])
+        self.assertEqual(posture["detected_manifests"], ["pyproject.toml"])
+
     def test_no_dependency_manifest_is_current_public_pass(self):
         with mock.patch.object(proof, "ROOT", Path(__file__).resolve().parents[1]):
             posture = proof.dependency_posture()


### PR DESCRIPTION
## What changed

This PR closes the public docs/surface synchronization loop for the factory:

- Adds core operator docs to `docs/public-surface.manifest.json` so quickstart, CLI reference, and validation/release docs cannot drift outside the surface model.
- Adds a MkDocs docs extra and a strict docs build job that writes to `$RUNNER_TEMP`, not the repository.
- Expands `mkdocs.yml` navigation so the public docs site is structurally buildable under `--strict`.
- Adds a manual/scheduled published-surface sync workflow for the public map URL.
- Updates the supply-chain proof to treat `docs` optional dependencies as non-runtime tooling while preserving follow-up for runtime dependencies.
- Keeps generated site output ignored via `site/`.

## Public surface publication

The canonical local HTML map was also republished to:

`gs://overkill-factory-public-assets-20apy/overkill-factory-map-v0.1.0.html`

The published check now passes against the GCS object.

## Validation

- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B -m unittest tests.test_open_source_docs tests.test_supply_chain_proof tests.test_public_surface_sync -q`
- `py -3.13 -m mkdocs build --strict --site-dir "$env:TEMP\overkill-mkdocs-site"`
- `python -B scripts\validate_public_surface_sync.py`
- `python -B scripts\validate_public_surface_sync.py --check-published`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_worker_profiles.py`
- `python -B scripts\validate_planning_bundles.py`
- `python -B scripts\validate_document_governance.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\release_integration_preflight.py`
- `git diff --check`

Closes #140
Closes #142
Closes #143
Refs #134
Refs #148
