### PR TITLE
[codex] Schema-validate public manifest inputs

### DIFF
--- a/scripts/validate_planning_bundles.py
+++ b/scripts/validate_planning_bundles.py
@@ -10,7 +10,14 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
+
 MANIFEST_PATH = ROOT / "planning-bundles" / "manifest.json"
+MANIFEST_SCHEMA_NAME = "planning-bundle-manifest.schema.json"
 
 REQUIRED_TEXT_MARKERS = (
     "candidate_only",
@@ -66,7 +73,9 @@ def contains_forbidden_fragment(value: str, fragments: tuple[str, ...]) -> str |
 
 
 def validate_manifest_data(manifest: dict[str, Any], *, root: Path = ROOT) -> list[str]:
-    findings: list[str] = []
+    findings = validate_manifest_schema(manifest)
+    if findings:
+        return findings
     bundles = manifest.get("bundles", [])
     if not isinstance(bundles, list) or not bundles:
         return ["planning-bundles/manifest.json: bundles must be a non-empty array"]
@@ -152,6 +161,15 @@ def validate_manifest_data(manifest: dict[str, Any], *, root: Path = ROOT) -> li
                 findings.append(f"{bundle_id}: missing required safety marker {marker!r}")
 
     return findings
+
+
+def validate_manifest_schema(manifest: dict[str, Any]) -> list[str]:
+    schemas = load_schemas()
+    schema = schemas[MANIFEST_SCHEMA_NAME]
+    return [
+        f"manifest schema: {error}"
+        for error in validate_node(schema, manifest, "$", schemas=schemas, root_schema=schema)
+    ]
 
 
 def validate(path: Path = MANIFEST_PATH) -> list[str]:

--- a/scripts/validate_public_surface_sync.py
+++ b/scripts/validate_public_surface_sync.py
@@ -14,7 +14,14 @@ from typing import Any, Callable
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
+
 MANIFEST_PATH = ROOT / "docs" / "public-surface.manifest.json"
+MANIFEST_SCHEMA_NAME = "public-surface-manifest.schema.json"
 
 RISK_TIERS = {"R0", "R1", "R2", "R3", "R4"}
 OVERCLAIM_PATTERNS = [
@@ -185,7 +192,9 @@ def validate_manifest_data(
     check_published: bool = False,
     fetcher: Callable[[str], bytes] | None = None,
 ) -> list[str]:
-    findings: list[str] = []
+    findings = validate_manifest_schema(manifest)
+    if findings:
+        return findings
     for ref in manifest.get("canonical_sources", []):
         if not source_ref_exists(root, str(ref)):
             findings.append(f"manifest: canonical source does not exist: {ref}")
@@ -206,6 +215,15 @@ def validate_manifest_data(
         else:
             findings.append("manifest: surface entry must be an object")
     return findings
+
+
+def validate_manifest_schema(manifest: dict[str, Any]) -> list[str]:
+    schemas = load_schemas()
+    schema = schemas[MANIFEST_SCHEMA_NAME]
+    return [
+        f"manifest schema: {error}"
+        for error in validate_node(schema, manifest, "$", schemas=schemas, root_schema=schema)
+    ]
 
 
 def validate_manifest(

--- a/tests/test_planning_bundles.py
+++ b/tests/test_planning_bundles.py
@@ -31,6 +31,21 @@ class PlanningBundleValidationTest(unittest.TestCase):
     def test_current_manifest_passes(self) -> None:
         self.assertEqual(planning_bundles.validate(), [])
 
+    def test_manifest_schema_blocks_string_compatibility_versions_before_semantic_checks(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["bundles"][0]["compatible_factory_method_versions"] = "OVERKILL_VFINAL"
+
+        findings = planning_bundles.validate_manifest_data(mutated)
+
+        self.assertTrue(
+            any(
+                "$.bundles[0].compatible_factory_method_versions" in finding and "expected type array" in finding
+                for finding in findings
+            ),
+            findings,
+        )
+
     def test_missing_included_file_is_detected(self) -> None:
         manifest = self.manifest()
         mutated = copy.deepcopy(manifest)
@@ -52,7 +67,7 @@ class PlanningBundleValidationTest(unittest.TestCase):
         findings = planning_bundles.validate_manifest_data(mutated)
 
         self.assertIn(
-            "product-sot-drafting-v1: expected output product_sot_candidate must be candidate_only",
+            "manifest schema: $.bundles[0].expected_outputs[0].authority: expected const 'candidate_only'",
             findings,
         )
 
@@ -77,7 +92,7 @@ class PlanningBundleValidationTest(unittest.TestCase):
 
         findings = planning_bundles.validate_manifest_data(mutated)
 
-        self.assertIn("product-sot-drafting-v1: bundle_kind must be planning_protocol", findings)
+        self.assertIn("manifest schema: $.bundles[0].bundle_kind: expected const 'planning_protocol'", findings)
 
     def test_included_files_must_stay_inside_bundle_directory(self) -> None:
         manifest = self.manifest()

--- a/tests/test_public_surface_sync.py
+++ b/tests/test_public_surface_sync.py
@@ -31,6 +31,18 @@ class PublicSurfaceSyncTest(unittest.TestCase):
     def test_public_surface_manifest_is_current(self) -> None:
         self.assertEqual(surface_sync.validate_manifest(), [])
 
+    def test_manifest_schema_blocks_claim_checks_string_before_semantic_checks(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["surfaces"][0]["claim_checks"] = "source_refs_exist"
+
+        findings = surface_sync.validate_manifest_data(mutated)
+
+        self.assertTrue(
+            any("$.surfaces[0].claim_checks" in finding and "expected type array" in finding for finding in findings),
+            findings,
+        )
+
     def test_worker_count_drift_is_detected(self) -> None:
         manifest = self.manifest()
         mutated = copy.deepcopy(manifest)


### PR DESCRIPTION
## Summary
- Makes `validate_public_surface_sync.py` schema-validate `docs/public-surface.manifest.json` before semantic checks.
- Makes `validate_planning_bundles.py` schema-validate `planning-bundles/manifest.json` before semantic checks.
- Adds regressions for type errors that previously could skip checks (`claim_checks` as a string and `compatible_factory_method_versions` as a string).

## Why
Issue #134 is about making the factory's public validation behave like gears, not best-effort text parsing. These scripts had strong schemas available, but their semantic logic read fields directly. If a list field became a string, Python iteration could silently skip or distort the intended check.

Now malformed manifests fail at the contract layer before semantic validation runs.

## Validation
- `python -B -m unittest tests.test_public_surface_sync tests.test_planning_bundles -q`
- `python -B scripts\validate_public_surface_sync.py`
- `python -B scripts\validate_planning_bundles.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`

Refs #134