### PR TITLE
[codex] Bind Hermes idempotency to materialization contracts

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -33,6 +34,33 @@ Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 RECOVERY_ATTEMPT_MARKER = "factory_recovery_attempt"
 ACTIVE_OR_TERMINAL_STATUSES = {"ready", "running", "done", "complete", "completed"}
 HISTORY_SOURCE_KEYS = ("events", "history", "timeline", "comments", "runs")
+CONTRACT_DIGEST_ALGORITHM = "sha256"
+IDEMPOTENCY_DIGEST_LENGTH = 16
+VOLATILE_CONTRACT_KEYS = {
+    "checked_at",
+    "created_at",
+    "generated_at",
+    "last_checked_at",
+    "timestamp",
+    "updated_at",
+}
+CANONICALIZATION_VERSION = "v1"
+IDEMPOTENCY_LINEAGE_POLICY = "base_identity_is_logical_lineage_contract_key_is_runtime_identity"
+WORKER_MATERIALIZATION_CONTRACT_FIELDS = (
+    "task_type",
+    "worker_id",
+    "gate_timing_class",
+    "queue_class",
+    "runtime_authority",
+    "local_state_authority",
+    "required_before",
+    "expected_receipt_field",
+    "status",
+    "dependency_authorization_state",
+    "review_task_authorizations",
+    "recovery_route_refs",
+    "packet",
+)
 
 
 def default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
