### PR TITLE
[codex] enforce review handoff graph gates

### DIFF
--- a/adapters/hermes/transition_hook.py
+++ b/adapters/hermes/transition_hook.py
@@ -73,6 +73,7 @@ def load_ledger(path: Path) -> dict[str, Any]:
             "runtime_authority": "hermes_kanban",
             "local_state_authority": False,
             "tasks": {},
+            "graph_requirements": {},
         }
     data = load_json(path)
     data.setdefault("$schema", "https://overkill-factory.dev/schemas/hermes-worker-ledger.schema.json")
@@ -82,15 +83,21 @@ def load_ledger(path: Path) -> dict[str, Any]:
     data.setdefault("local_state_authority", False)
     if not isinstance(data.get("tasks"), dict):
         data["tasks"] = {}
+    if not isinstance(data.get("graph_requirements"), dict):
+        data["graph_requirements"] = {}
     return data
 
 
 def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, Any]:
     ledger = load_ledger(ledger_path)
     tasks: dict[str, Any] = ledger["tasks"]
+    graph_requirements: dict[str, Any] = ledger["graph_requirements"]
     created: list[str] = []
     unchanged: list[str] = []
     updated: list[str] = []
+    graph_created: list[str] = []
+    graph_unchanged: list[str] = []
+    graph_updated: list[str] = []
     card_id = str(plan.get("event", {}).get("card_id") or "factory-card")
 
     for task in plan.get("worker_tasks", []):
@@ -115,6 +122,7 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
             "expected_receipt_field": task.get("expected_receipt_field"),
             "status": task.get("status"),
             "packet": task.get("packet"),
+            "graph_requirement_refs": task.get("graph_requirement_refs", []),
         }
         previous = tasks.get(ident)
         if previous is None:
@@ -126,6 +134,31 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
             tasks[ident] = payload
             updated.append(ident)
 
+    for requirement in plan.get("graph_requirements", []):
+        ident = str(requirement.get("requirement_id") or "").strip()
+        if not ident:
+            continue
+        payload = {
+            **requirement,
+            "requirement_id": ident,
+            "materialization_state": (
+                "projection_only" if requirement.get("status") == "satisfied" else "pending_hermes_materialization"
+            ),
+            "local_record_role": "idempotency_projection",
+            "card_id": card_id,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        }
+        previous = graph_requirements.get(ident)
+        if previous is None:
+            graph_requirements[ident] = payload
+            graph_created.append(ident)
+        elif previous == payload:
+            graph_unchanged.append(ident)
+        else:
+            graph_requirements[ident] = payload
+            graph_updated.append(ident)
+
     ledger["last_transition"] = plan.get("event", {})
     ledger["last_action"] = plan.get("transition_action")
     write_json(ledger_path, ledger)
@@ -135,6 +168,10 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
         "updated": updated,
         "unchanged": unchanged,
         "task_count": len(tasks),
+        "graph_created": graph_created,
+        "graph_updated": graph_updated,
+        "graph_unchanged": graph_unchanged,
+        "graph_requirement_count": len(graph_requirements),
     }
 
 

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -85,6 +85,34 @@
         "additionalProperties": true
       }
     },
+    "graph_requirements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "requirement_type",
+          "requirement_id",
+          "producer_field",
+          "producer_ref",
+          "review_worker_id",
+          "required_review_field",
+          "required_result",
+          "status",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "requirement_type": { "const": "review_before_consumption" },
+          "required_result": { "const": "PASS" },
+          "status": {
+            "enum": ["pending", "satisfied"]
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
+        },
+        "additionalProperties": true
+      }
+    },
     "completion_reconciliation": {
       "type": ["object", "null"],
       "additionalProperties": true

--- a/schemas/hermes-worker-ledger.schema.json
+++ b/schemas/hermes-worker-ledger.schema.json
@@ -59,6 +59,40 @@
         "additionalProperties": true
       }
     },
