### PR TITLE
Fix QVG public proof defaults

### DIFF
--- a/scripts/quasar_product_like_container_proof.py
+++ b/scripts/quasar_product_like_container_proof.py
@@ -17,6 +17,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 QUASAR_SOURCE = "github:blueshift-gg/quasar"
 QUASAR_SOURCE_HEAD = "a89a9329f05740a20520607608b2b3b78c74f7c4"
+PUBLIC_QVG_SOURCE_DIR = ROOT / "products" / "qvg-public-validation-product" / "onchain" / "quasar" / "src"
 PROJECT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
 
 
@@ -172,12 +173,12 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run product-like Quasar build/test proof in Docker.")
     parser.add_argument(
         "--source-dir",
         type=Path,
-        default=ROOT / "pilots" / "quasar-vault-guard-test" / "onchain" / "qvg-product-like" / "src",
+        default=PUBLIC_QVG_SOURCE_DIR,
     )
     parser.add_argument(
         "--out",
@@ -185,7 +186,7 @@ def parse_args() -> argparse.Namespace:
         default=ROOT / ".tmp" / "factory-runs" / "quasar-product-like-proof" / "qvg-quasar-runtime-proof.json",
     )
     parser.add_argument("--timeout-seconds", type=int, default=900)
-    parser.add_argument("--project-name", default="qvg-product-like")
+    parser.add_argument("--project-name", default="qvg-public-validation-product")
     parser.add_argument("--proof-kind", default="containerized_product_like_quasar_build_test")
     parser.add_argument(
         "--evidence-boundary",
@@ -198,11 +199,11 @@ def parse_args() -> argparse.Namespace:
         "--policy-decision",
         default="Use this product-like proof as stronger Auditor input than generated-minimal Quasar proof, while keeping production promotion gated.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     source_dir = args.source_dir if args.source_dir.is_absolute() else ROOT / args.source_dir
     source_dir = source_dir.resolve()
     if not source_dir.exists():

--- a/scripts/qvg_product_like_auditor_result.py
+++ b/scripts/qvg_product_like_auditor_result.py
@@ -16,6 +16,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
 AUDITOR_SOURCE = "https://github.com/solanabr/Auditor"
+PUBLIC_QVG_CARD = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
 ALLOWED_SOURCE_ENV_CLASSES = {
     "production-validation-quasar-source",
     "production-quasar-source",
@@ -353,7 +354,7 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Create QVG product-like Auditor code-audit result.")
     parser.add_argument("--auditor-dir", type=Path, required=True)
     parser.add_argument(
@@ -369,7 +370,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--card",
         type=Path,
-        default=ROOT / "pilots" / "quasar-vault-guard-test" / "cards" / "qvg-first-slice.md",
+        default=PUBLIC_QVG_CARD,
     )
     parser.add_argument(
         "--report-out",
@@ -389,11 +390,11 @@ def parse_args() -> argparse.Namespace:
         help="Required with --reusable-for-product.",
     )
     parser.add_argument("--approval-scope")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     auditor_dir = args.auditor_dir if args.auditor_dir.is_absolute() else ROOT / args.auditor_dir
     runtime_proof = args.runtime_proof if args.runtime_proof.is_absolute() else ROOT / args.runtime_proof
     card_path = args.card if args.card.is_absolute() else ROOT / args.card

--- a/scripts/qvg_quasar_cu_fuzz_property_proof.py
+++ b/scripts/qvg_quasar_cu_fuzz_property_proof.py
@@ -12,6 +12,7 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_QVG_SOURCE_DIR = ROOT / "products" / "qvg-public-validation-product" / "onchain" / "quasar" / "src"
 
 
 def utc_now() -> str:
@@ -220,12 +221,12 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Create QVG product-like CU/fuzz/property proof.")
     parser.add_argument(
         "--source-dir",
         type=Path,
-        default=ROOT / "pilots" / "quasar-vault-guard-test" / "onchain" / "qvg-product-like" / "src",
+        default=PUBLIC_QVG_SOURCE_DIR,
     )
     parser.add_argument(
         "--runtime-proof",
@@ -237,11 +238,11 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=ROOT / ".tmp" / "factory-runs" / "quasar-product-like-proof" / "qvg-quasar-cu-fuzz-property-proof.json",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     source_dir = args.source_dir if args.source_dir.is_absolute() else ROOT / args.source_dir
     runtime_proof = args.runtime_proof if args.runtime_proof.is_absolute() else ROOT / args.runtime_proof
     out = args.out if args.out.is_absolute() else ROOT / args.out

--- a/tests/test_qvg_public_defaults.py
+++ b/tests/test_qvg_public_defaults.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts import qvg_product_like_auditor_result as auditor_result
+from scripts import qvg_quasar_cu_fuzz_property_proof as property_proof
+from scripts import quasar_product_like_container_proof as container_proof
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FORBIDDEN_HISTORICAL_PILOT = "pilots/quasar-vault-guard-test"
+
+
+class QvgPublicDefaultsTests(unittest.TestCase):
+    def test_product_like_container_defaults_use_existing_public_source(self):
+        args = container_proof.parse_args([])
+
+        self.assertEqual(args.source_dir, container_proof.PUBLIC_QVG_SOURCE_DIR)
+        self.assertTrue(args.source_dir.exists())
+        self.assertEqual(args.source_dir.relative_to(ROOT).as_posix(), "products/qvg-public-validation-product/onchain/quasar/src")
+        self.assertEqual(args.project_name, "qvg-public-validation-product")
+
+    def test_cu_fuzz_property_defaults_use_existing_public_source(self):
+        args = property_proof.parse_args([])
+
+        self.assertEqual(args.source_dir, property_proof.PUBLIC_QVG_SOURCE_DIR)
+        self.assertTrue(args.source_dir.exists())
+        self.assertEqual(args.source_dir.relative_to(ROOT).as_posix(), "products/qvg-public-validation-product/onchain/quasar/src")
+
+    def test_auditor_result_default_card_uses_existing_public_fixture(self):
+        with TemporaryDirectory() as tmpdir:
+            args = auditor_result.parse_args(["--auditor-dir", tmpdir])
+
+        self.assertEqual(args.card, auditor_result.PUBLIC_QVG_CARD)
+        self.assertTrue(args.card.exists())
+        self.assertEqual(args.card.relative_to(ROOT).as_posix(), "examples/cards/v35_valid_onchain_auditor_scan.md")
+
+    def test_qvg_public_default_scripts_do_not_reference_historical_pilot(self):
+        for script in (
+            "scripts/quasar_product_like_container_proof.py",
+            "scripts/qvg_quasar_cu_fuzz_property_proof.py",
+            "scripts/qvg_product_like_auditor_result.py",
+        ):
+            text = (ROOT / script).read_text(encoding="utf-8")
+            self.assertNotIn(FORBIDDEN_HISTORICAL_PILOT, text, script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #166.

This PR removes the historical `pilots/quasar-vault-guard-test` defaults from the public QVG proof CLIs. Those paths are absent from the open-source repo, so a clean public checkout could default into a missing/private-looking pilot path instead of the current public QVG validation product.

Changes:
- points product-like Quasar build/test and CU/fuzz/property proof defaults to `products/qvg-public-validation-product/onchain/quasar/src`
- points the Auditor result default card to existing public fixture `examples/cards/v35_valid_onchain_auditor_scan.md`
- makes the affected `parse_args`/`main` functions testable with explicit argv
- adds regression tests asserting defaults exist and the historical pilot ref does not return in these scripts

No #84/cockpit scope.

## Validation

- `python -B -m unittest tests.test_qvg_public_defaults tests.test_qvg_quasar_cu_fuzz_property_proof tests.test_qvg_quasar_cu_svm_economic_proof -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`
- `python -B -m unittest discover -s tests -q`