### PR TITLE
Fail closed remote proof runner checks

### DIFF
--- a/scripts/crabbox_local_container_remote_proof.py
+++ b/scripts/crabbox_local_container_remote_proof.py
@@ -18,14 +18,19 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUT = ROOT / ".tmp" / "factory-runs" / "production" / "remote-proof" / "managed-testbox-result.json"
 DEFAULT_MD_OUT = ROOT / ".tmp" / "factory-runs" / "production" / "remote-proof" / "managed-testbox-result.md"
 PRODUCT_SOURCE = ROOT / "products" / "qvg-public-validation-product"
-DEFAULT_COMMAND = (
-    "python3 --version && "
-    "python3 scripts/validate_public_json_artifacts.py && "
-    "python3 scripts/secret_safety_scan.py && "
-    "python3 scripts/public_safety_scan.py && "
-    "python3 scripts/full_product_worker_graph.py --require-pass"
+MARKER_PREFIX = "OF_REMOTE_PROOF_CHECK"
+REQUIRED_PROOF_CHECKS = (
+    ("public_json_artifacts", "python3 scripts/validate_public_json_artifacts.py"),
+    ("secret_safety", "python3 scripts/secret_safety_scan.py"),
+    ("public_safety", "python3 scripts/public_safety_scan.py"),
+    ("supply_chain", "python3 scripts/supply_chain_proof.py --check --no-write"),
+    ("full_product_worker_graph", "python3 scripts/full_product_worker_graph.py --require-pass"),
+)
+DEFAULT_COMMAND = "python3 --version && " + " && ".join(
+    f"{command} && echo {MARKER_PREFIX} {name} PASS" for name, command in REQUIRED_PROOF_CHECKS
 )
 TIMING_RE = re.compile(r"\{.*\"provider\"\s*:\s*\"local-container\".*\}")
+CHECK_MARKER_RE = re.compile(rf"^{MARKER_PREFIX}\s+(?P<name>[a-z0-9_]+)\s+(?P<result>PASS|FAIL)\s*$")
 
 
 def utc_now() -> str:
@@ -79,19 +84,43 @@ def parse_timing_json(stdout: str, stderr: str) -> dict[str, Any]:
     raise ValueError("Crabbox timing JSON line was not found")
 
 
-def command_passed(stdout: str, timing: dict[str, Any], command: str) -> bool:
-    required = [
-        "python3 scripts/validate_public_json_artifacts.py",
-        "python3 scripts/secret_safety_scan.py",
-        "python3 scripts/public_safety_scan.py",
-        "python3 scripts/full_product_worker_graph.py --require-pass",
-    ]
-    return (
-        timing.get("exitCode") == 0
-        and stdout.count("OK") >= 3
-        and "PASS" in stdout
-        and all(item in command for item in required)
-    )
+def parse_check_markers(stdout: str, stderr: str = "") -> dict[str, str]:
+    markers: dict[str, str] = {}
+    for line in (stdout + "\n" + stderr).splitlines():
+        match = CHECK_MARKER_RE.match(line.strip())
+        if match:
+            markers[match.group("name")] = match.group("result")
+    return markers
+
+
+def proof_check_status(stdout: str, stderr: str, command: str) -> dict[str, Any]:
+    markers = parse_check_markers(stdout, stderr)
+    required_names = [name for name, _ in REQUIRED_PROOF_CHECKS]
+    missing_markers = [name for name in required_names if name not in markers]
+    failed_markers = [name for name, result in sorted(markers.items()) if result != "PASS"]
+    missing_commands = [check_command for _, check_command in REQUIRED_PROOF_CHECKS if check_command not in command]
+    return {
+        "required_markers": required_names,
+        "observed_markers": markers,
+        "missing_markers": missing_markers,
+        "failed_markers": failed_markers,
+        "missing_commands": missing_commands,
+        "all_required_passed": all(markers.get(name) == "PASS" for name in required_names)
+        and not failed_markers
+        and not missing_commands,
+    }
+
+
+def cleanup_status(timing: dict[str, Any], active_leases_after: int | None) -> dict[str, Any]:
+    lease_stopped = timing.get("leaseStopped") is True
+    active_lease_count_known = isinstance(active_leases_after, int)
+    no_active_leases_after = active_leases_after == 0
+    return {
+        "lease_stopped": lease_stopped,
+        "active_lease_count_known": active_lease_count_known,
+        "no_active_local_container_leases_after": no_active_leases_after,
+        "all_cleanup_confirmed": lease_stopped and active_lease_count_known and no_active_leases_after,
+    }
 
 
 def active_local_container_leases(crabbox_bin: str, env: dict[str, str]) -> tuple[int | None, str]:
@@ -120,11 +149,13 @@ def build_result(
     active_leases_after: int | None,
     lease_list_output: str,
 ) -> dict[str, Any]:
+    checks = proof_check_status(completed.stdout, completed.stderr, command)
+    cleanup = cleanup_status(timing, active_leases_after)
     pass_status = (
         completed.returncode == 0
-        and command_passed(completed.stdout, timing, command)
-        and timing.get("leaseStopped") is True
-        and active_leases_after in (0, None)
+        and timing.get("exitCode") == 0
+        and checks["all_required_passed"]
+        and cleanup["all_cleanup_confirmed"]
     )
     return {
         "$schema": "https://overkill-factory.dev/schemas/worker-result.schema.json",
@@ -174,19 +205,15 @@ def build_result(
             "stderr_tail": tail(completed.stderr),
         },
         "timing": timing,
+        "proof_checks": checks,
         "cleanup_evidence": {
-            "lease_stopped": timing.get("leaseStopped") is True,
+            **cleanup,
             "lease_id": timing.get("leaseId"),
             "slug": timing.get("slug"),
             "active_local_container_leases_after": active_leases_after,
             "lease_list_output_tail": lease_list_output,
         },
-        "checks_executed": [
-            "python3 scripts/validate_public_json_artifacts.py",
-            "python3 scripts/secret_safety_scan.py",
-            "python3 scripts/public_safety_scan.py",
-            "python3 scripts/full_product_worker_graph.py --require-pass",
-        ],
+        "checks_executed": [command for _, command in REQUIRED_PROOF_CHECKS],
         "evidence_refs": [
             ".tmp/factory-runs/production/remote-proof/managed-testbox-result.md",
             ".tmp/factory-runs/product-specific/qvg-full-product-worker-graph.json",

--- a/scripts/factory_completion_audit.py
+++ b/scripts/factory_completion_audit.py
@@ -141,7 +141,13 @@ def remote_proof_scope_is_valid(data: dict[str, Any]) -> bool:
     if cleanup.get("lease_stopped") is not True:
         return False
     active = cleanup.get("active_local_container_leases_after")
-    if active not in (0, None):
+    if active != 0:
+        return False
+    if cleanup.get("active_lease_count_known") is not True:
+        return False
+    if cleanup.get("no_active_local_container_leases_after") is not True:
+        return False
+    if cleanup.get("all_cleanup_confirmed") is not True:
         return False
 
     command = data.get("remote_command")
@@ -152,10 +158,25 @@ def remote_proof_scope_is_valid(data: dict[str, Any]) -> bool:
         "python3 scripts/validate_public_json_artifacts.py",
         "python3 scripts/secret_safety_scan.py",
         "python3 scripts/public_safety_scan.py",
+        "python3 scripts/supply_chain_proof.py --check --no-write",
         "python3 scripts/full_product_worker_graph.py --require-pass",
     }
     checks = {str(item) for item in data.get("checks_executed") or []}
     if not required_checks.issubset(checks):
+        return False
+    proof_checks = data.get("proof_checks")
+    if not isinstance(proof_checks, dict):
+        return False
+    if proof_checks.get("all_required_passed") is not True:
+        return False
+    if proof_checks.get("missing_markers") or proof_checks.get("failed_markers") or proof_checks.get("missing_commands"):
+        return False
+    observed_markers = proof_checks.get("observed_markers")
+    if not isinstance(observed_markers, dict):
+        return False
+    required_marker_names = {"public_json_artifacts", "secret_safety", "public_safety", "supply_chain", "full_product_worker_graph"}
+    passed_marker_names = {name for name, result in observed_markers.items() if result == "PASS"}
+    if not required_marker_names.issubset(passed_marker_names):
         return False
 
     provider_kind = str(data.get("provider_kind") or "")

--- a/scripts/supply_chain_proof.py
+++ b/scripts/supply_chain_proof.py
@@ -23,7 +23,7 @@ PINNED_ACTION_RE = re.compile(
 )
 USES_RE = re.compile(r"uses:\s*(\S+)")
 
-SKIP_PARTS = {".git", "__pycache__", ".mypy_cache", ".pytest_cache"}
+SKIP_PARTS = {".git", ".tmp", "__pycache__", ".mypy_cache", ".pytest_cache"}
 SKIP_OUTPUT_PARTS = {".tmp/factory-runs/supply-chain"}
 NON_RUNTIME_OPTIONAL_DEPENDENCY_GROUPS = {"ci", "dev", "doc", "docs", "test", "tests"}
 

--- a/tests/test_crabbox_local_container_remote_proof.py
+++ b/tests/test_crabbox_local_container_remote_proof.py
@@ -37,10 +37,12 @@ class CrabboxLocalContainerRemoteProofTest(unittest.TestCase):
             ["crabbox"],
             0,
             stdout=(
-                "OK\nOK\nOK\n"
-                "python3 scripts/validate_public_json_artifacts.py\n"
-                "python3 scripts/full_product_worker_graph.py --require-pass\n"
-                "PASS\n"
+                "OK\n"
+                "OF_REMOTE_PROOF_CHECK public_json_artifacts PASS\n"
+                "OF_REMOTE_PROOF_CHECK secret_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK public_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK supply_chain PASS\n"
+                "OF_REMOTE_PROOF_CHECK full_product_worker_graph PASS\n"
             ),
             stderr="",
         )
@@ -65,16 +67,47 @@ class CrabboxLocalContainerRemoteProofTest(unittest.TestCase):
         self.assertEqual(result["result"], "PASS")
         self.assertTrue(result["reusable_for_product"])
         self.assertEqual(result["provider"], "local-container")
+        self.assertTrue(result["proof_checks"]["all_required_passed"])
+        self.assertTrue(result["cleanup_evidence"]["all_cleanup_confirmed"])
+
+    def test_build_result_fails_when_required_marker_is_missing(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["crabbox"],
+            0,
+            stdout=(
+                "OK\nOK\nOK\nPASS\n"
+                "OF_REMOTE_PROOF_CHECK public_json_artifacts PASS\n"
+                "OF_REMOTE_PROOF_CHECK secret_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK public_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK full_product_worker_graph PASS\n"
+            ),
+            stderr="",
+        )
+        timing = {"provider": "local-container", "exitCode": 0, "leaseStopped": True}
+
+        result = module.build_result(
+            crabbox_version="0.26.0",
+            command=module.DEFAULT_COMMAND,
+            completed=completed,
+            timing=timing,
+            active_leases_after=0,
+            lease_list_output="",
+        )
+
+        self.assertEqual(result["result"], "FAIL")
+        self.assertIn("supply_chain", result["proof_checks"]["missing_markers"])
+        self.assertFalse(result["reusable_for_product"])
 
     def test_build_result_fails_when_lease_is_not_stopped(self) -> None:
         completed = subprocess.CompletedProcess(
             ["crabbox"],
             0,
             stdout=(
-                "OK\nOK\nOK\n"
-                "python3 scripts/validate_public_json_artifacts.py\n"
-                "python3 scripts/full_product_worker_graph.py --require-pass\n"
-                "PASS\n"
+                "OF_REMOTE_PROOF_CHECK public_json_artifacts PASS\n"
+                "OF_REMOTE_PROOF_CHECK secret_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK public_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK supply_chain PASS\n"
+                "OF_REMOTE_PROOF_CHECK full_product_worker_graph PASS\n"
             ),
             stderr="",
         )
@@ -90,6 +123,35 @@ class CrabboxLocalContainerRemoteProofTest(unittest.TestCase):
         )
 
         self.assertEqual(result["result"], "FAIL")