+    "graph_requirements": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "requirement_id",
+          "requirement_type",
+          "materialization_state",
+          "local_record_role",
+          "card_id",
+          "producer_field",
+          "review_worker_id",
+          "required_review_field",
+          "status",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "requirement_type": { "const": "review_before_consumption" },
+          "materialization_state": {
+            "enum": [
+              "pending_hermes_materialization",
+              "materialized_in_hermes",
+              "projection_only"
+            ]
+          },
+          "local_record_role": { "const": "idempotency_projection" },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false },
+          "status": { "enum": ["pending", "satisfied"] }
+        },
+        "additionalProperties": true
+      }
+    },
     "last_transition": {
       "type": "object",
       "additionalProperties": true

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4067,13 +4067,18 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             evidence_root=ROOT,
         )
         authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
+        evidence_ref = source_card_ref(path)
         records_by_type.setdefault(record_type, []).append(
             {
-                "evidence_ref": source_card_ref(path),
+                "evidence_ref": evidence_ref,
                 "created_at": data.get("created_at") or data.get("decision_at"),
                 "result": data.get("result") or data.get("decision"),
                 "active": authority.get("active", data.get("active", True)) is not False and not data.get("superseded_by"),
                 "valid": not errors,
+                "consumable": not errors,
+                "graph_requirements": (
+                    declared_graph_requirements(record_type, data, evidence_ref=evidence_ref) if not errors else []
+                ),
                 "validation_errors": errors,
             }
         )
@@ -4107,9 +4112,191 @@ def receipt_result_fields(
                 "evidence_ref": None,
                 "result": value.get("result") or value.get("decision"),
                 "valid": not errors,
+                "consumable": not errors,
+                "graph_requirements": (
+                    declared_graph_requirements(
+                        worker.output_field,
+                        value,
+                        evidence_ref=f"receipt:{worker.output_field}",
+                    )
+                    if not errors
+                    else []
+                ),
                 "validation_errors": errors,
             }
     return fields
