### PR TITLE
[codex] model review-required handoffs as review-ready

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -152,6 +152,17 @@ def ensure_blocked_event(
         raise RuntimeError(f"Hermes task {task_id} is not durably blocked after block command")
 
 
+def unblock_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    task_id: str,
+    reason: str,
+    runner: Runner = default_runner,
+) -> None:
+    run_checked(hermes_kanban(hermes_bin, board, "unblock", task_id, reason), runner)
+
+
 def record_live_binding(
     *,
     ledger_path: Path,
@@ -287,7 +298,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         card_path=card_path,
         from_status=args.from_status,
         to_status=args.to_status,
-        receipt_path=None,
+        receipt_path=args.receipt,
         worker_results_dir=None,
         ledger_path=ledger_path,
     )
@@ -343,6 +354,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         runner=runner,
     )
     worker_task_ids: dict[str, str] = {}
+    review_promoted_worker_task_ids: dict[str, str] = {}
     for task in plan.get("worker_tasks", []):
         worker_id = str(task.get("worker_id") or "").strip()
         if not worker_id or task.get("status") == "not_required_by_current_card":
@@ -362,6 +374,26 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         )
         worker_task_ids[worker_id] = task_id
         run_checked(hermes_kanban(args.hermes_bin, args.board, "link", task_id, main_task_id), runner)
+        review_authorized = (
+            task.get("dependency_authorization_state") == "review_ready"
+            and task.get("status") == "requires_execution"
+            and bool(task.get("review_task_authorizations"))
+        )
+        if review_authorized and not args.worker_ready:
+            auth = task["review_task_authorizations"][0]
+            requirement_id = str(auth.get("requirement_id") or "review-required-handoff")
+            producer_ref = str(auth.get("producer_ref") or "producer-handoff")
+            unblock_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=task_id,
+                reason=(
+                    "Review task authorized by valid review-required handoff "
+                    f"{requirement_id} from {producer_ref}; non-review downstream remains gated."
+                ),
+                runner=runner,
+            )
+            review_promoted_worker_task_ids[worker_id] = task_id
 
     record_live_binding(
         ledger_path=ledger_path,
@@ -379,6 +411,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         "board_created": board_created,
         "main_task_id": main_task_id,
         "worker_task_ids": worker_task_ids,
+        "review_promoted_worker_task_ids": review_promoted_worker_task_ids,
         "hook": result,
     }
     if args.out:
@@ -446,6 +479,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_mat.add_argument("--card", type=Path, required=True)
     p_mat.add_argument("--board", required=True)
     p_mat.add_argument("--ledger", type=Path, required=True)
+    p_mat.add_argument("--receipt", type=Path)
     p_mat.add_argument("--from-status", default="blocked")
     p_mat.add_argument("--to-status", default="ready")
     p_mat.add_argument("--hermes-bin", default="hermes")

--- a/adapters/hermes/transition_hook.py
+++ b/adapters/hermes/transition_hook.py
@@ -74,6 +74,7 @@ def load_ledger(path: Path) -> dict[str, Any]:
             "local_state_authority": False,
             "tasks": {},
             "graph_requirements": {},
+            "review_task_authorizations": {},
         }
     data = load_json(path)
     data.setdefault("$schema", "https://overkill-factory.dev/schemas/hermes-worker-ledger.schema.json")
@@ -85,6 +86,8 @@ def load_ledger(path: Path) -> dict[str, Any]:
         data["tasks"] = {}
     if not isinstance(data.get("graph_requirements"), dict):
         data["graph_requirements"] = {}
+    if not isinstance(data.get("review_task_authorizations"), dict):
+        data["review_task_authorizations"] = {}
     return data
 
 
@@ -92,12 +95,16 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
     ledger = load_ledger(ledger_path)
     tasks: dict[str, Any] = ledger["tasks"]
     graph_requirements: dict[str, Any] = ledger["graph_requirements"]
+    review_task_authorizations: dict[str, Any] = ledger["review_task_authorizations"]
     created: list[str] = []
     unchanged: list[str] = []
     updated: list[str] = []
     graph_created: list[str] = []
     graph_unchanged: list[str] = []
     graph_updated: list[str] = []
+    review_auth_created: list[str] = []
+    review_auth_unchanged: list[str] = []
+    review_auth_updated: list[str] = []
     card_id = str(plan.get("event", {}).get("card_id") or "factory-card")
 
     for task in plan.get("worker_tasks", []):
@@ -123,6 +130,8 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
             "status": task.get("status"),
             "packet": task.get("packet"),
             "graph_requirement_refs": task.get("graph_requirement_refs", []),
+            "dependency_authorization_state": task.get("dependency_authorization_state"),
+            "review_task_authorizations": task.get("review_task_authorizations", []),
         }
         previous = tasks.get(ident)
         if previous is None:
@@ -159,6 +168,30 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
             graph_requirements[ident] = payload
             graph_updated.append(ident)
 
+    for authorization in plan.get("review_task_authorizations", []):
+        requirement_id = str(authorization.get("requirement_id") or "").strip()
+        worker_id = str(authorization.get("authorized_worker_id") or "").strip()
+        ident = f"{requirement_id}:{worker_id}" if requirement_id and worker_id else requirement_id or worker_id
+        if not ident:
+            continue
+        payload = {
+            **authorization,
+            "authorization_id": ident,
+            "local_record_role": "idempotency_projection",
+            "card_id": card_id,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        }
+        previous = review_task_authorizations.get(ident)
+        if previous is None:
+            review_task_authorizations[ident] = payload
+            review_auth_created.append(ident)
+        elif previous == payload:
+            review_auth_unchanged.append(ident)
+        else:
+            review_task_authorizations[ident] = payload
+            review_auth_updated.append(ident)
+
     ledger["last_transition"] = plan.get("event", {})
     ledger["last_action"] = plan.get("transition_action")
     write_json(ledger_path, ledger)
@@ -172,6 +205,10 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
         "graph_updated": graph_updated,
         "graph_unchanged": graph_unchanged,
         "graph_requirement_count": len(graph_requirements),
+        "review_auth_created": review_auth_created,
+        "review_auth_updated": review_auth_updated,
+        "review_auth_unchanged": review_auth_unchanged,
+        "review_task_authorization_count": len(review_task_authorizations),
     }
 
 
@@ -202,6 +239,7 @@ def build_hook_result(
         "transition_action": plan["transition_action"],
         "blocked_reasons": plan["blocked_reasons"],
         "completion_reconciliation": plan.get("completion_reconciliation"),
+        "review_task_authorizations": plan.get("review_task_authorizations", []),
         "plan": plan,
         "ledger": ledger_result,
     }

--- a/schemas/evidence-graph.schema.json
+++ b/schemas/evidence-graph.schema.json
@@ -36,6 +36,25 @@
           "node_type": { "type": "string", "minLength": 3 },
           "ref": { "type": "string", "minLength": 1 },
           "status": { "enum": ["PASS", "BLOCKED", "MISSING"] },
+          "handoff_state": {
+            "enum": [
+              "consumable",
+              "implementation_ready_for_review",
+              "review_satisfied",
+              "blocked",
+              "invalid",
+              null
+            ]
+          },
+          "review_ready": { "type": "boolean" },
+          "authorized_downstream_scope": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 2 }
+          },
+          "graph_requirements": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          },
           "evidence_level": { "type": "string", "minLength": 3 },
           "staleness": { "type": "string" }
         },

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -29,6 +29,10 @@
     "worker_task_ids": {
       "type": "object"
     },
