### PR TITLE
[codex] report Hermes dispatch worker starts

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -32,11 +32,14 @@ This patch adds:
   cannot bypass the same Factory gate.
 - Dashboard/API `done` failures return HTTP 409 with the gate reason.
 - Worker CLI `done` failures return non-zero with the gate reason.
+- Dispatch JSON reports spawned workers with task refs, run refs and worker PID
+  when Hermes exposes them.
 - Regression tests.
 
-The patch was validated against official Hermes commit
-`56236b16e383cc656bb8c88429902f4de83f1faf`: `git apply --check` passed and
-the focused regression suite reported `119 passed, 1 warning`.
+The base patch line was validated against official Hermes commit
+`56236b16e383cc656bb8c88429902f4de83f1faf`. For current checkouts, run
+`adapters/hermes/compatibility-check.py`; it verifies the patch is parseable and
+that the required gate and dispatch-reporting markers are still present.
 
 ## Worker Automation Hook
 
@@ -125,6 +128,24 @@ Expected behavior:
 The done transition is therefore a reconciliation gate. A worker packet is not
 evidence. A PASS result without artifact refs is not enough. A human gate
 without a real decision record is not approval.
+
+## Dispatch Reporting
+
+Hermes owns dispatch. The adapter does not schedule workers itself, but it can
+wrap the native dispatch command and reconcile the immediate board state:
+
+```bash
+python adapters/hermes/live_kanban_adapter.py dispatch \
+  --board overkill-factory-live
+```
+
+The response includes:
+
+- `spawned_by_this_command`: workers reported by native Hermes dispatch;
+- `already_running_after_dispatch`: workers that were ready before dispatch and
+  running after dispatch, even if the native response reported `spawned: []`;
+- `run_id` and `worker_pid` when Hermes exposes them;
+- redacted workspace refs, never local absolute paths.
 
 ## Generated Transition Examples
 