@@ -64,6 +92,55 @@ def parse_json_output(output: str, *, command: str) -> Any:
 
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def stable_contract_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): stable_contract_value(item)
+            for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
+            if str(key) not in VOLATILE_CONTRACT_KEYS
+        }
+    if isinstance(value, list):
+        return [stable_contract_value(item) for item in value]
+    return value
+
+
+def contract_digest(value: Any) -> str:
+    stable_value = stable_contract_value(value)
+    if isinstance(stable_value, str):
+        payload = stable_value
+    else:
+        payload = json.dumps(stable_value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def idempotency_digest_fragment(digest: str) -> str:
+    return digest[:IDEMPOTENCY_DIGEST_LENGTH]
+
+
+def main_base_idempotency_key(card_id: str) -> str:
+    return f"overkill:{card_id}:main"
+
+
+def worker_base_idempotency_key(card_id: str, worker_id: str) -> str:
+    return f"overkill:{card_id}:{worker_id}"
+
+
+def main_task_idempotency_key(card_id: str, card_body: str) -> str:
+    return f"{main_base_idempotency_key(card_id)}:{idempotency_digest_fragment(contract_digest(card_body))}"
+
+
+def worker_materialization_contract(task: dict[str, Any]) -> dict[str, Any]:
+    return {field: task[field] for field in WORKER_MATERIALIZATION_CONTRACT_FIELDS if field in task}
+
+
+def worker_task_idempotency_key(card_id: str, worker_id: str, task_contract: dict[str, Any]) -> str:
+    return f"{worker_base_idempotency_key(card_id, worker_id)}:{idempotency_digest_fragment(contract_digest(task_contract))}"
+
+
+def recovery_route_digest(route: dict[str, Any]) -> str:
+    return f"{CONTRACT_DIGEST_ALGORITHM}:{contract_digest(route)}"
 
 
 def parse_task_id(output: str) -> str:
@@ -337,14 +414,15 @@ def has_history_source(payload: dict[str, Any]) -> bool:
     return any(isinstance(payload.get(key), list) for key in HISTORY_SOURCE_KEYS)
 
 
-def recovery_attempt_history_refs(payload: dict[str, Any], route_id: str) -> list[str]:
+def recovery_attempt_history_refs(payload: dict[str, Any], route_id: str, route_digest: str) -> list[str]:
     route = route_id.strip().lower()
-    if not route:
+    digest = route_digest.strip().lower()
+    if not route or not digest:
         return []
     refs: list[str] = []
     for key, index, item in history_items(payload):
         text = json.dumps(item, ensure_ascii=True, sort_keys=True).lower() if isinstance(item, dict) else str(item).lower()
-        if route in text and RECOVERY_ATTEMPT_MARKER in text:
+        if route in text and digest in text and RECOVERY_ATTEMPT_MARKER in text:
             refs.append(f"{key}:{index}")
     return refs
 
@@ -403,6 +481,7 @@ def record_live_binding(
     board: str,
     main_task_id: str,
     worker_task_ids: dict[str, str],
+    idempotency_contract: dict[str, Any] | None = None,
 ) -> None:
     ledger = load_json(ledger_path)
     tasks = ledger.setdefault("tasks", {})
@@ -422,6 +501,7 @@ def record_live_binding(
         task["local_record_role"] = "idempotency_projection"
     bindings = ledger.setdefault("live_bindings", {})
     bindings[card_id] = {
+        "card_id": card_id,
         "binding_role": "hermes_ref_projection",
         "runtime_authority": "hermes_kanban",
         "local_state_authority": False,
@@ -429,6 +509,8 @@ def record_live_binding(
         "main_task_id": main_task_id,
         "worker_task_ids": worker_task_ids,
     }
+    if idempotency_contract:
+        bindings[card_id]["idempotency_contract"] = idempotency_contract
     write_json(ledger_path, ledger)
 
 
@@ -584,13 +666,41 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
     if readiness_blockers:
         raise RuntimeError("pre-dispatch route readiness blocked live materialization: " + "; ".join(readiness_blockers))
 
+    card_body = card_path.read_text(encoding="utf-8")
+    main_contract_digest = contract_digest(card_body)
+    idempotency_contract: dict[str, Any] = {
+        "digest_algorithm": CONTRACT_DIGEST_ALGORITHM,
+        "canonicalization_version": CANONICALIZATION_VERSION,
+        "volatile_fields_ignored": sorted(VOLATILE_CONTRACT_KEYS),
+        "digest_scope": "main_card_body_and_stable_worker_packet_contract",
+        "lineage_policy": IDEMPOTENCY_LINEAGE_POLICY,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+        "main_task": {
+            "idempotency_identity": {
+                "card_id": card_id,
+                "task_role": "main",
+                "base_idempotency_key": main_base_idempotency_key(card_id),
+            },
+            "contract_digest": main_contract_digest,
+            "idempotency_key": main_task_idempotency_key(card_id, card_body),
+            "runtime_history_query_keys": [
+                main_base_idempotency_key(card_id),
+                main_task_idempotency_key(card_id, card_body),
+            ],
+            "previous_runtime_task_refs": [],
+            "supersedes_idempotency_keys": [],
+        },
+        "worker_tasks": {},
+    }
+
     main_task_id = create_task(
         hermes_bin=args.hermes_bin,
         board=args.board,
         title=f"OF {card_id} main gate",
-        body=card_path.read_text(encoding="utf-8"),
+        body=card_body,
         assignee=args.main_assignee,
-        idempotency_key=f"overkill:{card_id}:main",
+        idempotency_key=idempotency_contract["main_task"]["idempotency_key"],
         created_by="overkill-factory",
         workspace=f"dir:{ROOT}",
         blocked=True,
@@ -608,13 +718,33 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         if not worker_id or task.get("status") == "not_required_by_current_card":
             continue
         packet = task.get("packet") or {}
+        worker_task_contract = worker_materialization_contract(task)
+        worker_idempotency_key = worker_task_idempotency_key(card_id, worker_id, worker_task_contract)
+        worker_contract_digest = contract_digest(worker_task_contract)
+        idempotency_contract["worker_tasks"][worker_id] = {
+            "idempotency_identity": {
+                "card_id": card_id,
+                "worker_id": worker_id,
+                "task_role": "worker",
+                "base_idempotency_key": worker_base_idempotency_key(card_id, worker_id),
+            },
+            "contract_scope": "worker_task_materialization_contract",
+            "contract_digest": worker_contract_digest,
+            "idempotency_key": worker_idempotency_key,
+            "runtime_history_query_keys": [
+                worker_base_idempotency_key(card_id, worker_id),
+                worker_idempotency_key,
+            ],
+            "previous_runtime_task_refs": [],
+            "supersedes_idempotency_keys": [],
+        }
         task_id = create_task(
             hermes_bin=args.hermes_bin,
             board=args.board,
             title=str(task.get("title") or f"OF {card_id} {worker_id}"),
             body=json.dumps(packet, indent=2, ensure_ascii=True),
             assignee=args.worker_assignee_prefix + worker_id,
-            idempotency_key=f"overkill:{card_id}:{worker_id}",
+            idempotency_key=worker_idempotency_key,
             created_by="overkill-factory",
             workspace=f"dir:{ROOT}",
             blocked=not args.worker_ready,
@@ -656,6 +786,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         if recovery_authorized and not args.worker_ready:
             route = authorized_recovery_routes[0]
             route_id = str(route.get("recovery_route_id") or "factory-recovery-route")
+            route_digest = recovery_route_digest(route)
             fresh_review_ref = str(route.get("fresh_review_result_ref") or "fresh-review-required")
             shown_task = show_task(
                 hermes_bin=args.hermes_bin,
@@ -664,12 +795,13 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 runner=runner,
             )
             task_status_value = task_status(shown_task)
-            history_refs = recovery_attempt_history_refs(shown_task, route_id)
+            history_refs = recovery_attempt_history_refs(shown_task, route_id, route_digest)
             previous_attempts = len(history_refs)
             attempt_number = previous_attempts + 1
             max_attempts = retry_policy_max_attempts(route)
             recovery_attempts[worker_id] = {
                 "recovery_route_id": route_id,
+                "recovery_route_digest": route_digest,
                 "worker_id": worker_id,
                 "hermes_task_ref": task_id,
                 "previous_attempts": previous_attempts,
@@ -702,6 +834,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 task_id=task_id,
                 reason=(
                     f"{RECOVERY_ATTEMPT_MARKER} route_id={route_id} "
+                    f"route_digest={route_digest} "
                     f"attempt_number={attempt_number} max_attempts={max_attempts}; "
                     "Factory-owned recovery route authorized repair task; downstream remains gated until "
                     f"{fresh_review_ref} passes."
@@ -745,6 +878,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         board=args.board,
         main_task_id=main_task_id,
         worker_task_ids=worker_task_ids,
+        idempotency_contract=idempotency_contract,
     )
 
     envelope = {
@@ -760,6 +894,7 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         "recovery_retry_blocked_worker_task_ids": recovery_retry_blocked_worker_task_ids,
         "recovery_attempts": recovery_attempts,
         "downstream_promoted_worker_task_ids": downstream_promoted_worker_task_ids,
+        "idempotency_contract": idempotency_contract,
         "hook": result,
     }
     public_envelope = sanitize_public_refs(envelope)

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -65,6 +65,7 @@
         "type": "object",
         "required": [
           "recovery_route_id",
+          "recovery_route_digest",
           "worker_id",
           "hermes_task_ref",
           "previous_attempts",
@@ -81,6 +82,7 @@
         ],
         "properties": {
           "recovery_route_id": { "type": "string", "minLength": 3 },
+          "recovery_route_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
           "worker_id": { "type": "string", "minLength": 1 },
           "hermes_task_ref": { "type": "string", "minLength": 3 },
           "previous_attempts": { "type": "integer", "minimum": 0 },
@@ -112,9 +114,134 @@
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 3 }
     },
+    "idempotency_contract": {
+      "type": "object",
+      "required": [
+        "digest_algorithm",
+        "canonicalization_version",
+        "volatile_fields_ignored",
+        "digest_scope",
+        "lineage_policy",
+        "runtime_authority",
+        "local_state_authority",
+        "main_task",
+        "worker_tasks"
+      ],
+      "properties": {
+        "digest_algorithm": { "const": "sha256" },
+        "canonicalization_version": { "const": "v1" },
+        "volatile_fields_ignored": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "digest_scope": { "const": "main_card_body_and_stable_worker_packet_contract" },
+        "lineage_policy": { "const": "base_identity_is_logical_lineage_contract_key_is_runtime_identity" },
+        "runtime_authority": { "const": "hermes_kanban" },
+        "local_state_authority": { "const": false },
+        "main_task": {
+          "type": "object",
+          "required": [
+            "idempotency_identity",
+            "contract_digest",
+            "idempotency_key",
+            "runtime_history_query_keys",
+            "previous_runtime_task_refs",
+            "supersedes_idempotency_keys"
+          ],
+          "properties": {
+            "idempotency_identity": {
+              "type": "object",
+              "required": ["card_id", "task_role", "base_idempotency_key"],
+              "properties": {
+                "card_id": { "type": "string", "minLength": 1 },
+                "task_role": { "const": "main" },
+                "base_idempotency_key": { "type": "string", "pattern": "^overkill:.+:main$" }
+              },
+              "additionalProperties": false
+            },
+            "contract_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "idempotency_key": { "type": "string", "pattern": "^overkill:.+:main:[0-9a-f]{16}$" },
+            "runtime_history_query_keys": {
+              "type": "array",
+              "minItems": 2,
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "previous_runtime_task_refs": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "supersedes_idempotency_keys": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 3 }
+            }
+          },
+          "additionalProperties": false
+        },
+        "worker_tasks": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "idempotency_identity",
+              "contract_scope",
+              "contract_digest",
+              "idempotency_key",
+              "runtime_history_query_keys",
+              "previous_runtime_task_refs",
+              "supersedes_idempotency_keys"
+            ],
+            "properties": {
+              "idempotency_identity": {
+                "type": "object",
+                "required": ["card_id", "worker_id", "task_role", "base_idempotency_key"],
+                "properties": {
+                  "card_id": { "type": "string", "minLength": 1 },
+                  "worker_id": { "type": "string", "minLength": 1 },
+                  "task_role": { "const": "worker" },
+                  "base_idempotency_key": { "type": "string", "pattern": "^overkill:.+:.+$" }
+                },
+                "additionalProperties": false
+              },
+              "contract_scope": { "const": "worker_task_materialization_contract" },
+              "contract_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "idempotency_key": { "type": "string", "pattern": "^overkill:.+:.+:[0-9a-f]{16}$" },
+              "runtime_history_query_keys": {
+                "type": "array",
+                "minItems": 2,
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "previous_runtime_task_refs": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "supersedes_idempotency_keys": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 3 }
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "hook": {
       "type": "object"
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "mode": { "const": "materialize" },
+          "dry_run": { "const": false }
+        },
+        "required": ["mode", "dry_run"]
+      },
+      "then": {
+        "required": ["idempotency_contract"]
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -234,8 +234,49 @@ def assert_live_adapter_result_schema(testcase: unittest.TestCase, result: dict[
 
 
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
+    def test_worker_idempotency_key_is_contract_bound_and_ignores_volatile_metadata(self) -> None:
+        task_contract = {
+            "worker_id": "codex-security",
+            "queue_class": "blocking-before-done",
+            "gate_timing_class": "blocking-before-done",
+            "required_before": "done",
+            "expected_receipt_field": "security_scan_result",
+            "packet": {
+                "created_at": "2026-06-15T00:00:00Z",
+                "worker": {"id": "codex-security"},
+                "input_contract": {"required_fields": ["security_scan_packet"]},
+            },
+        }
+        same_contract = {
+            **task_contract,
+            "packet": {
+                **task_contract["packet"],
+                "created_at": "2026-06-16T00:00:00Z",
+                "checked_at": "2026-06-16T01:00:00Z",
+            },
+        }
+        changed_contract = {
+            **task_contract,
+            "queue_class": "blocking-before-ready",
+        }
+
+        key = adapter.worker_task_idempotency_key("CARD-1", "codex-security", task_contract)
+
+        self.assertEqual(key, adapter.worker_task_idempotency_key("CARD-1", "codex-security", same_contract))
+        self.assertNotEqual(key, adapter.worker_task_idempotency_key("CARD-1", "codex-security", changed_contract))
+        self.assertRegex(key, r"^overkill:CARD-1:codex-security:[0-9a-f]{16}$")
+
     def test_recovery_attempt_count_requires_stable_marker(self) -> None:
         route_id = "recovery:card-001:handoff-packer"
+        route_digest = adapter.recovery_route_digest(
+            {
+                "recovery_route_id": route_id,
+                "retry_policy": {"max_attempts": 10},
+                "fresh_review_result_ref": "worker-result:independent-reviewer:fresh-review",
+                "factory_owned_repair_allowed": True,
+                "human_gate_required": False,
+            }
+        )
 
         refs = adapter.recovery_attempt_history_refs(
             {
@@ -245,7 +286,16 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                         "type": "unblocked",
                         "reason": (
                             "factory_recovery_attempt "
-                            f"route_id={route_id} attempt_number=1 max_attempts=10"
+                            f"route_id={route_id} route_digest=sha256:0000 "
+                            "attempt_number=1 max_attempts=10"
+                        ),
+                    },
+                    {
+                        "type": "unblocked",
+                        "reason": (
+                            "factory_recovery_attempt "
+                            f"route_id={route_id} route_digest={route_digest} "
+                            "attempt_number=1 max_attempts=10"
                         ),
                     },
                 ],
@@ -253,15 +303,17 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     {
                         "body": (
                             "factory_recovery_attempt "
-                            f"route_id={route_id} attempt_number=2 max_attempts=10"
+                            f"route_id={route_id} route_digest={route_digest} "
+                            "attempt_number=2 max_attempts=10"
                         )
                     }
                 ],
             },
             route_id,
+            route_digest,
         )
 
-        self.assertEqual(refs, ["events:1", "comments:0"])
+        self.assertEqual(refs, ["events:2", "comments:0"])
 
     def test_blocked_event_detection_does_not_treat_unblocked_as_blocked(self) -> None:
         self.assertFalse(
@@ -348,6 +400,24 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(binding["binding_role"], "hermes_ref_projection")
         self.assertEqual(binding["runtime_authority"], "hermes_kanban")
         self.assertFalse(binding["local_state_authority"])
+        self.assertEqual(binding["idempotency_contract"], result["idempotency_contract"])
+        self.assertEqual(result["idempotency_contract"]["digest_algorithm"], "sha256")
+        self.assertEqual(result["idempotency_contract"]["runtime_authority"], "hermes_kanban")
+        self.assertFalse(result["idempotency_contract"]["local_state_authority"])
+        self.assertRegex(result["idempotency_contract"]["main_task"]["contract_digest"], r"^[0-9a-f]{64}$")
+        self.assertRegex(
+            result["idempotency_contract"]["main_task"]["idempotency_key"],
+            rf"^overkill:{binding['card_id']}:main:[0-9a-f]{{16}}$",
+        )
+        self.assertRegex(
+            result["idempotency_contract"]["worker_tasks"]["codex-security"]["idempotency_key"],
+            rf"^overkill:{binding['card_id']}:codex-security:[0-9a-f]{{16}}$",
+        )
+        create_keys = [call[call.index("--idempotency-key") + 1] for call in fake.calls if "--idempotency-key" in call]
+        self.assertIn(result["idempotency_contract"]["main_task"]["idempotency_key"], create_keys)
+        self.assertIn(result["idempotency_contract"]["worker_tasks"]["codex-security"]["idempotency_key"], create_keys)
+        self.assertNotIn(f"overkill:{binding['card_id']}:main", create_keys)
+        self.assertNotIn(f"overkill:{binding['card_id']}:codex-security", create_keys)
         materialized_tasks = [
             task for task in ledger_data["tasks"].values()
             if task["worker_id"] == "codex-security" and task["materialization_state"] == "materialized_in_hermes"
@@ -598,16 +668,25 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             )
             blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
             review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
-            route = factoryctl.build_transition_plan(
+            plan = factoryctl.build_transition_plan(
                 card_data,
                 card,
                 from_status="blocked",
                 to_status="ready",
                 worker_results_dir=worker_results,
-            )["recovery_routes"][0]
+            )
+            route = plan["recovery_routes"][0]
             route_id = route["recovery_route_id"]
+            route_digest = adapter.recovery_route_digest(route)
+            handoff_task = next(task for task in plan["worker_tasks"] if task["worker_id"] == "handoff-packer")
             existing_task_id = "t_" + "retry0001"
-            fake.idempotent_task_ids[f"overkill:{card_data['card_id']}:handoff-packer"] = existing_task_id
+            fake.idempotent_task_ids[
+                adapter.worker_task_idempotency_key(
+                    card_data["card_id"],
+                    "handoff-packer",
+                    adapter.worker_materialization_contract(handoff_task),
+                )
+            ] = existing_task_id
             fake.tasks[existing_task_id] = {
                 "status": "blocked",
                 "events": [
@@ -620,7 +699,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                             "type": "unblocked",
                             "reason": (
                                 "factory_recovery_attempt "
-                                f"route_id={route_id} attempt_number={index} max_attempts=10"
+                                f"route_id={route_id} route_digest={route_digest} "
+                                f"attempt_number={index} max_attempts=10"
                             ),
                         }
                         for index in range(1, 11)
@@ -703,16 +783,25 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             )
             blocked_review["graph_requirement_refs"] = [requirement["requirement_id"]]
             review_path.write_text(json.dumps(blocked_review), encoding="utf-8")
-            route = factoryctl.build_transition_plan(
+            plan = factoryctl.build_transition_plan(
                 card_data,
                 card,
                 from_status="blocked",
                 to_status="ready",
                 worker_results_dir=worker_results,
-            )["recovery_routes"][0]
+            )
+            route = plan["recovery_routes"][0]
             route_id = route["recovery_route_id"]
+            route_digest = adapter.recovery_route_digest(route)
+            handoff_task = next(task for task in plan["worker_tasks"] if task["worker_id"] == "handoff-packer")
             existing_task_id = "t_" + "ready1111"
-            fake.idempotent_task_ids[f"overkill:{card_data['card_id']}:handoff-packer"] = existing_task_id
+            fake.idempotent_task_ids[
+                adapter.worker_task_idempotency_key(
+                    card_data["card_id"],
+                    "handoff-packer",
+                    adapter.worker_materialization_contract(handoff_task),
+                )
+            ] = existing_task_id
             fake.tasks[existing_task_id] = {
                 "status": "ready",
                 "events": [
@@ -720,7 +809,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                         "type": "unblocked",
                         "reason": (
                             "factory_recovery_attempt "
-                            f"route_id={route_id} attempt_number=1 max_attempts=10"
+                            f"route_id={route_id} route_digest={route_digest} "
+                            "attempt_number=1 max_attempts=10"
                         ),
                     }
                 ],


### PR DESCRIPTION
Relates to #134.

## Summary
- Bind Hermes materialization idempotency to stable contract digests instead of only `card_id` / `worker_id`.
- Use a digest-suffixed runtime idempotency key while preserving a base logical lineage key for the same card/task role.
- Hash the main card body and a narrow worker task materialization contract including timing/queue/status/authorization/packet data, while ignoring volatile timestamp fields.
- Add `idempotency_contract` to the live adapter result and ledger projection with runtime authority and local-state false.
- Require recovery attempt history to match both `recovery_route_id` and `recovery_route_digest`, preventing retry counts from old route contracts contaminating a new one.
- Add focused tests for contract-bound keys, route-digest recovery markers, materialization ledger evidence, retry-limit preservation, and active rerun behavior.

## Validation
- `python -B -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q` (420 tests)
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`

## Notes
- This does not touch issue #84 / cockpit implementation.
- #134 should remain open for the broader Swiss-watch recovery loop.