+    "review_promoted_worker_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
     "hook": {
       "type": "object"
     }

--- a/schemas/hermes-transition-hook.schema.json
+++ b/schemas/hermes-transition-hook.schema.json
@@ -32,6 +32,33 @@
       "type": ["object", "null"],
       "additionalProperties": true
     },
+    "review_task_authorizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "authorization_type",
+          "authorization_state",
+          "requirement_id",
+          "producer_field",
+          "authorized_worker_id",
+          "authorized_scope",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "authorization_type": { "const": "review_task_only" },
+          "authorization_state": { "const": "review_task_ready" },
+          "authorized_scope": {
+            "type": "array",
+            "contains": { "const": "review" }
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
+        },
+        "additionalProperties": true
+      }
+    },
     "plan": {
       "type": "object",
       "required": [
@@ -66,7 +93,8 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "task_count": { "type": "integer" }
+        "task_count": { "type": "integer" },
+        "review_task_authorization_count": { "type": "integer" }
       },
       "additionalProperties": true
     }

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -80,6 +80,13 @@
               "blocked_missing_inputs",
               "not_required_by_current_card"
             ]
+          },
+          "dependency_authorization_state": {
+            "enum": ["review_ready", null]
+          },
+          "review_task_authorizations": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
           }
         },
         "additionalProperties": true
@@ -106,6 +113,49 @@
           "required_result": { "const": "PASS" },
           "status": {
             "enum": ["pending", "satisfied"]
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
+        },
+        "additionalProperties": true
+      }
+    },
+    "review_ready_handoffs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["worker_id", "output_field", "handoff_state", "authorized_downstream_scope"],
+        "properties": {
+          "handoff_state": { "const": "implementation_ready_for_review" },
+          "authorized_downstream_scope": {
+            "type": "array",
+            "contains": { "const": "review" }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "review_task_authorizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "authorization_type",
+          "authorization_state",
+          "requirement_id",
+          "producer_field",
+          "producer_ref",
+          "authorized_worker_id",
+          "authorized_scope",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "authorization_type": { "const": "review_task_only" },
+          "authorization_state": { "const": "review_task_ready" },
+          "authorized_scope": {
+            "type": "array",
+            "contains": { "const": "review" }
           },
           "runtime_authority": { "const": "hermes_kanban" },
           "local_state_authority": { "const": false }

--- a/schemas/hermes-worker-ledger.schema.json
+++ b/schemas/hermes-worker-ledger.schema.json
@@ -54,7 +54,14 @@
             },
             "additionalProperties": false
           },
-          "local_record_role": { "const": "idempotency_projection" }
+          "local_record_role": { "const": "idempotency_projection" },
+          "dependency_authorization_state": {
+            "enum": ["review_ready", null]
+          },
+          "review_task_authorizations": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          }
         },
         "additionalProperties": true
       }
@@ -89,6 +96,37 @@
           "runtime_authority": { "const": "hermes_kanban" },
           "local_state_authority": { "const": false },
           "status": { "enum": ["pending", "satisfied"] }
+        },
+        "additionalProperties": true
+      }
+    },
+    "review_task_authorizations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "authorization_id",
+          "authorization_type",
+          "authorization_state",
+          "local_record_role",
+          "card_id",
+          "requirement_id",
+          "producer_field",
+          "authorized_worker_id",
+          "authorized_scope",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "authorization_type": { "const": "review_task_only" },
+          "authorization_state": { "const": "review_task_ready" },
+          "local_record_role": { "const": "idempotency_projection" },
+          "authorized_scope": {
+            "type": "array",
+            "contains": { "const": "review" }
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
         },
         "additionalProperties": true
       }

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -287,6 +287,37 @@
         "blocked_missing_profile_binding",
         "not_required_by_current_card"
       ]
+    },
+    "graph_requirement_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "review_task_authorizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "authorization_type",
+          "authorization_state",
+          "requirement_id",
+          "producer_field",
+          "authorized_worker_id",
+          "authorized_scope",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "authorization_type": { "const": "review_task_only" },
+          "authorization_state": { "const": "review_task_ready" },
+          "authorized_scope": {
+            "type": "array",
+            "contains": { "const": "review" }
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
+        },
+        "additionalProperties": true
+      }
     }
   },
   "additionalProperties": true

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -150,6 +150,97 @@
     "reusable_for_product": {
       "type": "boolean"
     },
