### PR TITLE
[codex] Derive recovery retry attempts from Hermes history

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -147,7 +147,14 @@ When a `BLOCKED` review produces a factory-owned `recovery_route`, the adapter
 unblocks only the repair worker task authorized by that route. Downstream work
 stays blocked until a fresh review result provides the stated unblock
 authority. The adapter verifies Hermes readback after block/unblock operations;
-it does not keep a parallel lifecycle state.
+it does not keep a parallel lifecycle state. Recovery retry attempts are derived
+from stable `factory_recovery_attempt` markers in the Hermes task history for
+that route before each unblock. If Hermes cannot return a task history source,
+or if the route's `retry_policy.max_attempts` is exceeded, the adapter leaves
+the task blocked and reports `recovery_retry_blocked_worker_task_ids`. If an
+idempotent rerun finds the repair task already ready, running or done, the
+adapter records an `already_active_no_new_attempt` no-op instead of blocking or
+unblocking it again.
 
 When that fresh review records a matching `PASS`, the adapter can reopen only
 the explicitly authorized downstream worker ids from the transition plan. This

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -30,6 +30,9 @@ TASK_ID_RE = PRIVATE_KANBAN_TASK_MARKER_RE
 LIVE_ADAPTER_SCHEMA = "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json"
 ROUTE_READINESS_SCHEMA = "https://overkill-factory.dev/schemas/hermes-worker-route-readiness.schema.json"
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+RECOVERY_ATTEMPT_MARKER = "factory_recovery_attempt"
+ACTIVE_OR_TERMINAL_STATUSES = {"ready", "running", "done", "complete", "completed"}
+HISTORY_SOURCE_KEYS = ("events", "history", "timeline", "comments", "runs")
 
 
 def default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
