### PR TITLE
[codex] Authorize exact downstream unblocks after fresh review

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -149,6 +149,14 @@ stays blocked until a fresh review result provides the stated unblock
 authority. The adapter verifies Hermes readback after block/unblock operations;
 it does not keep a parallel lifecycle state.
 
+When that fresh review records a matching `PASS`, the adapter can reopen only
+the explicitly authorized downstream worker ids from the transition plan. This
+is not a broad card approval: satisfied producer/reviewer tasks stay closed for
+execution purposes, `human-gate-clerk` stays blocked until real human evidence
+exists, and the main card remains blocked until the normal completion gate
+passes. Without `downstream_task_authorizations`, no downstream worker is
+unblocked.
+
 ## Dispatch Reporting
 
 Hermes owns dispatch. The adapter does not schedule workers itself, but it can

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -257,6 +257,59 @@ def task_has_unblocked_event(payload: dict[str, Any]) -> bool:
     return False
 
 
+def worker_satisfied_by_reconciliation(plan: dict[str, Any], worker_id: str) -> bool:
+    reconciliation = plan.get("completion_reconciliation")
+    if not isinstance(reconciliation, dict):
+        return False
+    workers = reconciliation.get("workers")
+    if not isinstance(workers, dict):
+        return False
+    row = workers.get(worker_id)
+    return isinstance(row, dict) and row.get("satisfied") is True
+
+
+def downstream_authorizations_by_worker(plan: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    by_worker: dict[str, list[dict[str, Any]]] = {}
+    for authorization in plan.get("downstream_task_authorizations") or []:
+        if not isinstance(authorization, dict):
+            continue
+        if (
+            authorization.get("authorization_type") != "fresh_review_downstream_task"
+            or authorization.get("authorization_state") != "worker_task_ready"
+            or authorization.get("runtime_authority") != "hermes_kanban"
+            or authorization.get("local_state_authority") is not False
+        ):
+            continue
+        for worker_id in authorization.get("authorized_worker_ids") or []:
+            worker_id = str(worker_id or "").strip()
+            if worker_id and worker_id != "human-gate-clerk":
+                by_worker.setdefault(worker_id, []).append(authorization)
+    return by_worker
+
+
+def downstream_worker_ready_after_fresh_review(
+    plan: dict[str, Any],
+    task: dict[str, Any],
+    authorizations: dict[str, list[dict[str, Any]]],
+) -> bool:
+    if plan.get("transition_action") != "allow_and_create_worker_tasks":
+        return False
+    worker_id = str(task.get("worker_id") or "").strip()
+    if not worker_id or worker_id == "human-gate-clerk":
+        return False
+    if worker_id not in authorizations:
+        return False
+    if task.get("status") != "requires_execution":
+        return False
+    if task.get("required_before") != "done":
+        return False
+    if task.get("dependency_authorization_state") == "review_ready":
+        return False
+    if worker_satisfied_by_reconciliation(plan, worker_id):
+        return False
+    return True
+
+
 def ensure_blocked_event(
     *,
     hermes_bin: str,
@@ -489,6 +542,8 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
     worker_task_ids: dict[str, str] = {}
     review_promoted_worker_task_ids: dict[str, str] = {}
     recovery_promoted_worker_task_ids: dict[str, str] = {}
+    downstream_promoted_worker_task_ids: dict[str, str] = {}
+    downstream_authorizations = downstream_authorizations_by_worker(plan)
     for task in plan.get("worker_tasks", []):
         worker_id = str(task.get("worker_id") or "").strip()
         if not worker_id or task.get("status") == "not_required_by_current_card":
@@ -533,12 +588,14 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
             for route in (packet.get("input_contract") or {}).get("recovery_routes", [])
             if isinstance(route, dict)
         ]
-        recovery_authorized = any(
-            route.get("factory_owned_repair_allowed") is True and route.get("human_gate_required") is False
+        authorized_recovery_routes = [
+            route
             for route in recovery_routes
-        )
+            if route.get("factory_owned_repair_allowed") is True and route.get("human_gate_required") is False
+        ]
+        recovery_authorized = bool(authorized_recovery_routes)
         if recovery_authorized and not args.worker_ready:
-            route = recovery_routes[0]
+            route = authorized_recovery_routes[0]
             route_id = str(route.get("recovery_route_id") or "factory-recovery-route")
             fresh_review_ref = str(route.get("fresh_review_result_ref") or "fresh-review-required")
             unblock_task(
@@ -552,6 +609,35 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 runner=runner,
             )
             recovery_promoted_worker_task_ids[worker_id] = task_id
+        downstream_authorized = (
+            downstream_worker_ready_after_fresh_review(plan, task, downstream_authorizations)
+            and worker_id not in review_promoted_worker_task_ids
+            and worker_id not in recovery_promoted_worker_task_ids
+        )
+        if downstream_authorized and not args.worker_ready:
+            auths = downstream_authorizations[worker_id]
+            requirement_ids = [
+                str(auth.get("requirement_id") or "").strip()
+                for auth in auths
+                if str(auth.get("requirement_id") or "").strip()
+            ]
+            review_refs = [
+                str(auth.get("review_evidence_ref") or "").strip()
+                for auth in auths
+                if str(auth.get("review_evidence_ref") or "").strip()
+            ]
+            unblock_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=task_id,
+                reason=(
+                    "Fresh PASS review authorized exact downstream worker "
+                    f"{worker_id}; requirement(s): {', '.join(requirement_ids)}; "
+                    f"review ref(s): {', '.join(review_refs)}; main gate remains blocked."
+                ),
+                runner=runner,
+            )
+            downstream_promoted_worker_task_ids[worker_id] = task_id
 
     record_live_binding(
         ledger_path=ledger_path,
@@ -571,6 +657,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         "worker_task_ids": worker_task_ids,
         "review_promoted_worker_task_ids": review_promoted_worker_task_ids,
         "recovery_promoted_worker_task_ids": recovery_promoted_worker_task_ids,
+        "downstream_promoted_worker_task_ids": downstream_promoted_worker_task_ids,
         "hook": result,
     }
     public_envelope = sanitize_public_refs(envelope)

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -55,6 +55,10 @@
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 3 }
     },
