### PR TITLE
[codex] Enforce contains in public JSON validation

### DIFF
--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -232,6 +232,26 @@ def validate_node(
             if key in seen:
                 errors.append(f"{at}[{index}]: duplicate item violates uniqueItems")
             seen.add(key)
+    if isinstance(value, list) and isinstance(schema.get("contains"), dict):
+        contains_schema = schema["contains"]
+        matched_count = sum(
+            1
+            for index, item in enumerate(value)
+            if schema_matches(
+                contains_schema,
+                item,
+                f"{at}[{index}]",
+                schemas=schemas,
+                root_schema=root,
+                seen_refs=seen,
+            )
+        )
+        min_contains = int(schema.get("minContains", 1))
+        max_contains = schema.get("maxContains")
+        if matched_count < min_contains:
+            errors.append(f"{at}: array does not contain at least {min_contains} matching item(s)")
+        if max_contains is not None and matched_count > int(max_contains):
+            errors.append(f"{at}: array contains more than {int(max_contains)} matching item(s)")
     if isinstance(value, dict) and "minProperties" in schema and len(value) < int(schema["minProperties"]):
         errors.append(f"{at}: object has fewer properties than minProperties {schema['minProperties']}")
 

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -52,6 +52,15 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         errors = validator.validate_node(schema, {"result": "BLOCKED"}, "$")
         self.assertTrue(any("recovery_recommendation" in error for error in errors))
 
+    def test_enforces_contains_used_by_review_authorization_schemas(self) -> None:
+        validator = load_validator()
+        schema = {"type": "array", "contains": {"const": "review"}}
+
+        self.assertEqual(validator.validate_node(schema, ["implementation", "review"], "$"), [])
+        errors = validator.validate_node(schema, ["implementation", "qa"], "$")
+
+        self.assertTrue(any("does not contain" in error for error in errors))
+
     def test_resolves_schema_file_refs_used_by_factory_card(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
Relates to #134.

## Summary
- Enforces JSON Schema `contains` in the public JSON artifact validator.
- Supports `minContains` and `maxContains` so array membership requirements are no longer silently ignored.
- Adds a regression test for the review-authorization pattern that depends on `contains: { const: "review" }`.

## Why this matters
The factory's public validation layer already has schemas that express required review authority through `contains`, but the validator did not enforce that keyword. That means a public artifact could look schema-backed while missing the specific required scope. For the Swiss-watch operating model, this is a gear mismatch: the contract says one thing, the local validator proves less.

This PR closes that gap without touching cockpit/#84 and without adding historical/audit artifacts to the public repo.

## Validation
- `python -B -m unittest tests.test_public_json_artifact_validator -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `git diff --check`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`