@@ -149,6 +152,10 @@ def show_task(
     return payload if isinstance(payload, dict) else {}
 
 
+def task_status(payload: dict[str, Any]) -> str:
+    return str(payload.get("status") or "").strip().lower()
+
+
 def enrich_dispatch_task(
     *,
     hermes_bin: str,
@@ -244,7 +251,14 @@ def task_has_blocked_event(payload: dict[str, Any]) -> bool:
     if str(payload.get("status") or "").strip().lower() == "blocked":
         events = payload.get("events") or payload.get("history") or payload.get("timeline") or []
         if isinstance(events, list):
-            return any("block" in str(event).lower() for event in events)
+            for event in events:
+                if isinstance(event, dict):
+                    event_type = str(event.get("type") or event.get("event") or event.get("action") or "").strip().lower()
+                    if event_type in {"block", "blocked"}:
+                        return True
+                text = str(event).lower()
+                if re.search(r"\bblocked\b", text) and not re.search(r"\bunblocked\b", text):
+                    return True
     return False
 
 
@@ -308,6 +322,39 @@ def downstream_worker_ready_after_fresh_review(
     if worker_satisfied_by_reconciliation(plan, worker_id):
         return False
     return True
+
+
+def history_items(payload: dict[str, Any]) -> list[tuple[str, int, Any]]:
+    items: list[tuple[str, int, Any]] = []
+    for key in HISTORY_SOURCE_KEYS:
+        value = payload.get(key)
+        if isinstance(value, list):
+            items.extend((key, index, item) for index, item in enumerate(value))
+    return items
+
+
+def has_history_source(payload: dict[str, Any]) -> bool:
+    return any(isinstance(payload.get(key), list) for key in HISTORY_SOURCE_KEYS)
+
+
+def recovery_attempt_history_refs(payload: dict[str, Any], route_id: str) -> list[str]:
+    route = route_id.strip().lower()
+    if not route:
+        return []
+    refs: list[str] = []
+    for key, index, item in history_items(payload):
+        text = json.dumps(item, ensure_ascii=True, sort_keys=True).lower() if isinstance(item, dict) else str(item).lower()
+        if route in text and RECOVERY_ATTEMPT_MARKER in text:
+            refs.append(f"{key}:{index}")
+    return refs
+
+
+def retry_policy_max_attempts(route: dict[str, Any]) -> int:
+    policy = route.get("retry_policy")
+    value = policy.get("max_attempts") if isinstance(policy, dict) else None
+    if isinstance(value, int) and value >= 1:
+        return value
+    return 1
 
 
 def ensure_blocked_event(
@@ -467,13 +514,23 @@ def create_task(
         args.extend(["--initial-status", "blocked"])
     task_id = parse_task_id(run_checked(args, runner).stdout)
     if blocked:
-        ensure_blocked_event(
+        shown_task = show_task(
             hermes_bin=hermes_bin,
             board=board,
             task_id=task_id,
-            reason="Overkill Factory gate starts blocked until required authority evidence passes.",
             runner=runner,
         )
+        status = task_status(shown_task)
+        if status in ACTIVE_OR_TERMINAL_STATUSES:
+            return task_id
+        if not task_has_blocked_event(shown_task):
+            ensure_blocked_event(
+                hermes_bin=hermes_bin,
+                board=board,
+                task_id=task_id,
+                reason="Overkill Factory gate starts blocked until required authority evidence passes.",
+                runner=runner,
+            )
     return task_id
 
 
@@ -542,6 +599,8 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
     worker_task_ids: dict[str, str] = {}
     review_promoted_worker_task_ids: dict[str, str] = {}
     recovery_promoted_worker_task_ids: dict[str, str] = {}
+    recovery_retry_blocked_worker_task_ids: dict[str, str] = {}
+    recovery_attempts: dict[str, dict[str, Any]] = {}
     downstream_promoted_worker_task_ids: dict[str, str] = {}
     downstream_authorizations = downstream_authorizations_by_worker(plan)
     for task in plan.get("worker_tasks", []):
@@ -598,13 +657,54 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
             route = authorized_recovery_routes[0]
             route_id = str(route.get("recovery_route_id") or "factory-recovery-route")
             fresh_review_ref = str(route.get("fresh_review_result_ref") or "fresh-review-required")
+            shown_task = show_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=task_id,
+                runner=runner,
+            )
+            task_status_value = task_status(shown_task)
+            history_refs = recovery_attempt_history_refs(shown_task, route_id)
+            previous_attempts = len(history_refs)
+            attempt_number = previous_attempts + 1
+            max_attempts = retry_policy_max_attempts(route)
+            recovery_attempts[worker_id] = {
+                "recovery_route_id": route_id,
+                "worker_id": worker_id,
+                "hermes_task_ref": task_id,
+                "previous_attempts": previous_attempts,
+                "attempt_number": attempt_number,
+                "max_attempts": max_attempts,
+                "attempt_source": "hermes_task_history",
+                "history_refs": history_refs,
+                "history_ref_count": len(history_refs),
+                "task_status": task_status_value or "unknown",
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "attempted_this_run": False,
+            }
+            if task_status_value in ACTIVE_OR_TERMINAL_STATUSES:
+                recovery_attempts[worker_id]["status"] = "already_active_no_new_attempt"
+                continue
+            if not has_history_source(shown_task):
+                recovery_attempts[worker_id]["status"] = "history_unavailable"
+                recovery_retry_blocked_worker_task_ids[worker_id] = task_id
+                continue
+            if attempt_number > max_attempts:
+                recovery_attempts[worker_id]["status"] = "retry_limit_exceeded"
+                recovery_retry_blocked_worker_task_ids[worker_id] = task_id
+                continue
+            recovery_attempts[worker_id]["status"] = "attempt_authorized"
+            recovery_attempts[worker_id]["attempted_this_run"] = True
             unblock_task(
                 hermes_bin=args.hermes_bin,
                 board=args.board,
                 task_id=task_id,
                 reason=(
-                    "Factory-owned recovery route authorized repair task "
-                    f"{route_id}; downstream remains gated until {fresh_review_ref} passes."
+                    f"{RECOVERY_ATTEMPT_MARKER} route_id={route_id} "
+                    f"attempt_number={attempt_number} max_attempts={max_attempts}; "
+                    "Factory-owned recovery route authorized repair task; downstream remains gated until "
+                    f"{fresh_review_ref} passes."
                 ),
                 runner=runner,
             )
@@ -657,6 +757,8 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         "worker_task_ids": worker_task_ids,
         "review_promoted_worker_task_ids": review_promoted_worker_task_ids,
         "recovery_promoted_worker_task_ids": recovery_promoted_worker_task_ids,
+        "recovery_retry_blocked_worker_task_ids": recovery_retry_blocked_worker_task_ids,
+        "recovery_attempts": recovery_attempts,
         "downstream_promoted_worker_task_ids": downstream_promoted_worker_task_ids,
         "hook": result,
     }

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -55,6 +55,59 @@
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 3 }
     },
+    "recovery_retry_blocked_worker_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
+    "recovery_attempts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "recovery_route_id",
+          "worker_id",
+          "hermes_task_ref",
+          "previous_attempts",
+          "attempt_number",
+          "max_attempts",
+          "attempt_source",
+          "history_refs",
+          "history_ref_count",
+          "task_status",
+          "status",
+          "runtime_authority",
+          "local_state_authority",
+          "attempted_this_run"
+        ],
+        "properties": {
+          "recovery_route_id": { "type": "string", "minLength": 3 },
+          "worker_id": { "type": "string", "minLength": 1 },
+          "hermes_task_ref": { "type": "string", "minLength": 3 },
+          "previous_attempts": { "type": "integer", "minimum": 0 },
+          "attempt_number": { "type": "integer", "minimum": 0 },
+          "max_attempts": { "type": "integer", "minimum": 1 },
+          "attempt_source": { "const": "hermes_task_history" },
+          "history_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "history_ref_count": { "type": "integer", "minimum": 0 },
+          "task_status": { "type": "string", "minLength": 3 },
+          "status": {
+            "enum": [
+              "attempt_authorized",
+              "retry_limit_exceeded",
+              "already_active_no_new_attempt",
+              "history_unavailable"
+            ]
+          },
+          "runtime_authority": { "const": "hermes_kanban" },
+          "local_state_authority": { "const": false },
+          "attempted_this_run": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
     "downstream_promoted_worker_task_ids": {
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 3 }

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 ADAPTER_DIR = ROOT / "adapters" / "hermes"
 MODULE_PATH = ADAPTER_DIR / "live_kanban_adapter.py"
 FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
 TEST_BOARD = "overkill-" + "factory-live-smoke"
 MAIN_TASK_ID = "t_" + "00000001"
 READY_TASK_ID = "t_" + "ready0001"
@@ -29,6 +30,12 @@ factoryctl = importlib.util.module_from_spec(FACTORYCTL_SPEC)
 assert FACTORYCTL_SPEC.loader is not None
 sys.modules["factoryctl_live_test"] = factoryctl
 FACTORYCTL_SPEC.loader.exec_module(factoryctl)
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("public_json_validator_live_test", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["public_json_validator_live_test"] = validator
+VALIDATOR_SPEC.loader.exec_module(validator)
 
 
 class FakeHermes:
@@ -36,6 +43,7 @@ class FakeHermes:
         self.calls: list[list[str]] = []
         self.counter = 0
         self.tasks: dict[str, dict[str, object]] = {}
+        self.idempotent_task_ids: dict[str, str] = {}
 
     def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
         self.calls.append(argv)
@@ -44,10 +52,17 @@ class FakeHermes:
         if argv[:4] == ["hermes", "kanban", "boards", "create"]:
             return subprocess.CompletedProcess(argv, 0, stdout="created", stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "create":
+            idempotency_key = argv[argv.index("--idempotency-key") + 1] if "--idempotency-key" in argv else ""
+            if idempotency_key and idempotency_key in self.idempotent_task_ids:
+                task_id = self.idempotent_task_ids[idempotency_key]
+                self.tasks.setdefault(task_id, {"status": "blocked", "events": []})
+                return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
             self.counter += 1
             task_id = "t_" + f"{self.counter:08x}"
             initial_status = "blocked" if "--initial-status" in argv and "blocked" in argv else "ready"
             self.tasks[task_id] = {"status": initial_status, "events": []}
+            if idempotency_key:
+                self.idempotent_task_ids[idempotency_key] = task_id
             return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
         if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "block":
             task = self.tasks.setdefault(argv[5], {"status": "ready", "events": []})
@@ -212,7 +227,60 @@ def write_route_readiness(path: Path) -> None:
     )
 
 
+def assert_live_adapter_result_schema(testcase: unittest.TestCase, result: dict[str, object]) -> None:
+    schema = json.loads((ROOT / "schemas" / "hermes-live-adapter-result.schema.json").read_text(encoding="utf-8"))
+    errors = validator.validate_node(schema, result, "$", schemas={"hermes-live-adapter-result.schema.json": schema}, root_schema=schema)
+    testcase.assertEqual(errors, [])
+
+
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
+    def test_recovery_attempt_count_requires_stable_marker(self) -> None:
+        route_id = "recovery:card-001:handoff-packer"
+
+        refs = adapter.recovery_attempt_history_refs(
+            {
+                "events": [
+                    {"type": "comment", "reason": f"{route_id} recovery attempt wording only"},
+                    {
+                        "type": "unblocked",
+                        "reason": (
+                            "factory_recovery_attempt "
+                            f"route_id={route_id} attempt_number=1 max_attempts=10"
+                        ),
+                    },
+                ],
+                "comments": [
+                    {
+                        "body": (
+                            "factory_recovery_attempt "
+                            f"route_id={route_id} attempt_number=2 max_attempts=10"
+                        )
+                    }
+                ],
+            },
+            route_id,
+        )
+
+        self.assertEqual(refs, ["events:1", "comments:0"])
+
+    def test_blocked_event_detection_does_not_treat_unblocked_as_blocked(self) -> None:
+        self.assertFalse(
+            adapter.task_has_blocked_event(
+                {
+                    "status": "blocked",
+                    "events": [{"type": "unblocked", "reason": "previous unblock"}],
+                }
+            )
+        )
+        self.assertTrue(
+            adapter.task_has_blocked_event(
+                {
+                    "status": "blocked",
+                    "events": [{"type": "blocked", "reason": "current gate"}],
+                }
+            )
+        )
+
     def test_dispatch_reports_tasks_that_entered_running_even_when_native_spawned_is_empty(self) -> None:
         fake = FakeDispatchHermes(native_spawned=False)
         args = adapter.build_parser().parse_args(["dispatch", "--board", TEST_BOARD])
@@ -468,6 +536,12 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         self.assertEqual(result["recovery_promoted_worker_task_ids"], {"handoff-packer": adapter.PUBLIC_SAFE_KANBAN_REF})
         self.assertEqual(result["review_promoted_worker_task_ids"], {"independent-reviewer": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["attempt_number"], 1)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["attempt_source"], "hermes_task_history")
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["history_ref_count"], 0)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["status"], "attempt_authorized")
+        self.assertTrue(result["recovery_attempts"]["handoff-packer"]["attempted_this_run"])
+        assert_live_adapter_result_schema(self, result)
         handoff_task = next(task for task in ledger_data["tasks"].values() if task["worker_id"] == "handoff-packer")
         handoff_task_id = handoff_task["runtime_refs"]["hermes_task_ref"]
         self.assertTrue(handoff_task["recovery_route_refs"])
@@ -475,6 +549,210 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(fake.tasks[MAIN_TASK_ID]["status"], "blocked")
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertTrue(any(call[5] == handoff_task_id and "downstream remains gated" in call[6] for call in unblock_calls))
+        self.assertTrue(any(call[5] == handoff_task_id and "factory_recovery_attempt" in call[6] for call in unblock_calls))
+        self.assertTrue(any(call[5] == handoff_task_id and "attempt_number=1 max_attempts=10" in call[6] for call in unblock_calls))
+
+    def test_materialize_keeps_recovery_task_blocked_after_retry_limit(self) -> None:
+        fake = FakeHermes()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="continue after review",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            readiness = tmp_path / "route-readiness.json"
+            worker_results = tmp_path / "worker-results"
+            worker_results.mkdir()
+            ledger = tmp_path / "ledger.json"
+            handoff_path = worker_results / "handoff.json"
+            review_path = worker_results / "review.json"
+            write_route_readiness(readiness)
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]
+            blocked_review = factoryctl.build_worker_result(
+                "independent-reviewer",
+                card_data,
+                result="BLOCKED",
+                tool_or_profile="independent-review-smoke",
+                executed_by="independent-reviewer",
+                evidence_refs=["README.md"],
+                blocking_findings=True,
+                findings_summary="Review found the handoff packet incomplete.",
+                next_action="repair handoff packet and rerun independent review",
+                reusable_for_product=False,
+            )
+            blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+            review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
+            route = factoryctl.build_transition_plan(
+                card_data,
+                card,
+                from_status="blocked",
+                to_status="ready",
+                worker_results_dir=worker_results,
+            )["recovery_routes"][0]
+            route_id = route["recovery_route_id"]
+            existing_task_id = "t_" + "retry0001"
+            fake.idempotent_task_ids[f"overkill:{card_data['card_id']}:handoff-packer"] = existing_task_id
+            fake.tasks[existing_task_id] = {
+                "status": "blocked",
+                "events": [
+                    {
+                        "type": "comment",
+                        "reason": f"{route_id} mentions recovery but is not a stable attempt marker",
+                    },
+                    *[
+                        {
+                            "type": "unblocked",
+                            "reason": (
+                                "factory_recovery_attempt "
+                                f"route_id={route_id} attempt_number={index} max_attempts=10"
+                            ),
+                        }
+                        for index in range(1, 11)
+                    ],
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize",
+                    "--card",
+                    str(card),
+                    "--board",
+                    TEST_BOARD,
+                    "--ledger",
+                    str(ledger),
+                    "--worker-results-dir",
+                    str(worker_results),
+                    "--route-readiness",
+                    str(readiness),
+                ]
+            )
+            result = adapter.materialize(args, runner=fake)
+
+        self.assertEqual(result["recovery_promoted_worker_task_ids"], {})
+        self.assertEqual(result["recovery_retry_blocked_worker_task_ids"], {"handoff-packer": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["previous_attempts"], 10)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["attempt_number"], 11)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["max_attempts"], 10)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["history_ref_count"], 10)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["status"], "retry_limit_exceeded")
+        self.assertFalse(result["recovery_attempts"]["handoff-packer"]["attempted_this_run"])
+        assert_live_adapter_result_schema(self, result)
+        self.assertEqual(fake.tasks[existing_task_id]["status"], "blocked")
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertFalse(any(call[5] == existing_task_id for call in unblock_calls))
+
+    def test_materialize_does_not_reblock_or_unblock_active_recovery_task_on_rerun(self) -> None:
+        fake = FakeHermes()
+        card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card_data = factoryctl.load_json_like(card)
+        handoff = factoryctl.build_worker_result(
+            "handoff-packer",
+            card_data,
+            result="PASS",
+            tool_or_profile="handoff-pack-smoke",
+            executed_by="handoff-packer",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Handoff packet declares an independent review gate.",
+            next_action="continue after review",
+            reviewer_required=True,
+            reviewer_result="PENDING",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            readiness = tmp_path / "route-readiness.json"
+            worker_results = tmp_path / "worker-results"
+            worker_results.mkdir()
+            ledger = tmp_path / "ledger.json"
+            handoff_path = worker_results / "handoff.json"
+            review_path = worker_results / "review.json"
+            write_route_readiness(readiness)
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]
+            blocked_review = factoryctl.build_worker_result(
+                "independent-reviewer",
+                card_data,
+                result="BLOCKED",
+                tool_or_profile="independent-review-smoke",
+                executed_by="independent-reviewer",
+                evidence_refs=["README.md"],
+                blocking_findings=True,
+                findings_summary="Review found the handoff packet incomplete.",
+                next_action="repair handoff packet and rerun independent review",
+                reusable_for_product=False,
+            )
+            blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
+            review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
+            route = factoryctl.build_transition_plan(
+                card_data,
+                card,
+                from_status="blocked",
+                to_status="ready",
+                worker_results_dir=worker_results,
+            )["recovery_routes"][0]
+            route_id = route["recovery_route_id"]
+            existing_task_id = "t_" + "ready1111"
+            fake.idempotent_task_ids[f"overkill:{card_data['card_id']}:handoff-packer"] = existing_task_id
+            fake.tasks[existing_task_id] = {
+                "status": "ready",
+                "events": [
+                    {
+                        "type": "unblocked",
+                        "reason": (
+                            "factory_recovery_attempt "
+                            f"route_id={route_id} attempt_number=1 max_attempts=10"
+                        ),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize",
+                    "--card",
+                    str(card),
+                    "--board",
+                    TEST_BOARD,
+                    "--ledger",
+                    str(ledger),
+                    "--worker-results-dir",
+                    str(worker_results),
+                    "--route-readiness",
+                    str(readiness),
+                ]
+            )
+            result = adapter.materialize(args, runner=fake)
+
+        self.assertEqual(result["recovery_promoted_worker_task_ids"], {})
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["previous_attempts"], 1)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["attempt_number"], 2)
+        self.assertEqual(result["recovery_attempts"]["handoff-packer"]["status"], "already_active_no_new_attempt")
+        self.assertFalse(result["recovery_attempts"]["handoff-packer"]["attempted_this_run"])
+        assert_live_adapter_result_schema(self, result)
+        block_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "block"]
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertFalse(any(call[5] == existing_task_id for call in block_calls))
+        self.assertFalse(any(call[5] == existing_task_id for call in unblock_calls))
+        self.assertEqual(fake.tasks[existing_task_id]["status"], "ready")
 
     def test_materialize_promotes_downstream_workers_after_fresh_review_pass(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
Relates to #134.

## Summary
- derives factory recovery retry attempts from Hermes task history using a stable `factory_recovery_attempt` marker instead of local planner state or loose text matching
- leaves factory-owned repair tasks blocked when `retry_policy.max_attempts` is exceeded, and reports `recovery_retry_blocked_worker_task_ids`
- treats idempotent reruns against already ready/running/done repair tasks as `already_active_no_new_attempt` no-ops, avoiding false re-block/unblock cycles
- tightens the live adapter result schema and documents the runtime authority boundary
- fixes blocked-event detection so `unblocked` history no longer counts as a durable blocked event

## Why
The factory loop must behave like deterministic gears: retry cannot mean "how many times the operator reran materialize" and cannot be inferred from local state. Hermes Kanban is the runtime authority for task status and recovery history.

## Validation
- `python -B -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -B -m unittest tests.test_hermes_live_kanban_adapter tests.test_factoryctl tests.test_hermes_transition_hook -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\release_integration_preflight.py`
- `git diff --check`