### PR TITLE
[codex] Block done audits with unresolved SOT claims

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3050,13 +3050,18 @@ def validate_receipt(data: dict[str, Any]) -> list[str]:
 
 def validate_completion_audit_contract(card: dict[str, Any], audit: dict[str, Any]) -> list[str]:
     errors: list[str] = []
+    decision = str(audit.get("decision") or "").strip().lower()
+    if decision not in {"done", "block", "done_with_owner"}:
+        errors.append("completion_audit.decision must be done, block or done_with_owner")
     claim_results = audit.get("sot_claim_results")
+    sot_statuses: list[str] = []
     if not isinstance(claim_results, list) or not claim_results:
         errors.append("completion_audit.sot_claim_results is required")
     else:
         for index, item in enumerate(claim_results):
             item = item if isinstance(item, dict) else {}
             status = str(item.get("status") or "").strip().upper()
+            sot_statuses.append(status)
             if not _non_empty_text(item.get("claim_ref")):
                 errors.append(f"completion_audit.sot_claim_results[{index}].claim_ref is required")
             if status not in COMPLETION_SOT_STATUSES:
@@ -3065,6 +3070,14 @@ def validate_completion_audit_contract(card: dict[str, Any], audit: dict[str, An
                 )
             if status in {"BLOCKED", "DEFERRED_WITH_OWNER", "OUT_OF_SCOPE"} and not _non_empty_text(item.get("owner")):
                 errors.append(f"completion_audit.sot_claim_results[{index}].owner is required for non-DONE status")
+        if "BLOCKED" in sot_statuses and decision != "block":
+            errors.append("completion_audit.decision must be block when any SOT claim is BLOCKED")
+        elif "DEFERRED_WITH_OWNER" in sot_statuses and decision != "done_with_owner":
+            errors.append("completion_audit.decision must be done_with_owner when any SOT claim is DEFERRED_WITH_OWNER")
+        elif decision == "done":
+            incomplete = sorted(set(sot_statuses) - {"DONE", "OUT_OF_SCOPE"})
+            if incomplete:
+                errors.append("completion_audit.decision=done requires SOT claims to be DONE or OUT_OF_SCOPE, found " + ", ".join(incomplete))
 
     method_results = audit.get("method_execution_results")
     if not isinstance(method_results, list) or not method_results:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -554,6 +554,41 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("kanban_transition_event.allowed must be true for done promotion", errors)
         self.assertIn("receipt_five_reconciliation_result is required for done promotion", errors)
 
+    def test_completion_audit_blocks_done_with_blocked_sot_claim(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        audit = {
+            "decision": "done",
+            "sot_claim_results": [
+                {"claim_ref": "product-sot#scope", "status": "BLOCKED", "owner": "product-owner"}
+            ],
+            "method_execution_results": [
+                {"method": "security-review", "status": "EXECUTED", "evidence_refs": ["README.md"]}
+            ],
+        }
+
+        errors = factoryctl.validate_completion_audit_contract(card, audit)
+
+        self.assertIn("completion_audit.decision must be block when any SOT claim is BLOCKED", errors)
+
+    def test_completion_audit_routes_deferred_sot_to_done_with_owner(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        audit = {
+            "decision": "done",
+            "sot_claim_results": [
+                {"claim_ref": "product-sot#scope", "status": "DEFERRED_WITH_OWNER", "owner": "product-owner"}
+            ],
+            "method_execution_results": [
+                {"method": "security-review", "status": "EXECUTED", "evidence_refs": ["README.md"]}
+            ],
+        }
+
+        errors = factoryctl.validate_completion_audit_contract(card, audit)
+
+        self.assertIn(
+            "completion_audit.decision must be done_with_owner when any SOT claim is DEFERRED_WITH_OWNER",
+            errors,
+        )
+
     def test_product_face_completion_rejects_screenshot_without_plan_alignment(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
         card["product_face_result_required"] = True


### PR DESCRIPTION
Relates to #134.

## Summary
- Validates `completion_audit.decision` explicitly.
- Blocks `decision=done` when any SOT claim is `BLOCKED`.
- Routes `DEFERRED_WITH_OWNER` SOT claims to `done_with_owner` instead of plain `done`.
- Keeps plain `done` limited to SOT claims that are `DONE` or `OUT_OF_SCOPE`.
- Adds regression tests for blocked and deferred SOT claims.

## Why this matters
The factory cannot call a product complete when the Product SOT still has blocked scope. This closes a contract hole where method execution could be clean while SOT scope was still unresolved.

This PR does not touch #84/cockpit and does not add audit/history artifacts to the public repo.

## Validation
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_completion_audit_blocks_done_with_blocked_sot_claim -q`
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_completion_audit_routes_deferred_sot_to_done_with_owner -q`
- `python -B -m unittest tests.test_factoryctl -q`
- `git diff --check`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`