### PR TITLE
[codex] Unify completion validation with done promotion gate

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3092,8 +3092,15 @@ def validate_completion_audit_contract(card: dict[str, Any], audit: dict[str, An
     return errors
 
 
-def validate_completion(card: dict[str, Any], metadata: dict[str, Any]) -> list[str]:
+def validate_completion(
+    card: dict[str, Any],
+    metadata: dict[str, Any],
+    *,
+    from_status: str | None = None,
+    to_status: str | None = None,
+) -> list[str]:
     errors = validate_receipt(metadata)
+    errors.extend(done_promotion_errors(metadata, from_status=from_status, to_status=to_status))
     receipt = metadata.get("receipt_five") if isinstance(metadata.get("receipt_five"), dict) else {}
     if receipt.get("reviewer_required") is True and str(receipt.get("reviewer_result") or "").strip().upper() != "PASS":
         errors.append("reviewer_result must be PASS when reviewer_required=true")
@@ -4943,6 +4950,24 @@ def receipt_reconciliation_errors(metadata: dict[str, Any] | None) -> list[str]:
     return errors
 
 
+def done_promotion_errors(
+    metadata: dict[str, Any] | None,
+    *,
+    from_status: str | None = None,
+    to_status: str | None = None,
+) -> list[str]:
+    errors = receipt_reconciliation_errors(metadata)
+    if from_status is not None and to_status is not None and isinstance(metadata, dict):
+        errors.extend(
+            validate_transition_event_matches(
+                metadata,
+                from_status=from_status,
+                to_status=to_status,
+            )
+        )
+    return errors
+
+
 def build_transition_plan(
     card: dict[str, Any],
     source_path: Path,
@@ -5062,10 +5087,9 @@ def build_transition_plan(
             completion = graph_completion
             append_unsatisfied_graph_requirement_blocks()
         else:
-            blocked_reasons.extend(validate_completion(card, receipt))
-            blocked_reasons.extend(receipt_reconciliation_errors(receipt))
             blocked_reasons.extend(
-                validate_transition_event_matches(
+                validate_completion(
+                    card,
                     receipt,
                     from_status=from_status,
                     to_status=to_status,

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -482,6 +482,7 @@ class FactoryCtlTest(unittest.TestCase):
                 "allowed": True,
             },
             "independent_review_result": worker_result("independent_review_result", source_card=card),
+            "receipt_five_reconciliation_result": worker_result("receipt_five_reconciliation_result", source_card=card),
             "product_face_result": {
                 "result": "PASS",
                 "tool_or_profile": "browser-proof-runner",
@@ -526,6 +527,32 @@ class FactoryCtlTest(unittest.TestCase):
         }
 
         self.assertEqual(factoryctl.validate_completion(card, receipt), [])
+
+    def test_validate_completion_requires_done_promotion_gate(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        receipt = {
+            "receipt_five": {
+                "changed": "validated onchain gate",
+                "artifact_paths": ["examples/minimal-hermes-project/card.md"],
+                "verification_commands": ["python scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md"],
+                "verification_result": "PASS",
+                "reviewer_required": False,
+                "next_action": "continue",
+            },
+            "kanban_transition_event": {
+                "from_status": "review",
+                "to_status": "done",
+                "actor": "factory-orchestrator",
+                "worker": "factory-orchestrator",
+                "receipt_refs": ["receipt_five"],
+                "artifact_refs": ["examples/minimal-hermes-project/card.md"],
+            },
+        }
+
+        errors = factoryctl.validate_completion(card, receipt)
+
+        self.assertIn("kanban_transition_event.allowed must be true for done promotion", errors)
+        self.assertIn("receipt_five_reconciliation_result is required for done promotion", errors)
 
     def test_product_face_completion_rejects_screenshot_without_plan_alignment(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")


### PR DESCRIPTION
Relates to #134.

## Summary
- Makes `validate_completion` enforce the same done-promotion requirements used by the Hermes transition plan.
- Adds a single `done_promotion_errors` helper for Receipt Five reconciliation and optional requested transition matching.
- Updates transition planning to call `validate_completion(..., from_status=..., to_status=...)` instead of carrying separate done-gate checks.
- Adds a regression proving `validate-completion` rejects a done receipt without `kanban_transition_event.allowed=true` and without `receipt_five_reconciliation_result`.

## Why this matters
Before this change, the public completion validator could say OK for a receipt shape that the real `done` transition would block. In the Swiss-watch operating model, a local validator cannot be weaker than the gear it claims to validate.

This PR closes that false-green path without touching #84/cockpit and without adding audit/history artifacts to the public repo.

## Validation
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_validate_completion_requires_done_promotion_gate -q`
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_accepts_visual_result -q`
- `python -B -m unittest tests.test_factoryctl -q`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`