### PR TITLE
[codex] Block raw Kanban task markers in public artifacts

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -16,7 +16,17 @@ from transition_hook import ACTION_BLOCK_TRANSITION, build_hook_result, write_js
 
 
 ROOT = Path(__file__).resolve().parents[2]
-TASK_ID_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from public_refs import (  # noqa: E402
+    PRIVATE_KANBAN_TASK_MARKER_RE,
+    PUBLIC_SAFE_KANBAN_REF,
+    sanitize_public_refs,
+)
+
+TASK_ID_RE = PRIVATE_KANBAN_TASK_MARKER_RE
 LIVE_ADAPTER_SCHEMA = "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json"
 ROUTE_READINESS_SCHEMA = "https://overkill-factory.dev/schemas/hermes-worker-route-readiness.schema.json"
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
@@ -521,9 +531,10 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         "review_promoted_worker_task_ids": review_promoted_worker_task_ids,
         "hook": result,
     }
+    public_envelope = sanitize_public_refs(envelope)
     if args.out:
-        write_json(args.out, envelope)
-    return envelope
+        write_json(args.out, public_envelope)
+    return public_envelope
 
 
 def enforce_done(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
@@ -544,10 +555,11 @@ def enforce_done(args: argparse.Namespace, runner: Runner = default_runner) -> d
         "main_task_id": args.main_task_id,
         "hook": result,
     }
+    public_envelope = sanitize_public_refs(envelope)
     if args.out:
-        write_json(args.out, envelope)
+        write_json(args.out, public_envelope)
     if blocked:
-        return envelope
+        return public_envelope
     readiness_blockers = route_readiness_blockers(args.route_readiness, ["evidence-reconciler"])
     if readiness_blockers:
         raise RuntimeError("pre-completion route readiness blocked live completion: " + "; ".join(readiness_blockers))
@@ -575,7 +587,7 @@ def enforce_done(args: argparse.Namespace, runner: Runner = default_runner) -> d
             ),
             runner,
         )
-    return envelope
+    return public_envelope
 
 
 def dispatch(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
@@ -679,9 +691,10 @@ def dispatch(args: argparse.Namespace, runner: Runner = default_runner) -> dict[
             "reporting_policy": "Hermes dispatch remains authoritative; this adapter only enriches the returned report from Hermes state.",
         },
     }
+    public_envelope = sanitize_public_refs(envelope)
     if args.out:
-        write_json(args.out, envelope)
-    return envelope
+        write_json(args.out, public_envelope)
+    return public_envelope
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -23,6 +23,11 @@ from typing import Any
 
 
 CODE_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from public_refs import contains_private_kanban_task_marker, public_safe_kanban_ref, sanitize_public_refs  # noqa: E402
 
 
 def installed_asset_root() -> Path | None:
@@ -1127,6 +1132,8 @@ def classify_artifact_ref(ref: Any) -> dict[str, Any]:
     normalized = value.replace("\\", "/")
     if not value:
         return {"ref": value, "artifact_class": "invalid", "public_safe": False, "reason": "empty artifact ref"}
+    if contains_private_kanban_task_marker(value):
+        return {"ref": value, "artifact_class": "private_run_evidence", "public_safe": False, "reason": "raw private Kanban task id"}
     if value.startswith("external:"):
         return {"ref": value, "artifact_class": "sanitized_report", "public_safe": True, "reason": "explicit external/sanitized ref"}
     if value.startswith(("http://", "https://", "file://")) or Path(value).is_absolute() or ":" in normalized.split("/", 1)[0]:
@@ -1154,7 +1161,8 @@ def artifact_contract_for_refs(refs: list[str]) -> dict[str, Any]:
 
 
 def public_safe_text(value: Any) -> bool:
-    return PRIVATE_RUNTIME_REF_RE.search(str(value or "")) is None
+    text = str(value or "")
+    return PRIVATE_RUNTIME_REF_RE.search(text) is None and not contains_private_kanban_task_marker(text)
 
 
 def sanitize_slug(value: Any, *, fallback: str = "item") -> str:
