### PR TITLE
[codex] Materialize recovery repair routes in Hermes adapter

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -129,6 +129,26 @@ The done transition is therefore a reconciliation gate. A worker packet is not
 evidence. A PASS result without artifact refs is not enough. A human gate
 without a real decision record is not approval.
 
+## Live Materialization
+
+The live adapter can materialize the transition plan into Hermes tasks:
+
+```bash
+python adapters/hermes/live_kanban_adapter.py materialize \
+  --card path/to/card.md \
+  --board overkill-factory-live \
+  --ledger path/to/worker-ledger.json \
+  --receipt path/to/receipt-five.json \
+  --worker-results-dir path/to/worker-results \
+  --route-readiness path/to/route-readiness.json
+```
+
+When a `BLOCKED` review produces a factory-owned `recovery_route`, the adapter
+unblocks only the repair worker task authorized by that route. Downstream work
+stays blocked until a fresh review result provides the stated unblock
+authority. The adapter verifies Hermes readback after block/unblock operations;
+it does not keep a parallel lifecycle state.
+
 ## Dispatch Reporting
 
 Hermes owns dispatch. The adapter does not schedule workers itself, but it can

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -248,6 +248,15 @@ def task_has_blocked_event(payload: dict[str, Any]) -> bool:
     return False
 
 
+def task_has_unblocked_event(payload: dict[str, Any]) -> bool:
+    if str(payload.get("status") or "").strip().lower() == "blocked":
+        return False
+    events = payload.get("events") or payload.get("history") or payload.get("timeline") or []
+    if isinstance(events, list):
+        return any("unblock" in str(event).lower() for event in events)
+    return False
+
+
 def ensure_blocked_event(
     *,
     hermes_bin: str,
@@ -278,6 +287,13 @@ def unblock_task(
     runner: Runner = default_runner,
 ) -> None:
     run_checked(hermes_kanban(hermes_bin, board, "unblock", task_id, reason), runner)
+    shown = run_checked(hermes_kanban(hermes_bin, board, "show", task_id, "--json"), runner)
+    try:
+        payload = json.loads(shown.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Hermes show --json did not return JSON while verifying unblock event") from exc
+    if not isinstance(payload, dict) or not task_has_unblocked_event(payload):
+        raise RuntimeError(f"Hermes task {task_id} is not durably unblocked after unblock command")
 
 
 def record_live_binding(
@@ -416,7 +432,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         from_status=args.from_status,
         to_status=args.to_status,
         receipt_path=args.receipt,
-        worker_results_dir=None,
+        worker_results_dir=args.worker_results_dir,
         ledger_path=ledger_path,
     )
     plan = result["plan"]
@@ -472,6 +488,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
     )
     worker_task_ids: dict[str, str] = {}
     review_promoted_worker_task_ids: dict[str, str] = {}
+    recovery_promoted_worker_task_ids: dict[str, str] = {}
     for task in plan.get("worker_tasks", []):
         worker_id = str(task.get("worker_id") or "").strip()
         if not worker_id or task.get("status") == "not_required_by_current_card":
@@ -511,6 +528,30 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 runner=runner,
             )
             review_promoted_worker_task_ids[worker_id] = task_id
+        recovery_routes = [
+            route
+            for route in (packet.get("input_contract") or {}).get("recovery_routes", [])
+            if isinstance(route, dict)
+        ]
+        recovery_authorized = any(
+            route.get("factory_owned_repair_allowed") is True and route.get("human_gate_required") is False
+            for route in recovery_routes
+        )
+        if recovery_authorized and not args.worker_ready:
+            route = recovery_routes[0]
+            route_id = str(route.get("recovery_route_id") or "factory-recovery-route")
+            fresh_review_ref = str(route.get("fresh_review_result_ref") or "fresh-review-required")
+            unblock_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=task_id,
+                reason=(
+                    "Factory-owned recovery route authorized repair task "
+                    f"{route_id}; downstream remains gated until {fresh_review_ref} passes."
+                ),
+                runner=runner,
+            )
+            recovery_promoted_worker_task_ids[worker_id] = task_id
 
     record_live_binding(
         ledger_path=ledger_path,
@@ -529,6 +570,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         "main_task_id": main_task_id,
         "worker_task_ids": worker_task_ids,
         "review_promoted_worker_task_ids": review_promoted_worker_task_ids,
+        "recovery_promoted_worker_task_ids": recovery_promoted_worker_task_ids,
         "hook": result,
     }
     public_envelope = sanitize_public_refs(envelope)
@@ -706,6 +748,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_mat.add_argument("--board", required=True)
     p_mat.add_argument("--ledger", type=Path, required=True)
     p_mat.add_argument("--receipt", type=Path)
+    p_mat.add_argument("--worker-results-dir", type=Path)
     p_mat.add_argument("--from-status", default="blocked")
     p_mat.add_argument("--to-status", default="ready")
     p_mat.add_argument("--hermes-bin", default="hermes")

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -51,6 +51,10 @@
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 3 }
     },
+    "recovery_promoted_worker_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
     "hook": {
       "type": "object"
     }

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -35,6 +35,7 @@ class FakeHermes:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
         self.counter = 0
