### PR TITLE
[codex] Add Hermes-native recovery routes for blocked reviews

### DIFF
--- a/adapters/hermes/transition_hook.py
+++ b/adapters/hermes/transition_hook.py
@@ -130,6 +130,7 @@ def persist_worker_tasks(plan: dict[str, Any], ledger_path: Path) -> dict[str, A
             "status": task.get("status"),
             "packet": task.get("packet"),
             "graph_requirement_refs": task.get("graph_requirement_refs", []),
+            "recovery_route_refs": task.get("recovery_route_refs", []),
             "dependency_authorization_state": task.get("dependency_authorization_state"),
             "review_task_authorizations": task.get("review_task_authorizations", []),
         }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,7 +41,7 @@ factoryctl init --out ../my-product-factory --project-name my-product
 factoryctl validate-card examples/minimal-hermes-project/card.md
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
-factoryctl recovery-plan --card examples/minimal-hermes-project/card.md
+factoryctl recovery-plan --card examples/minimal-hermes-project/card.md --receipt .tmp/receipt.json --worker-results-dir .tmp/worker-results
 factoryctl help-next --card examples/minimal-hermes-project/card.md --out .tmp/factory-help.json
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
@@ -58,9 +58,10 @@ does not replace Hermes, card contracts, gate reports or Receipt Five as the
 source of truth.
 
 `recovery-plan` emits machine-readable recovery routes for blocked factory
-work. It does not execute workers or unblock cards. Recovery work must be
-materialized as native Hermes Kanban tasks, links, comments, runs and
-block/unblock events.
+work. With `--receipt` or `--worker-results-dir`, it also turns `BLOCKED`
+worker/review results into semantic repair routes. It does not execute workers
+or unblock cards. Recovery work must be materialized as native Hermes Kanban
+tasks, links, comments, runs and block/unblock events.
 
 ## Evidence And Truth Commands
 

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -163,6 +163,40 @@
         "additionalProperties": true
       }
     },
