### PR TITLE
[codex] Reject inactive worker results during closure

### DIFF
--- a/scripts/evidence_reconciler.py
+++ b/scripts/evidence_reconciler.py
@@ -43,9 +43,6 @@ def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict
         evidence_root=ROOT,
     )
     authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
-    active = authority.get("active")
-    if active is None:
-        active = data.get("active", True)
     superseded_by = data.get("superseded_by") or authority.get("superseded_by")
     evidence_ref = factoryctl.source_card_ref(path)
     review_declared = factoryctl.worker_result_declares_review(data)
@@ -61,7 +58,7 @@ def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict
         "blocking_findings": data.get("blocking_findings"),
         "created_at": data.get("created_at") or data.get("decision_at"),
         "evidence_ref": evidence_ref,
-        "active": bool(active) and not bool(superseded_by),
+        "active": factoryctl.worker_result_is_active(data),
         "supersession_key": data.get("supersession_key") or record_type,
         "supersedes": data.get("supersedes") or authority.get("supersedes"),
         "superseded_by": superseded_by,

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4306,6 +4306,16 @@ def validate_worker_result_record(
     return errors
 
 
+def worker_result_is_active(data: dict[str, Any]) -> bool:
+    authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
+    return (
+        data.get("active", True) is not False
+        and authority.get("active", True) is not False
+        and not data.get("superseded_by")
+        and not authority.get("superseded_by")
+    )
+
+
 def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None) -> dict[str, dict[str, Any]]:
     if results_dir is None or not results_dir.exists():
         return {}
@@ -4326,7 +4336,6 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             card=card,
             evidence_root=ROOT,
         )
-        authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
         evidence_ref = source_card_ref(path)
         review_declared = worker_result_declares_review(data)
         graph_requirements = declared_graph_requirements(record_type, data, evidence_ref=evidence_ref) if not errors else []
@@ -4336,7 +4345,7 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             "result": data.get("result") or data.get("decision"),
             "findings_summary": data.get("findings_summary"),
             "next_action": data.get("next_action"),
-            "active": authority.get("active", data.get("active", True)) is not False and not data.get("superseded_by"),
+            "active": worker_result_is_active(data),
             "valid": not errors,
             "consumable": not errors,
             "review_declared": review_declared,
@@ -4404,6 +4413,7 @@ def receipt_result_fields(
                 "result": value.get("result") or value.get("decision"),
                 "findings_summary": value.get("findings_summary"),
                 "next_action": value.get("next_action"),
+                "active": worker_result_is_active(value),
                 "valid": not errors,
                 "consumable": not errors,
                 "review_declared": review_declared,
@@ -4862,13 +4872,15 @@ def build_worker_closure(
         queue_class = worker_queue_class(worker_id, card)
         required_for_done = queue_class == "blocking-before-done"
         record = present_fields.get(worker.output_field)
+        active = bool(record and record.get("active", True))
         valid = bool(record and record.get("valid"))
         consumable = bool(record and record.get("consumable", True))
-        satisfied = bool(valid and consumable)
+        satisfied = bool(active and valid and consumable)
         rows[worker_id] = {
             "queue_class": queue_class,
             "required_for_done": required_for_done,
             "output_field": worker.output_field,
+            "active": active,
             "valid": valid,
             "consumable": consumable,
             "satisfied": satisfied,
@@ -4883,7 +4895,9 @@ def build_worker_closure(
             "validation_errors": record.get("validation_errors", []) if record else [],
         }
         if required_for_done and not satisfied:
-            if record and valid:
+            if record and not active:
+                unconsumable_blocking.append(worker_id)
+            elif record and valid:
                 unconsumable_blocking.append(worker_id)
             elif record:
                 invalid_blocking.append(worker_id)

--- a/tests/test_evidence_reconciler.py
+++ b/tests/test_evidence_reconciler.py
@@ -139,6 +139,27 @@ class EvidenceReconcilerTest(unittest.TestCase):
             {item["record_type"] for item in index["superseded_results"]},
         )
 
+    def test_top_level_inactive_result_does_not_satisfy_receipt_five(self) -> None:
+        card = closure_card()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            results_dir = Path(tmp)
+            write_results(card, results_dir)
+            inactive_security = result_for("codex-security", card, "2026-06-06T00:50:00+00:00")
+            inactive_security["active"] = False
+            results_dir.joinpath("codex-security.json").write_text(
+                factoryctl.json.dumps(inactive_security, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            index = evidence_reconciler.reconcile(card, results_dir)
+
+        self.assertFalse(index["receipt_five_ready"])
+        self.assertIn("security_scan_result", index["missing_required_fields"])
+        self.assertIn(
+            "security_scan_result",
+            {item["record_type"] for item in index["superseded_results"]},
+        )
+
     def test_missing_required_result_blocks_receipt_five(self) -> None:
         card = closure_card()
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1112,6 +1112,25 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertTrue(records["security_scan_result"]["valid"])
         self.assertEqual(records["security_scan_result"]["result"], "PASS")
 
+    def test_worker_closure_rejects_inactive_inline_worker_result(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        inactive_result = worker_result("security_scan_result", source_card=card)
+        inactive_result["active"] = False
+
+        closure = factoryctl.build_worker_closure(
+            card,
+            {"security_scan_result": inactive_result},
+            None,
+        )
+
+        security_row = closure["workers"]["codex-security"]
+        self.assertFalse(security_row["active"])
+        self.assertTrue(security_row["valid"])
+        self.assertTrue(security_row["consumable"])
+        self.assertFalse(security_row["satisfied"])
+        self.assertIn("codex-security", closure["unconsumable_blocking_workers"])
+
     def test_inline_worker_result_requires_existing_evidence_ref_for_done(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         receipt = {


### PR DESCRIPTION
Relates to #134.

## Summary
- Centralizes worker-result activity semantics in `factoryctl.worker_result_is_active`.
- Treats any top-level or `promotion_authority` inactivation/supersession marker as non-current evidence.
- Requires `active and valid and consumable` before a worker result can satisfy closure/done reconciliation.
- Applies the same rule to `evidence_reconciler` so Receipt Five cannot be built from stale/inactive worker evidence.

## Why this matters
The factory already distinguished current evidence from superseded evidence, but two closure paths could still treat a valid-shaped worker result as satisfying work even when the result itself was marked inactive at the top level. That breaks the Swiss-watch model: a gear labeled stale must not keep driving the done transition.

This PR makes stale/inactive evidence visible as a blocker instead of silently usable. It does not touch cockpit/#84 and does not add audit/history artifacts to the public repo.

## Validation
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_worker_closure_rejects_inactive_inline_worker_result -q`
- `python -B -m unittest tests.test_evidence_reconciler.EvidenceReconcilerTest.test_top_level_inactive_result_does_not_satisfy_receipt_five -q`
- `python -B -m unittest tests.test_factoryctl -q`
- `python -B -m unittest tests.test_evidence_reconciler -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`