### PR TITLE
[codex] Clarify recovery retry authority and human gates

### DIFF
--- a/schemas/factory-recovery-plan.schema.json
+++ b/schemas/factory-recovery-plan.schema.json
@@ -120,10 +120,24 @@
           "unblock_authority_ref": { "type": "string", "minLength": 3 },
           "retry_policy": {
             "type": "object",
-            "required": ["max_attempts", "attempt_number", "stop_classes"],
+            "required": [
+              "max_attempts",
+              "attempt_number",
+              "attempt_number_role",
+              "runtime_attempt_source",
+              "runtime_attempt_marker",
+              "runtime_authority",
+              "local_state_authority",
+              "stop_classes"
+            ],
             "properties": {
               "max_attempts": { "type": "integer", "minimum": 1 },
               "attempt_number": { "type": "integer", "minimum": 1 },
+              "attempt_number_role": { "const": "planner_seed_not_runtime_counter" },
+              "runtime_attempt_source": { "const": "hermes_task_history" },
+              "runtime_attempt_marker": { "const": "factory_recovery_attempt" },
+              "runtime_authority": { "const": "hermes_kanban" },
+              "local_state_authority": { "const": false },
               "stop_classes": {
                 "type": "array",
                 "minItems": 1,
@@ -171,7 +185,37 @@
             "additionalProperties": true
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "allOf": [
+          {
+            "if": {
+              "properties": { "blocker_type": { "const": "human_gate" } },
+              "required": ["blocker_type"]
+            },
+            "then": {
+              "properties": {
+                "factory_owned_repair_allowed": { "const": false },
+                "human_gate_required": { "const": true },
+                "fresh_review_required": { "const": false },
+                "unblock_authority_ref": { "const": "human_gate_record" }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": { "repair_owner_worker": { "const": "human-gate-clerk" } },
+              "required": ["repair_owner_worker"]
+            },
+            "then": {
+              "properties": {
+                "factory_owned_repair_allowed": { "const": false },
+                "human_gate_required": { "const": true },
+                "fresh_review_required": { "const": false },
+                "unblock_authority_ref": { "const": "human_gate_record" }
+              }
+            }
+          }
+        ]
       }
     },
     "hermes_runtime_boundary": {

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -132,7 +132,37 @@
             "contains": { "const": "review" }
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "allOf": [
+          {
+            "if": {
+              "properties": { "blocker_type": { "const": "human_gate" } },
+              "required": ["blocker_type"]
+            },
+            "then": {
+              "properties": {
+                "factory_owned_repair_allowed": { "const": false },
+                "human_gate_required": { "const": true },
+                "fresh_review_required": { "const": false },
+                "unblock_authority_ref": { "const": "human_gate_record" }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": { "repair_owner_worker": { "const": "human-gate-clerk" } },
+              "required": ["repair_owner_worker"]
+            },
+            "then": {
+              "properties": {
+                "factory_owned_repair_allowed": { "const": false },
+                "human_gate_required": { "const": true },
+                "fresh_review_required": { "const": false },
+                "unblock_authority_ref": { "const": "human_gate_record" }
+              }
+            }
+          }
+        ]
       }
     },
     "review_task_authorizations": {
@@ -216,6 +246,35 @@
         "properties": {
           "runtime_authority": { "const": "hermes_kanban" },
           "local_state_authority": { "const": false },
+          "retry_policy": {
+            "type": "object",
+            "required": [
+              "max_attempts",
+              "attempt_number",
+              "attempt_number_role",
+              "runtime_attempt_source",
+              "runtime_attempt_marker",
+              "runtime_authority",
+              "local_state_authority",
+              "stop_classes"
+            ],
+            "properties": {
+              "max_attempts": { "type": "integer", "minimum": 1 },
+              "attempt_number": { "type": "integer", "minimum": 1 },
+              "attempt_number_role": { "const": "planner_seed_not_runtime_counter" },
+              "runtime_attempt_source": { "const": "hermes_task_history" },
+              "runtime_attempt_marker": { "const": "factory_recovery_attempt" },
+              "runtime_authority": { "const": "hermes_kanban" },
+              "local_state_authority": { "const": false },
+              "stop_classes": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "escalation_reason": { "type": "string" }
+            },
+            "additionalProperties": true
+          },
           "hermes_materialization": {
             "type": "object",
             "required": ["runtime_authority", "local_state_authority"],
@@ -226,7 +285,37 @@
             "additionalProperties": true
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "allOf": [
+          {
+            "if": {
+              "properties": { "blocker_type": { "const": "human_gate" } },
+              "required": ["blocker_type"]
+            },
+            "then": {
+              "properties": {
+                "factory_owned_repair_allowed": { "const": false },
+                "human_gate_required": { "const": true },
+                "fresh_review_required": { "const": false },
+                "unblock_authority_ref": { "const": "human_gate_record" }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": { "repair_owner_worker": { "const": "human-gate-clerk" } },
+              "required": ["repair_owner_worker"]
+            },
+            "then": {
+              "properties": {
+                "factory_owned_repair_allowed": { "const": false },
+                "human_gate_required": { "const": true },
+                "fresh_review_required": { "const": false },
+                "unblock_authority_ref": { "const": "human_gate_record" }
+              }
+            }
+          }
+        ]
       }
     },
     "completion_reconciliation": {

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -359,10 +359,24 @@
         "unblock_authority_ref": { "type": "string", "minLength": 3 },
         "retry_policy": {
           "type": "object",
-          "required": ["max_attempts", "attempt_number", "stop_classes"],
+          "required": [
+            "max_attempts",
+            "attempt_number",
+            "attempt_number_role",
+            "runtime_attempt_source",
+            "runtime_attempt_marker",
+            "runtime_authority",
+            "local_state_authority",
+            "stop_classes"
+          ],
           "properties": {
             "max_attempts": { "type": "integer", "minimum": 1 },
             "attempt_number": { "type": "integer", "minimum": 1 },
+            "attempt_number_role": { "const": "planner_seed_not_runtime_counter" },
+            "runtime_attempt_source": { "const": "hermes_task_history" },
+            "runtime_attempt_marker": { "const": "factory_recovery_attempt" },
+            "runtime_authority": { "const": "hermes_kanban" },
+            "local_state_authority": { "const": false },
             "stop_classes": {
               "type": "array",
               "minItems": 1,
@@ -387,7 +401,37 @@
           "additionalProperties": true
         }
       },
-      "additionalProperties": true
+      "additionalProperties": true,
+      "allOf": [
+        {
+          "if": {
+            "properties": { "blocker_type": { "const": "human_gate" } },
+            "required": ["blocker_type"]
+          },
+          "then": {
+            "properties": {
+              "factory_owned_repair_allowed": { "const": false },
+              "human_gate_required": { "const": true },
+              "fresh_review_required": { "const": false },
+              "unblock_authority_ref": { "const": "human_gate_record" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "repair_owner_worker": { "const": "human-gate-clerk" } },
+            "required": ["repair_owner_worker"]
+          },
+          "then": {
+            "properties": {
+              "factory_owned_repair_allowed": { "const": false },
+              "human_gate_required": { "const": true },
+              "fresh_review_required": { "const": false },
+              "unblock_authority_ref": { "const": "human_gate_record" }
+            }
+          }
+        }
+      ]
     }
   },
   "allOf": [

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -1289,6 +1289,33 @@ def recovery_runtime_boundary() -> dict[str, Any]:
     }
 
 
+def recovery_retry_policy(*, attempt_number: int = 1, base: dict[str, Any] | None = None) -> dict[str, Any]:
+    policy = dict(base or {})
+    policy.setdefault("max_attempts", 10)
+    policy.setdefault("attempt_number", attempt_number)
+    policy.setdefault(
+        "stop_classes",
+        [
+            "human_gate",
+            "secret_or_access_required",
+            "external_mutation_required",
+            "ambiguous_product_decision",
+            "repeated_failed_recovery",
+        ],
+    )
+    policy.setdefault("escalation_reason", "Escalate only when the blocker leaves factory-owned safe repair scope.")
+    policy["attempt_number_role"] = "planner_seed_not_runtime_counter"
+    policy["runtime_attempt_source"] = "hermes_task_history"
+    policy["runtime_attempt_marker"] = "factory_recovery_attempt"
+    policy["runtime_authority"] = "hermes_kanban"
+    policy["local_state_authority"] = False
+    return policy
+
+
+def is_human_gate_recovery(*, blocker_type: str, repair_owner_worker: str) -> bool:
+    return blocker_type == "human_gate" or repair_owner_worker == "human-gate-clerk"
+
+
 def recovery_recommendation_for_worker(
     *,
     worker_id: str,
@@ -1322,18 +1349,7 @@ def recovery_recommendation_for_worker(
         "fresh_review_required": not human_gate_required,
         "fresh_review_result_ref": f"worker-result:{output_field}:fresh-review",
         "unblock_authority_ref": "Hermes blocked event plus fresh review PASS" if not human_gate_required else "human_gate_record",
-        "retry_policy": {
-            "max_attempts": 10,
-            "attempt_number": attempt_number,
-            "stop_classes": [
-                "human_gate",
-                "secret_or_access_required",
-                "external_mutation_required",
-                "ambiguous_product_decision",
-                "repeated_failed_recovery",
-            ],
-            "escalation_reason": "Escalate only when the blocker leaves factory-owned safe repair scope.",
-        },
+        "retry_policy": recovery_retry_policy(attempt_number=attempt_number),
         "hermes_runtime_boundary": recovery_runtime_boundary(),
     }
 
@@ -3659,18 +3675,7 @@ def recovery_route_from_action(card: dict[str, Any], action: dict[str, Any], ind
         "fresh_review_required": not human_gate_required,
         "fresh_review_result_ref": f"worker-result:{field}:fresh-review",
         "unblock_authority_ref": "Hermes blocked event plus fresh review PASS" if not human_gate_required else "human_gate_record",
-        "retry_policy": {
-            "max_attempts": 10,
-            "attempt_number": 1,
-            "stop_classes": [
-                "human_gate",
-                "secret_or_access_required",
-                "external_mutation_required",
-                "ambiguous_product_decision",
-                "repeated_failed_recovery",
-            ],
-            "escalation_reason": "Escalate only when the blocker leaves factory-owned safe repair scope.",
-        },
+        "retry_policy": recovery_retry_policy(),
         "audit_trail_refs": [
             "factoryctl:gate-report",
             f"worker:{worker_id}",
@@ -3743,17 +3748,21 @@ def recovery_route_from_recommendation(
     route_id = str(recommendation.get("recovery_route_id") or "").strip()
     if not route_id:
         route_id = f"recovery:{card_id}:{index}:{sanitize_slug(worker.worker_id, fallback='worker')}"
-    human_gate_required = recommendation.get("human_gate_required") is True
     blocker_type = str(recommendation.get("blocker_type") or blocker_type_for_worker(worker.worker_id)).strip()
+    repair_owner_worker = str(recommendation.get("repair_owner_worker") or worker.worker_id)
+    human_gate_required = recommendation.get("human_gate_required") is True or is_human_gate_recovery(
+        blocker_type=blocker_type,
+        repair_owner_worker=repair_owner_worker,
+    )
     audit_refs = ["factoryctl:worker-result-recovery", f"worker:{worker.worker_id}"]
     if evidence_ref:
         audit_refs.append(evidence_ref)
     return {
         "recovery_route_id": route_id,
         "blocker_type": blocker_type,
-        "factory_owned_repair_allowed": recommendation.get("factory_owned_repair_allowed") is not False,
+        "factory_owned_repair_allowed": False if human_gate_required else recommendation.get("factory_owned_repair_allowed") is not False,
         "human_gate_required": human_gate_required,
-        "repair_owner_worker": str(recommendation.get("repair_owner_worker") or worker.worker_id),
+        "repair_owner_worker": repair_owner_worker,
         "repair_task_ref": str(recommendation.get("repair_task_ref") or f"hermes:intent:{route_id}"),
         "repair_inputs": string_list(recommendation.get("repair_inputs"))
         or [
@@ -3780,16 +3789,12 @@ def recovery_route_from_recommendation(
         "fresh_review_required": recommendation.get("fresh_review_required") is not False and not human_gate_required,
         "fresh_review_result_ref": str(recommendation.get("fresh_review_result_ref") or f"worker-result:{field}:fresh-review"),
         "unblock_authority_ref": str(
-            recommendation.get("unblock_authority_ref")
+            "human_gate_record" if human_gate_required else recommendation.get("unblock_authority_ref")
             or ("human_gate_record" if human_gate_required else "Hermes blocked event plus fresh review PASS")
         ),
-        "retry_policy": recommendation.get("retry_policy")
-        if isinstance(recommendation.get("retry_policy"), dict)
-        else {
-            "max_attempts": 10,
-            "attempt_number": 1,
-            "stop_classes": ["human_gate", "repeated_failed_recovery"],
-        },
+        "retry_policy": recovery_retry_policy(
+            base=recommendation.get("retry_policy") if isinstance(recommendation.get("retry_policy"), dict) else None
+        ),
         "audit_trail_refs": audit_refs,
         "hermes_materialization": recovery_materialization_contract(route_id),
     }
@@ -4208,8 +4213,31 @@ def validate_worker_result_record(
                     errors.append("recovery_recommendation must not claim local runtime state authority")
                 if not str(recovery.get("recovery_route_id") or "").strip():
                     errors.append("recovery_recommendation.recovery_route_id is required")
-                if not isinstance(recovery.get("retry_policy"), dict):
+                blocker_type = str(recovery.get("blocker_type") or "").strip()
+                repair_owner_worker = str(recovery.get("repair_owner_worker") or "").strip()
+                if is_human_gate_recovery(blocker_type=blocker_type, repair_owner_worker=repair_owner_worker):
+                    if recovery.get("human_gate_required") is not True:
+                        errors.append("human_gate recovery requires human_gate_required=true")
+                    if recovery.get("factory_owned_repair_allowed") is not False:
+                        errors.append("human_gate recovery must not allow factory-owned repair")
+                    if recovery.get("fresh_review_required") is not False:
+                        errors.append("human_gate recovery must not route through fresh review")
+                    if recovery.get("unblock_authority_ref") != "human_gate_record":
+                        errors.append("human_gate recovery unblock_authority_ref must be human_gate_record")
+                retry_policy = recovery.get("retry_policy") if isinstance(recovery.get("retry_policy"), dict) else None
+                if not isinstance(retry_policy, dict):
                     errors.append("recovery_recommendation.retry_policy is required")
+                else:
+                    if retry_policy.get("attempt_number_role") != "planner_seed_not_runtime_counter":
+                        errors.append("recovery_recommendation.retry_policy.attempt_number_role must be planner_seed_not_runtime_counter")
+                    if retry_policy.get("runtime_attempt_source") != "hermes_task_history":
+                        errors.append("recovery_recommendation.retry_policy.runtime_attempt_source must be hermes_task_history")
+                    if retry_policy.get("runtime_attempt_marker") != "factory_recovery_attempt":
+                        errors.append("recovery_recommendation.retry_policy.runtime_attempt_marker must be factory_recovery_attempt")
+                    if retry_policy.get("runtime_authority") != "hermes_kanban":
+                        errors.append("recovery_recommendation.retry_policy.runtime_authority must be hermes_kanban")
+                    if retry_policy.get("local_state_authority") is not False:
+                        errors.append("recovery_recommendation.retry_policy must not claim local runtime state authority")
         if data.get("blocking_findings") is not False:
             errors.append("blocking_findings must be false")
         for field in ("worker", "card_ref", "findings_summary", "tool_or_profile", "executed_by", "next_action"):

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -19,6 +19,14 @@ assert SPEC.loader is not None
 sys.modules["factoryctl"] = factoryctl
 SPEC.loader.exec_module(factoryctl)
 
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
 
 def load_card(name: str) -> dict:
     return factoryctl.load_json_like(ROOT / "examples" / "cards" / name)
@@ -924,6 +932,12 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertTrue(recovery["factory_owned_repair_allowed"])
         self.assertEqual(recovery["hermes_runtime_boundary"]["runtime_authority"], "hermes_kanban")
         self.assertFalse(recovery["hermes_runtime_boundary"]["local_state_authority"])
+        self.assertEqual(recovery["retry_policy"]["attempt_number"], 1)
+        self.assertEqual(recovery["retry_policy"]["attempt_number_role"], "planner_seed_not_runtime_counter")
+        self.assertEqual(recovery["retry_policy"]["runtime_attempt_source"], "hermes_task_history")
+        self.assertEqual(recovery["retry_policy"]["runtime_attempt_marker"], "factory_recovery_attempt")
+        self.assertEqual(recovery["retry_policy"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(recovery["retry_policy"]["local_state_authority"])
         errors = factoryctl.validate_worker_result_record(
             result,
             expected_field="security_scan_result",
@@ -933,6 +947,77 @@ class FactoryCtlTest(unittest.TestCase):
         )
         self.assertIn("result must be PASS or WAIVED to satisfy a required worker", errors)
         self.assertNotIn("BLOCKED worker result requires recovery_recommendation", errors)
+
+    def test_blocked_worker_result_rejects_local_retry_authority(self) -> None:
+        card = load_card("v35_valid_security_with_scan.md")
+        result = factoryctl.build_worker_result(
+            "codex-security",
+            card,
+            result="BLOCKED",
+            tool_or_profile="codex-security:security-scan",
+            executed_by="security-runner",
+            evidence_refs=["reports/security.md"],
+            blocking_findings=True,
+            findings_summary="Security finding blocks continuation.",
+            next_action="repair finding and rerun security scan",
+        )
+        bad = json.loads(json.dumps(result))
+        bad["recovery_recommendation"]["retry_policy"].pop("runtime_attempt_source")
+        bad["recovery_recommendation"]["retry_policy"]["local_state_authority"] = True
+
+        errors = factoryctl.validate_worker_result_record(
+            bad,
+            expected_field="security_scan_result",
+            expected_worker_id="codex-security",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn("recovery_recommendation.retry_policy.runtime_attempt_source must be hermes_task_history", errors)
+        self.assertIn("recovery_recommendation.retry_policy must not claim local runtime state authority", errors)
+
+    def test_human_gate_recovery_cannot_be_factory_owned_repair(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        recovery = factoryctl.recovery_recommendation_for_worker(
+            worker_id="human-gate-clerk",
+            card=card,
+            reason="Human approval is required before continuation.",
+        )
+        result = worker_result("blocked_worker_result", result="BLOCKED", source_card=card)
+        result.update(
+            {
+                "$schema": factoryctl.worker_result_schema_url("human-gate-clerk"),
+                "worker": {"id": "human-gate-clerk", "name": "Human Gate Clerk", "factory_phase": "F15"},
+                "tool_or_profile": "human-gate-routing-check",
+                "executed_by": "human-gate-clerk",
+                "blocking_findings": True,
+                "findings_summary": "Human approval is required before continuation.",
+                "next_action": "wait for explicit human gate record",
+                "recovery_recommendation": recovery,
+            }
+        )
+
+        self.assertEqual(recovery["blocker_type"], "human_gate")
+        self.assertTrue(recovery["human_gate_required"])
+        self.assertFalse(recovery["factory_owned_repair_allowed"])
+        self.assertFalse(recovery["fresh_review_required"])
+        self.assertEqual(recovery["unblock_authority_ref"], "human_gate_record")
+
+        bad = json.loads(json.dumps(result))
+        bad["recovery_recommendation"]["factory_owned_repair_allowed"] = True
+        bad["recovery_recommendation"]["fresh_review_required"] = True
+        bad["recovery_recommendation"]["unblock_authority_ref"] = "Hermes blocked event plus fresh review PASS"
+
+        errors = factoryctl.validate_worker_result_record(
+            bad,
+            expected_worker_id="human-gate-clerk",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn("human_gate recovery must not allow factory-owned repair", errors)
+        self.assertIn("human_gate recovery must not route through fresh review", errors)
+        self.assertIn("human_gate recovery unblock_authority_ref must be human_gate_record", errors)
 
     def test_worker_result_public_card_ref_redacts_raw_kanban_task_markers(self) -> None:
         card = dict(load_card("v35_valid_security_with_scan.md"))
@@ -1196,6 +1281,9 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("repair_task_ref", route)
         self.assertIn("downstream_freeze_scope", route)
         self.assertIn("unblock_authority_ref", route)
+        self.assertEqual(route["retry_policy"]["attempt_number_role"], "planner_seed_not_runtime_counter")
+        self.assertEqual(route["retry_policy"]["runtime_attempt_source"], "hermes_task_history")
+        self.assertFalse(route["retry_policy"]["local_state_authority"])
         self.assertEqual(route["hermes_materialization"]["runtime_authority"], "hermes_kanban")
         self.assertFalse(route["hermes_materialization"]["local_state_authority"])
         self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_scheduler"])
@@ -1240,6 +1328,8 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(route["repair_owner_worker"], "handoff-packer")
         self.assertEqual(route["blocker_type"], "dependency")
         self.assertTrue(route["fresh_review_required"])
+        self.assertEqual(route["retry_policy"]["attempt_number_role"], "planner_seed_not_runtime_counter")
+        self.assertEqual(route["retry_policy"]["runtime_attempt_marker"], "factory_recovery_attempt")
         self.assertIn("handoff_packet_result", route["expected_repair_outputs"])
         self.assertIn("independent_review_result", route["expected_repair_outputs"])
         self.assertIn(requirement["requirement_id"], route["dependency_edge_patch"]["old_edges"])
@@ -1361,6 +1451,46 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn(action, transition_plan_schema["properties"]["transition_action"]["enum"])
         self.assertIn(action, transition_hook_schema["properties"]["transition_action"]["enum"])
         self.assertIn(action, worker_ledger_schema["properties"]["last_action"]["enum"])
+
+    def test_hermes_transition_schema_rejects_factory_owned_human_gate_recovery(self) -> None:
+        schema = json.loads((ROOT / "schemas" / "hermes-transition-plan.schema.json").read_text(encoding="utf-8"))
+        plan = {
+            "plan_type": "hermes_kanban_transition_plan",
+            "created_at": "2026-06-15T00:00:00+00:00",
+            "source_card_path": "examples/cards/v35_valid_onchain_auditor_scan.md",
+            "event": {"from_status": "review", "to_status": "done", "card_id": "KFP-V35-POS-ONCHAIN-AUDITOR"},
+            "transition_action": "block_transition",
+            "blocked_reasons": ["human gate required"],
+            "gate_report": {},
+            "worker_tasks": [],
+            "recovery_routes": [
+                {
+                    "recovery_route_id": "recovery:human-gate",
+                    "blocker_type": "human_gate",
+                    "factory_owned_repair_allowed": True,
+                    "human_gate_required": False,
+                    "repair_owner_worker": "human-gate-clerk",
+                    "repair_task_ref": "hermes:intent:human-gate",
+                    "invalidates_refs": [],
+                    "supersedes_refs": [],
+                    "fresh_review_required": True,
+                    "unblock_authority_ref": "Hermes blocked event plus fresh review PASS",
+                    "retry_policy": factoryctl.recovery_retry_policy(),
+                    "hermes_materialization": {
+                        "runtime_authority": "hermes_kanban",
+                        "local_state_authority": False,
+                    },
+                }
+            ],
+        }
+
+        errors = public_json_validator.validate_node(schema, plan, "$", schemas={"hermes-transition-plan.schema.json": schema}, root_schema=schema)
+
+        joined = "\n".join(errors)
+        self.assertIn("factory_owned_repair_allowed", joined)
+        self.assertIn("human_gate_required", joined)
+        self.assertIn("fresh_review_required", joined)
+        self.assertIn("unblock_authority_ref", joined)
 
     def test_transition_plan_enforce_blocks_before_ready_action(self) -> None:
         args = Namespace(


### PR DESCRIPTION
Relates to #134.

## Summary
- Normalize recovery retry policy as a planner seed, not a local runtime counter.
- Require Hermes task history plus the stable `factory_recovery_attempt` marker as the runtime attempt source.
- Enforce retry runtime-boundary fields in worker result, factory recovery plan, and Hermes transition plan schemas.
- Prevent `human_gate` / `human-gate-clerk` recovery from being treated as factory-owned repair or fresh-review unblock; human gates must use `human_gate_record`.
- Add negative tests proving malformed local retry authority and factory-owned human gate recovery are rejected.

## Validation
- `python -B -m unittest discover -s tests -p "test_*.py" -q` (419 tests)
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\public_safety_scan.py`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`

## Notes
- This does not touch issue #84 / cockpit implementation.
- #134 should remain open for the broader Swiss-watch recovery audit loop.