@@ -1167,6 +1175,7 @@ def redact_private_text(value: Any) -> str:
     text = re.sub(r"[A-Za-z]:[\\/][^ \];,\"]+", "[redacted-private-ref]", text)
     text = re.sub(r"/(?:home|Users|srv|var)/[^ \];,\"]+", "[redacted-private-ref]", text)
     text = PRIVATE_RUNTIME_REF_RE.sub("[redacted-private-marker]", text)
+    text = public_safe_kanban_ref(text) or ""
     return text
 
 
@@ -4728,7 +4737,7 @@ def build_transition_plan(
 
 
 def card_ref(card: dict[str, Any]) -> dict[str, Any]:
-    return {
+    return sanitize_public_refs({
         "card_id": card.get("card_id"),
         "slice_id": card.get("slice_id"),
         "phase": card.get("phase"),
@@ -4736,7 +4745,7 @@ def card_ref(card: dict[str, Any]) -> dict[str, Any]:
         "surfaces": card.get("surfaces", []),
         "executor_identity": card.get("executor_identity"),
         "reviewer_identity": card.get("reviewer_identity"),
-    }
+    })
 
 
 def build_worker_result(

--- a/scripts/issue84/build_local_cockpit_data.py
+++ b/scripts/issue84/build_local_cockpit_data.py
@@ -21,6 +21,12 @@ from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT = SCRIPT_DIR.parents[1]
+SCRIPTS_ROOT = SCRIPT_DIR.parent
+if str(SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from public_refs import PRIVATE_KANBAN_TASK_MARKER_RE  # noqa: E402
+
 FIXTURE_DIR = ROOT / "fixtures" / "issue-84" / "status-snapshot-v0"
 DEFAULT_OUTPUT = ROOT / "ui" / "issue-84-local-cockpit" / "data" / "status-cockpit.json"
 
@@ -155,7 +161,7 @@ _PRIVATE_WINDOWS_DOUBLE = "C:" + "\\\\" + "Users"
 PRIVATE_PATTERNS = [
     re.compile(re.escape(_PRIVATE_RUNTIME_ROOT) + r"[^\s\"']*"),
     re.compile(r"file://[^\s\"']*"),
-    re.compile(r"\bt_[a-f0-9]{8}\b"),
+    PRIVATE_KANBAN_TASK_MARKER_RE,
     *[re.compile(r"\b" + re.escape(marker) + r"\b") for marker in _PRIVATE_PRODUCT_MARKERS],
     *[re.compile(r"\b" + re.escape(marker) + r"\b") for marker in _PRIVATE_OWNER_MARKERS],
     re.compile(re.escape(_PRIVATE_WINDOWS_DOUBLE) + r"[^\s\"']*"),

--- a/scripts/issue84/validate_evidence_refs.py
+++ b/scripts/issue84/validate_evidence_refs.py
@@ -18,8 +18,12 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+SCRIPTS_ROOT = SCRIPT_DIR.parent
+if str(SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_ROOT))
 
 import status_snapshot_contract as contract
+from public_refs import contains_private_kanban_task_marker  # noqa: E402
 
 PRIVATE_RUNTIME_FRAGMENT = "/" + "srv/hermes"
 LOCAL_PATH_RE = re.compile(
@@ -28,7 +32,6 @@ LOCAL_PATH_RE = re.compile(
 )
 FILE_URI_RE = re.compile(r"^file:", re.IGNORECASE)
 CHAT_ID_RE = re.compile(r"(discord(?:\.com|://)|slack(?:\.com|://)|telegram(?:\.me|://)|\bchannel[_-]?id\b|\bmessage[_-]?id\b)", re.IGNORECASE)
-PRIVATE_TASK_RE = re.compile(r"\bt_[a-f0-9]{8}\b")
 SECRET_RE = re.compile(
     r"(?i)(aws_access_key_id|aws_secret_access_key|api[_-]?key|token|secret|password|private[_-]?key)\s*[:=]\s*[A-Za-z0-9_./+=-]{8,}"
 )
@@ -78,7 +81,7 @@ def scan_evidence_ref(evidence: dict[str, Any], *, deny_raw_private: bool = True
             continue
         if deny_local_paths and (FILE_URI_RE.search(value) or LOCAL_PATH_RE.search(value)):
             errors.append(f"{evidence_id}:{at}: local path or file URI is forbidden")
-        if deny_chat_ids and (CHAT_ID_RE.search(value) or PRIVATE_TASK_RE.search(value)):
+        if deny_chat_ids and (CHAT_ID_RE.search(value) or contains_private_kanban_task_marker(value)):
             errors.append(f"{evidence_id}:{at}: private task/chat identifier is forbidden")
         if deny_secrets and SECRET_RE.search(value):
             errors.append(f"{evidence_id}:{at}: secret-looking value is forbidden")

--- a/scripts/public_refs.py
+++ b/scripts/public_refs.py
@@ -1,0 +1,32 @@
+"""Public-safe reference helpers for generated factory artifacts."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+PUBLIC_SAFE_KANBAN_REF = "kanban:<redacted>"
+PRIVATE_KANBAN_TASK_MARKER_PATTERN = r"\bt_(?:[A-Fa-f0-9]{8,}|(?=[A-Za-z0-9_-]*\d)[A-Za-z0-9][A-Za-z0-9_-]{5,})\b"
+PRIVATE_KANBAN_TASK_MARKER_RE = re.compile(PRIVATE_KANBAN_TASK_MARKER_PATTERN)
+PRIVATE_KANBAN_TASK_MARKER_BYTES_RE = re.compile(PRIVATE_KANBAN_TASK_MARKER_PATTERN.encode("ascii"))
+
+
+def public_safe_kanban_ref(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return PRIVATE_KANBAN_TASK_MARKER_RE.sub(PUBLIC_SAFE_KANBAN_REF, value)
+
+
+def contains_private_kanban_task_marker(value: Any) -> bool:
+    return PRIVATE_KANBAN_TASK_MARKER_RE.search(str(value or "")) is not None
+
+
+def sanitize_public_refs(value: Any) -> Any:
+    if isinstance(value, str):
+        return public_safe_kanban_ref(value)
+    if isinstance(value, list):
+        return [sanitize_public_refs(item) for item in value]
+    if isinstance(value, dict):
+        return {key: sanitize_public_refs(item) for key, item in value.items()}
+    return value

--- a/scripts/public_safety_scan.py
+++ b/scripts/public_safety_scan.py
@@ -14,6 +14,16 @@ from pathlib import Path, PurePosixPath
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from public_refs import (  # noqa: E402
+    PRIVATE_KANBAN_TASK_MARKER_BYTES_RE,
+    PRIVATE_KANBAN_TASK_MARKER_RE,
+    PUBLIC_SAFE_KANBAN_REF,
+    public_safe_kanban_ref,
+)
 
 SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico", ".pdf", ".tgz", ".zip"}
 SKIP_PARTS = {".git", ".tmp", ".pytest_cache", ".venv", "__pycache__", "build", "dist", "node_modules", "venv"}
@@ -31,9 +41,8 @@ PATTERN_SPECS = [
     ("private_windows_path", re.compile(r"C:\\\\Users")),
     ("private_sync_root", re.compile(r"OneDrive")),
     ("private_workspace_marker", re.compile(r"felipe-s-workspace")),
-    ("private_task_marker", re.compile(r"\bt_[a-f0-9]{8}\b")),
+    ("private_task_marker", PRIVATE_KANBAN_TASK_MARKER_RE),
     ("private_live_smoke_marker", re.compile(r"\boverkill-factory-live-smoke\b")),
-    ("private_task_marker", re.compile(r"\bHermes task:\s*t_[a-f0-9]{8}\b", re.IGNORECASE)),
     ("private_whimsical_board_marker", re.compile(r"\bWhimsical primary board:\s*[A-Za-z0-9_-]{4,}\b")),
     ("private_whimsical_board_marker", re.compile(r"--board-id\s+(?!<)[A-Za-z0-9_-]{4,}\b")),
 ]
@@ -50,6 +59,10 @@ BYTE_PATTERN_SPECS = [
     ("private_runtime_path", b"/srv/hermes"),
     ("private_workspace_marker", b"felipe-s-workspace"),
     ("private_live_smoke_marker", b"overkill-factory-live-smoke"),
+]
+
+BYTE_REGEX_PATTERN_SPECS = [
+    ("private_task_marker", PRIVATE_KANBAN_TASK_MARKER_BYTES_RE),
 ]
 
 
@@ -127,6 +140,12 @@ def scan_binary(rel: str, data: bytes) -> list[str]:
         if pattern in data:
             findings.append(f"{rel}:binary: {category}")
             break
+    if findings:
+        return findings
+    for category, pattern in BYTE_REGEX_PATTERN_SPECS:
+        if pattern.search(data):
+            findings.append(f"{rel}:binary: {category}")
+            break
     return findings
 
 
@@ -141,6 +160,7 @@ def finding_category(finding: str) -> str:
 def safe_ref(value: str | None) -> str | None:
     if value is None:
         return None
+    value = public_safe_kanban_ref(value)
     for _, pattern in PATTERN_SPECS:
         if pattern.search(value):
             return "redacted-ref"
@@ -165,6 +185,8 @@ def build_summary(findings: list[str], *, git_ref: str | None = None, created_at
             "private_run_evidence": "not_scanned_for_publication",
             "sanitized_report": "allowed_when_raw_private_markers_are_absent",
             "publication_candidate": "fail_closed_on_any_private_marker",
+            "private_kanban_task_ids": f"replace_with_{PUBLIC_SAFE_KANBAN_REF}",
+            "stable_issue_refs": "allowed",
         },
         "forbidden_hits": [
             {"category": category, "count": count}

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -17,6 +17,12 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from public_refs import contains_private_kanban_task_marker  # noqa: E402
+
 SCHEMA_DIR = ROOT / "schemas"
 SCAN_DIRS = [
     ROOT / "examples",
@@ -259,6 +265,7 @@ def validate_node(
 
 def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
     errors: list[str] = []
+    errors.extend(validate_public_ref_hygiene(data, at))
     if data.get("record_type") in RESEARCH_RECORD_TYPES:
         serialized = json.dumps(data, sort_keys=True)
         if PRIVATE_MARKERS.search(serialized):
@@ -446,6 +453,20 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
         for field in required_checks:
             if checks.get(field) is not True:
                 errors.append(f"{at}: discord_control_tower_ux_audit requires {field}=true")
+    return errors
+
+
+def validate_public_ref_hygiene(value: Any, at: str = "$") -> list[str]:
+    errors: list[str] = []
+    if isinstance(value, str):
+        if contains_private_kanban_task_marker(value):
+            errors.append(f"{at}: public artifact must not contain raw Hermes Kanban task id")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            errors.extend(validate_public_ref_hygiene(item, f"{at}[{index}]"))
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            errors.extend(validate_public_ref_hygiene(item, f"{at}.{key}"))
     return errors
 
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -19,6 +19,13 @@ Templates are starter contract files paired with schemas and tests.
 Templates are examples of valid shape. Schemas and validation scripts decide
 whether an artifact is acceptable.
 
+## Public Runtime Refs
+
+Public templates and generated public artifacts must never contain raw Hermes
+Kanban task IDs. Use stable issue refs such as `github-issue-84`, semantic
+artifact refs, or `kanban:<redacted>` when private runtime traceability exists
+only in Hermes.
+
 ## How It Is Validated
 
 Run template and schema checks:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -934,6 +934,40 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("result must be PASS or WAIVED to satisfy a required worker", errors)
         self.assertNotIn("BLOCKED worker result requires recovery_recommendation", errors)
 
+    def test_worker_result_public_card_ref_redacts_raw_kanban_task_markers(self) -> None:
+        card = dict(load_card("v35_valid_security_with_scan.md"))
+        raw_task = "t_" + "ready0001"
+        card["card_id"] = raw_task
+        card["slice_id"] = f"slice-{raw_task}"
+
+        result = factoryctl.build_worker_result(
+            "codex-security",
+            card,
+            result="PASS",
+            tool_or_profile="codex-security:scoped-security-scan",
+            executed_by="codex-security-runner",
+            evidence_refs=["reports/security.md"],
+            blocking_findings=False,
+            findings_summary="No blocking finding.",
+            next_action="continue",
+        )
+        serialized = json.dumps(result)
+
+        self.assertEqual(result["card_ref"]["card_id"], "kanban:<redacted>")
+        self.assertEqual(result["card_ref"]["slice_id"], "slice-kanban:<redacted>")
+        self.assertNotIn(raw_task, serialized)
+
+    def test_artifact_ref_with_raw_kanban_task_marker_is_private(self) -> None:
+        raw_task = "t_" + "ready0001"
+
+        classification = factoryctl.classify_artifact_ref(f"reports/{raw_task}.json")
+        sanitized, redaction = factoryctl.sanitize_public_ref(f"reports/{raw_task}.json")
+
+        self.assertFalse(classification["public_safe"])
+        self.assertEqual(classification["artifact_class"], "private_run_evidence")
+        self.assertEqual(sanitized, "redacted:private-runtime-ref")
+        self.assertIsNotNone(redaction)
+
     def test_real_specialist_result_requires_domain_contract_fields(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md")
         result = worker_result("appsec_owasp_result")

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -15,6 +15,7 @@ MODULE_PATH = ADAPTER_DIR / "live_kanban_adapter.py"
 FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
 TEST_BOARD = "overkill-" + "factory-live-smoke"
 MAIN_TASK_ID = "t_" + "00000001"
+READY_TASK_ID = "t_" + "ready0001"
 sys.path.insert(0, str(ADAPTER_DIR))
 SPEC = importlib.util.spec_from_file_location("live_kanban_adapter", MODULE_PATH)
 assert SPEC is not None
@@ -82,7 +83,7 @@ class FakeDispatchHermes:
                     stdout=json.dumps(
                         [
                             {
-                                "id": "t_ready0001",
+                                "id": READY_TASK_ID,
                                 "assignee": "implementation-worker",
                                 "workspace": private_windows_workspace_ref(),
                             }
@@ -100,7 +101,7 @@ class FakeDispatchHermes:
                     stdout=json.dumps(
                         [
                             {
-                                "id": "t_ready0001",
+                                "id": READY_TASK_ID,
                                 "assignee": "implementation-worker",
                                 "current_run_id": 42,
                                 "worker_pid": 12345,
@@ -114,7 +115,7 @@ class FakeDispatchHermes:
             spawned = (
                 [
                     {
-                        "task_id": "t_ready0001",
+                        "task_id": READY_TASK_ID,
                         "assignee": "implementation-worker",
                         "workspace": private_windows_workspace_ref(),
                     }
@@ -214,7 +215,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         result = adapter.dispatch(args, runner=fake)
 
         self.assertEqual(result["mode"], "dispatch")
-        self.assertEqual(result["spawned"][0]["task_id"], "t_ready0001")
+        self.assertEqual(result["spawned"][0]["task_id"], adapter.PUBLIC_SAFE_KANBAN_REF)
         self.assertEqual(result["spawned"][0]["run_id"], 42)
         self.assertEqual(result["spawned"][0]["worker_pid"], 12345)
         self.assertEqual(result["spawned"][0]["workspace"], "redacted:absolute-hermes-workspace")
@@ -236,7 +237,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         self.assertEqual(len(result["spawned_by_this_command"]), 1)
         spawned = result["spawned_by_this_command"][0]
-        self.assertEqual(spawned["task_id"], "t_ready0001")
+        self.assertEqual(spawned["task_id"], adapter.PUBLIC_SAFE_KANBAN_REF)
         self.assertEqual(spawned["run_id"], 42)
         self.assertEqual(spawned["worker_pid"], 12345)
         self.assertEqual(spawned["dispatch_observation"], "native_dispatch_spawned")
@@ -267,8 +268,9 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             result = adapter.materialize(args, runner=fake)
             ledger_data = json.loads((Path(tmp) / "ledger.json").read_text(encoding="utf-8"))
 
-        self.assertEqual(result["main_task_id"], MAIN_TASK_ID)
+        self.assertEqual(result["main_task_id"], adapter.PUBLIC_SAFE_KANBAN_REF)
         self.assertIn("codex-security", result["worker_task_ids"])
+        self.assertEqual(result["worker_task_ids"]["codex-security"], adapter.PUBLIC_SAFE_KANBAN_REF)
         binding = ledger_data["live_bindings"]["KFP-V35-POS-ONCHAIN-AUDITOR"]
         self.assertEqual(binding["binding_role"], "hermes_ref_projection")
         self.assertEqual(binding["runtime_authority"], "hermes_kanban")
@@ -377,13 +379,21 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 ]
             )
             result = adapter.materialize(args, runner=fake)
+            ledger_data = json.loads(ledger.read_text(encoding="utf-8"))
 
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        review_tasks = [
+            task for task in ledger_data["tasks"].values()
+            if task["worker_id"] == "independent-reviewer" and task["materialization_state"] == "materialized_in_hermes"
+        ]
+        self.assertEqual(len(review_tasks), 1)
+        review_task_id = review_tasks[0]["runtime_refs"]["hermes_task_ref"]
         self.assertEqual(len(unblock_calls), 1)
-        self.assertEqual(unblock_calls[0][5], result["worker_task_ids"]["independent-reviewer"])
+        self.assertEqual(unblock_calls[0][5], review_task_id)
+        self.assertEqual(result["worker_task_ids"]["independent-reviewer"], adapter.PUBLIC_SAFE_KANBAN_REF)
         self.assertEqual(
             result["review_promoted_worker_task_ids"],
-            {"independent-reviewer": result["worker_task_ids"]["independent-reviewer"]},
+            {"independent-reviewer": adapter.PUBLIC_SAFE_KANBAN_REF},
         )
         self.assertNotIn("handoff-packer", result["review_promoted_worker_task_ids"])
 

--- a/tests/test_issue84_local_cockpit_ui.py
+++ b/tests/test_issue84_local_cockpit_ui.py
@@ -10,6 +10,12 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from public_refs import PRIVATE_KANBAN_TASK_MARKER_RE  # noqa: E402
+
 DATA_BUILDER_PATH = ROOT / "scripts" / "issue84" / "build_local_cockpit_data.py"
 FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
 UI_DIR = ROOT / "ui" / "issue-84-local-cockpit"
@@ -49,7 +55,7 @@ def private_marker_patterns() -> list[re.Pattern[str]]:
     return [
         re.compile(re.escape(runtime_root)),
         re.compile(r"file://"),
-        re.compile(r"\bt_[a-f0-9]{8}\b"),
+        PRIVATE_KANBAN_TASK_MARKER_RE,
         re.compile(r"\b" + re.escape(product_marker) + r"\b"),
         re.compile(r"\b" + re.escape(owner_marker) + r"\b"),
         re.compile(re.escape(windows_root)),

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -122,6 +122,21 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         self.assertTrue(any("truth_source_available" in error and "expected const True" in error for error in errors))
         self.assertTrue(any("source_of_truth.freshness" in error and "expected const 'runtime_fresh'" in error for error in errors))
 
+    def test_public_ref_hygiene_blocks_raw_kanban_task_ids_recursively(self) -> None:
+        validator = load_validator()
+        raw_task = "t_" + "ready0001"
+
+        errors = validator.validate_public_ref_hygiene(
+            {"evidence_refs": [{"ref": f"Hermes task {raw_task}"}]},
+            "$",
+        )
+
+        self.assertTrue(any("$.evidence_refs[0].ref" in error for error in errors))
+        self.assertEqual(
+            validator.validate_public_ref_hygiene({"ref": "kanban:<redacted>", "issue": "github-issue-84"}, "$"),
+            [],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_public_safety_scan.py
+++ b/tests/test_public_safety_scan.py
@@ -21,6 +21,8 @@ sys.modules["public_safety_scan"] = public_safety_scan
 SPEC.loader.exec_module(public_safety_scan)
 
 PRIVATE_MARKER = "KA" + "XIS"
+RAW_TASK_MARKER = "t_" + "deadbeefcafebabe"
+RAW_ALPHANUM_TASK_MARKER = "t_" + "ready0001"
 
 
 class PublicSafetyScanTest(unittest.TestCase):
@@ -64,6 +66,34 @@ class PublicSafetyScanTest(unittest.TestCase):
         )
 
         self.assertEqual(findings, [])
+
+    def test_blocks_long_raw_kanban_task_marker(self) -> None:
+        findings = public_safety_scan.scan_text("docs/example.md", f"leaked {RAW_TASK_MARKER}")
+
+        self.assertTrue(findings)
+        self.assertIn("private_task_marker", findings[0])
+
+    def test_blocks_alphanumeric_raw_kanban_task_marker(self) -> None:
+        findings = public_safety_scan.scan_text("docs/example.md", f"leaked {RAW_ALPHANUM_TASK_MARKER}")
+
+        self.assertTrue(findings)
+        self.assertIn("private_task_marker", findings[0])
+
+    def test_blocks_long_raw_kanban_task_marker_in_binary_metadata(self) -> None:
+        findings = public_safety_scan.scan_binary("screenshots/example.png", f"meta {RAW_TASK_MARKER}".encode())
+
+        self.assertTrue(findings)
+        self.assertIn("private_task_marker", findings[0])
+
+    def test_public_safe_kanban_ref_redacts_raw_runtime_ids(self) -> None:
+        self.assertEqual(
+            public_safety_scan.public_safe_kanban_ref(f"Hermes task {RAW_TASK_MARKER}"),
+            "Hermes task kanban:<redacted>",
+        )
+        self.assertEqual(
+            public_safety_scan.scan_text("docs/example.md", "tracked as kanban:<redacted> and github-issue-84"),
+            [],
+        )
 
     def test_allows_canonical_public_repo_url_only_in_metadata_and_blocks_loose_owner_marker(self) -> None:
         owner = "feli" + "pegermano17"
@@ -133,6 +163,17 @@ class PublicSafetyScanTest(unittest.TestCase):
         self.assertEqual(summary["finding_count"], 1)
         self.assertIn("private_product_marker", summary_text)
         self.assertNotIn(PRIVATE_MARKER, summary_text)
+
+    def test_summary_sanitizes_raw_kanban_task_ref_target(self) -> None:
+        summary = public_safety_scan.build_summary(
+            [],
+            git_ref=RAW_TASK_MARKER,
+            created_at="2026-06-10T00:00:00Z",
+        )
+        summary_text = json.dumps(summary)
+
+        self.assertEqual(summary["target"]["ref"], "kanban:<redacted>")
+        self.assertNotIn(RAW_TASK_MARKER, summary_text)
 
     def test_cli_writes_public_safe_summary_for_failing_git_ref_scan(self) -> None:
         original_root = public_safety_scan.ROOT


### PR DESCRIPTION
Closes #155.

## What changed
- Added a shared public ref sanitizer for raw Hermes/Kanban task markers.
- Made `public_safety_scan.py` and `validate_public_json_artifacts.py` fail closed on raw `t_<id>` markers in public artifacts.
- Sanitized public Hermes adapter envelopes while preserving raw IDs inside private Hermes/runtime traceability.
- Sanitized `factoryctl` public refs/card refs and classified raw task-marker refs as private run evidence.
- Reused the canonical scanner in issue-84 public-safety validation paths only; this does not implement or change cockpit scope.

## Validation
- `python -B -m unittest tests.test_public_safety_scan tests.test_public_json_artifact_validator tests.test_factoryctl tests.test_hermes_live_kanban_adapter tests.test_issue84_local_cockpit_ui -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`

## Release preflight note
`python -B scripts\release_integration_preflight.py` is still BLOCKED before merge because it intentionally scans `origin/main`, and `origin/main` does not yet contain this #155 remediation. Worktree and HEAD public-safety scans pass.