+        self.assertFalse(result["reusable_for_product"])
+
+    def test_build_result_fails_when_cleanup_count_is_unknown(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["crabbox"],
+            0,
+            stdout=(
+                "OF_REMOTE_PROOF_CHECK public_json_artifacts PASS\n"
+                "OF_REMOTE_PROOF_CHECK secret_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK public_safety PASS\n"
+                "OF_REMOTE_PROOF_CHECK supply_chain PASS\n"
+                "OF_REMOTE_PROOF_CHECK full_product_worker_graph PASS\n"
+            ),
+            stderr="",
+        )
+        timing = {"provider": "local-container", "exitCode": 0, "leaseStopped": True}
+
+        result = module.build_result(
+            crabbox_version="0.26.0",
+            command=module.DEFAULT_COMMAND,
+            completed=completed,
+            timing=timing,
+            active_leases_after=None,
+            lease_list_output="crabbox list failed",
+        )
+
+        self.assertEqual(result["result"], "FAIL")
+        self.assertFalse(result["cleanup_evidence"]["active_lease_count_known"])
+        self.assertFalse(result["cleanup_evidence"]["all_cleanup_confirmed"])
         self.assertFalse(result["reusable_for_product"])
 
 

--- a/tests/test_factory_completion_audit.py
+++ b/tests/test_factory_completion_audit.py
@@ -83,18 +83,101 @@ class FactoryCompletionAuditTests(unittest.TestCase):
             "cleanup_evidence": {
                 "lease_stopped": True,
                 "active_local_container_leases_after": 0,
+                "active_lease_count_known": True,
+                "no_active_local_container_leases_after": True,
+                "all_cleanup_confirmed": True,
             },
             "remote_command": {"exit_code": 0},
             "checks_executed": [
                 "python3 scripts/validate_public_json_artifacts.py",
                 "python3 scripts/secret_safety_scan.py",
                 "python3 scripts/public_safety_scan.py",
+                "python3 scripts/supply_chain_proof.py --check --no-write",
                 "python3 scripts/full_product_worker_graph.py --require-pass",
             ],