+    "handoff_state": {
+      "enum": [
+        "consumable",
+        "implementation_ready_for_review",
+        "review_satisfied",
+        "blocked",
+        "invalid"
+      ]
+    },
+    "reviewer_required": { "type": "boolean" },
+    "review_worker_id": { "type": "string", "minLength": 3 },
+    "reviewer_worker_id": { "type": "string", "minLength": 3 },
+    "reviewer_result": { "type": "string", "minLength": 2 },
+    "review_declared": { "type": "boolean" },
+    "review_ready": { "type": "boolean" },
+    "authorized_downstream_scope": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 2 }
+    },
+    "graph_requirement_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "review_requirement_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "reviewed_requirement_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "reviewed_producer_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "producer_refs_reviewed": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "review_required_handoff": {
+      "type": "object",
+      "required": [
+        "review_required",
+        "review_worker_id",
+        "required_review_field",
+        "authorized_scope",
+        "forbidden_scope_until_review_pass"
+      ],
+      "properties": {
+        "review_required": { "const": true },
+        "review_worker_id": { "type": "string", "minLength": 3 },
+        "required_review_field": { "type": "string", "minLength": 3 },
+        "authorized_scope": {
+          "type": "array",
+          "contains": { "const": "review" }
+        },
+        "forbidden_scope_until_review_pass": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "review_task_authorizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "authorization_type",
+          "authorization_state",
+          "requirement_id",
+          "producer_field",
+          "producer_ref",
+          "authorized_worker_id",
+          "authorized_scope",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "authorization_type": { "const": "review_task_only" },
+          "authorization_state": { "const": "review_task_ready" },
+          "authorized_scope": {
+            "type": "array",
+            "contains": { "const": "review" }
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
+        },
+        "additionalProperties": true
+      }
+    },
     "evidence_provenance": {
       "type": "object",
       "description": "Structured provenance for production-strict file-backed evidence.",

--- a/scripts/evidence_reconciler.py
+++ b/scripts/evidence_reconciler.py
@@ -47,19 +47,36 @@ def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict
     if active is None:
         active = data.get("active", True)
     superseded_by = data.get("superseded_by") or authority.get("superseded_by")
+    evidence_ref = factoryctl.source_card_ref(path)
+    review_declared = factoryctl.worker_result_declares_review(data)
+    graph_requirements = (
+        factoryctl.declared_graph_requirements(record_type, data, evidence_ref=evidence_ref)
+        if not validation_errors
+        else []
+    )
     return {
         "record_type": record_type,
         "worker_id": worker_ref.get("id"),
         "result": data.get("result") or data.get("decision"),
         "blocking_findings": data.get("blocking_findings"),
         "created_at": data.get("created_at") or data.get("decision_at"),
-        "evidence_ref": factoryctl.source_card_ref(path),
+        "evidence_ref": evidence_ref,
         "active": bool(active) and not bool(superseded_by),
         "supersession_key": data.get("supersession_key") or record_type,
         "supersedes": data.get("supersedes") or authority.get("supersedes"),
         "superseded_by": superseded_by,
         "supersession_reason": data.get("supersession_reason") or authority.get("supersession_reason"),
         "valid_for_closure": not validation_errors,
+        "review_declared": review_declared,
+        "graph_requirements": graph_requirements,
+        "graph_requirement_refs": factoryctl.string_list(data.get("graph_requirement_refs")),
+        "review_requirement_refs": factoryctl.string_list(data.get("review_requirement_refs")),
+        "reviewed_requirement_refs": factoryctl.string_list(data.get("reviewed_requirement_refs")),
+        "reviewed_producer_refs": factoryctl.string_list(data.get("reviewed_producer_refs")),
+        "producer_refs_reviewed": factoryctl.string_list(data.get("producer_refs_reviewed")),
+        "review_task_authorizations": [
+            item for item in data.get("review_task_authorizations", []) if isinstance(item, dict)
+        ],
         "validation_errors": validation_errors,
     }
 
@@ -156,12 +173,43 @@ def reconcile(
         field for field in required_fields if field not in effective_results
     ]
     blocking_current_results: list[dict[str, Any]] = []
+    closure_fields = {
+        field: {
+            "valid": bool(entry.get("valid_for_closure")),
+            "result": entry.get("result"),
+            "evidence_ref": entry.get("evidence_ref"),
+            "review_declared": entry.get("review_declared", False),
+            "graph_requirements": entry.get("graph_requirements", []),
+            "graph_requirement_refs": entry.get("graph_requirement_refs", []),
+            "review_requirement_refs": entry.get("review_requirement_refs", []),
+            "reviewed_requirement_refs": entry.get("reviewed_requirement_refs", []),
+            "reviewed_producer_refs": entry.get("reviewed_producer_refs", []),
+            "producer_refs_reviewed": entry.get("producer_refs_reviewed", []),
+            "review_task_authorizations": entry.get("review_task_authorizations", []),
+        }
+        for field, entry in effective_results.items()
+    }
+    factoryctl.resolve_graph_requirements(closure_fields)
     for field in required_fields:
         current = effective_results.get(field)
         if not current:
             continue
         if not current.get("valid_for_closure"):
             blocking_current_results.append(current)
+            continue
+        closure_record = closure_fields.get(field, {})
+        if closure_record.get("review_ready"):
+            blocking_current_results.append(
+                {
+                    **current,
+                    "valid_for_closure": False,
+                    "handoff_state": closure_record.get("handoff_state"),
+                    "review_ready": True,
+                    "validation_errors": [
+                        "review-required handoff is valid for review task execution but not Receipt Five closure"
+                    ],
+                }
+            )
 
     receipt_five_ready = not missing_required_fields and not blocking_current_results
     return {

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4009,12 +4009,27 @@ def validate_worker_result_record(
         if not isinstance(authority, dict):
             errors.append("promotion_authority object is required")
         else:
+            review_declared = worker_result_declares_review(data)
             if authority.get("active") is False:
                 errors.append("superseded worker result cannot satisfy promotion")
             if str(authority.get("result") or "").strip().upper() != "PASS":
                 errors.append("promotion_authority.result must be PASS")
-            scopes = string_list(authority.get("allowed_transition_scopes"))
-            if "done" not in [scope.lower() for scope in scopes]:
+            scopes = [scope.lower() for scope in string_list(authority.get("allowed_transition_scopes"))]
+            if review_declared:
+                if "review" not in scopes:
+                    errors.append("review-required handoff authority must include review scope")
+                forbidden_scopes = {
+                    "done",
+                    "release",
+                    "deployment",
+                    "github_mutation",
+                    "issue_completion",
+                    "product_acceptance",
+                }
+                leaked = sorted(forbidden_scopes & set(scopes))
+                if leaked:
+                    errors.append("review-required handoff authority must not include " + ", ".join(leaked))
+            elif "done" not in scopes:
                 errors.append("promotion_authority.allowed_transition_scopes must include done")
 
     evidence_refs = string_list(data.get("evidence_refs"))
@@ -4068,19 +4083,30 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
         )
         authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
         evidence_ref = source_card_ref(path)
+        review_declared = worker_result_declares_review(data)
+        graph_requirements = declared_graph_requirements(record_type, data, evidence_ref=evidence_ref) if not errors else []
+        record = {
+            "evidence_ref": evidence_ref,
+            "created_at": data.get("created_at") or data.get("decision_at"),
+            "result": data.get("result") or data.get("decision"),
+            "active": authority.get("active", data.get("active", True)) is not False and not data.get("superseded_by"),
+            "valid": not errors,
+            "consumable": not errors,
+            "review_declared": review_declared,
+            "graph_requirements": graph_requirements,
+            "graph_requirement_refs": string_list(data.get("graph_requirement_refs")),
+            "review_requirement_refs": string_list(data.get("review_requirement_refs")),
+            "reviewed_requirement_refs": string_list(data.get("reviewed_requirement_refs")),
+            "reviewed_producer_refs": string_list(data.get("reviewed_producer_refs")),
+            "producer_refs_reviewed": string_list(data.get("producer_refs_reviewed")),
+            "review_task_authorizations": [
+                item for item in data.get("review_task_authorizations", []) if isinstance(item, dict)
+            ],
+            "validation_errors": errors,
+        }
+        apply_record_consumption_state(record)
         records_by_type.setdefault(record_type, []).append(
-            {
-                "evidence_ref": evidence_ref,
-                "created_at": data.get("created_at") or data.get("decision_at"),
-                "result": data.get("result") or data.get("decision"),
-                "active": authority.get("active", data.get("active", True)) is not False and not data.get("superseded_by"),
-                "valid": not errors,
-                "consumable": not errors,
-                "graph_requirements": (
-                    declared_graph_requirements(record_type, data, evidence_ref=evidence_ref) if not errors else []
-                ),
-                "validation_errors": errors,
-            }
+            record
         )
     records: dict[str, dict[str, Any]] = {}
     for record_type, candidates in records_by_type.items():
@@ -4108,57 +4134,75 @@ def receipt_result_fields(
                 card=card,
                 evidence_root=evidence_root,
             )
-            fields[worker.output_field] = {
+            review_declared = worker_result_declares_review(value)
+            graph_requirements = (
+                declared_graph_requirements(
+                    worker.output_field,
+                    value,
+                    evidence_ref=f"receipt:{worker.output_field}",
+                )
+                if not errors
+                else []
+            )
+            record = {
                 "evidence_ref": None,
                 "result": value.get("result") or value.get("decision"),
                 "valid": not errors,
                 "consumable": not errors,
-                "graph_requirements": (
-                    declared_graph_requirements(
-                        worker.output_field,
-                        value,
-                        evidence_ref=f"receipt:{worker.output_field}",
-                    )
-                    if not errors
-                    else []
-                ),
+                "review_declared": review_declared,
+                "graph_requirements": graph_requirements,
+                "graph_requirement_refs": string_list(value.get("graph_requirement_refs")),
+                "review_requirement_refs": string_list(value.get("review_requirement_refs")),
+                "reviewed_requirement_refs": string_list(value.get("reviewed_requirement_refs")),
+                "reviewed_producer_refs": string_list(value.get("reviewed_producer_refs")),
+                "producer_refs_reviewed": string_list(value.get("producer_refs_reviewed")),
+                "review_task_authorizations": [
+                    item for item in value.get("review_task_authorizations", []) if isinstance(item, dict)
+                ],
                 "validation_errors": errors,
             }
+            apply_record_consumption_state(record)
+            fields[worker.output_field] = record
     return fields
 
 
-def _review_declared_by_next_action(value: Any) -> bool:
-    text = str(value or "").strip().lower()
-    if "review" not in text:
-        return False
-    return any(marker in text for marker in ("before", "required", "independent", "gate", "handoff"))
-
-
 def _review_required_by_handoff_metadata(data: dict[str, Any]) -> bool:
-    for key in ("handoff", "handoff_gate", "gate_handoff", "review_gate", "handoff_metadata"):
+    for key in ("handoff", "handoff_gate", "gate_handoff", "review_gate", "handoff_metadata", "review_required_handoff"):
         value = data.get(key)
         if not isinstance(value, dict):
             continue
         if value.get("reviewer_required") is True or value.get("requires_review") is True:
             return True
-        if _review_declared_by_next_action(value.get("next_action") or value.get("action")):
+        if value.get("review_required") is True or value.get("enabled") is True:
             return True
     return False
 
 
+def worker_result_declares_review(data: dict[str, Any]) -> bool:
+    return (
+        data.get("reviewer_required") is True
+        or data.get("handoff_requires_review") is True
+        or data.get("review_declared") is True
+        or data.get("review_ready") is True
+        or str(data.get("handoff_state") or "").strip() == "implementation_ready_for_review"
+        or _review_required_by_handoff_metadata(data)
+    )
+
+
 def _declared_review_worker_id(data: dict[str, Any]) -> str:
-    worker_id = str(data.get("review_worker_id") or data.get("reviewer_worker_id") or "").strip()
+    nested = data.get("review_required_handoff") if isinstance(data.get("review_required_handoff"), dict) else {}
+    worker_id = str(
+        data.get("review_worker_id")
+        or data.get("reviewer_worker_id")
+        or nested.get("review_worker_id")
+        or nested.get("reviewer_worker_id")
+        or ""
+    ).strip()
     return worker_id if worker_id in WORKERS else "independent-reviewer"
 
 
 def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evidence_ref: str | None) -> list[dict[str, Any]]:
-    reviewer_required = (
-        data.get("reviewer_required") is True
-        or data.get("handoff_requires_review") is True
-        or _review_declared_by_next_action(data.get("next_action"))
-        or _review_required_by_handoff_metadata(data)
-    )
-    if not reviewer_required:
+    if not worker_result_declares_review(data):
         return []
     review_worker_id = _declared_review_worker_id(data)
     required_review_field = WORKERS[review_worker_id].output_field
@@ -4180,10 +4224,84 @@ def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evide
             "status": status,
             "reviewer_result": reviewer_result or "missing",
             "downstream_scope": ["implementation", "done", "release"],
+            "review_authorized_scope": ["review"],
+            "producer_handoff_state": "implementation_ready_for_review"
+            if status == "pending"
+            else "review_satisfied",
             "runtime_authority": "hermes_kanban",
             "local_state_authority": False,
         }
     ]
