### PR TITLE
[codex] Audit public schemas outside schema directory

### DIFF
--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -24,6 +24,15 @@ if str(SCRIPT_DIR) not in sys.path:
 from public_refs import contains_private_kanban_task_marker  # noqa: E402
 
 SCHEMA_DIR = ROOT / "schemas"
+PUBLIC_SCHEMA_DIRS = [
+    SCHEMA_DIR,
+    ROOT / "agents",
+    ROOT / "docs",
+    ROOT / "examples",
+    ROOT / "planning-bundles",
+    ROOT / "products",
+    ROOT / "templates",
+]
 SCAN_DIRS = [
     ROOT / "examples",
     ROOT / ".tmp" / "factory-runs",
@@ -142,9 +151,21 @@ def schema_name(schema_ref: str) -> str:
     return schema_ref.rsplit("/", 1)[-1]
 
 
+def iter_schema_files() -> list[Path]:
+    paths: set[Path] = set()
+    for directory in PUBLIC_SCHEMA_DIRS:
+        if not directory.exists():
+            continue
+        if directory == SCHEMA_DIR:
+            paths.update(directory.glob("*.json"))
+        else:
+            paths.update(directory.rglob("*.schema.json"))
+    return sorted(paths)
+
+
 def load_schemas() -> dict[str, dict[str, Any]]:
     schemas: dict[str, dict[str, Any]] = {}
-    for path in sorted(SCHEMA_DIR.glob("*.json")):
+    for path in iter_schema_files():
         schema = load_json(path)
         schema_id = str(schema.get("$id") or "")
         schemas[path.name] = schema
@@ -565,11 +586,11 @@ def iter_public_json() -> list[Path]:
 def main() -> int:
     schemas = load_schemas()
     findings: list[str] = []
-    for schema_path_ref, schema in sorted(schemas.items()):
-        if not schema_path_ref.endswith(".json"):
-            continue
+    for schema_path_ref in iter_schema_files():
+        schema = load_json(schema_path_ref)
+        rel = schema_path_ref.relative_to(ROOT).as_posix()
         for error in validate_schema_keywords(schema):
-            findings.append(f"schemas/{schema_path_ref}: {error}")
+            findings.append(f"{rel}: {error}")
     for path in iter_public_json():
         try:
             data = load_json(path)

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -89,6 +89,14 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_public_schema_discovery_includes_agent_contract_schema(self) -> None:
+        validator = load_validator()
+        schema_paths = {path.relative_to(ROOT).as_posix() for path in validator.iter_schema_files()}
+        schemas = validator.load_schemas()
+
+        self.assertIn("agents/worker-contract.schema.json", schema_paths)
+        self.assertIn("worker-contract.schema.json", schemas)
+
     def test_factory_card_schema_rejects_absurd_required_field_shapes(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary
- Extends public schema discovery beyond `schemas/` to public directories that can expose `*.schema.json` files.
- Ensures `agents/worker-contract.schema.json` is loaded and audited by `validate_public_json_artifacts.py`.
- Keeps existing schema lookup by filename and `$id` intact for current validators/tests.

## Why
Issue #134 identified that public schemas outside `schemas/` could be invisible to the fail-closed keyword audit. `agents/worker-contract.schema.json` is documented publicly, but the validator previously loaded only `schemas/*.json`. That meant an unsupported JSON Schema keyword could be introduced in a public agent schema without being caught.

Now public schema discovery covers the known public surface directories while avoiding private/history artifacts.

## Validation
- `python -B -m unittest tests.test_public_json_artifact_validator -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B -m unittest discover -s tests -p "test_*.py" -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`

Refs #134