+    "downstream_promoted_worker_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
     "hook": {
       "type": "object"
     }

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -163,6 +163,38 @@
         "additionalProperties": true
       }
     },
+    "downstream_task_authorizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "authorization_type",
+          "authorization_state",
+          "requirement_id",
+          "review_evidence_ref",
+          "authorized_worker_ids",
+          "forbidden_worker_ids",
+          "runtime_authority",
+          "local_state_authority"
+        ],
+        "properties": {
+          "authorization_type": { "const": "fresh_review_downstream_task" },
+          "authorization_state": { "const": "worker_task_ready" },
+          "authorized_worker_ids": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "forbidden_worker_ids": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false }
+        },
+        "additionalProperties": true
+      }
+    },
     "recovery_routes": {
       "type": "array",
       "items": {

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -169,6 +169,10 @@
       "type": "array",
       "items": { "type": "string", "minLength": 2 }
     },
+    "authorized_downstream_worker_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
     "graph_requirement_refs": {
       "type": "array",
       "items": { "type": "string", "minLength": 3 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4318,6 +4318,11 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             "reviewed_requirement_refs": string_list(data.get("reviewed_requirement_refs")),
             "reviewed_producer_refs": string_list(data.get("reviewed_producer_refs")),
             "producer_refs_reviewed": string_list(data.get("producer_refs_reviewed")),
+            "authorized_downstream_worker_ids": registered_nonhuman_worker_ids(
+                data.get("authorized_downstream_worker_ids")
+                or data.get("authorized_next_worker_ids")
+                or data.get("downstream_worker_ids")
+            ),
             "review_task_authorizations": [
                 item for item in data.get("review_task_authorizations", []) if isinstance(item, dict)
             ],
@@ -4380,6 +4385,11 @@ def receipt_result_fields(
                 "reviewed_requirement_refs": string_list(value.get("reviewed_requirement_refs")),
                 "reviewed_producer_refs": string_list(value.get("reviewed_producer_refs")),
                 "producer_refs_reviewed": string_list(value.get("producer_refs_reviewed")),
+                "authorized_downstream_worker_ids": registered_nonhuman_worker_ids(
+                    value.get("authorized_downstream_worker_ids")
+                    or value.get("authorized_next_worker_ids")
+                    or value.get("downstream_worker_ids")
+                ),
                 "review_task_authorizations": [
                     item for item in value.get("review_task_authorizations", []) if isinstance(item, dict)
                 ],
@@ -4426,6 +4436,14 @@ def _declared_review_worker_id(data: dict[str, Any]) -> str:
         or ""
     ).strip()
     return worker_id if worker_id in WORKERS else "independent-reviewer"
+
+
+def registered_nonhuman_worker_ids(value: Any) -> list[str]:
+    worker_ids: list[str] = []
+    for worker_id in string_list(value):
+        if worker_id in WORKERS and worker_id != "human-gate-clerk" and worker_id not in worker_ids:
+            worker_ids.append(worker_id)
+    return worker_ids
 
 
 def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evidence_ref: str | None) -> list[dict[str, Any]]:
@@ -4546,6 +4564,13 @@ def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[s
                     requirement["status"] = "satisfied"
                     requirement["reviewer_result"] = "PASS"
                     requirement["review_evidence_ref"] = review_record.get("evidence_ref") or "receipt:review"
+                    authorized_worker_ids = registered_nonhuman_worker_ids(
+                        review_record.get("authorized_downstream_worker_ids")
+                        or review_record.get("authorized_next_worker_ids")
+                        or review_record.get("downstream_worker_ids")
+                    )
+                    if authorized_worker_ids:
+                        requirement["authorized_downstream_worker_ids"] = authorized_worker_ids
             requirements.append(requirement)
     for record in fields.values():
         graph_requirements = [dict(item) for item in record.get("graph_requirements", [])]
@@ -4557,6 +4582,62 @@ def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[s
         record["graph_requirements"] = resolved_for_record
         apply_record_consumption_state(record)
     return requirements
+
+
+def downstream_task_authorization(requirement: dict[str, Any], worker_tasks: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if requirement.get("status") != "satisfied":
+        return None
+    review_evidence_ref = str(requirement.get("review_evidence_ref") or "").strip()
+    if not review_evidence_ref:
+        return None
+    available_workers = {
+        str(task.get("worker_id") or "")
+        for task in worker_tasks
+        if task.get("status") == "requires_execution"
+    }
+    producer_worker = _worker_id_for_output_field(str(requirement.get("producer_field") or ""))
+    review_worker = str(requirement.get("review_worker_id") or "")
+    forbidden_worker_ids = sorted(
+        worker_id
+        for worker_id in {"human-gate-clerk", producer_worker or "", review_worker}
+        if worker_id
+    )
+    authorized_worker_ids = [
+        worker_id
+        for worker_id in registered_nonhuman_worker_ids(requirement.get("authorized_downstream_worker_ids"))
+        if worker_id in available_workers and worker_id not in forbidden_worker_ids
+    ]
+    if not authorized_worker_ids:
+        return None
+    requirement_id = str(requirement.get("requirement_id") or "").strip()
+    return {
+        "authorization_type": "fresh_review_downstream_task",
+        "authorization_state": "worker_task_ready",
+        "requirement_id": requirement_id,
+        "producer_field": requirement.get("producer_field"),
+        "producer_ref": requirement.get("producer_ref"),
+        "review_evidence_ref": review_evidence_ref,
+        "authorized_worker_ids": authorized_worker_ids,
+        "forbidden_worker_ids": forbidden_worker_ids,
+        "unblock_reason": (
+            f"Fresh PASS review {review_evidence_ref} satisfied {requirement_id}; "
+            f"authorized next worker(s): {', '.join(authorized_worker_ids)}"
+        ),
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+    }
+
+
+def downstream_task_authorizations(
+    graph_requirements: list[dict[str, Any]],
+    worker_tasks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    authorizations: list[dict[str, Any]] = []
+    for requirement in graph_requirements:
+        authorization = downstream_task_authorization(requirement, worker_tasks)
+        if authorization:
+            authorizations.append(authorization)
+    return authorizations
 
 
 def graph_requirement_block_reason(requirement: dict[str, Any]) -> str:
@@ -4871,6 +4952,7 @@ def build_transition_plan(
         attach_graph_requirement_tasks(worker_tasks, graph_requirements, card, source_path)
     if recovery_routes:
         attach_recovery_routes_to_tasks(worker_tasks, recovery_routes, card, source_path)
+    downstream_authorizations = downstream_task_authorizations(graph_requirements, worker_tasks)
 
     def append_unsatisfied_graph_requirement_blocks() -> None:
         for requirement in unsatisfied_graph_requirements:
@@ -4912,7 +4994,7 @@ def build_transition_plan(
             transition_action = "block_and_create_before_ready_tasks"
         else:
             transition_action = "block_transition" if blocked_reasons else "allow_and_create_worker_tasks"
-        completion = None
+        completion = graph_completion
     elif transition_is_review_ready(normalized_to):
         blocked_reasons.extend(gate["card_validation_errors"])
         for worker_id in gate["blocked_workers"]:
@@ -4989,6 +5071,7 @@ def build_transition_plan(
         "recovery_routes": recovery_routes,
         "review_ready_handoffs": review_ready_handoffs,
         "review_task_authorizations": review_task_authorizations,
+        "downstream_task_authorizations": downstream_authorizations,
         "completion_reconciliation": completion,
     }
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1530,6 +1530,59 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(closure["unsatisfied_graph_requirements"], [])
         self.assertEqual(closure["graph_requirements"][0]["status"], "satisfied")
 
+    def test_transition_plan_downstream_authorization_requires_explicit_review_worker_ids(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+        requirement_id = factoryctl.declared_graph_requirements(
+            "handoff_packet_result",
+            handoff,
+            evidence_ref="receipt:handoff_packet_result",
+        )[0]["requirement_id"]
+        review = worker_result("independent_review_result", source_card=card)
+        review["graph_requirement_refs"] = [requirement_id]
+        receipt = {
+            "handoff_packet_result": handoff,
+            "independent_review_result": review,
+            "orchestration_result": worker_result("orchestration_result", source_card=card),
+            "source_ledger_result": worker_result("source_ledger_result", source_card=card),
+            "security_orchestration_result": worker_result("security_orchestration_result", source_card=card),
+            "supply_chain_result": worker_result("supply_chain_result", source_card=card),
+        }
+
+        without_explicit_auth = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="review",
+            to_status="ready",
+            receipt=receipt,
+        )
+
+        self.assertEqual(without_explicit_auth["downstream_task_authorizations"], [])
+
+        review["authorized_downstream_worker_ids"] = [
+            "qa-verification-worker",
+            "human-gate-clerk",
+            "handoff-packer",
+            "unknown-worker",
+        ]
+        with_explicit_auth = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="review",
+            to_status="ready",
+            receipt=receipt,
+        )
+
+        self.assertEqual(len(with_explicit_auth["downstream_task_authorizations"]), 1)
+        authorization = with_explicit_auth["downstream_task_authorizations"][0]
+        self.assertEqual(authorization["authorization_type"], "fresh_review_downstream_task")
+        self.assertEqual(authorization["authorized_worker_ids"], ["qa-verification-worker"])
+        self.assertIn("human-gate-clerk", authorization["forbidden_worker_ids"])
+        self.assertIn("handoff-packer", authorization["forbidden_worker_ids"])
+        self.assertIn("independent-reviewer", authorization["forbidden_worker_ids"])
+
     def test_worker_closure_does_not_satisfy_handoff_review_with_generic_review_result(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -476,6 +476,145 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertTrue(any(call[5] == handoff_task_id and "downstream remains gated" in call[6] for call in unblock_calls))
 
+    def test_materialize_promotes_downstream_workers_after_fresh_review_pass(self) -> None:
+        fake = FakeHermes()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="continue after review",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+        requirement = factoryctl.declared_graph_requirements(
+            "handoff_packet_result",
+            handoff,
+            evidence_ref="receipt:handoff_packet_result",
+        )[0]
+        review = factoryctl.build_worker_result(
+            "independent-reviewer",
+            card_data,
+            result="PASS",
+            tool_or_profile="independent-review-smoke",
+            executed_by="independent-reviewer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Fresh review passed the repaired handoff packet.",
+            next_action="continue downstream",
+        )
+        review["graph_requirement_refs"] = [requirement["requirement_id"]]
+        review["authorized_downstream_worker_ids"] = [
+            "qa-verification-worker",
+            "human-gate-clerk",
+            "handoff-packer",
+            "unknown-worker",
+        ]
+        receipt_payload = {
+            "handoff_packet_result": handoff,
+            "independent_review_result": review,
+            "orchestration_result": factoryctl.build_worker_result(
+                "factory-orchestrator",
+                card_data,
+                result="PASS",
+                tool_or_profile="orchestration-smoke",
+                executed_by="factory-orchestrator",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Orchestration precondition passed.",
+                next_action="continue",
+            ),
+            "source_ledger_result": factoryctl.build_worker_result(
+                "source-ledger-worker",
+                card_data,
+                result="PASS",
+                tool_or_profile="source-ledger-smoke",
+                executed_by="source-ledger-worker",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Source ledger precondition passed.",
+                next_action="continue",
+            ),
+            "security_orchestration_result": factoryctl.build_worker_result(
+                "security-orchestrator",
+                card_data,
+                result="PASS",
+                tool_or_profile="security-orchestration-smoke",
+                executed_by="security-orchestrator",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Security orchestration precondition passed.",
+                next_action="continue",
+            ),
+            "supply_chain_result": factoryctl.build_worker_result(
+                "supply-chain-gate",
+                card_data,
+                result="PASS",
+                tool_or_profile="supply-chain-smoke",
+                executed_by="supply-chain-gate",
+                evidence_refs=["README.md"],
+                blocking_findings=False,
+                findings_summary="Supply chain precondition passed.",
+                next_action="continue",
+            ),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            readiness = tmp_path / "route-readiness.json"
+            receipt = tmp_path / "receipt.json"
+            ledger = tmp_path / "ledger.json"
+            write_route_readiness(readiness)
+            receipt.write_text(json.dumps(receipt_payload), encoding="utf-8")
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize",
+                    "--card",
+                    str(card),
+                    "--board",
+                    TEST_BOARD,
+                    "--ledger",
+                    str(ledger),
+                    "--receipt",
+                    str(receipt),
+                    "--from-status",
+                    "review",
+                    "--to-status",
+                    "ready",
+                    "--route-readiness",
+                    str(readiness),
+                ]
+            )
+            result = adapter.materialize(args, runner=fake)
+            ledger_data = json.loads(ledger.read_text(encoding="utf-8"))
+
+        promoted = result["downstream_promoted_worker_task_ids"]
+        self.assertEqual(promoted, {"qa-verification-worker": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertNotIn("codex-security", promoted)
+        self.assertNotIn("human-gate-clerk", promoted)
+        self.assertNotIn("handoff-packer", promoted)
+        self.assertNotIn("independent-reviewer", promoted)
+        qa_task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "qa-verification-worker")
+        codex_security_task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "codex-security")
+        human_gate_task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "human-gate-clerk")
+        self.assertEqual(fake.tasks[qa_task["runtime_refs"]["hermes_task_ref"]]["status"], "ready")
+        self.assertEqual(fake.tasks[codex_security_task["runtime_refs"]["hermes_task_ref"]]["status"], "blocked")
+        self.assertEqual(fake.tasks[human_gate_task["runtime_refs"]["hermes_task_ref"]]["status"], "blocked")
+        self.assertEqual(fake.tasks[MAIN_TASK_ID]["status"], "blocked")
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertTrue(
+            any(
+                call[5] == qa_task["runtime_refs"]["hermes_task_ref"]
+                and "Fresh PASS review authorized exact downstream worker" in call[6]
+                for call in unblock_calls
+            )
+        )
+
     def test_materialize_dry_run_does_not_call_hermes_create(self) -> None:
         fake = FakeHermes()
         card = ROOT / "examples" / "cards" / "v35_valid_product_face.md"


### PR DESCRIPTION
Relates to #134. Does not close it.

## What changed
- Added explicit `downstream_task_authorizations` to Hermes transition plans.
- Preserved `authorized_downstream_worker_ids` from inline receipts and worker-result files.
- Updated the live Hermes adapter to unblock downstream tasks only when an explicit fresh-review authorization names that worker.
- Kept `human-gate-clerk`, the producer worker, the review worker, unknown workers, already-satisfied workers and the main gate blocked.
- Fixed recovery materialization to use the filtered authorized recovery route instead of `recovery_routes[0]`.
- Extended schemas, adapter docs and tests for the exact-unblock contract.

## Why
PR #159 made factory-owned repair tasks materialize in Hermes, but the next step after a fresh review PASS still needed a deterministic exact-worker authorization. Broadly reopening downstream workers would violate #134's core rule: the factory must behave like precise gears, not a hopeful queue fan-out.

This PR makes the next-worker unblock explicit and machine-readable. If the review PASS does not name authorized downstream worker ids, the adapter does not unblock downstream work.

## Validation
- `python -B -m unittest tests.test_hermes_live_kanban_adapter tests.test_factoryctl tests.test_hermes_transition_hook -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q` (412 tests)
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\release_integration_preflight.py`

## Remaining for #134
- Derive retry attempt count and loop history from Hermes task/run events, not a local Factory counter.
- Add bounded retry/audit behavior around repeated BLOCK -> repair -> fresh review loops.