+
+
+def review_task_authorization(requirement: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "authorization_type": "review_task_only",
+        "authorization_state": "review_task_ready",
+        "requirement_id": requirement.get("requirement_id"),
+        "producer_field": requirement.get("producer_field"),
+        "producer_ref": requirement.get("producer_ref"),
+        "authorized_worker_id": requirement.get("review_worker_id"),
+        "authorized_receipt_field": requirement.get("required_review_field"),
+        "authorized_scope": ["review"],
+        "forbidden_scope_until_review_pass": [
+            "release",
+            "deployment",
+            "github_mutation",
+            "issue_completion",
+            "product_acceptance",
+        ],
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+    }
+
+
+def review_record_matches_requirement(review_record: dict[str, Any], requirement: dict[str, Any]) -> bool:
+    requirement_id = str(requirement.get("requirement_id") or "").strip()
+    producer_ref = str(requirement.get("producer_ref") or "").strip()
+    explicit_refs = set(string_list(review_record.get("graph_requirement_refs")))
+    explicit_refs.update(string_list(review_record.get("review_requirement_refs")))
+    explicit_refs.update(string_list(review_record.get("reviewed_requirement_refs")))
+    if requirement_id and requirement_id in explicit_refs:
+        return True
+    producer_refs = set(string_list(review_record.get("reviewed_producer_refs")))
+    producer_refs.update(string_list(review_record.get("producer_refs_reviewed")))
+    if producer_ref and producer_ref in producer_refs:
+        return True
+    for authorization in review_record.get("review_task_authorizations", []):
+        if not isinstance(authorization, dict):
+            continue
+        if requirement_id and authorization.get("requirement_id") == requirement_id:
+            return True
+        if producer_ref and authorization.get("producer_ref") == producer_ref:
+            return True
+    return False
+
+
+def apply_record_consumption_state(record: dict[str, Any]) -> None:
+    valid = bool(record.get("valid"))
+    requirements = [dict(item) for item in record.get("graph_requirements", [])]
+    pending = [requirement for requirement in requirements if requirement.get("status") != "satisfied"]
+    review_declared = bool(record.get("review_declared") or requirements)
+
+    if not valid:
+        handoff_state = "blocked" if review_declared else "invalid"
+        consumable = False
+        authorized_scope: list[str] = []
+    elif pending:
+        handoff_state = "implementation_ready_for_review"
+        consumable = False
+        authorized_scope = ["review"]
+    else:
+        handoff_state = "consumable"
+        consumable = True
+        authorized_scope = ["implementation", "done", "release"]
+
+    record["handoff_state"] = handoff_state
+    record["review_ready"] = handoff_state == "implementation_ready_for_review"
+    record["consumable"] = consumable
+    record["authorized_downstream_scope"] = authorized_scope
+    record["review_task_authorizations"] = [review_task_authorization(requirement) for requirement in pending]
 
 
 def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
@@ -4193,7 +4311,11 @@ def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[s
             requirement = dict(requirement)
             review_record = fields.get(str(requirement.get("required_review_field") or ""))
             if requirement.get("status") != "satisfied" and review_record:
-                if review_record.get("valid") and str(review_record.get("result") or "").strip().upper() == "PASS":
+                if (
+                    review_record.get("valid")
+                    and str(review_record.get("result") or "").strip().upper() == "PASS"
+                    and review_record_matches_requirement(review_record, requirement)
+                ):
                     requirement["status"] = "satisfied"
                     requirement["reviewer_result"] = "PASS"
                     requirement["review_evidence_ref"] = review_record.get("evidence_ref") or "receipt:review"
@@ -4206,9 +4328,7 @@ def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[s
             if requirement.get("producer_field") in {item.get("producer_field") for item in graph_requirements}
         ]
         record["graph_requirements"] = resolved_for_record
-        record["consumable"] = bool(record.get("valid")) and not any(
-            requirement.get("status") != "satisfied" for requirement in resolved_for_record
-        )
+        apply_record_consumption_state(record)
     return requirements
 
 
@@ -4226,9 +4346,21 @@ def transition_consumes_graph_requirements(normalized_to: str) -> bool:
         "review",
         "review-ready",
         "ready_for_review",
+        "implementation-ready-for-review",
+        "implementation_ready_for_review",
         "done",
         "closed",
         "complete",
+    }
+
+
+def transition_is_review_ready(normalized_to: str) -> bool:
+    return normalized_to in {
+        "review",
+        "review-ready",
+        "ready_for_review",
+        "implementation-ready-for-review",
+        "implementation_ready_for_review",
     }
 
 