+
+
+def _review_declared_by_next_action(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    if "review" not in text:
+        return False
+    return any(marker in text for marker in ("before", "required", "independent", "gate", "handoff"))
+
+
+def _review_required_by_handoff_metadata(data: dict[str, Any]) -> bool:
+    for key in ("handoff", "handoff_gate", "gate_handoff", "review_gate", "handoff_metadata"):
+        value = data.get(key)
+        if not isinstance(value, dict):
+            continue
+        if value.get("reviewer_required") is True or value.get("requires_review") is True:
+            return True
+        if _review_declared_by_next_action(value.get("next_action") or value.get("action")):
+            return True
+    return False
+
+
+def _declared_review_worker_id(data: dict[str, Any]) -> str:
+    worker_id = str(data.get("review_worker_id") or data.get("reviewer_worker_id") or "").strip()
+    return worker_id if worker_id in WORKERS else "independent-reviewer"
+
+
+def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evidence_ref: str | None) -> list[dict[str, Any]]:
+    reviewer_required = (
+        data.get("reviewer_required") is True
+        or data.get("handoff_requires_review") is True
+        or _review_declared_by_next_action(data.get("next_action"))
+        or _review_required_by_handoff_metadata(data)
+    )
+    if not reviewer_required:
+        return []
+    review_worker_id = _declared_review_worker_id(data)
+    required_review_field = WORKERS[review_worker_id].output_field
+    reviewer_result = str(data.get("reviewer_result") or "").strip().upper()
+    status = "satisfied" if reviewer_result == "PASS" else "pending"
+    requirement_ref = evidence_ref or f"external:{record_type}"
+    return [
+        {
+            "requirement_type": "review_before_consumption",
+            "requirement_id": (
+                f"review-before-consumption:{sanitize_slug(record_type, fallback='record')}:"
+                f"{sanitize_slug(requirement_ref, fallback='evidence')}"
+            ),
+            "producer_field": record_type,
+            "producer_ref": requirement_ref,
+            "review_worker_id": review_worker_id,
+            "required_review_field": required_review_field,
+            "required_result": "PASS",
+            "status": status,
+            "reviewer_result": reviewer_result or "missing",
+            "downstream_scope": ["implementation", "done", "release"],
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        }
+    ]
+
+
+def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    requirements: list[dict[str, Any]] = []
+    for record in fields.values():
+        for requirement in record.get("graph_requirements", []):
+            requirement = dict(requirement)
+            review_record = fields.get(str(requirement.get("required_review_field") or ""))
+            if requirement.get("status") != "satisfied" and review_record:
+                if review_record.get("valid") and str(review_record.get("result") or "").strip().upper() == "PASS":
+                    requirement["status"] = "satisfied"
+                    requirement["reviewer_result"] = "PASS"
+                    requirement["review_evidence_ref"] = review_record.get("evidence_ref") or "receipt:review"
+            requirements.append(requirement)
+    for record in fields.values():
+        graph_requirements = [dict(item) for item in record.get("graph_requirements", [])]
+        resolved_for_record = [
+            requirement
+            for requirement in requirements
+            if requirement.get("producer_field") in {item.get("producer_field") for item in graph_requirements}
+        ]
+        record["graph_requirements"] = resolved_for_record
+        record["consumable"] = bool(record.get("valid")) and not any(
+            requirement.get("status") != "satisfied" for requirement in resolved_for_record
+        )
+    return requirements
+
+
+def graph_requirement_block_reason(requirement: dict[str, Any]) -> str:
+    producer = str(requirement.get("producer_field") or "worker result")
+    review_worker = str(requirement.get("review_worker_id") or "independent-reviewer")
+    return f"{producer} requires {review_worker} PASS before downstream consumption"
+
+
+def transition_consumes_graph_requirements(normalized_to: str) -> bool:
+    return normalized_to in {
+        "ready",
+        "in_progress",
+        "doing",
+        "review",
+        "review-ready",
+        "ready_for_review",
+        "done",
+        "closed",
+        "complete",
+    }
+
+
+def build_graph_requirement_review_task(
+    requirement: dict[str, Any],
+    card: dict[str, Any],
+    source_path: Path,
+) -> dict[str, Any]:
+    worker_id = str(requirement.get("review_worker_id") or "independent-reviewer")
+    worker = WORKERS.get(worker_id, WORKERS["independent-reviewer"])
+    task = build_worker_task(worker.worker_id, card, source_path)
+    packet = dict(task.get("packet") or {})
+    missing_inputs = missing_required_inputs(worker, card)
+    status = "blocked_missing_inputs" if missing_inputs else "requires_execution"
+    queue_class = worker_queue_class(worker.worker_id, card)
+    requirement_id = str(requirement.get("requirement_id") or "")
+
+    packet["status"] = status
+    packet["trigger"] = {
+        **dict(packet.get("trigger") or {}),
+        "required": True,
+        "reason": graph_requirement_block_reason(requirement),
+        "timing": "after producer evidence exists and before downstream consumption",
+        "blocking_policy": "Declared handoff reviews must PASS before the producer result can be consumed downstream.",
+    }
+    input_contract = dict(packet.get("input_contract") or {})
+    input_contract["missing_fields"] = missing_inputs
+    input_contract["graph_requirement_ref"] = requirement_id
+    packet["input_contract"] = input_contract
+
+    task.update(
+        {
+            "gate_timing_class": queue_class,
+            "queue_class": queue_class,
+            "required_before": "ready" if queue_class == "blocking-before-ready" else "done",
+            "status": status,
+            "packet": packet,
+            "graph_requirement_refs": [requirement_id],
+        }
+    )
+    return task
+
+
+def attach_graph_requirement_tasks(
+    worker_tasks: list[dict[str, Any]],
+    graph_requirements: list[dict[str, Any]],
+    card: dict[str, Any],
+    source_path: Path,
+) -> None:
+    tasks_by_worker = {str(task.get("worker_id") or ""): task for task in worker_tasks}
+    for requirement in graph_requirements:
+        if requirement.get("status") == "satisfied":
+            continue
+        worker_id = str(requirement.get("review_worker_id") or "independent-reviewer")
+        requirement_id = str(requirement.get("requirement_id") or "")
+        existing = tasks_by_worker.get(worker_id)
+        if existing:
+            refs = list(existing.get("graph_requirement_refs") or [])
+            if requirement_id and requirement_id not in refs:
+                refs.append(requirement_id)
+            existing["graph_requirement_refs"] = refs
+            packet = existing.get("packet") if isinstance(existing.get("packet"), dict) else {}
+            packet.setdefault("graph_requirement_refs", refs)
+            existing["packet"] = packet
+            continue
+        task = build_graph_requirement_review_task(requirement, card, source_path)
+        worker_tasks.append(task)
+        tasks_by_worker[worker_id] = task
 
 
 def _worker_record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