+            "proof_checks": {
+                "required_markers": [
+                    "public_json_artifacts",
+                    "secret_safety",
+                    "public_safety",
+                    "supply_chain",
+                    "full_product_worker_graph",
+                ],
+                "observed_markers": {
+                    "public_json_artifacts": "PASS",
+                    "secret_safety": "PASS",
+                    "public_safety": "PASS",
+                    "supply_chain": "PASS",
+                    "full_product_worker_graph": "PASS",
+                },
+                "missing_markers": [],
+                "failed_markers": [],
+                "missing_commands": [],
+                "all_required_passed": True,
+            },
         }
 
         self.assertTrue(audit.remote_proof_scope_is_valid(proof))
         proof["cleanup_evidence"]["lease_stopped"] = False
+        self.assertFalse(audit.remote_proof_scope_is_valid(proof))
+        proof["cleanup_evidence"]["lease_stopped"] = True
+        proof["cleanup_evidence"]["active_local_container_leases_after"] = None
+        proof["cleanup_evidence"]["active_lease_count_known"] = False
+        proof["cleanup_evidence"]["no_active_local_container_leases_after"] = False
+        proof["cleanup_evidence"]["all_cleanup_confirmed"] = False
+        self.assertFalse(audit.remote_proof_scope_is_valid(proof))
+
+    def test_remote_proof_scope_requires_named_markers(self):
+        proof = {
+            "record_type": "remote_proof_result",
+            "result": "PASS",
+            "evidence_kind": "real",
+            "reusable_for_product": True,
+            "tool_or_profile": "crabbox local-container",
+            "managed_by_crabbox": True,
+            "provider_kind": "crabbox_ephemeral_container",
+            "product_target": {
+                "product_id": "qvg-public-validation-product",
+                "source_ref": "products/qvg-public-validation-product",
+                "source_sha256": "a" * 64,
+                "approval_scope": "Reusable only for the public validation product.",
+            },
+            "cleanup_evidence": {
+                "lease_stopped": True,
+                "active_local_container_leases_after": 0,
+                "active_lease_count_known": True,
+                "no_active_local_container_leases_after": True,
+                "all_cleanup_confirmed": True,
+            },
+            "remote_command": {"exit_code": 0},
+            "checks_executed": [
+                "python3 scripts/validate_public_json_artifacts.py",
+                "python3 scripts/secret_safety_scan.py",
+                "python3 scripts/public_safety_scan.py",
+                "python3 scripts/supply_chain_proof.py --check --no-write",
+                "python3 scripts/full_product_worker_graph.py --require-pass",
+            ],
+            "proof_checks": {
+                "required_markers": [
+                    "public_json_artifacts",
+                    "secret_safety",
+                    "public_safety",
+                    "supply_chain",
+                    "full_product_worker_graph",
+                ],
+                "observed_markers": {
+                    "public_json_artifacts": "PASS",
+                    "secret_safety": "PASS",
+                    "public_safety": "PASS",
+                    "full_product_worker_graph": "PASS",
+                },
+                "missing_markers": ["supply_chain"],
+                "failed_markers": [],
+                "missing_commands": [],
+                "all_required_passed": False,
+            },
+        }
+
         self.assertFalse(audit.remote_proof_scope_is_valid(proof))
 
     def test_shallow_auditor_result_cannot_clear_production_scope(self):

