### PR TITLE
[codex] Tighten receipt transition event schema

### DIFF
--- a/schemas/receipt-five.schema.json
+++ b/schemas/receipt-five.schema.json
@@ -20,23 +20,41 @@
         "artifact_paths": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string" }
+          "items": { "type": "string", "minLength": 1 }
         },
         "verification_commands": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string" }
+          "items": { "type": "string", "minLength": 1 }
         },
         "verification_result": { "enum": ["PASS", "BLOCKED", "WAIVED"] },
         "reviewer_required": { "type": "boolean" },
         "reviewer_result": { "type": "string" },
-        "next_action": { "type": "string" }
+        "next_action": { "type": "string", "minLength": 3 }
       },
       "additionalProperties": true
     },
     "kanban_transition_event": {
       "type": "object",
       "required": ["from_status", "to_status", "actor", "worker", "receipt_refs", "artifact_refs"],
+      "properties": {
+        "from_status": { "type": "string", "minLength": 1 },
+        "to_status": { "type": "string", "minLength": 1 },
+        "actor": { "type": "string", "minLength": 1 },
+        "worker": { "type": "string", "minLength": 1 },
+        "receipt_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "artifact_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "allowed": { "type": "boolean" },
+        "result": { "enum": ["PASS", "ALLOW", "APPROVED"] }
+      },
       "additionalProperties": true
     },
     "hermes_legacy_completion_required": {

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -112,6 +112,27 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         self.assertTrue(any("$.review" in error and "expected type object" in error for error in errors))
         self.assertTrue(any("$.owner_worker" in error and "expected type string" in error for error in errors))
 
+    def test_receipt_five_schema_rejects_invalid_transition_event_shapes(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["receipt-five.schema.json"]
+        receipt = json.loads((ROOT / "templates" / "receipt-five.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, receipt, "$", schemas=schemas, root_schema=schema), [])
+
+        invalid = json.loads(json.dumps(receipt))
+        invalid["kanban_transition_event"]["from_status"] = ""
+        invalid["kanban_transition_event"]["receipt_refs"] = "receipt_five"
+        invalid["kanban_transition_event"]["artifact_refs"] = [""]
+        invalid["kanban_transition_event"]["allowed"] = "yes"
+
+        errors = validator.validate_node(schema, invalid, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("$.kanban_transition_event.from_status" in error and "shorter" in error for error in errors))
+        self.assertTrue(any("$.kanban_transition_event.receipt_refs" in error and "expected type array" in error for error in errors))
+        self.assertTrue(any("$.kanban_transition_event.artifact_refs[0]" in error and "shorter" in error for error in errors))
+        self.assertTrue(any("$.kanban_transition_event.allowed" in error and "expected type boolean" in error for error in errors))
+
     def test_resolves_schema_file_refs_used_by_factory_card(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary
- Tightens `receipt-five.schema.json` for Receipt Five and `kanban_transition_event` field shapes.
- Requires transition status/actor/worker values to be non-empty strings.
- Requires `receipt_refs` and `artifact_refs` to be non-empty string arrays.
- Requires optional `allowed` to be boolean and optional promotion result to be one of the accepted approval values.
- Adds regression coverage for invalid transition event shapes.

## Why
Issue #134 requires the public contract surface to match the factory's deterministic completion gears. `factoryctl` already rejects malformed transition evidence, but the public schema only required field names. A receipt with `receipt_refs` as a string, empty `artifact_refs`, or textual `allowed` could look schema-valid while failing the real done/promotion gate.

This PR removes that mismatch.

## Validation
- `python -B -m unittest tests.test_public_json_artifact_validator -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`

Note: `examples\receipts\v35_valid_security_completion_metadata.json` remains an old metadata example, not a current done-promotion-valid Receipt Five under the stricter #134 completion gate.

Refs #134