@@ -4148,36 +4335,51 @@ def build_worker_closure(
     present_fields = receipt_result_fields(card, metadata, evidence_root=ROOT)
     result_files = collect_worker_result_fields(card, results_dir)
     present_fields.update(result_files)
+    graph_requirements = resolve_graph_requirements(present_fields)
     rows: dict[str, dict[str, Any]] = {}
     missing_blocking: list[str] = []
     invalid_blocking: list[str] = []
+    unconsumable_blocking: list[str] = []
 
     for worker_id in required_worker_ids(card):
         worker = WORKERS[worker_id]
         queue_class = worker_queue_class(worker_id, card)
         required_for_done = queue_class == "blocking-before-done"
         record = present_fields.get(worker.output_field)
-        satisfied = bool(record and record.get("valid"))
+        valid = bool(record and record.get("valid"))
+        consumable = bool(record and record.get("consumable", True))
+        satisfied = bool(valid and consumable)
         rows[worker_id] = {
             "queue_class": queue_class,
             "required_for_done": required_for_done,
             "output_field": worker.output_field,
+            "valid": valid,
+            "consumable": consumable,
             "satisfied": satisfied,
             "evidence_ref": record.get("evidence_ref") if record else None,
             "result": record.get("result") if record else None,
+            "graph_requirements": record.get("graph_requirements", []) if record else [],
             "validation_errors": record.get("validation_errors", []) if record else [],
         }
         if required_for_done and not satisfied:
-            if record:
+            if record and valid:
+                unconsumable_blocking.append(worker_id)
+            elif record:
                 invalid_blocking.append(worker_id)
             else:
                 missing_blocking.append(worker_id)
+    unsatisfied_graph_requirements = [
+        requirement for requirement in graph_requirements if requirement.get("status") != "satisfied"
+    ]
 
     return {
         "closure_type": "worker_result_reconciliation",
         "required_workers": required_worker_ids(card),
         "missing_blocking_workers": missing_blocking,
         "invalid_blocking_workers": invalid_blocking,
+        "unconsumable_blocking_workers": unconsumable_blocking,
+        "graph_requirements": graph_requirements,
+        "unsatisfied_graph_requirements": unsatisfied_graph_requirements,
         "workers": rows,
     }
 
@@ -4221,6 +4423,23 @@ def build_transition_plan(
         for worker_id in gate["required_workers"]
         if gate["workers"][worker_id]["status"] != "not_required_by_current_card"
     ]
+    graph_completion = (
+        build_worker_closure(card, receipt or {}, worker_results_dir)
+        if transition_consumes_graph_requirements(normalized_to)
+        else None
+    )
+    graph_requirements = graph_completion.get("graph_requirements", []) if graph_completion else []
+    unsatisfied_graph_requirements = (
+        graph_completion.get("unsatisfied_graph_requirements", []) if graph_completion else []
+    )
+    if graph_requirements:
+        attach_graph_requirement_tasks(worker_tasks, graph_requirements, card, source_path)
+
+    def append_unsatisfied_graph_requirement_blocks() -> None:
+        for requirement in unsatisfied_graph_requirements:
+            reason = graph_requirement_block_reason(requirement)
+            if reason not in blocked_reasons:
+                blocked_reasons.append(reason)
 
     if normalized_to in {"ready", "in_progress", "doing"}:
         blocked_reasons.extend(gate["card_validation_errors"])
@@ -4234,6 +4453,7 @@ def build_transition_plan(
         ]
         for worker_id in before_ready:
             blocked_reasons.append(f"{worker_id} result is required before ready")
+        append_unsatisfied_graph_requirement_blocks()
         if blocked_reasons and before_ready:
             transition_action = "block_and_create_before_ready_tasks"
         else:
@@ -4251,15 +4471,17 @@ def build_transition_plan(
         ]
         for worker_id in before_ready:
             blocked_reasons.append(f"{worker_id} result is required before review-ready")
+        append_unsatisfied_graph_requirement_blocks()
         transition_action = "block_transition" if blocked_reasons else "allow_review_ready"
-        completion = build_worker_closure(card, receipt or {}, worker_results_dir)
+        completion = graph_completion
     elif normalized_to in {"done", "closed", "complete"}:
         blocked_reasons.extend(gate["card_validation_errors"])
         for worker_id in gate["blocked_workers"]:
             blocked_reasons.append(f"{worker_id} missing inputs before done")
         if receipt is None:
             blocked_reasons.append("receipt metadata is required for done transition")
-            completion = build_worker_closure(card, {}, worker_results_dir)
+            completion = graph_completion
+            append_unsatisfied_graph_requirement_blocks()
         else:
             blocked_reasons.extend(validate_completion(card, receipt))
             blocked_reasons.extend(receipt_reconciliation_errors(receipt))
@@ -4270,11 +4492,24 @@ def build_transition_plan(
                     to_status=to_status,
                 )
             )