--- a/adapters/hermes/compatibility-check.py
+++ b/adapters/hermes/compatibility-check.py
@@ -32,6 +32,8 @@ REQUIRED_PATCH_MARKERS = {
         "security_scan_result",
         "auditor_result.audit_mode=code_audit",
         "human_gate_record",
+        "spawned_by_this_command",
+        "worker_pid",
         "cannot complete {tid}: {exc}",
         "HTTPException(status_code=409",
         "test_overkill_ready_gate_blocks_missing_product_face_packet",

--- a/adapters/hermes/compatibility-manifest.md
+++ b/adapters/hermes/compatibility-manifest.md
@@ -28,6 +28,8 @@ adapters/hermes/patches/0001-overkill-factory-v35-gates-official-main.patch
 - `security_scan_result`
 - `auditor_result.audit_mode=code_audit`
 - `human_gate_record`
+- `spawned_by_this_command`
+- `worker_pid`
 
 ## Required Surfaces
 
@@ -45,6 +47,9 @@ adapters/hermes/patches/0001-overkill-factory-v35-gates-official-main.patch
   production use.
 - Worker CLI completion must surface gate failures as non-zero operational
   errors.
+- Dispatch reporting must distinguish workers spawned by the command from
+  workers already running after the dispatch interval and include run/PID refs
+  when Hermes exposes them.
 
 ## Incompatible Signs
 
@@ -58,6 +63,8 @@ adapters/hermes/patches/0001-overkill-factory-v35-gates-official-main.patch
 - Product-facing or onchain cards can close with Receipt Five but without the
   required worker result records.
 - Auditor preflight can be represented as a real onchain code-audit PASS.
+- Dispatch JSON can return `spawned: []` while board state moved ready tasks to
+  `running` without an explicit `already_running_after_dispatch` report.
 
 ## Required Local Checks
 

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -42,6 +42,13 @@ def run_checked(argv: list[str], runner: Runner = default_runner) -> subprocess.
     return completed
 
 
+def parse_json_output(output: str, *, command: str) -> Any:
+    try:
+        return json.loads(output or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{command} did not return JSON") from exc
+
+
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -66,6 +73,106 @@ def parse_task_id(output: str) -> str:
 
 def hermes_kanban(hermes_bin: str, board: str, *args: str) -> list[str]:
     return [hermes_bin, "kanban", "--board", board, *args]
+
+
+def public_safe_workspace_ref(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    normalized = text.replace("\\", "/")
+    if normalized.lower().startswith("dir:"):
+        normalized = normalized[4:]
+    if re.match(r"^[A-Za-z]:/", normalized) or normalized.startswith("/"):
+        return "redacted:absolute-hermes-workspace"
+    return text
+
+
+def normalize_task_record(record: dict[str, Any]) -> dict[str, Any]:
+    task_id = str(record.get("task_id") or record.get("id") or "")
+    normalized: dict[str, Any] = {"task_id": task_id}
+    assignee = record.get("assignee") or record.get("profile")
+    if assignee:
+        normalized["assignee"] = str(assignee)
+    workspace = record.get("workspace") or record.get("workspace_path")
+    if workspace:
+        normalized["workspace"] = public_safe_workspace_ref(workspace)
+    for source_key, target_key in (
+        ("current_run_id", "run_id"),
+        ("run_id", "run_id"),
+        ("worker_pid", "worker_pid"),
+        ("pid", "worker_pid"),
+    ):
+        value = record.get(source_key)
+        if value is not None and target_key not in normalized:
+            normalized[target_key] = value
+    return normalized
+
+
+def list_tasks_by_status(
+    *,
+    hermes_bin: str,
+    board: str,
+    status: str,
+    runner: Runner = default_runner,
+) -> list[dict[str, Any]]:
+    completed = run_checked(hermes_kanban(hermes_bin, board, "list", "--status", status, "--json"), runner)
+    payload = parse_json_output(completed.stdout, command=f"hermes kanban list --status {status} --json")
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("tasks", "items", status):
+            items = payload.get(key)
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+    return []
+
+
+def show_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    task_id: str,
+    runner: Runner = default_runner,
+) -> dict[str, Any]:
+    completed = run_checked(hermes_kanban(hermes_bin, board, "show", task_id, "--json"), runner)
+    payload = parse_json_output(completed.stdout, command="hermes kanban show --json")
+    return payload if isinstance(payload, dict) else {}
+
+
+def enrich_dispatch_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    record: dict[str, Any],
+    after_running_by_id: dict[str, dict[str, Any]],
+    runner: Runner = default_runner,
+) -> dict[str, Any]:
+    task_id = str(record.get("task_id") or record.get("id") or "")
+    merged: dict[str, Any] = {}
+    if task_id:
+        merged.update(after_running_by_id.get(task_id) or {})
+    merged.update(record)
+    normalized = normalize_task_record(merged)
+    if task_id and ("run_id" not in normalized or "worker_pid" not in normalized):
+        shown = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+        shown_normalized = normalize_task_record(shown)
+        for key in ("run_id", "worker_pid", "assignee", "workspace"):
+            if key not in normalized and key in shown_normalized:
+                normalized[key] = shown_normalized[key]
+    return normalized
+
+
+def normalize_native_spawned(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    records = payload.get("spawned")
+    if not isinstance(records, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for item in records:
+        if isinstance(item, dict):
+            record = normalize_task_record(item)
+            if record.get("task_id"):
+                normalized.append(record)
+    return normalized
 
 
 def route_readiness_blockers(path: Path | None, required_worker_ids: list[str]) -> list[str]:
@@ -471,6 +578,112 @@ def enforce_done(args: argparse.Namespace, runner: Runner = default_runner) -> d
     return envelope
 
 
+def dispatch(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
+    before_ready = list_tasks_by_status(
+        hermes_bin=args.hermes_bin,
+        board=args.board,
+        status="ready",
+        runner=runner,
+    )
+    before_running = list_tasks_by_status(
+        hermes_bin=args.hermes_bin,
+        board=args.board,
+        status="running",
+        runner=runner,
+    )
+    before_ready_ids = {
+        str(task.get("task_id") or task.get("id") or "")
+        for task in before_ready
+        if str(task.get("task_id") or task.get("id") or "").strip()
+    }
+    before_running_ids = {
+        str(task.get("task_id") or task.get("id") or "")
+        for task in before_running
+        if str(task.get("task_id") or task.get("id") or "").strip()
+    }
+
+    dispatch_args = ["dispatch", "--json"]
+    if args.dry_run:
+        dispatch_args.append("--dry-run")
+    if args.max is not None:
+        dispatch_args.extend(["--max", str(args.max)])
+    if args.failure_limit is not None:
+        dispatch_args.extend(["--failure-limit", str(args.failure_limit)])
+    completed = run_checked(hermes_kanban(args.hermes_bin, args.board, *dispatch_args), runner)
+    native_payload = parse_json_output(completed.stdout, command="hermes kanban dispatch --json")
+    if not isinstance(native_payload, dict):
+        raise RuntimeError("hermes kanban dispatch --json returned a non-object payload")
+
+    after_running = [] if args.dry_run else list_tasks_by_status(
+        hermes_bin=args.hermes_bin,
+        board=args.board,
+        status="running",
+        runner=runner,
+    )
+    after_running_by_id = {
+        str(task.get("task_id") or task.get("id") or ""): task
+        for task in after_running
+        if str(task.get("task_id") or task.get("id") or "").strip()
+    }
+
+    spawned_by_this_command = [
+        enrich_dispatch_task(
+            hermes_bin=args.hermes_bin,
+            board=args.board,
+            record=record,
+            after_running_by_id=after_running_by_id,
+            runner=runner,
+        )
+        for record in normalize_native_spawned(native_payload)
+    ]
+    spawned_ids = {record["task_id"] for record in spawned_by_this_command if record.get("task_id")}
+    observed_ids = sorted((set(after_running_by_id) - before_running_ids) & before_ready_ids)
+    already_running_after_dispatch = [
+        enrich_dispatch_task(
+            hermes_bin=args.hermes_bin,
+            board=args.board,
+            record={"task_id": task_id, "observed_source": "ready_before_running_after_dispatch"},
+            after_running_by_id=after_running_by_id,
+            runner=runner,
+        )
+        for task_id in observed_ids
+        if task_id not in spawned_ids
+    ]
+    for record in spawned_by_this_command:
+        record["dispatch_observation"] = "native_dispatch_spawned"
+    for record in already_running_after_dispatch:
+        record["dispatch_observation"] = "already_running_after_native_dispatch"
+
+    combined_spawned = [*spawned_by_this_command, *already_running_after_dispatch]
+    native_sanitized = dict(native_payload)
+    native_sanitized["spawned"] = normalize_native_spawned(native_payload)
+
+    envelope = {
+        "$schema": LIVE_ADAPTER_SCHEMA,
+        "mode": "dispatch",
+        "dry_run": bool(args.dry_run),
+        "board": args.board,
+        "spawned": combined_spawned,
+        "spawned_by_this_command": spawned_by_this_command,
+        "already_running_after_dispatch": already_running_after_dispatch,
+        "native_dispatch": native_sanitized,
+        "dispatch_observed_state": {
+            "ready_before_count": len(before_ready_ids),
+            "running_before_count": len(before_running_ids),
+            "running_after_count": len(after_running_by_id),
+        },
+        "hook": {
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "no_shadow_dispatcher": True,
+            "reporting_policy": "Hermes dispatch remains authoritative; this adapter only enriches the returned report from Hermes state.",
+        },
+    }
+    if args.out:
+        write_json(args.out, envelope)
+    return envelope
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Operate Overkill Factory gates on Hermes Kanban.")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -506,13 +719,26 @@ def build_parser() -> argparse.ArgumentParser:
     p_done.add_argument("--result", default="Overkill Factory gate satisfied.")
     p_done.add_argument("--summary", default="Worker evidence reconciled by Overkill Factory.")
     p_done.add_argument("--out", type=Path)
+
+    p_dispatch = sub.add_parser("dispatch", help="Run native Hermes dispatch and enrich the public-safe result.")
+    p_dispatch.add_argument("--board", required=True)
+    p_dispatch.add_argument("--hermes-bin", default="hermes")
+    p_dispatch.add_argument("--dry-run", action="store_true")
+    p_dispatch.add_argument("--max", type=int)
+    p_dispatch.add_argument("--failure-limit", type=int)
+    p_dispatch.add_argument("--out", type=Path)
     return parser
 
 
 def main() -> int:
     args = build_parser().parse_args()
     try:
-        envelope = materialize(args) if args.command == "materialize" else enforce_done(args)
+        if args.command == "materialize":
+            envelope = materialize(args)
+        elif args.command == "enforce-done":
+            envelope = enforce_done(args)
+        else:
+            envelope = dispatch(args)
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/adapters/hermes/patches/0001-overkill-factory-v35-gates-official-main.patch
+++ b/adapters/hermes/patches/0001-overkill-factory-v35-gates-official-main.patch
@@ -35,6 +35,38 @@ index 31c4bf6..f062e57 100644
              else:
                  print(f"Completed {tid}")
      return 0 if not failed else 1
+@@ -2140,6 +2149,18 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
+             default_assignee=default_assignee,
+             max_in_progress_per_profile=max_in_progress_per_profile,
+         )
++        spawned_details = []
++        for tid, who, ws in res.spawned:
++            task = kb.get_task(conn, tid)
++            detail = {
++                "task_id": tid,
++                "assignee": who,
++                "workspace": ws,
++            }
++            if task is not None:
++                detail["run_id"] = task.current_run_id
++                detail["worker_pid"] = task.worker_pid
++            spawned_details.append(detail)
+     if getattr(args, "json", False):
+         print(json.dumps({
+             "reclaimed": res.reclaimed,
+@@ -2155,10 +2179,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
+             "auto_blocked": res.auto_blocked,
+             "promoted": res.promoted,
+-            "spawned": [
+-                {"task_id": tid, "assignee": who, "workspace": ws}
+-                for (tid, who, ws) in res.spawned
+-            ],
++            "spawned": spawned_details,
++            "spawned_by_this_command": spawned_details,
+             "skipped_unassigned": res.skipped_unassigned,
+             "skipped_nonspawnable": res.skipped_nonspawnable,
+             "skipped_per_profile_capped": [
+                 {"task_id": tid, "assignee": who, "current": current}
 diff --git a/hermes_cli/kanban_db.py b/hermes_cli/kanban_db.py
 index c8c53db..ec7f2ba 100644
 --- a/hermes_cli/kanban_db.py

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -8,7 +8,7 @@
       "const": "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json"
     },
     "mode": {
-      "enum": ["materialize", "enforce-done"]
+      "enum": ["materialize", "enforce-done", "dispatch"]
     },
     "dry_run": {
       "type": "boolean"
@@ -27,6 +27,24 @@
       "type": ["string", "null"]
     },
     "worker_task_ids": {
+      "type": "object"
+    },
+    "spawned": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "spawned_by_this_command": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "already_running_after_dispatch": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "native_dispatch": {
+      "type": "object"
+    },
+    "dispatch_observed_state": {
       "type": "object"
     },
     "review_promoted_worker_task_ids": {

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -61,6 +61,102 @@ class FakeHermes:
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected command")
 
 
+def private_windows_workspace_ref() -> str:
+    return "dir:" + "C" + ":" + "\\private-workspace"
+
+
+class FakeDispatchHermes:
+    def __init__(self, *, native_spawned: bool = False) -> None:
+        self.calls: list[list[str]] = []
+        self.native_spawned = native_spawned
+        self.running_list_calls = 0
+
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(argv)
+        if len(argv) >= 8 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "list":
+            status = argv[argv.index("--status") + 1]
+            if status == "ready":
+                return subprocess.CompletedProcess(
+                    argv,
+                    0,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "id": "t_ready0001",
+                                "assignee": "implementation-worker",
+                                "workspace": private_windows_workspace_ref(),
+                            }
+                        ]
+                    ),
+                    stderr="",
+                )
+            if status == "running":
+                self.running_list_calls += 1
+                if self.running_list_calls == 1:
+                    return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+                return subprocess.CompletedProcess(
+                    argv,
+                    0,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "id": "t_ready0001",
+                                "assignee": "implementation-worker",
+                                "current_run_id": 42,
+                                "worker_pid": 12345,
+                                "workspace": private_windows_workspace_ref(),
+                            }
+                        ]
+                    ),
+                    stderr="",
+                )
+        if len(argv) >= 6 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "dispatch":
+            spawned = (
+                [
+                    {
+                        "task_id": "t_ready0001",
+                        "assignee": "implementation-worker",
+                        "workspace": private_windows_workspace_ref(),
+                    }
+                ]
+                if self.native_spawned
+                else []
+            )
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=json.dumps(
+                    {
+                        "reclaimed": 0,
+                        "crashed": [],
+                        "timed_out": [],
+                        "stale": [],
+                        "auto_blocked": [],
+                        "promoted": 0,
+                        "spawned": spawned,
+                    }
+                ),
+                stderr="",
+            )
+        if len(argv) >= 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=json.dumps(
+                    {
+                        "id": argv[5],
+                        "status": "running",
+                        "assignee": "implementation-worker",
+                        "current_run_id": 42,
+                        "worker_pid": 12345,
+                        "workspace": private_windows_workspace_ref(),
+                    }
+                ),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected command")
+
+
 def write_route_readiness(path: Path) -> None:
     workers = [
         "codex-security",
@@ -111,6 +207,42 @@ def write_route_readiness(path: Path) -> None:
 
 
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
+    def test_dispatch_reports_tasks_that_entered_running_even_when_native_spawned_is_empty(self) -> None:
+        fake = FakeDispatchHermes(native_spawned=False)
+        args = adapter.build_parser().parse_args(["dispatch", "--board", TEST_BOARD])
+
+        result = adapter.dispatch(args, runner=fake)
+
+        self.assertEqual(result["mode"], "dispatch")
+        self.assertEqual(result["spawned"][0]["task_id"], "t_ready0001")
+        self.assertEqual(result["spawned"][0]["run_id"], 42)
+        self.assertEqual(result["spawned"][0]["worker_pid"], 12345)
+        self.assertEqual(result["spawned"][0]["workspace"], "redacted:absolute-hermes-workspace")
+        self.assertEqual(
+            result["spawned"][0]["dispatch_observation"],
+            "already_running_after_native_dispatch",
+        )
+        self.assertEqual(result["spawned_by_this_command"], [])
+        self.assertEqual(len(result["already_running_after_dispatch"]), 1)
+        self.assertEqual(result["native_dispatch"]["spawned"], [])
+        self.assertTrue(result["hook"]["no_shadow_dispatcher"])
+        self.assertFalse(result["hook"]["local_state_authority"])
+
+    def test_dispatch_enriches_native_spawned_with_run_id_and_pid(self) -> None:
+        fake = FakeDispatchHermes(native_spawned=True)
+        args = adapter.build_parser().parse_args(["dispatch", "--board", TEST_BOARD])
+
+        result = adapter.dispatch(args, runner=fake)
+
+        self.assertEqual(len(result["spawned_by_this_command"]), 1)
+        spawned = result["spawned_by_this_command"][0]
+        self.assertEqual(spawned["task_id"], "t_ready0001")
+        self.assertEqual(spawned["run_id"], 42)
+        self.assertEqual(spawned["worker_pid"], 12345)
+        self.assertEqual(spawned["dispatch_observation"], "native_dispatch_spawned")
+        self.assertEqual(spawned["workspace"], "redacted:absolute-hermes-workspace")
+        self.assertEqual(result["already_running_after_dispatch"], [])
+
     def test_materialize_creates_workers_as_parents_of_main_card(self) -> None:
         fake = FakeHermes()
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"


### PR DESCRIPTION
## Summary

Fixes the dispatch reporting trust gap from #153 without creating a second runtime source of truth.

Hermes remains the dispatcher and durable state owner. The factory adapter now wraps native `hermes kanban dispatch --json`, observes ready/running state before and after the command, and reports:

- `spawned_by_this_command` for workers native Hermes says it spawned;
- `already_running_after_dispatch` for tasks that were ready before dispatch and running after dispatch even when native `spawned` is empty;
- `run_id` and `worker_pid` when Hermes exposes them;
- public-safe workspace refs with local absolute paths redacted.

Also extends the Hermes patch/compatibility manifest so dispatch JSON is an explicit adapter invariant.

Closes #153.

## Validation

- `python -B -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B adapters\hermes\compatibility-check.py`
- `git apply --numstat adapters\hermes\patches\0001-overkill-factory-v35-gates-official-main.patch`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py`
- `python -B scripts\release_integration_preflight.py`