### PR TITLE
[codex] Tighten factory card core schema fields

### DIFF
--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -34,6 +34,40 @@
     "kanban_transition_event_ref"
   ],
   "properties": {
+    "card_id": { "type": "string", "minLength": 1 },
+    "slice_id": { "type": "string", "minLength": 1 },
+    "owner_profile": { "type": "string", "minLength": 3 },
+    "source_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "outcome": { "type": "string", "minLength": 3 },
+    "acceptance_criteria": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "scope_in": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "scope_out": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "risk_class": { "type": "string", "minLength": 2 },
+    "codex_mode": { "type": "string", "minLength": 3 },
+    "review": {
+      "type": "object",
+      "properties": {
+        "independent_review_required": { "type": "boolean" },
+        "human_gate_required": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
     "factory_method_version": {
       "enum": ["OVERKILL_V3_5_AGENT_WORKFORCE", "OVERKILL_V3_5_FACTORY_10", "OVERKILL_VFINAL"]
     },
@@ -68,10 +102,26 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
     },
+    "phase": { "type": "string", "minLength": 2 },
+    "authority_max": { "type": "string", "minLength": 3 },
+    "owner_worker": { "type": "string", "minLength": 3 },
     "executor_identity": { "type": "string", "minLength": 3 },
     "reviewer_identity": { "type": "string", "minLength": 3 },
+    "runtime_decision": { "type": "string", "minLength": 3 },
     "runtime_contract": { "type": "object" },
     "security_contract": { "type": "object" },
+    "forbidden_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "done_definition": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "transition_event_required": { "type": "boolean" },
+    "kanban_transition_event_ref": { "type": "string", "minLength": 1 },
     "security_role_separation": { "type": "boolean" },
     "security_role_separation_exception": { "type": "string" },
     "product_face_packet": { "$ref": "product-face-packet.schema.json" },

--- a/templates/factory-card.json
+++ b/templates/factory-card.json
@@ -43,7 +43,7 @@
   "runtime_contract": { "mode": "bounded_worker" },
   "security_contract": { "security_boundary": "no_sensitive_action" },
   "forbidden_actions": ["deploy", "secret_access", "funds", "mainnet"],
-  "done_definition": "Define exactly what must be true before done.",
+  "done_definition": ["Define exactly what must be true before done."],
   "transition_event_required": true,
   "kanban_transition_event_ref": "required_before_ready",
   "capability_pack_contract": {

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -89,6 +89,29 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_factory_card_schema_rejects_absurd_required_field_shapes(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["factory-card.schema.json"]
+        card = json.loads((ROOT / "templates" / "vfinal-factory-card.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, card, "$", schemas=schemas, root_schema=schema), [])
+
+        invalid = dict(card)
+        invalid["source_refs"] = "source-ledger.md"
+        invalid["done_definition"] = "ship it"
+        invalid["transition_event_required"] = "yes"
+        invalid["review"] = "self-review"
+        invalid["owner_worker"] = []
+
+        errors = validator.validate_node(schema, invalid, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("$.source_refs" in error and "expected type array" in error for error in errors))
+        self.assertTrue(any("$.done_definition" in error and "expected type array" in error for error in errors))
+        self.assertTrue(any("$.transition_event_required" in error and "expected type boolean" in error for error in errors))
+        self.assertTrue(any("$.review" in error and "expected type object" in error for error in errors))
+        self.assertTrue(any("$.owner_worker" in error and "expected type string" in error for error in errors))
+
     def test_resolves_schema_file_refs_used_by_factory_card(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary
- Adds schema constraints for core required `factory-card` fields that previously had no type/shape enforcement.
- Normalizes `templates/factory-card.json` so `done_definition` uses the canonical list shape.
- Adds regression coverage proving absurd required field values are rejected by the public JSON validator.

## Why
Issue #134 is about removing false proof from the factory's gears. The `factory-card` schema required fields such as `source_refs`, `done_definition`, `transition_event_required`, `review`, and `owner_worker`, but did not define their type. That meant a public artifact could include those fields with structurally useless values and still look schema-compliant.

This keeps the schema extensible with `additionalProperties: true`, but makes the card spine machine-checkable.

## Validation
- `python -B -m unittest tests.test_public_json_artifact_validator -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\factoryctl.py validate-card templates\factory-card.json`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`

Refs #134