-            completion = build_worker_closure(card, receipt, worker_results_dir)
+            completion = graph_completion
             for worker_id in completion["missing_blocking_workers"]:
                 blocked_reasons.append(f"{worker_id} result is required before done")
             for worker_id in completion.get("invalid_blocking_workers", []):
                 blocked_reasons.append(f"{worker_id} result is invalid before done")
+            for worker_id in completion.get("unconsumable_blocking_workers", []):
+                worker = WORKERS[worker_id]
+                record = completion.get("workers", {}).get(worker_id, {})
+                requirements = record.get("graph_requirements", [])
+                if requirements:
+                    for requirement in requirements:
+                        if requirement.get("status") != "satisfied":
+                            reason = graph_requirement_block_reason(requirement)
+                            if reason not in blocked_reasons:
+                                blocked_reasons.append(reason)
+                else:
+                    blocked_reasons.append(f"{worker_id} result is not consumable before done")
+            append_unsatisfied_graph_requirement_blocks()
         transition_action = "block_transition" if blocked_reasons else "allow_done"
     else:
         blocked_reasons.extend(gate["card_validation_errors"])
@@ -4295,6 +4530,7 @@ def build_transition_plan(
         "blocked_reasons": blocked_reasons,
         "gate_report": gate,
         "worker_tasks": worker_tasks,
+        "graph_requirements": graph_requirements,
         "completion_reconciliation": completion,
     }
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1170,6 +1170,71 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("appsec-owasp-specialist missing inputs for blocking-before-done", plan["blocked_reasons"])
         self.assertIn("factory-orchestrator result is required before ready", plan["blocked_reasons"])
 