--- a/tests/test_supply_chain_proof.py
+++ b/tests/test_supply_chain_proof.py
@@ -95,6 +95,18 @@ class SupplyChainProofTests(unittest.TestCase):
             json.dumps(result)
             json.dumps(sbom)
 
+    def test_source_inventory_excludes_tmp_runtime_artifacts(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / ".tmp" / "factory-runs").mkdir(parents=True)
+            (root / ".tmp" / "factory-runs" / "transient.json").write_text("{}", encoding="utf-8")
+            (root / "public.txt").write_text("public\n", encoding="utf-8")
+
+            with mock.patch.object(proof, "ROOT", root):
+                refs = [proof.repo_ref(path) for path in proof.iter_repo_files()]
+
+        self.assertEqual(refs, ["public.txt"])
+
     def test_dependency_manifest_requires_followup(self):
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

Closes #170.

This PR makes the remote proof lane fail closed instead of inferring proof success from generic stdout text.

Changes:
- replaces loose `OK`/`PASS` counting in `crabbox_local_container_remote_proof.py` with required named markers: public JSON artifacts, secret safety, public safety, supply-chain, and full product worker graph
- requires Crabbox timing exit code plus local process exit code to be zero
- requires cleanup to be explicitly confirmed: lease stopped, active lease count known, and active local-container leases after cleanup equal `0`
- hardens `factory_completion_audit.py` so downstream completion cannot consume old pass-shaped remote proof records without markers and explicit cleanup
- makes `supply_chain_proof.py --check --no-write` stable by excluding transient `.tmp` runtime artifacts from source SBOM inventory
- adds regressions for missing markers, unknown cleanup count, and `.tmp` inventory exclusion

No #84/cockpit scope.

## Validation

- `python -B -m unittest tests.test_supply_chain_proof tests.test_crabbox_local_container_remote_proof tests.test_factory_completion_audit -q`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `python -B -m unittest tests.test_full_product_worker_graph tests.test_production_full_product_worker_graph tests.test_factory_completion_audit -q`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`
- `python -B scripts\release_integration_preflight.py`
- `python -B -m unittest discover -s tests -q`