@@ -4245,6 +4377,7 @@ def build_graph_requirement_review_task(
     status = "blocked_missing_inputs" if missing_inputs else "requires_execution"
     queue_class = worker_queue_class(worker.worker_id, card)
     requirement_id = str(requirement.get("requirement_id") or "")
+    authorization = review_task_authorization(requirement)
 
     packet["status"] = status
     packet["trigger"] = {
@@ -4257,7 +4390,9 @@ def build_graph_requirement_review_task(
     input_contract = dict(packet.get("input_contract") or {})
     input_contract["missing_fields"] = missing_inputs
     input_contract["graph_requirement_ref"] = requirement_id
+    input_contract["review_task_authorizations"] = [authorization]
     packet["input_contract"] = input_contract
+    packet["review_task_authorizations"] = [authorization]
 
     task.update(
         {
@@ -4267,6 +4402,8 @@ def build_graph_requirement_review_task(
             "status": status,
             "packet": packet,
             "graph_requirement_refs": [requirement_id],
+            "dependency_authorization_state": "review_ready",
+            "review_task_authorizations": [authorization],
         }
     )
     return task
@@ -4285,13 +4422,23 @@ def attach_graph_requirement_tasks(
         worker_id = str(requirement.get("review_worker_id") or "independent-reviewer")
         requirement_id = str(requirement.get("requirement_id") or "")
         existing = tasks_by_worker.get(worker_id)
+        authorization = review_task_authorization(requirement)
         if existing:
             refs = list(existing.get("graph_requirement_refs") or [])
             if requirement_id and requirement_id not in refs:
                 refs.append(requirement_id)
             existing["graph_requirement_refs"] = refs
+            authorizations = list(existing.get("review_task_authorizations") or [])
+            if authorization not in authorizations:
+                authorizations.append(authorization)
+            existing["dependency_authorization_state"] = "review_ready"
+            existing["review_task_authorizations"] = authorizations
             packet = existing.get("packet") if isinstance(existing.get("packet"), dict) else {}
-            packet.setdefault("graph_requirement_refs", refs)
+            packet["graph_requirement_refs"] = refs
+            packet["review_task_authorizations"] = authorizations
+            input_contract = dict(packet.get("input_contract") or {})
+            input_contract["review_task_authorizations"] = authorizations
+            packet["input_contract"] = input_contract
             existing["packet"] = packet
             continue
         task = build_graph_requirement_review_task(requirement, card, source_path)
@@ -4358,6 +4505,11 @@ def build_worker_closure(
             "satisfied": satisfied,
             "evidence_ref": record.get("evidence_ref") if record else None,
             "result": record.get("result") if record else None,
+            "review_declared": record.get("review_declared", False) if record else False,
+            "handoff_state": record.get("handoff_state") if record else None,
+            "review_ready": record.get("review_ready", False) if record else False,
+            "authorized_downstream_scope": record.get("authorized_downstream_scope", []) if record else [],
+            "review_task_authorizations": record.get("review_task_authorizations", []) if record else [],
             "graph_requirements": record.get("graph_requirements", []) if record else [],
             "validation_errors": record.get("validation_errors", []) if record else [],
         }
@@ -4432,6 +4584,26 @@ def build_transition_plan(
     unsatisfied_graph_requirements = (
         graph_completion.get("unsatisfied_graph_requirements", []) if graph_completion else []
     )
+    review_ready_handoffs: list[dict[str, Any]] = []
+    review_task_authorizations: list[dict[str, Any]] = []
+    if graph_completion:
+        for worker_id, row in graph_completion.get("workers", {}).items():
+            if not row.get("review_ready"):
+                continue
+            row_authorizations = list(row.get("review_task_authorizations", []))
+            review_ready_handoffs.append(
+                {
+                    "worker_id": worker_id,
+                    "output_field": row.get("output_field"),
+                    "handoff_state": row.get("handoff_state"),
+                    "evidence_ref": row.get("evidence_ref"),
+                    "authorized_downstream_scope": row.get("authorized_downstream_scope", []),
+                    "review_task_authorization_refs": [
+                        authorization.get("requirement_id") for authorization in row_authorizations
+                    ],
+                }
+            )
+            review_task_authorizations.extend(row_authorizations)
     if graph_requirements:
         attach_graph_requirement_tasks(worker_tasks, graph_requirements, card, source_path)
 
@@ -4440,6 +4612,22 @@ def build_transition_plan(
             reason = graph_requirement_block_reason(requirement)
             if reason not in blocked_reasons:
                 blocked_reasons.append(reason)
+
+    def worker_result_satisfied(worker_id: str) -> bool:
+        if not graph_completion:
+            return False
+        row = graph_completion.get("workers", {}).get(worker_id, {})
+        return bool(row.get("satisfied") or row.get("review_ready"))
+
+    def append_invalid_review_handoff_blocks() -> None:
+        if not graph_completion:
+            return
+        for row in graph_completion.get("workers", {}).values():
+            if row.get("review_declared") and not row.get("valid"):
+                field = str(row.get("output_field") or "worker result")
+                reason = f"{field} cannot authorize review because result is invalid"
+                if reason not in blocked_reasons:
+                    blocked_reasons.append(reason)
 
     if normalized_to in {"ready", "in_progress", "doing"}:
         blocked_reasons.extend(gate["card_validation_errors"])
@@ -4452,14 +4640,15 @@ def build_transition_plan(
             if task["queue_class"] == "blocking-before-ready"
         ]
         for worker_id in before_ready:
-            blocked_reasons.append(f"{worker_id} result is required before ready")
+            if not worker_result_satisfied(worker_id):
+                blocked_reasons.append(f"{worker_id} result is required before ready")
         append_unsatisfied_graph_requirement_blocks()
         if blocked_reasons and before_ready:
             transition_action = "block_and_create_before_ready_tasks"
         else:
             transition_action = "block_transition" if blocked_reasons else "allow_and_create_worker_tasks"
         completion = None
-    elif normalized_to in {"review", "review-ready", "ready_for_review"}:
+    elif transition_is_review_ready(normalized_to):
         blocked_reasons.extend(gate["card_validation_errors"])
         for worker_id in gate["blocked_workers"]:
             queue_class = worker_queue_class(worker_id, card)
@@ -4470,8 +4659,9 @@ def build_transition_plan(
             if task["queue_class"] == "blocking-before-ready"
         ]
         for worker_id in before_ready:
-            blocked_reasons.append(f"{worker_id} result is required before review-ready")
-        append_unsatisfied_graph_requirement_blocks()
+            if not worker_result_satisfied(worker_id):
+                blocked_reasons.append(f"{worker_id} result is required before review-ready")
+        append_invalid_review_handoff_blocks()
         transition_action = "block_transition" if blocked_reasons else "allow_review_ready"
         completion = graph_completion
     elif normalized_to in {"done", "closed", "complete"}:
@@ -4531,6 +4721,8 @@ def build_transition_plan(
         "gate_report": gate,
         "worker_tasks": worker_tasks,
         "graph_requirements": graph_requirements,
+        "review_ready_handoffs": review_ready_handoffs,
+        "review_task_authorizations": review_task_authorizations,
         "completion_reconciliation": completion,
     }
 
@@ -4560,6 +4752,9 @@ def build_worker_result(
     next_action: str,
     evidence_kind: str = "real",
     reusable_for_product: bool = True,
+    reviewer_required: bool = False,
+    review_worker_id: str | None = None,
+    reviewer_result: str | None = None,
 ) -> dict[str, Any]:
     if worker_id == "human-gate-clerk":
         raise ValueError("use human-gate-record for human decisions")
@@ -4571,6 +4766,8 @@ def build_worker_result(
     worker = WORKERS[worker_id]
     artifact_contract = artifact_contract_for_refs(evidence_refs)
     positive_authority = result in PROMOTION_PASS_RESULTS and blocking_findings is False
+    review_worker = review_worker_id if review_worker_id in WORKERS else "independent-reviewer"
+    allowed_transition_scopes = ["review"] if reviewer_required and positive_authority else ["done"] if positive_authority else []
     payload = {
         "$schema": worker_result_schema_url(worker_id),
         "record_type": worker.output_field,
@@ -4594,11 +4791,40 @@ def build_worker_result(
         "next_action": next_action,
         "promotion_authority": {
             "result": "PASS" if positive_authority else "BLOCK",
-            "predicate": "worker result is PASS/WAIVED, valid, scoped to the current card, and has blocking_findings=false",
-            "allowed_transition_scopes": ["done"] if positive_authority else [],
+            "predicate": (
+                "worker result is valid and authorizes only the required review child"
+                if reviewer_required and positive_authority
+                else "worker result is PASS/WAIVED, valid, scoped to the current card, and has blocking_findings=false"
+            ),
+            "allowed_transition_scopes": allowed_transition_scopes,
             "active": True,
         },
     }
+    if reviewer_required:
+        payload.update(
+            {
+                "reviewer_required": True,
+                "review_worker_id": review_worker,
+                "reviewer_result": reviewer_result or "PENDING",
+                "handoff_state": "implementation_ready_for_review" if positive_authority else "blocked",
+                "review_declared": True,
+                "review_ready": positive_authority,
+                "authorized_downstream_scope": ["review"] if positive_authority else [],
+                "review_required_handoff": {
+                    "review_required": True,
+                    "review_worker_id": review_worker,
+                    "required_review_field": WORKERS[review_worker].output_field,
+                    "authorized_scope": ["review"],
+                    "forbidden_scope_until_review_pass": [
+                        "release",
+                        "deployment",
+                        "github_mutation",
+                        "issue_completion",
+                        "product_acceptance",
+                    ],
+                },
+            }
+        )
     if result == "BLOCKED":
         payload["recovery_recommendation"] = recovery_recommendation_for_worker(
             worker_id=worker_id,
@@ -5287,6 +5513,12 @@ def build_evidence_graph(
 ) -> dict[str, Any]:
     effective_gate = gate_report or build_gate_report(card)
     worker_results = collect_worker_result_records(worker_results_dir)
+    worker_closure = build_worker_closure(card, {}, worker_results_dir) if worker_results_dir else None
+    closure_by_field = {
+        str(row.get("output_field") or ""): row
+        for row in (worker_closure or {}).get("workers", {}).values()
+        if isinstance(row, dict)
+    }
     receipt = load_optional_json(receipt_path)
     hermes_package = load_optional_json(hermes_evidence_path)
     nodes: dict[str, dict[str, Any]] = {}
@@ -5382,6 +5614,8 @@ def build_evidence_graph(
             safe_validation_errors = [redact_private_text(error) for error in validation_errors]
             result_status = str(result.get("result") or result.get("decision") or "UNKNOWN")
             stale = bool(result.get("superseded_by") or result.get("active") is False)
+            closure_row = closure_by_field.get(worker.output_field, {})
+            review_ready = bool(closure_row.get("review_ready"))
             graph_add_node(
                 nodes,
                 {
@@ -5390,11 +5624,26 @@ def build_evidence_graph(
                     "ref": str(result.get("_public_ref") or f"external:{worker.output_field}"),
                     "status": "BLOCKED" if validation_errors or stale or result_status not in PROMOTION_PASS_RESULTS else "PASS",
                     "worker_id": worker_id,
+                    "handoff_state": closure_row.get("handoff_state"),
+                    "review_ready": review_ready,
+                    "authorized_downstream_scope": closure_row.get("authorized_downstream_scope", []),
+                    "graph_requirements": closure_row.get("graph_requirements", []),
                     "evidence_level": "worker_result",
                     "staleness": "stale" if stale else "current",
                     "validation_errors": safe_validation_errors,
                 },
             )
+            if review_ready:
+                findings.append(
+                    {
+                        "severity": "BLOCKED",
+                        "node_id": result_id,
+                        "message": (
+                            f"{worker.output_field} is implementation_ready_for_review; "
+                            "only the matching review task may consume it until review PASS"
+                        ),
+                    }
+                )
             for ref_index, ref in enumerate(_list_items(result.get("evidence_refs")), start=1):
                 safe_ref, finding = sanitize_public_ref(ref)
                 artifact_id = f"artifact:{worker.output_field}:{ref_index}"
@@ -5898,6 +6147,9 @@ def command_evidence_record(args: argparse.Namespace) -> int:
             next_action=args.next_action,
             evidence_kind=args.evidence_kind,
             reusable_for_product=not args.not_reusable_for_product,
+            reviewer_required=args.reviewer_required,
+            review_worker_id=args.review_worker_id,
+            reviewer_result=args.reviewer_result,
         )
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
@@ -6171,6 +6423,9 @@ def build_parser() -> argparse.ArgumentParser:
     evidence_record_parser.add_argument("--next-action", default="")
     evidence_record_parser.add_argument("--evidence-kind", choices=["real", "synthetic", "waiver"], default="real")
     evidence_record_parser.add_argument("--not-reusable-for-product", action="store_true")
+    evidence_record_parser.add_argument("--reviewer-required", action="store_true")
+    evidence_record_parser.add_argument("--review-worker-id")
+    evidence_record_parser.add_argument("--reviewer-result")
     evidence_record_parser.add_argument("--out", type=Path)
     evidence_record_parser.set_defaults(func=command_evidence_record)
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -24,7 +24,15 @@ def load_card(name: str) -> dict:
     return factoryctl.load_json_like(ROOT / "examples" / "cards" / name)
 
 
-def worker_result(record_type: str, *, result: str = "PASS", source_card: dict | None = None) -> dict:
+def worker_result(
+    record_type: str,
+    *,
+    result: str = "PASS",
+    source_card: dict | None = None,
+    reviewer_required: bool = False,
+    reviewer_result: str = "PENDING",
+    review_worker_id: str = "independent-reviewer",
+) -> dict:
     worker_id = {
         "security_scan_result": "codex-security",
         "auditor_result": "solana-quasar-auditor",
@@ -47,6 +55,7 @@ def worker_result(record_type: str, *, result: str = "PASS", source_card: dict |
     phase = str((source_card or {}).get("phase") or "F13")
     risk_effective = str((source_card or {}).get("risk_effective") or "R3")
     surfaces = (source_card or {}).get("surfaces") or ["solana-quasar"]
+    positive_authority = result in {"PASS", "WAIVED"}
     payload = {
         "$schema": factoryctl.worker_result_schema_url(worker_id) if worker_id in factoryctl.WORKERS else "https://overkill-factory.dev/schemas/worker-result.schema.json",
         "record_type": record_type,
@@ -73,10 +82,39 @@ def worker_result(record_type: str, *, result: str = "PASS", source_card: dict |
         "promotion_authority": {
             "result": "PASS" if result in {"PASS", "WAIVED"} else "BLOCK",
             "predicate": "synthetic fixture authority",
-            "allowed_transition_scopes": ["done"] if result in {"PASS", "WAIVED"} else [],
+            "allowed_transition_scopes": ["review"] if reviewer_required and positive_authority else ["done"] if positive_authority else [],
             "active": True,
         },
     }
+    if reviewer_required:
+        review_field = factoryctl.WORKERS.get(
+            review_worker_id,
+            factoryctl.WORKERS["independent-reviewer"],
+        ).output_field
+        payload.update(
+            {
+                "reviewer_required": True,
+                "review_worker_id": review_worker_id,
+                "reviewer_result": reviewer_result,
+                "handoff_state": "implementation_ready_for_review" if positive_authority else "blocked",
+                "review_declared": True,
+                "review_ready": positive_authority,
+                "authorized_downstream_scope": ["review"] if positive_authority else [],
+                "review_required_handoff": {
+                    "review_required": True,
+                    "review_worker_id": review_worker_id,
+                    "required_review_field": review_field,
+                    "authorized_scope": ["review"],
+                    "forbidden_scope_until_review_pass": [
+                        "release",
+                        "deployment",
+                        "github_mutation",
+                        "issue_completion",
+                        "product_acceptance",
+                    ],
+                },
+            }
+        )
     if record_type == "security_scan_result":
         payload["scanner_agent"] = "codex-security-runner"
         payload["tool"] = "codex-security:security-scan"
@@ -1173,9 +1211,7 @@ class FactoryCtlTest(unittest.TestCase):
     def test_worker_closure_marks_review_required_handoff_valid_but_not_consumable(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
-        handoff = worker_result("handoff_packet_result", source_card=card)
-        handoff["reviewer_required"] = True
-        handoff["reviewer_result"] = "PENDING"
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
 
         closure = factoryctl.build_worker_closure(card, {"handoff_packet_result": handoff}, None)
 
@@ -1191,9 +1227,7 @@ class FactoryCtlTest(unittest.TestCase):
         card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         card = factoryctl.load_json_like(card_path)
         card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
-        handoff = worker_result("handoff_packet_result", source_card=card)
-        handoff["reviewer_required"] = True
-        handoff["reviewer_result"] = "PENDING"
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
 
         plan = factoryctl.build_transition_plan(
             card,
@@ -1212,12 +1246,110 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertTrue(review_tasks)
         self.assertIn(plan["graph_requirements"][0]["requirement_id"], review_tasks[0]["graph_requirement_refs"])
 
+    def test_transition_plan_allows_review_ready_for_valid_review_required_handoff(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+        receipt = {
+            "handoff_packet_result": handoff,
+            "orchestration_result": worker_result("orchestration_result", source_card=card),
+            "source_ledger_result": worker_result("source_ledger_result", source_card=card),
+            "security_orchestration_result": worker_result("security_orchestration_result", source_card=card),
+            "supply_chain_result": worker_result("supply_chain_result", source_card=card),
+        }
+
+        plan = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="doing",
+            to_status="implementation-ready-for-review",
+            receipt=receipt,
+        )
+
+        self.assertEqual(plan["transition_action"], "allow_review_ready")
+        self.assertEqual(plan["blocked_reasons"], [])
+        self.assertEqual(plan["review_ready_handoffs"][0]["handoff_state"], "implementation_ready_for_review")
+        self.assertEqual(plan["review_ready_handoffs"][0]["authorized_downstream_scope"], ["review"])
+        self.assertEqual(plan["review_task_authorizations"][0]["authorization_state"], "review_task_ready")
+        review_tasks = [task for task in plan["worker_tasks"] if task["worker_id"] == "independent-reviewer"]
+        self.assertEqual(review_tasks[0]["dependency_authorization_state"], "review_ready")
+        self.assertEqual(review_tasks[0]["review_task_authorizations"][0]["authorized_scope"], ["review"])
+
+    def test_transition_plan_keeps_unsafe_review_handoff_blocked(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card,
+            result="BLOCKED",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=True,
+            findings_summary="Handoff is missing required artifacts.",
+            next_action="independent review required after repair",
+            evidence_kind="synthetic",
+            reusable_for_product=False,
+            reviewer_required=True,
+        )
+        receipt = {
+            "handoff_packet_result": handoff,
+            "orchestration_result": worker_result("orchestration_result", source_card=card),
+            "source_ledger_result": worker_result("source_ledger_result", source_card=card),
+            "security_orchestration_result": worker_result("security_orchestration_result", source_card=card),
+            "supply_chain_result": worker_result("supply_chain_result", source_card=card),
+        }
+
+        plan = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="doing",
+            to_status="implementation-ready-for-review",
+            receipt=receipt,
+        )
+
+        self.assertEqual(plan["transition_action"], "block_transition")
+        self.assertIn(
+            "handoff_packet_result cannot authorize review because result is invalid",
+            plan["blocked_reasons"],
+        )
+        self.assertEqual(plan["review_ready_handoffs"], [])
+        self.assertEqual(plan["review_task_authorizations"], [])
+
     def test_worker_closure_satisfies_handoff_review_from_independent_review_result(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
-        handoff = worker_result("handoff_packet_result", source_card=card)
-        handoff["reviewer_required"] = True
-        handoff["reviewer_result"] = "PENDING"
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+        requirement_id = factoryctl.declared_graph_requirements(
+            "handoff_packet_result",
+            handoff,
+            evidence_ref="receipt:handoff_packet_result",
+        )[0]["requirement_id"]
+        review = worker_result("independent_review_result", source_card=card)
+        review["graph_requirement_refs"] = [requirement_id]
+
+        closure = factoryctl.build_worker_closure(
+            card,
+            {
+                "handoff_packet_result": handoff,
+                "independent_review_result": review,
+            },
+            None,
+        )
+
+        handoff_row = closure["workers"]["handoff-packer"]
+        self.assertTrue(handoff_row["valid"])
+        self.assertTrue(handoff_row["consumable"])
+        self.assertTrue(handoff_row["satisfied"])
+        self.assertEqual(closure["unsatisfied_graph_requirements"], [])
+        self.assertEqual(closure["graph_requirements"][0]["status"], "satisfied")
+
+    def test_worker_closure_does_not_satisfy_handoff_review_with_generic_review_result(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
 
         closure = factoryctl.build_worker_closure(
             card,
@@ -1229,11 +1361,9 @@ class FactoryCtlTest(unittest.TestCase):
         )
 
         handoff_row = closure["workers"]["handoff-packer"]
-        self.assertTrue(handoff_row["valid"])
-        self.assertTrue(handoff_row["consumable"])
-        self.assertTrue(handoff_row["satisfied"])
-        self.assertEqual(closure["unsatisfied_graph_requirements"], [])
-        self.assertEqual(closure["graph_requirements"][0]["status"], "satisfied")
+        self.assertFalse(handoff_row["consumable"])
+        self.assertEqual(closure["graph_requirements"][0]["status"], "pending")
+        self.assertEqual(closure["unsatisfied_graph_requirements"][0]["producer_field"], "handoff_packet_result")
 
     def test_transition_plan_done_blocks_missing_required_worker_results(self) -> None:
         card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -12,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ADAPTER_DIR = ROOT / "adapters" / "hermes"
 MODULE_PATH = ADAPTER_DIR / "live_kanban_adapter.py"
+FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
 TEST_BOARD = "overkill-" + "factory-live-smoke"
 MAIN_TASK_ID = "t_" + "00000001"
 sys.path.insert(0, str(ADAPTER_DIR))
@@ -21,6 +22,12 @@ adapter = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 sys.modules["live_kanban_adapter"] = adapter
 SPEC.loader.exec_module(adapter)
+FACTORYCTL_SPEC = importlib.util.spec_from_file_location("factoryctl_live_test", FACTORYCTL_PATH)
+assert FACTORYCTL_SPEC is not None
+factoryctl = importlib.util.module_from_spec(FACTORYCTL_SPEC)
+assert FACTORYCTL_SPEC.loader is not None
+sys.modules["factoryctl_live_test"] = factoryctl
+FACTORYCTL_SPEC.loader.exec_module(factoryctl)
 
 
 class FakeHermes:
@@ -40,6 +47,8 @@ class FakeHermes:
             return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
         if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "block":
             return subprocess.CompletedProcess(argv, 0, stdout='{"status":"blocked"}', stderr="")
+        if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "unblock":
+            return subprocess.CompletedProcess(argv, 0, stdout='{"status":"ready"}', stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
             return subprocess.CompletedProcess(
                 argv,
@@ -144,6 +153,107 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         for call in link_calls:
             self.assertEqual(call[-1], MAIN_TASK_ID)
             self.assertNotEqual(call[-2], MAIN_TASK_ID)
+
+    def test_materialize_promotes_only_authorized_review_child(self) -> None:
+        fake = FakeHermes()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="continue after review",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+        receipt_payload = {
+            "handoff_packet_result": handoff,
+            "orchestration_result": factoryctl.build_worker_result(
+                "factory-orchestrator",
+                card_data,
+                result="PASS",
+                tool_or_profile="orchestration-smoke",
+                executed_by="factory-orchestrator",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Orchestration precondition passed.",
+                next_action="continue",
+            ),
+            "source_ledger_result": factoryctl.build_worker_result(
+                "source-ledger-worker",
+                card_data,
+                result="PASS",
+                tool_or_profile="source-ledger-smoke",
+                executed_by="source-ledger-worker",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Source ledger precondition passed.",
+                next_action="continue",
+            ),
+            "security_orchestration_result": factoryctl.build_worker_result(
+                "security-orchestrator",
+                card_data,
+                result="PASS",
+                tool_or_profile="security-orchestration-smoke",
+                executed_by="security-orchestrator",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Security orchestration precondition passed.",
+                next_action="continue",
+            ),
+            "supply_chain_result": factoryctl.build_worker_result(
+                "supply-chain-gate",
+                card_data,
+                result="PASS",
+                tool_or_profile="supply-chain-smoke",
+                executed_by="supply-chain-gate",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Supply chain precondition passed.",
+                next_action="continue",
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            readiness = tmp_path / "route-readiness.json"
+            receipt = tmp_path / "receipt.json"
+            ledger = tmp_path / "ledger.json"
+            write_route_readiness(readiness)
+            receipt.write_text(json.dumps(receipt_payload), encoding="utf-8")
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize",
+                    "--card",
+                    str(card),
+                    "--board",
+                    TEST_BOARD,
+                    "--ledger",
+                    str(ledger),
+                    "--receipt",
+                    str(receipt),
+                    "--from-status",
+                    "doing",
+                    "--to-status",
+                    "implementation-ready-for-review",
+                    "--route-readiness",
+                    str(readiness),
+                ]
+            )
+            result = adapter.materialize(args, runner=fake)
+
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(len(unblock_calls), 1)
+        self.assertEqual(unblock_calls[0][5], result["worker_task_ids"]["independent-reviewer"])
+        self.assertEqual(
+            result["review_promoted_worker_task_ids"],
+            {"independent-reviewer": result["worker_task_ids"]["independent-reviewer"]},
+        )
+        self.assertNotIn("handoff-packer", result["review_promoted_worker_task_ids"])
 
     def test_materialize_dry_run_does_not_call_hermes_create(self) -> None:
         fake = FakeHermes()

--- a/tests/test_hermes_transition_hook.py
+++ b/tests/test_hermes_transition_hook.py
@@ -86,9 +86,9 @@ class HermesTransitionHookTest(unittest.TestCase):
             blocking_findings=False,
             findings_summary="Handoff packet declares an independent review gate.",
             next_action="independent review required before implementation consumption",
+            reviewer_required=True,
+            reviewer_result="PENDING",
         )
-        handoff["reviewer_required"] = True
-        handoff["reviewer_result"] = "PENDING"
 
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
             tmp_path = Path(tmp)
@@ -119,6 +119,94 @@ class HermesTransitionHookTest(unittest.TestCase):
                 for task in ledger_data["tasks"].values()
             )
         )
+
+    def test_hook_persists_review_ready_authorizations(self) -> None:
+        factoryctl = transition_hook.load_factoryctl()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="independent review required before implementation consumption",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+        receipt_payload = {
+            "handoff_packet_result": handoff,
+            "orchestration_result": factoryctl.build_worker_result(
+                "factory-orchestrator",
+                card_data,
+                result="PASS",
+                tool_or_profile="orchestration-smoke",
+                executed_by="factory-orchestrator",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Orchestration precondition passed.",
+                next_action="continue",
+            ),
+            "source_ledger_result": factoryctl.build_worker_result(
+                "source-ledger-worker",
+                card_data,
+                result="PASS",
+                tool_or_profile="source-ledger-smoke",
+                executed_by="source-ledger-worker",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Source ledger precondition passed.",
+                next_action="continue",
+            ),
+            "security_orchestration_result": factoryctl.build_worker_result(
+                "security-orchestrator",
+                card_data,
+                result="PASS",
+                tool_or_profile="security-orchestration-smoke",
+                executed_by="security-orchestrator",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Security orchestration precondition passed.",
+                next_action="continue",
+            ),
+            "supply_chain_result": factoryctl.build_worker_result(
+                "supply-chain-gate",
+                card_data,
+                result="PASS",
+                tool_or_profile="supply-chain-smoke",
+                executed_by="supply-chain-gate",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Supply chain precondition passed.",
+                next_action="continue",
+            ),
+        }
+
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            tmp_path = Path(tmp)
+            receipt = tmp_path / "receipt.json"
+            ledger = tmp_path / "worker-ledger.json"
+            receipt.write_text(json.dumps(receipt_payload), encoding="utf-8")
+
+            result = transition_hook.build_hook_result(
+                card_path=card,
+                from_status="doing",
+                to_status="implementation-ready-for-review",
+                receipt_path=receipt,
+                worker_results_dir=None,
+                ledger_path=ledger,
+            )
+            ledger_data = json.loads(ledger.read_text(encoding="utf-8"))
+
+        self.assertEqual(result["transition_action"], "allow_review_ready")
+        self.assertEqual(result["blocked_reasons"], [])
+        self.assertTrue(ledger_data["review_task_authorizations"])
+        task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "independent-reviewer")
+        self.assertEqual(task["dependency_authorization_state"], "review_ready")
+        self.assertEqual(task["review_task_authorizations"][0]["authorized_scope"], ["review"])
 
     def test_cli_is_fail_closed_for_before_ready_blocks(self) -> None:
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"


### PR DESCRIPTION
## Summary
- models explicit review-required handoffs as `implementation_ready_for_review` instead of generic blocked state
- authorizes only the matching review child task while freezing done, release, deployment, GitHub mutation, issue completion, and product acceptance
- persists review-task authorization in the Hermes transition plan, hook ledger, live materialization path, worker packets, and evidence graph/reconciler surfaces
- removes text-based `next_action` review inference from graph authorization and requires structured review handoff fields

## Validation
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py`
- `python -B scripts\release_integration_preflight.py`

Closes #152.
Refs #134.