+    "recovery_routes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "recovery_route_id",
+          "blocker_type",
+          "factory_owned_repair_allowed",
+          "human_gate_required",
+          "repair_owner_worker",
+          "repair_task_ref",
+          "invalidates_refs",
+          "supersedes_refs",
+          "fresh_review_required",
+          "unblock_authority_ref",
+          "retry_policy",
+          "hermes_materialization"
+        ],
+        "properties": {
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false },
+          "hermes_materialization": {
+            "type": "object",
+            "required": ["runtime_authority", "local_state_authority"],
+            "properties": {
+              "runtime_authority": { "const": "hermes_kanban" },
+              "local_state_authority": { "const": false }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
     "completion_reconciliation": {
       "type": ["object", "null"],
       "additionalProperties": true

--- a/schemas/hermes-worker-ledger.schema.json
+++ b/schemas/hermes-worker-ledger.schema.json
@@ -61,6 +61,10 @@
           "review_task_authorizations": {
             "type": "array",
             "items": { "type": "object", "additionalProperties": true }
+          },
+          "recovery_route_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
           }
         },
         "additionalProperties": true

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3706,7 +3706,202 @@ def recovery_route_from_validation_error(card: dict[str, Any], error: str, index
     )
 
 
-def build_factory_recovery_plan(card: dict[str, Any]) -> dict[str, Any]:
+def recovery_materialization_contract(route_id: str) -> dict[str, Any]:
+    return {
+        "runtime_authority": "hermes_kanban",
+        "native_primitives": [
+            "kanban_task",
+            "parent_link",
+            "blocked_state",
+            "comment_metadata",
+            "run_history",
+            "reclaim_reassign",
+        ],
+        "task_intent": "Create or route a Hermes repair task; do not mutate a local task lifecycle.",
+        "parent_link_policy": (
+            "Repair task remains linked to the blocked parent and downstream work stays blocked until fresh review passes."
+        ),
+        "comments_metadata_policy": (
+            "Store blocker type, invalidation refs, retry attempt and unblock authority in Hermes comments/metadata."
+        ),
+        "local_state_authority": False,
+        "semantic_route_ref": route_id,
+    }
+
+
+def recovery_route_from_recommendation(
+    card: dict[str, Any],
+    *,
+    worker_id: str,
+    field: str,
+    evidence_ref: str | None,
+    recommendation: dict[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    worker = WORKERS.get(worker_id, WORKERS["factory-orchestrator"])
+    card_id = sanitize_slug(card.get("card_id") or "factory-card", fallback="factory-card")
+    route_id = str(recommendation.get("recovery_route_id") or "").strip()
+    if not route_id:
+        route_id = f"recovery:{card_id}:{index}:{sanitize_slug(worker.worker_id, fallback='worker')}"
+    human_gate_required = recommendation.get("human_gate_required") is True
+    blocker_type = str(recommendation.get("blocker_type") or blocker_type_for_worker(worker.worker_id)).strip()
+    audit_refs = ["factoryctl:worker-result-recovery", f"worker:{worker.worker_id}"]
+    if evidence_ref:
+        audit_refs.append(evidence_ref)
+    return {
+        "recovery_route_id": route_id,
+        "blocker_type": blocker_type,
+        "factory_owned_repair_allowed": recommendation.get("factory_owned_repair_allowed") is not False,
+        "human_gate_required": human_gate_required,
+        "repair_owner_worker": str(recommendation.get("repair_owner_worker") or worker.worker_id),
+        "repair_task_ref": str(recommendation.get("repair_task_ref") or f"hermes:intent:{route_id}"),
+        "repair_inputs": string_list(recommendation.get("repair_inputs"))
+        or [
+            f"card:{card_id}",
+            f"blocked-field:{field}",
+            "blocked worker result requires factory-owned repair",
+        ],
+        "expected_repair_outputs": string_list(recommendation.get("expected_repair_outputs")) or [field],
+        "commands_or_worker_routes": string_list(recommendation.get("commands_or_worker_routes"))
+        or [f"route {worker.worker_id} through Hermes Kanban"],
+        "invalidates_refs": string_list(recommendation.get("invalidates_refs"))
+        or [f"worker-result:{field}:blocking-or-stale"],
+        "supersedes_refs": string_list(recommendation.get("supersedes_refs"))
+        or [f"worker-result:{field}:fresh-pass-required"],
+        "dependency_edge_patch": recommendation.get("dependency_edge_patch")
+        if isinstance(recommendation.get("dependency_edge_patch"), dict)
+        else {
+            "old_edges": [f"blocked:{field}"],
+            "new_edges": [f"fresh-review:{field}"],
+            "patch_authority": "fresh review PASS recorded in Hermes before unblock",
+        },
+        "downstream_freeze_scope": string_list(recommendation.get("downstream_freeze_scope"))
+        or ["next worker", "done promotion", "Receipt Five closure"],
+        "fresh_review_required": recommendation.get("fresh_review_required") is not False and not human_gate_required,
+        "fresh_review_result_ref": str(recommendation.get("fresh_review_result_ref") or f"worker-result:{field}:fresh-review"),
+        "unblock_authority_ref": str(
+            recommendation.get("unblock_authority_ref")
+            or ("human_gate_record" if human_gate_required else "Hermes blocked event plus fresh review PASS")
+        ),
+        "retry_policy": recommendation.get("retry_policy")
+        if isinstance(recommendation.get("retry_policy"), dict)
+        else {
+            "max_attempts": 10,
+            "attempt_number": 1,
+            "stop_classes": ["human_gate", "repeated_failed_recovery"],
+        },
+        "audit_trail_refs": audit_refs,
+        "hermes_materialization": recovery_materialization_contract(route_id),
+    }
+
+
+def recovery_routes_from_worker_records(
+    card: dict[str, Any],
+    worker_records: dict[str, dict[str, Any]],
+    *,
+    start_index: int = 1,
+) -> list[dict[str, Any]]:
+    routes: list[dict[str, Any]] = []
+    route_index = start_index
+    requirements_by_id: dict[str, dict[str, Any]] = {}
+    for record in worker_records.values():
+        for requirement in record.get("graph_requirements", []):
+            requirement_id = str(requirement.get("requirement_id") or "").strip()
+            if requirement_id:
+                requirements_by_id[requirement_id] = requirement
+    for field, record in sorted(worker_records.items()):
+        if str(record.get("result") or "").strip().upper() != "BLOCKED":
+            continue
+        recovery = record.get("recovery_recommendation")
+        if not isinstance(recovery, dict):
+            continue
+        matched_requirements = [
+            requirements_by_id[ref]
+            for ref in (
+                string_list(record.get("graph_requirement_refs"))
+                + string_list(record.get("review_requirement_refs"))
+                + string_list(record.get("reviewed_requirement_refs"))
+            )
+            if ref in requirements_by_id
+        ]
+        review_block_routed = False
+        for requirement in matched_requirements:
+            if str(requirement.get("required_review_field") or "") != field:
+                continue
+            producer_field = str(requirement.get("producer_field") or "").strip()
+            producer_worker = _worker_id_for_output_field(producer_field)
+            if not producer_field or not producer_worker:
+                continue
+            requirement_id = str(requirement.get("requirement_id") or "").strip()
+            producer_ref = str(requirement.get("producer_ref") or f"worker-result:{producer_field}").strip()
+            route_id = (
+                f"recovery:{sanitize_slug(card.get('card_id') or 'factory-card', fallback='factory-card')}:"
+                f"review-block:{sanitize_slug(requirement_id, fallback=producer_field)}"
+            )
+            recommendation_override = {
+                **recovery,
+                "blocker_type": blocker_type_for_worker(producer_worker),
+                "factory_owned_repair_allowed": recovery.get("factory_owned_repair_allowed") is not False,
+                "human_gate_required": False,
+                "recovery_route_id": route_id,
+                "repair_owner_worker": producer_worker,
+                "repair_task_ref": f"hermes:intent:{route_id}",
+                "repair_inputs": [
+                    producer_ref,
+                    record.get("evidence_ref") or f"worker-result:{field}:blocked-review",
+                    requirement_id,
+                    str(record.get("findings_summary") or record.get("next_action") or "review blocked the producer handoff"),
+                ],
+                "expected_repair_outputs": [producer_field, field],
+                "invalidates_refs": [producer_ref, f"worker-result:{field}:blocked-review"],
+                "supersedes_refs": [
+                    f"worker-result:{producer_field}:fresh-repair",
+                    f"worker-result:{field}:fresh-review-pass",
+                ],
+                "dependency_edge_patch": {
+                    "old_edges": [requirement_id, f"blocked-review:{field}"],
+                    "new_edges": [f"fresh-repair:{producer_field}", f"fresh-review:{field}:PASS"],
+                    "patch_authority": "fresh reviewer PASS linked to the original graph requirement before downstream unblock",
+                },
+                "downstream_freeze_scope": ["producer consumption", "next worker", "done promotion", "Receipt Five closure"],
+                "fresh_review_required": True,
+                "fresh_review_result_ref": f"worker-result:{field}:fresh-review-pass",
+                "unblock_authority_ref": f"graph-requirement:{requirement_id}:fresh-review-pass",
+            }
+            routes.append(
+                recovery_route_from_recommendation(
+                    card,
+                    worker_id=producer_worker,
+                    field=producer_field,
+                    evidence_ref=producer_ref,
+                    recommendation=recommendation_override,
+                    index=route_index,
+                )
+            )
+            route_index += 1
+            review_block_routed = True
+        if review_block_routed:
+            continue
+        worker_id = _worker_id_for_output_field(field) or str(recovery.get("repair_owner_worker") or "factory-orchestrator")
+        routes.append(
+            recovery_route_from_recommendation(
+                card,
+                worker_id=worker_id,
+                field=field,
+                evidence_ref=record.get("evidence_ref"),
+                recommendation=recovery,
+                index=route_index,
+            )
+        )
+        route_index += 1
+    return routes
+
+
+def build_factory_recovery_plan(
+    card: dict[str, Any],
+    worker_results_dir: Path | None = None,
+    receipt: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     report = build_gate_report(card)
     routes: list[dict[str, Any]] = []
     route_index = 1
@@ -3719,13 +3914,26 @@ def build_factory_recovery_plan(card: dict[str, Any]) -> dict[str, Any]:
                 continue
             routes.append(recovery_route_from_action(card, action, route_index))
             route_index += 1
+    worker_completion = (
+        build_worker_closure(card, receipt or {}, worker_results_dir)
+        if worker_results_dir is not None or receipt is not None
+        else None
+    )
+    worker_routes = list(worker_completion.get("recovery_routes", [])) if worker_completion else []
+    routes.extend(worker_routes)
+    blocked_worker_ids = list(report.get("blocked_workers", []))
+    for route in worker_routes:
+        worker_id = str(route.get("repair_owner_worker") or "").strip()
+        if worker_id and worker_id not in blocked_worker_ids:
+            blocked_worker_ids.append(worker_id)
+    gate_predicate_result = "BLOCK" if routes else report.get("gate_predicate_result")
     return {
         "$schema": "https://overkill-factory.dev/schemas/factory-recovery-plan.schema.json",
         "record_type": "factory_recovery_plan",
         "created_at": utc_now(),
         "card_id": report.get("card_id"),
-        "gate_predicate_result": report.get("gate_predicate_result"),
-        "blocked_workers": report.get("blocked_workers", []),
+        "gate_predicate_result": gate_predicate_result,
+        "blocked_workers": blocked_worker_ids,
         "next_safe_actions": report.get("next_safe_actions", []),
         "recovery_routes": routes,
         "hermes_runtime_boundary": {
@@ -4098,6 +4306,8 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             "evidence_ref": evidence_ref,
             "created_at": data.get("created_at") or data.get("decision_at"),
             "result": data.get("result") or data.get("decision"),
+            "findings_summary": data.get("findings_summary"),
+            "next_action": data.get("next_action"),
             "active": authority.get("active", data.get("active", True)) is not False and not data.get("superseded_by"),
             "valid": not errors,
             "consumable": not errors,
@@ -4111,6 +4321,9 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             "review_task_authorizations": [
                 item for item in data.get("review_task_authorizations", []) if isinstance(item, dict)
             ],
+            "recovery_recommendation": data.get("recovery_recommendation")
+            if isinstance(data.get("recovery_recommendation"), dict)
+            else None,
             "validation_errors": errors,
         }
         apply_record_consumption_state(record)
@@ -4156,6 +4369,8 @@ def receipt_result_fields(
             record = {
                 "evidence_ref": None,
                 "result": value.get("result") or value.get("decision"),
+                "findings_summary": value.get("findings_summary"),
+                "next_action": value.get("next_action"),
                 "valid": not errors,
                 "consumable": not errors,
                 "review_declared": review_declared,
@@ -4168,6 +4383,9 @@ def receipt_result_fields(
                 "review_task_authorizations": [
                     item for item in value.get("review_task_authorizations", []) if isinstance(item, dict)
                 ],
+                "recovery_recommendation": value.get("recovery_recommendation")
+                if isinstance(value.get("recovery_recommendation"), dict)
+                else None,
                 "validation_errors": errors,
             }
             apply_record_consumption_state(record)
@@ -4455,6 +4673,39 @@ def attach_graph_requirement_tasks(
         tasks_by_worker[worker_id] = task
 
 
+def attach_recovery_routes_to_tasks(
+    worker_tasks: list[dict[str, Any]],
+    recovery_routes: list[dict[str, Any]],
+    card: dict[str, Any],
+    source_path: Path,
+) -> None:
+    tasks_by_worker = {str(task.get("worker_id") or ""): task for task in worker_tasks}
+    for route in recovery_routes:
+        worker_id = str(route.get("repair_owner_worker") or "").strip()
+        if worker_id not in WORKERS:
+            continue
+        task = tasks_by_worker.get(worker_id)
+        if task is None:
+            task = build_worker_task(worker_id, card, source_path)
+            worker_tasks.append(task)
+            tasks_by_worker[worker_id] = task
+        route_id = str(route.get("recovery_route_id") or "").strip()
+        refs = list(task.get("recovery_route_refs") or [])
+        if route_id and route_id not in refs:
+            refs.append(route_id)
+        task["recovery_route_refs"] = refs
+        packet = task.get("packet") if isinstance(task.get("packet"), dict) else {}
+        packet["recovery_route_refs"] = refs
+        input_contract = dict(packet.get("input_contract") or {})
+        route_payloads = [item for item in input_contract.get("recovery_routes", []) if isinstance(item, dict)]
+        if route not in route_payloads:
+            route_payloads.append(route)
+        input_contract["recovery_routes"] = route_payloads
+        input_contract["recovery_route_refs"] = refs
+        packet["input_contract"] = input_contract
+        task["packet"] = packet
+
+
 def _worker_record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
     return (
         str(record.get("created_at") or ""),
@@ -4532,6 +4783,7 @@ def build_worker_closure(
     unsatisfied_graph_requirements = [
         requirement for requirement in graph_requirements if requirement.get("status") != "satisfied"
     ]
+    recovery_routes = recovery_routes_from_worker_records(card, present_fields)
 
     return {
         "closure_type": "worker_result_reconciliation",
@@ -4541,6 +4793,7 @@ def build_worker_closure(
         "unconsumable_blocking_workers": unconsumable_blocking,
         "graph_requirements": graph_requirements,
         "unsatisfied_graph_requirements": unsatisfied_graph_requirements,
+        "recovery_routes": recovery_routes,
         "workers": rows,
     }
 
@@ -4593,6 +4846,7 @@ def build_transition_plan(
     unsatisfied_graph_requirements = (
         graph_completion.get("unsatisfied_graph_requirements", []) if graph_completion else []
     )
+    recovery_routes = graph_completion.get("recovery_routes", []) if graph_completion else []
     review_ready_handoffs: list[dict[str, Any]] = []
     review_task_authorizations: list[dict[str, Any]] = []
     if graph_completion:
@@ -4615,6 +4869,8 @@ def build_transition_plan(
             review_task_authorizations.extend(row_authorizations)
     if graph_requirements:
         attach_graph_requirement_tasks(worker_tasks, graph_requirements, card, source_path)
+    if recovery_routes:
+        attach_recovery_routes_to_tasks(worker_tasks, recovery_routes, card, source_path)
 
     def append_unsatisfied_graph_requirement_blocks() -> None:
         for requirement in unsatisfied_graph_requirements:
@@ -4730,6 +4986,7 @@ def build_transition_plan(
         "gate_report": gate,
         "worker_tasks": worker_tasks,
         "graph_requirements": graph_requirements,
+        "recovery_routes": recovery_routes,
         "review_ready_handoffs": review_ready_handoffs,
         "review_task_authorizations": review_task_authorizations,
         "completion_reconciliation": completion,
@@ -6123,13 +6380,15 @@ def command_gate_report(args: argparse.Namespace) -> int:
 
 
 def command_unblock_plan(args: argparse.Namespace) -> int:
-    plan = build_factory_recovery_plan(load_json_like(args.card))
+    receipt = load_json_like(args.receipt) if args.receipt else None
+    plan = build_factory_recovery_plan(load_json_like(args.card), worker_results_dir=args.worker_results_dir, receipt=receipt)
     write_json(args.out, plan)
     return 1 if plan.get("gate_predicate_result") == "BLOCK" else 0
 
 
 def command_recovery_plan(args: argparse.Namespace) -> int:
-    plan = build_factory_recovery_plan(load_json_like(args.card))
+    receipt = load_json_like(args.receipt) if args.receipt else None
+    plan = build_factory_recovery_plan(load_json_like(args.card), worker_results_dir=args.worker_results_dir, receipt=receipt)
     write_json(args.out, plan)
     return 1 if plan.get("gate_predicate_result") == "BLOCK" else 0
 
@@ -6402,11 +6661,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     unblock_plan_parser = sub.add_parser("unblock-plan")
     unblock_plan_parser.add_argument("--card", type=Path, required=True)
+    unblock_plan_parser.add_argument("--receipt", type=Path)
+    unblock_plan_parser.add_argument("--worker-results-dir", type=Path)
     unblock_plan_parser.add_argument("--out", type=Path)
     unblock_plan_parser.set_defaults(func=command_unblock_plan)
 
     recovery_plan_parser = sub.add_parser("recovery-plan", help="Emit semantic recovery routes without replacing Hermes runtime state.")
     recovery_plan_parser.add_argument("--card", type=Path, required=True)
+    recovery_plan_parser.add_argument("--receipt", type=Path)
+    recovery_plan_parser.add_argument("--worker-results-dir", type=Path)
     recovery_plan_parser.add_argument("--out", type=Path)
     recovery_plan_parser.set_defaults(func=command_recovery_plan)
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1202,6 +1202,156 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_dispatcher"])
         self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_dependency_engine"])
 
+    def test_recovery_plan_routes_blocked_review_back_to_handoff_producer(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmpdir:
+            results_dir = Path(tmpdir)
+            handoff_path = results_dir / "handoff.json"
+            review_path = results_dir / "review.json"
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]
+            blocked_review = factoryctl.build_worker_result(
+                "independent-reviewer",
+                card,
+                result="BLOCKED",
+                tool_or_profile="independent-review-smoke",
+                executed_by="independent-reviewer",
+                evidence_refs=["README.md"],
+                blocking_findings=True,
+                findings_summary="Review found the handoff packet incomplete.",
+                next_action="repair handoff packet and rerun independent review",
+                evidence_kind="synthetic",
+                reusable_for_product=False,
+            )
+            blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+            review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
+
+            plan = factoryctl.build_factory_recovery_plan(card, worker_results_dir=results_dir)
+
+        self.assertEqual(plan["gate_predicate_result"], "BLOCK")
+        route = plan["recovery_routes"][0]
+        self.assertEqual(route["repair_owner_worker"], "handoff-packer")
+        self.assertEqual(route["blocker_type"], "dependency")
+        self.assertTrue(route["fresh_review_required"])
+        self.assertIn("handoff_packet_result", route["expected_repair_outputs"])
+        self.assertIn("independent_review_result", route["expected_repair_outputs"])
+        self.assertIn(requirement["requirement_id"], route["dependency_edge_patch"]["old_edges"])
+        self.assertEqual(route["hermes_materialization"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(route["hermes_materialization"]["local_state_authority"])
+
+    def test_recovery_plan_reads_blocked_review_from_receipt_metadata(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+        requirement = factoryctl.declared_graph_requirements(
+            "handoff_packet_result",
+            handoff,
+            evidence_ref="receipt:handoff_packet_result",
+        )[0]
+        blocked_review = factoryctl.build_worker_result(
+            "independent-reviewer",
+            card,
+            result="BLOCKED",
+            tool_or_profile="independent-review-smoke",
+            executed_by="independent-reviewer",
+            evidence_refs=["README.md"],
+            blocking_findings=True,
+            findings_summary="Review found the inline handoff packet incomplete.",
+            next_action="repair handoff packet and rerun independent review",
+            evidence_kind="synthetic",
+            reusable_for_product=False,
+        )
+        blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+
+        plan = factoryctl.build_factory_recovery_plan(
+            card,
+            receipt={
+                "handoff_packet_result": handoff,
+                "independent_review_result": blocked_review,
+            },
+        )
+
+        route = plan["recovery_routes"][0]
+        self.assertEqual(plan["gate_predicate_result"], "BLOCK")
+        self.assertEqual(route["repair_owner_worker"], "handoff-packer")
+        self.assertIn("receipt:handoff_packet_result", route["invalidates_refs"])
+
+    def test_transition_plan_attaches_recovery_route_to_repair_worker_task(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmpdir:
+            results_dir = Path(tmpdir)
+            handoff_path = results_dir / "handoff.json"
+            review_path = results_dir / "review.json"
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]
+            blocked_review = factoryctl.build_worker_result(
+                "independent-reviewer",
+                card,
+                result="BLOCKED",
+                tool_or_profile="independent-review-smoke",
+                executed_by="independent-reviewer",
+                evidence_refs=["README.md"],
+                blocking_findings=True,
+                findings_summary="Review found the handoff packet incomplete.",
+                next_action="repair handoff packet and rerun independent review",
+                evidence_kind="synthetic",
+                reusable_for_product=False,
+            )
+            blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+            review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
+
+            plan = factoryctl.build_transition_plan(
+                card,
+                card_path,
+                from_status="review",
+                to_status="done",
+                receipt={
+                    "receipt_five": {
+                        "changed": "fixture",
+                        "artifact_paths": ["README.md"],
+                        "verification_commands": ["fixture"],
+                        "verification_result": "PASS",
+                        "reviewer_required": True,
+                        "reviewer_result": "BLOCKED",
+                        "next_action": "repair",
+                    },
+                    "kanban_transition_event": {
+                        "from_status": "review",
+                        "to_status": "done",
+                        "actor": "factory-orchestrator",
+                        "worker": "factory-orchestrator",
+                        "receipt_refs": ["receipt_five"],
+                        "artifact_refs": ["README.md"],
+                        "allowed": True,
+                    },
+                },
+                worker_results_dir=results_dir,
+            )
+
+        self.assertEqual(plan["transition_action"], "block_transition")
+        self.assertTrue(plan["recovery_routes"])
+        route_id = plan["recovery_routes"][0]["recovery_route_id"]
+        repair_task = next(task for task in plan["worker_tasks"] if task["worker_id"] == "handoff-packer")
+        self.assertIn(route_id, repair_task["recovery_route_refs"])
+        self.assertIn(route_id, repair_task["packet"]["input_contract"]["recovery_route_refs"])
+        self.assertEqual(repair_task["packet"]["input_contract"]["recovery_routes"][0]["repair_owner_worker"], "handoff-packer")
+        self.assertTrue(any("requires independent-reviewer PASS" in reason for reason in plan["blocked_reasons"]))
+
     def test_hermes_schemas_allow_before_ready_block_action(self) -> None:
         action = "block_and_create_before_ready_tasks"
         transition_plan_schema = json.loads((ROOT / "schemas" / "hermes-transition-plan.schema.json").read_text(encoding="utf-8"))

--- a/tests/test_hermes_transition_hook.py
+++ b/tests/test_hermes_transition_hook.py
@@ -208,6 +208,69 @@ class HermesTransitionHookTest(unittest.TestCase):
         self.assertEqual(task["dependency_authorization_state"], "review_ready")
         self.assertEqual(task["review_task_authorizations"][0]["authorized_scope"], ["review"])
 
+    def test_hook_persists_recovery_routes_from_blocked_review_results(self) -> None:
+        factoryctl = transition_hook.load_factoryctl()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        card_data["source_refs"] = [*card_data.get("source_refs", []), "synthetic validation fixture"]
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="independent review required before implementation consumption",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            tmp_path = Path(tmp)
+            results_dir = tmp_path / "worker-results"
+            results_dir.mkdir()
+            handoff_path = results_dir / "handoff.json"
+            review_path = results_dir / "review.json"
+            ledger = tmp_path / "worker-ledger.json"
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]
+            blocked_review = factoryctl.build_worker_result(
+                "independent-reviewer",
+                card_data,
+                result="BLOCKED",
+                tool_or_profile="independent-review-smoke",
+                executed_by="independent-reviewer",
+                evidence_refs=["README.md"],
+                blocking_findings=True,
+                findings_summary="Review found the handoff packet incomplete.",
+                next_action="repair handoff packet and rerun independent review",
+                reusable_for_product=False,
+            )
+            blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+            review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
+
+            result = transition_hook.build_hook_result(
+                card_path=card,
+                from_status="draft",
+                to_status="ready",
+                receipt_path=None,
+                worker_results_dir=results_dir,
+                ledger_path=ledger,
+            )
+            ledger_data = json.loads(ledger.read_text(encoding="utf-8"))
+
+        self.assertTrue(result["plan"]["recovery_routes"])
+        route_id = result["plan"]["recovery_routes"][0]["recovery_route_id"]
+        task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "handoff-packer")
+        self.assertIn(route_id, task["recovery_route_refs"])
+        self.assertIn(route_id, task["packet"]["input_contract"]["recovery_route_refs"])
+
     def test_cli_is_fail_closed_for_before_ready_blocks(self) -> None:
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:


### PR DESCRIPTION
Relates to #134. This is an incremental #134 PR; it does not close the issue yet.

## What changed
- `factoryctl recovery-plan` / `unblock-plan` can now read `--receipt` and `--worker-results-dir`.
- `BLOCKED` worker/review results with `recovery_recommendation` now become Hermes-native semantic `recovery_routes`.
- A blocked independent review linked to a `review_before_consumption` graph requirement is routed back to the original producer worker, not treated as generic reviewer work.
- `transition-plan` carries `recovery_routes` and attaches `recovery_route_refs` plus route payloads to the repair worker packet.
- Hermes transition hook persists `recovery_route_refs` into the projection ledger while keeping Hermes as runtime authority.
- Schemas document recovery routes in transition plans and ledger projections.

## Why this matters
Before this, the Factory could produce a machine-readable `recovery_recommendation`, but `recovery-plan` mostly came from gate-report/card blockers. A real post-review `BLOCKED` worker result could still require the operator to translate the failed review into a producer repair route. This PR removes that manual interpretation step without creating a shadow scheduler, dispatcher, queue, dependency engine, or local runtime authority.

## Boundaries
- No Product Face/cockpit work.
- No worker execution, gate approval, release approval, GitHub mutation approval, deployment, mainnet, secrets or funds approval.
- Recovery remains semantic until Hermes materializes the repair task/link/comment/run.

## Validation
- `python -B -m unittest discover -s tests -p "test_*.py" -q` (409 tests)
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\release_integration_preflight.py`

## Still remaining for #134
- Live adapter materialization of recovery repair tasks through native Hermes task/link/comment primitives.
- Fresh review PASS readback and exact next-worker unblock by Hermes evidence.
- Retry attempt derivation from Hermes history rather than local counters.