+        self.tasks: dict[str, dict[str, object]] = {}
 
     def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(argv)
@@ -45,18 +46,22 @@ class FakeHermes:
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "create":
             self.counter += 1
             task_id = "t_" + f"{self.counter:08x}"
+            initial_status = "blocked" if "--initial-status" in argv and "blocked" in argv else "ready"
+            self.tasks[task_id] = {"status": initial_status, "events": []}
             return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
         if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "block":
+            task = self.tasks.setdefault(argv[5], {"status": "ready", "events": []})
+            task["status"] = "blocked"
+            task.setdefault("events", []).append({"type": "blocked", "reason": argv[6]})
             return subprocess.CompletedProcess(argv, 0, stdout='{"status":"blocked"}', stderr="")
         if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "unblock":
+            task = self.tasks.setdefault(argv[5], {"status": "blocked", "events": []})
+            task["status"] = "ready"
+            task.setdefault("events", []).append({"type": "unblocked", "reason": argv[6]})
             return subprocess.CompletedProcess(argv, 0, stdout='{"status":"ready"}', stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
-            return subprocess.CompletedProcess(
-                argv,
-                0,
-                stdout='{"status":"blocked","events":[{"type":"blocked","reason":"gate"}]}',
-                stderr="",
-            )
+            payload = self.tasks.get(argv[5], {"status": "blocked", "events": [{"type": "blocked", "reason": "gate"}]})
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "link":
             return subprocess.CompletedProcess(argv, 0, stdout="linked", stderr="")
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected command")
@@ -396,6 +401,80 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             {"independent-reviewer": adapter.PUBLIC_SAFE_KANBAN_REF},
         )
         self.assertNotIn("handoff-packer", result["review_promoted_worker_task_ids"])
+
+    def test_materialize_promotes_factory_owned_recovery_repair_task(self) -> None:
+        fake = FakeHermes()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="continue after review",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            readiness = tmp_path / "route-readiness.json"
+            worker_results = tmp_path / "worker-results"
+            worker_results.mkdir()
+            ledger = tmp_path / "ledger.json"
+            handoff_path = worker_results / "handoff.json"
+            review_path = worker_results / "review.json"
+            write_route_readiness(readiness)
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]
+            blocked_review = factoryctl.build_worker_result(
+                "independent-reviewer",
+                card_data,
+                result="BLOCKED",
+                tool_or_profile="independent-review-smoke",
+                executed_by="independent-reviewer",
+                evidence_refs=["README.md"],
+                blocking_findings=True,
+                findings_summary="Review found the handoff packet incomplete.",
+                next_action="repair handoff packet and rerun independent review",
+                reusable_for_product=False,
+            )
+            blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+            review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize",
+                    "--card",
+                    str(card),
+                    "--board",
+                    TEST_BOARD,
+                    "--ledger",
+                    str(ledger),
+                    "--worker-results-dir",
+                    str(worker_results),
+                    "--route-readiness",
+                    str(readiness),
+                ]
+            )
+            result = adapter.materialize(args, runner=fake)
+            ledger_data = json.loads(ledger.read_text(encoding="utf-8"))
+
+        self.assertEqual(result["recovery_promoted_worker_task_ids"], {"handoff-packer": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertEqual(result["review_promoted_worker_task_ids"], {"independent-reviewer": adapter.PUBLIC_SAFE_KANBAN_REF})
+        handoff_task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "handoff-packer")
+        handoff_task_id = handoff_task["runtime_refs"]["hermes_task_ref"]
+        self.assertTrue(handoff_task["recovery_route_refs"])
+        self.assertEqual(fake.tasks[handoff_task_id]["status"], "ready")
+        self.assertEqual(fake.tasks[MAIN_TASK_ID]["status"], "blocked")
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertTrue(any(call[5] == handoff_task_id and "downstream remains gated" in call[6] for call in unblock_calls))
 
     def test_materialize_dry_run_does_not_call_hermes_create(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
Relates to #134. Does not close it.

## What changed
- `materialize` now reads `--worker-results-dir` so Hermes live materialization can see recovery routes emitted by worker results.
- The live Hermes adapter promotes only factory-owned, non-human recovery repair tasks back to `ready`.
- The original/downstream card remains blocked until the fresh review path passes.
- `unblock` now performs a Hermes `show --json` readback and fails if the durable unblock event is not present.
- The adapter envelope schema and Hermes adapter docs now expose `recovery_promoted_worker_task_ids`.

## Why
#134 is about making the factory behave like deterministic gears: if work is blocked and the block is factory-owned, the system must route repair back into Hermes instead of leaving a manual dead end or inventing a parallel lifecycle state.

This PR closes the next live-runtime gap after the recovery-route contract work: the route is now materialized into Hermes by unblocking only the authorized repair task, while keeping the parent flow gated behind fresh review evidence.

## Validation
- `python -B -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q` (410 tests)
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\release_integration_preflight.py`

## Remaining for #134
- After a fresh PASS review, unblock the exact next worker through Hermes rather than relying on broad card-level readiness.
- Derive retry attempt count and loop history from Hermes task events so repair loops are bounded, auditable, and not local-shadow state.