+    def test_worker_closure_marks_review_required_handoff_valid_but_not_consumable(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card)
+        handoff["reviewer_required"] = True
+        handoff["reviewer_result"] = "PENDING"
+
+        closure = factoryctl.build_worker_closure(card, {"handoff_packet_result": handoff}, None)
+
+        handoff_row = closure["workers"]["handoff-packer"]
+        self.assertTrue(handoff_row["valid"])
+        self.assertFalse(handoff_row["consumable"])
+        self.assertFalse(handoff_row["satisfied"])
+        self.assertIn("handoff-packer", closure["unconsumable_blocking_workers"])
+        self.assertEqual(closure["unsatisfied_graph_requirements"][0]["requirement_type"], "review_before_consumption")
+        self.assertEqual(closure["unsatisfied_graph_requirements"][0]["review_worker_id"], "independent-reviewer")
+
+    def test_transition_plan_blocks_declared_handoff_review_before_downstream_consumption(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card)
+        handoff["reviewer_required"] = True
+        handoff["reviewer_result"] = "PENDING"
+
+        plan = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="draft",
+            to_status="ready",
+            receipt={"handoff_packet_result": handoff},
+        )
+
+        self.assertEqual(plan["graph_requirements"][0]["status"], "pending")
+        self.assertIn(
+            "handoff_packet_result requires independent-reviewer PASS before downstream consumption",
+            plan["blocked_reasons"],
+        )
+        review_tasks = [task for task in plan["worker_tasks"] if task["worker_id"] == "independent-reviewer"]
+        self.assertTrue(review_tasks)
+        self.assertIn(plan["graph_requirements"][0]["requirement_id"], review_tasks[0]["graph_requirement_refs"])
+
+    def test_worker_closure_satisfies_handoff_review_from_independent_review_result(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card)
+        handoff["reviewer_required"] = True
+        handoff["reviewer_result"] = "PENDING"
+
+        closure = factoryctl.build_worker_closure(
+            card,
+            {
+                "handoff_packet_result": handoff,
+                "independent_review_result": worker_result("independent_review_result", source_card=card),
+            },
+            None,
+        )
+
+        handoff_row = closure["workers"]["handoff-packer"]
+        self.assertTrue(handoff_row["valid"])
+        self.assertTrue(handoff_row["consumable"])
+        self.assertTrue(handoff_row["satisfied"])
+        self.assertEqual(closure["unsatisfied_graph_requirements"], [])
+        self.assertEqual(closure["graph_requirements"][0]["status"], "satisfied")
+
     def test_transition_plan_done_blocks_missing_required_worker_results(self) -> None:
         card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         card = factoryctl.load_json_like(card_path)

--- a/tests/test_hermes_transition_hook.py
+++ b/tests/test_hermes_transition_hook.py
@@ -72,6 +72,54 @@ class HermesTransitionHookTest(unittest.TestCase):
         self.assertEqual(result["transition_action"], "block_transition")
         self.assertTrue(any("result is required before done" in reason for reason in result["blocked_reasons"]))
 
+    def test_hook_persists_declared_graph_review_requirements(self) -> None:
+        factoryctl = transition_hook.load_factoryctl()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="independent review required before implementation consumption",
+        )
+        handoff["reviewer_required"] = True
+        handoff["reviewer_result"] = "PENDING"
+
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            tmp_path = Path(tmp)
+            receipt = tmp_path / "receipt.json"
+            ledger = tmp_path / "worker-ledger.json"
+            receipt.write_text(json.dumps({"handoff_packet_result": handoff}), encoding="utf-8")
+
+            result = transition_hook.build_hook_result(
+                card_path=card,
+                from_status="draft",
+                to_status="ready",
+                receipt_path=receipt,
+                worker_results_dir=None,
+                ledger_path=ledger,
+            )
+            ledger_data = json.loads(ledger.read_text(encoding="utf-8"))
+
+        requirement = result["plan"]["graph_requirements"][0]
+        self.assertEqual(requirement["status"], "pending")
+        self.assertIn(requirement["requirement_id"], ledger_data["graph_requirements"])
+        self.assertEqual(
+            ledger_data["graph_requirements"][requirement["requirement_id"]]["materialization_state"],
+            "pending_hermes_materialization",
+        )
+        self.assertTrue(
+            any(
+                requirement["requirement_id"] in task.get("graph_requirement_refs", [])
+                for task in ledger_data["tasks"].values()
+            )
+        )
+
     def test_cli_is_fail_closed_for_before_ready_blocks(self) -> None:
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:


### PR DESCRIPTION
## Summary
- separates valid worker results from downstream-consumable worker results when the result declares a review-before-consumption handoff
- adds transition-plan `graph_requirements` so Hermes can see the review gate as a graph edge instead of loose prose
- persists graph requirements and task links in the Hermes worker ledger as idempotent projections while keeping Hermes Kanban as runtime authority

## Validation
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py`
- `python -B scripts\release_integration_preflight.py`

Closes #148.
Refs #134.