### PR TITLE
Pin Quasar proof execution inputs

### DIFF
--- a/schemas/auditor-result.schema.json
+++ b/schemas/auditor-result.schema.json
@@ -35,7 +35,13 @@
       "type": "object",
       "required": [
         "install_source",
+        "source_ref",
+        "source_head_expected",
         "source_head",
+        "source_head_matches",
+        "container_image",
+        "solana_release",
+        "solana_install_url",
         "rustc",
         "cargo",
         "solana",
@@ -49,7 +55,13 @@
       ],
       "properties": {
         "install_source": { "type": "string", "minLength": 1 },
-        "source_head": { "type": "string", "minLength": 7 },
+        "source_ref": { "type": "string", "minLength": 7 },
+        "source_head_expected": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "source_head": { "type": "string" },
+        "source_head_matches": { "type": "boolean" },
+        "container_image": { "type": "string", "pattern": "@sha256:[0-9a-f]{64}$" },
+        "solana_release": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+([-._a-zA-Z0-9]+)?$" },
+        "solana_install_url": { "type": "string", "pattern": "^https://release\\.anza\\.xyz/v[0-9]+\\.[0-9]+\\.[0-9]+([-._a-zA-Z0-9]+)?/install$" },
         "rustc": { "type": "string", "minLength": 1 },
         "cargo": { "type": "string", "minLength": 1 },
         "solana": { "type": "string", "minLength": 1 },
@@ -96,5 +108,36 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "result": {
+            "const": "PASS"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "quasar_toolchain_proof": {
+            "properties": {
+              "source_head_matches": {
+                "const": true
+              },
+              "source_head": {
+                "pattern": "^[0-9a-f]{40}$"
+              },
+              "build_status": {
+                "const": "PASS"
+              },
+              "test_status": {
+                "const": "PASS"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/schemas/quasar-cu-svm-economic-proof.schema.json
+++ b/schemas/quasar-cu-svm-economic-proof.schema.json
@@ -12,7 +12,9 @@
     "source_target",
     "source_sha256",
     "runtime_proof_ref",
+    "runtime_source_match",
     "product_target",
+    "toolchain_proof",
     "property_fuzz_coverage",
     "compute_unit_profile",
     "svm_or_client_flow_coverage",
@@ -52,6 +54,27 @@
     "runtime_proof_ref": {
       "type": "string",
       "minLength": 3
+    },
+    "runtime_source_match": {
+      "type": "object",
+      "required": ["runtime_source_sha256", "current_source_sha256", "matches", "blocking_for_this_proof"],
+      "properties": {
+        "runtime_source_sha256": {
+          "type": "string",
+          "minLength": 64
+        },
+        "current_source_sha256": {
+          "type": "string",
+          "minLength": 64
+        },
+        "matches": {
+          "type": "boolean"
+        },
+        "blocking_for_this_proof": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
     },
     "product_target": {
       "type": "object",
@@ -123,6 +146,72 @@
       },
       "additionalProperties": true
     },
+    "toolchain_proof": {
+      "type": "object",
+      "required": [
+        "container_image",
+        "solana_release",
+        "solana_install_url",
+        "install_source",
+        "source_ref",
+        "source_head_expected",
+        "source_head",
+        "source_head_matches",
+        "rustc",
+        "cargo",
+        "solana",
+        "quasar",
+        "init_command",
+        "build_command",
+        "svm_test_command",
+        "build_status",
+        "svm_test_status",
+        "returncode"
+      ],
+      "properties": {
+        "container_image": {
+          "type": "string",
+          "pattern": "@sha256:[0-9a-f]{64}$"
+        },
+        "solana_release": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+([-._a-zA-Z0-9]+)?$"
+        },
+        "solana_install_url": {
+          "type": "string",
+          "pattern": "^https://release\\.anza\\.xyz/v[0-9]+\\.[0-9]+\\.[0-9]+([-._a-zA-Z0-9]+)?/install$"
+        },
+        "install_source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_ref": {
+          "type": "string",
+          "minLength": 7
+        },
+        "source_head_expected": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "source_head": {
+          "type": "string"
+        },
+        "source_head_matches": {
+          "type": "boolean"
+        },
+        "rustc": { "type": "string", "minLength": 1 },
+        "cargo": { "type": "string", "minLength": 1 },
+        "solana": { "type": "string", "minLength": 1 },
+        "quasar": { "type": "string", "minLength": 1 },
+        "init_command": { "type": "string", "minLength": 1 },
+        "build_command": { "type": "string", "minLength": 1 },
+        "svm_test_command": { "type": "string", "minLength": 1 },
+        "build_status": { "type": "string", "minLength": 1 },
+        "svm_test_status": { "type": "string", "minLength": 1 },
+        "returncode": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
     "svm_or_client_flow_coverage": {
       "type": "object",
       "required": ["quasar_test_passed", "flows", "real_svm_transaction_harness"],
@@ -179,5 +268,49 @@
       "minLength": 3
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "result": {
+            "const": "PASS"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "runtime_source_match": {
+            "properties": {
+              "matches": {
+                "const": true
+              },
+              "blocking_for_this_proof": {
+                "const": true
+              }
+            }
+          },
+          "toolchain_proof": {
+            "properties": {
+              "source_head_matches": {
+                "const": true
+              },
+              "source_head": {
+                "pattern": "^[0-9a-f]{40}$"
+              },
+              "build_status": {
+                "const": "PASS"
+              },
+              "svm_test_status": {
+                "const": "PASS"
+              },
+              "returncode": {
+                "const": 0
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/schemas/quasar-runtime-proof.schema.json
+++ b/schemas/quasar-runtime-proof.schema.json
@@ -6,6 +6,13 @@
     "result",
     "proof_kind",
     "install_source",
+    "source_ref",
+    "source_head_expected",
+    "source_head",
+    "source_head_matches",
+    "container_image",
+    "solana_release",
+    "solana_install_url",
     "policy_decision"
   ],
   "properties": {
@@ -29,6 +36,29 @@
     "source_head": {
       "type": "string"
     },
+    "source_ref": {
+      "type": "string",
+      "minLength": 7
+    },
+    "source_head_expected": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "source_head_matches": {
+      "type": "boolean"
+    },
+    "container_image": {
+      "type": "string",
+      "pattern": "@sha256:[0-9a-f]{64}$"
+    },
+    "solana_release": {
+      "type": "string",
+      "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+([-._a-zA-Z0-9]+)?$"
+    },
+    "solana_install_url": {
+      "type": "string",
+      "pattern": "^https://release\\.anza\\.xyz/v[0-9]+\\.[0-9]+\\.[0-9]+([-._a-zA-Z0-9]+)?/install$"
+    },
     "build_status": {
       "type": "string"
     },
@@ -40,5 +70,26 @@
       "minLength": 1
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "result": {
+            "const": "PASS"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "source_head_matches": {
+            "const": true
+          },
+          "source_head": {
+            "pattern": "^[0-9a-f]{40}$"
+          }
+        }
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -292,7 +292,13 @@ AUDITOR_PROGRAM_CHECKLIST_PREFIXES = ("01", "02", "03", "04", "05", "06", "07")
 AUDITOR_MIN_KNOWN_VECTORS = 100
 QUASAR_TOOLCHAIN_PROOF_REQUIRED = (
     "install_source",
+    "source_ref",
+    "source_head_expected",
     "source_head",
+    "source_head_matches",
+    "container_image",
+    "solana_release",
+    "solana_install_url",
     "rustc",
     "cargo",
     "solana",
@@ -2868,10 +2874,29 @@ def validate_quasar_toolchain_proof(proof: object) -> list[str]:
         errors.append("auditor_result quasar_toolchain_proof missing " + ", ".join(missing))
     install_source = str(proof.get("install_source") or "").lower()
     source_head = str(proof.get("source_head") or "").strip()
+    source_head_expected = str(proof.get("source_head_expected") or "").strip()
+    container_image = str(proof.get("container_image") or "").strip()
+    solana_install_url = str(proof.get("solana_install_url") or "").strip().lower()
     if "crates.io" in install_source and not source_head:
         errors.append("auditor_result quasar_toolchain_proof cannot rely on crates.io quasar-cli without a source_head pin")
     if source_head and len(source_head) < 7:
         errors.append("auditor_result quasar_toolchain_proof source_head must be a commit-like pin")
+    if source_head_expected and len(source_head_expected) < 7:
+        errors.append("auditor_result quasar_toolchain_proof source_head_expected must be a commit-like pin")
+    if source_head and source_head_expected and source_head != source_head_expected:
+        errors.append("auditor_result quasar_toolchain_proof source_head must match source_head_expected")
+    if proof.get("source_head_matches") is not True:
+        errors.append("auditor_result quasar_toolchain_proof source_head_matches must be true")
+    if container_image:
+        if ":latest" in container_image:
+            errors.append("auditor_result quasar_toolchain_proof container_image must not use latest")
+        if "@sha256:" not in container_image:
+            errors.append("auditor_result quasar_toolchain_proof container_image must be digest-pinned")
+    if solana_install_url:
+        if "/stable/" in solana_install_url:
+            errors.append("auditor_result quasar_toolchain_proof solana_install_url must not use stable")
+        if not re.search(r"/v\d+\.\d+\.\d+(?:[-._a-z0-9]+)?/install$", solana_install_url):
+            errors.append("auditor_result quasar_toolchain_proof solana_install_url must use an explicit release")
     if proof.get("build_status") not in (None, "") and not _status_is_pass(proof.get("build_status")):
         errors.append("auditor_result quasar_toolchain_proof build_status must be PASS")
     if proof.get("test_status") not in (None, "") and not _status_is_pass(proof.get("test_status")):

--- a/scripts/quasar_product_like_container_proof.py
+++ b/scripts/quasar_product_like_container_proof.py
@@ -16,7 +16,12 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 QUASAR_SOURCE = "github:blueshift-gg/quasar"
+QUASAR_SOURCE_REPOSITORY = "https://github.com/blueshift-gg/quasar.git"
 QUASAR_SOURCE_HEAD = "a89a9329f05740a20520607608b2b3b78c74f7c4"
+QUASAR_SOURCE_REF = QUASAR_SOURCE_HEAD
+RUST_CONTAINER_IMAGE = "rust:1.91.0-bookworm@sha256:e187887ec511b3d93e45c0231d2f0fd59f1347526c58aa86343aa83c74f3e1a9"
+SOLANA_RELEASE = "v4.0.2"
+SOLANA_INSTALL_URL = f"https://release.anza.xyz/{SOLANA_RELEASE}/install"
 PUBLIC_QVG_SOURCE_DIR = ROOT / "products" / "qvg-public-validation-product" / "onchain" / "quasar" / "src"
 PROJECT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
 
@@ -71,15 +76,26 @@ def read_marker(work_dir: Path, name: str) -> str:
 def docker_script(project_name: str) -> str:
     return f"""set -eux
 export DEBIAN_FRONTEND=noninteractive
+readonly SOLANA_INSTALL_URL="{SOLANA_INSTALL_URL}"
+readonly QUASAR_SOURCE_REPOSITORY="{QUASAR_SOURCE_REPOSITORY}"
+readonly QUASAR_SOURCE_REF="{QUASAR_SOURCE_REF}"
+readonly QUASAR_SOURCE_HEAD="{QUASAR_SOURCE_HEAD}"
 apt-get update
 apt-get install -y --no-install-recommends git ca-certificates curl pkg-config libssl-dev perl make clang llvm-dev libclang-dev protobuf-compiler
 cd /tmp
-curl -sSfL https://release.anza.xyz/stable/install | sh
+curl -sSfL "$SOLANA_INSTALL_URL" | sh
 export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 solana --version | tee /out/solana.txt
-git clone --depth 1 https://github.com/blueshift-gg/quasar.git /tmp/quasar
+git init /tmp/quasar
 cd /tmp/quasar
-git rev-parse HEAD | tee /out/quasar_head.txt
+git remote add origin "$QUASAR_SOURCE_REPOSITORY"
+git fetch --depth 1 origin "$QUASAR_SOURCE_REF"
+git checkout --detach FETCH_HEAD
+resolved_quasar_head="$(git rev-parse HEAD)"
+printf '%s\\n' "$QUASAR_SOURCE_REF" | tee /out/quasar_ref.txt
+printf '%s\\n' "$QUASAR_SOURCE_HEAD" | tee /out/quasar_expected_head.txt
+printf '%s\\n' "$resolved_quasar_head" | tee /out/quasar_head.txt
+test "$resolved_quasar_head" = "$QUASAR_SOURCE_HEAD"
 cargo install --path cli --locked
 cd /tmp
 quasar init {project_name} --yes --toolchain solana --test-language rust --rust-framework quasar-svm --template minimal --no-git --verbose
@@ -109,7 +125,7 @@ def run_container(source_dir: Path, work_dir: Path, timeout: int, project_name: 
         f"{source_dir.resolve()}:/repo-src:ro",
         "-v",
         f"{work_dir.resolve()}:/out",
-        "rust:latest",
+        RUST_CONTAINER_IMAGE,
         "bash",
         "/out/run-quasar-proof.sh",
     ]
@@ -131,7 +147,13 @@ def build_result(
 ) -> dict[str, Any]:
     build_status = read_marker(work_dir, "build_status.txt")
     test_status = read_marker(work_dir, "test_status.txt")
-    result = "PASS" if completed.returncode == 0 and build_status == "PASS" and test_status == "PASS" else "FAIL"
+    quasar_source_head = read_marker(work_dir, "quasar_head.txt")
+    source_head_matches = quasar_source_head == QUASAR_SOURCE_HEAD
+    result = (
+        "PASS"
+        if completed.returncode == 0 and build_status == "PASS" and test_status == "PASS" and source_head_matches
+        else "FAIL"
+    )
     source_files = [
         repo_ref(path)
         for path in sorted(source_dir.rglob("*"))
@@ -149,8 +171,13 @@ def build_result(
         "source_files": source_files,
         "source_sha256": sha256_sources(source_dir),
         "install_source": QUASAR_SOURCE,
-        "source_head": read_marker(work_dir, "quasar_head.txt") or QUASAR_SOURCE_HEAD,
-        "container_image": "rust:latest",
+        "source_ref": read_marker(work_dir, "quasar_ref.txt") or QUASAR_SOURCE_REF,
+        "source_head_expected": QUASAR_SOURCE_HEAD,
+        "source_head": quasar_source_head,
+        "source_head_matches": source_head_matches,
+        "container_image": RUST_CONTAINER_IMAGE,
+        "solana_release": SOLANA_RELEASE,
+        "solana_install_url": SOLANA_INSTALL_URL,
         "rustc": read_marker(work_dir, "rustc.txt"),
         "cargo": read_marker(work_dir, "cargo.txt"),
         "solana": read_marker(work_dir, "solana.txt"),

--- a/scripts/qvg_product_like_auditor_result.py
+++ b/scripts/qvg_product_like_auditor_result.py
@@ -108,7 +108,13 @@ def checklist_coverage(auditor_dir: Path) -> dict[str, Any]:
 def build_quasar_toolchain_proof(runtime_proof: dict[str, Any], runtime_ref: str) -> dict[str, Any]:
     return {
         "install_source": runtime_proof.get("install_source"),
+        "source_ref": runtime_proof.get("source_ref"),
+        "source_head_expected": runtime_proof.get("source_head_expected"),
         "source_head": runtime_proof.get("source_head"),
+        "source_head_matches": runtime_proof.get("source_head_matches"),
+        "container_image": runtime_proof.get("container_image"),
+        "solana_release": runtime_proof.get("solana_release"),
+        "solana_install_url": runtime_proof.get("solana_install_url"),
         "rustc": runtime_proof.get("rustc"),
         "cargo": runtime_proof.get("cargo"),
         "solana": runtime_proof.get("solana"),
@@ -166,6 +172,8 @@ def validate_reusable_product_scope(
         raise ValueError("reusable production Auditor evidence requires a 64-char source_sha256")
     if toolchain.get("build_status") != "PASS" or toolchain.get("test_status") != "PASS":
         raise ValueError("reusable production Auditor evidence requires PASS Quasar build and test status")
+    if toolchain.get("source_head_matches") is not True:
+        raise ValueError("reusable production Auditor evidence requires matching pinned Quasar source head")
     coverage = result.get("known_vectors_coverage") or {}
     if int(coverage.get("total") or 0) < 100:
         raise ValueError("reusable production Auditor evidence requires at least 100 known vectors")
@@ -271,6 +279,7 @@ def build_result(
     total_known_vectors = max(100, len(known_vector_files))
     property_result = str((property_proof or {}).get("result") or "")
     property_passed = property_proof is None or property_result == "PASS"
+    runtime_passed = runtime_proof.get("result") == "PASS" and runtime_proof.get("source_head_matches") is True
     result = {
         "$schema": "https://overkill-factory.dev/schemas/auditor-result.schema.json",
         "record_type": "auditor_result",
@@ -281,8 +290,8 @@ def build_result(
             "factory_phase": "F7/F13",
         },
         "card_ref": load_card_ref(card_path),
-        "result": "PASS" if runtime_proof.get("result") == "PASS" and property_passed else "FAIL",
-        "blocking_findings": runtime_proof.get("result") != "PASS" or not property_passed,
+        "result": "PASS" if runtime_passed and property_passed else "FAIL",
+        "blocking_findings": not runtime_passed or not property_passed,
         "findings_summary": "QVG Quasar target built/tested, deterministic property/fuzz coverage was applied, and Auditor corpus checklist coverage found no blocking issue.",
         "tool_or_profile": "solanabr/Auditor corpus plus Quasar product-like build/test proof",
         "executed_by": "solana-quasar-auditor",

--- a/scripts/qvg_quasar_cu_svm_economic_proof.py
+++ b/scripts/qvg_quasar_cu_svm_economic_proof.py
@@ -15,6 +15,13 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+QUASAR_SOURCE = "github:blueshift-gg/quasar"
+QUASAR_SOURCE_REPOSITORY = "https://github.com/blueshift-gg/quasar.git"
+QUASAR_SOURCE_HEAD = "a89a9329f05740a20520607608b2b3b78c74f7c4"
+QUASAR_SOURCE_REF = QUASAR_SOURCE_HEAD
+RUST_CONTAINER_IMAGE = "rust:1.91.0-bookworm@sha256:e187887ec511b3d93e45c0231d2f0fd59f1347526c58aa86343aa83c74f3e1a9"
+SOLANA_RELEASE = "v4.0.2"
+SOLANA_INSTALL_URL = f"https://release.anza.xyz/{SOLANA_RELEASE}/install"
 PROJECT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
 CU_LINE_RE = re.compile(r"^OF_SVM_CU\s+(?P<name>[a-z0-9_]+)\s+(?P<cu>\d+)\s*$")
 FLOW_LINE_RE = re.compile(r"^OF_SVM_FLOW\s+(?P<name>[a-z0-9_]+)\s+(?P<status>PASS|FAIL)\s*$")
@@ -324,6 +331,10 @@ def docker_script(project_name: str, compute_budget: int) -> str:
     test_module = svm_test_module(project_name, compute_budget)
     return f"""set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
+readonly SOLANA_INSTALL_URL="{SOLANA_INSTALL_URL}"
+readonly QUASAR_SOURCE_REPOSITORY="{QUASAR_SOURCE_REPOSITORY}"
+readonly QUASAR_SOURCE_REF="{QUASAR_SOURCE_REF}"
+readonly QUASAR_SOURCE_HEAD="{QUASAR_SOURCE_HEAD}"
 retry() {{
   local attempts="$1"
   shift
@@ -339,12 +350,19 @@ retry() {{
 apt-get update
 apt-get install -y --no-install-recommends git ca-certificates curl pkg-config libssl-dev perl make clang llvm-dev libclang-dev protobuf-compiler
 cd /tmp
-curl -sSfL https://release.anza.xyz/stable/install | sh
+curl -sSfL "$SOLANA_INSTALL_URL" | sh
 export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 solana --version | tee /out/solana.txt
-git clone --depth 1 https://github.com/blueshift-gg/quasar.git /tmp/quasar
+git init /tmp/quasar
 cd /tmp/quasar
-git rev-parse HEAD | tee /out/quasar_head.txt
+git remote add origin "$QUASAR_SOURCE_REPOSITORY"
+git fetch --depth 1 origin "$QUASAR_SOURCE_REF"
+git checkout --detach FETCH_HEAD
+resolved_quasar_head="$(git rev-parse HEAD)"
+printf '%s\\n' "$QUASAR_SOURCE_REF" | tee /out/quasar_ref.txt
+printf '%s\\n' "$QUASAR_SOURCE_HEAD" | tee /out/quasar_expected_head.txt
+printf '%s\\n' "$resolved_quasar_head" | tee /out/quasar_head.txt
+test "$resolved_quasar_head" = "$QUASAR_SOURCE_HEAD"
 cargo install --path cli --locked
 cd /tmp
 quasar init {project_name} --yes --toolchain solana --test-language rust --rust-framework quasar-svm --template minimal --no-git --verbose
@@ -388,7 +406,7 @@ def run_container(source_dir: Path, work_dir: Path, timeout: int, project_name: 
         f"{source_dir.resolve()}:/repo-src:ro",
         "-v",
         f"{work_dir.resolve()}:/out",
-        "rust:latest",
+        RUST_CONTAINER_IMAGE,
         "bash",
         "/out/run-quasar-svm-proof.sh",
     ]
@@ -463,11 +481,15 @@ def build_result(
     source_economic_surface_pass = not any(source_surface.values())
     build_status = read_marker(work_dir, "build_status.txt")
     svm_test_status = read_marker(work_dir, "svm_test_status.txt")
+    quasar_source_head = read_marker(work_dir, "quasar_head.txt")
+    source_head_matches = quasar_source_head == QUASAR_SOURCE_HEAD
     prior_runtime_source_matches = str(runtime_proof.get("source_sha256") or "") == source_hash
     result = (
         completed.returncode == 0
         and build_status == "PASS"
         and svm_test_status == "PASS"
+        and source_head_matches
+        and prior_runtime_source_matches
         and marker_summary["required_markers_present"]
         and marker_summary["all_cu_within_budget"]
         and all_negative_cases_pass
@@ -493,10 +515,10 @@ def build_result(
             "runtime_source_sha256": str(runtime_proof.get("source_sha256") or ""),
             "current_source_sha256": source_hash,
             "matches": prior_runtime_source_matches,
-            "blocking_for_this_proof": False,
-            "why_non_blocking": (
-                "This CU/SVM/economic proof runs a fresh Quasar build and SVM test in the same container. "
-                "The prior runtime proof is retained as a historical reference, not as the current-pass authority."
+            "blocking_for_this_proof": True,
+            "why_blocking": (
+                "The CU/SVM/economic proof references the runtime proof as evidence. "
+                "Both proofs must describe the same product source hash before this lane can pass."
             ),
         },
         "product_target": {
@@ -511,9 +533,14 @@ def build_result(
             ),
         },
         "toolchain_proof": {
-            "container_image": "rust:latest",
-            "install_source": "github:blueshift-gg/quasar",
-            "source_head": read_marker(work_dir, "quasar_head.txt"),
+            "container_image": RUST_CONTAINER_IMAGE,
+            "solana_release": SOLANA_RELEASE,
+            "solana_install_url": SOLANA_INSTALL_URL,
+            "install_source": QUASAR_SOURCE,
+            "source_ref": read_marker(work_dir, "quasar_ref.txt") or QUASAR_SOURCE_REF,
+            "source_head_expected": QUASAR_SOURCE_HEAD,
+            "source_head": quasar_source_head,
+            "source_head_matches": source_head_matches,
             "rustc": read_marker(work_dir, "rustc.txt"),
             "cargo": read_marker(work_dir, "cargo.txt"),
             "solana": read_marker(work_dir, "solana.txt"),

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -32,6 +32,31 @@ def load_card(name: str) -> dict:
     return factoryctl.load_json_like(ROOT / "examples" / "cards" / name)
 
 
+def valid_quasar_toolchain_proof(**overrides: object) -> dict:
+    proof = {
+        "install_source": "github:blueshift-gg/quasar",
+        "source_ref": "a89a9329f05740a20520607608b2b3b78c74f7c4",
+        "source_head_expected": "a89a9329f05740a20520607608b2b3b78c74f7c4",
+        "source_head": "a89a9329f05740a20520607608b2b3b78c74f7c4",
+        "source_head_matches": True,
+        "container_image": "rust:1.91.0-bookworm@sha256:e187887ec511b3d93e45c0231d2f0fd59f1347526c58aa86343aa83c74f3e1a9",
+        "solana_release": "v4.0.2",
+        "solana_install_url": "https://release.anza.xyz/v4.0.2/install",
+        "rustc": "rustc 1.91.0",
+        "cargo": "cargo 1.91.0",
+        "solana": "solana-cli 4.0.2",
+        "quasar": "quasar 0.0.0",
+        "init_command": "quasar init factory-quasar-proof --yes --toolchain solana --test-language rust --rust-framework quasar-svm --template minimal --no-git",
+        "build_command": "quasar build",
+        "test_command": "quasar test",
+        "build_status": "PASS",
+        "test_status": "PASS",
+        "evidence_refs": [".tmp/factory-runs/quasar-real-proof/quasar-source-proof-result.json"],
+    }
+    proof.update(overrides)
+    return proof
+
+
 def worker_result(
     record_type: str,
     *,
@@ -825,20 +850,7 @@ class FactoryCtlTest(unittest.TestCase):
             "known_vectors_coverage": {"total": 2},
             "instruction_matrix": [{"instruction": "deposit"}],
             "state_model": {"accounts": ["vault"]},
-            "quasar_toolchain_proof": {
-                "install_source": "github:blueshift-gg/quasar",
-                "source_head": "a89a9329f05740a20520607608b2b3b78c74f7c4",
-                "rustc": "rustc 1.96.0",
-                "cargo": "cargo 1.96.0",
-                "solana": "solana-cli 4.0.1",
-                "quasar": "quasar 0.0.0",
-                "init_command": "quasar init factory-quasar-proof --yes --toolchain solana --test-language rust --rust-framework quasar-svm --template minimal --no-git",
-                "build_command": "quasar build",
-                "test_command": "quasar test",
-                "build_status": "PASS",
-                "test_status": "PASS",
-                "evidence_refs": [".tmp/factory-runs/quasar-real-proof/quasar-source-proof-result.json"],
-            },
+            "quasar_toolchain_proof": valid_quasar_toolchain_proof(),
             "findings": [],
             "waivers": [],
         }
@@ -869,20 +881,7 @@ class FactoryCtlTest(unittest.TestCase):
             "known_vectors_coverage": {"total": 100},
             "instruction_matrix": [{"instruction": "deposit"}],
             "state_model": {"accounts": ["vault"], "pdas": ["vault"]},
-            "quasar_toolchain_proof": {
-                "install_source": "github:blueshift-gg/quasar",
-                "source_head": "a89a9329f05740a20520607608b2b3b78c74f7c4",
-                "rustc": "rustc 1.96.0",
-                "cargo": "cargo 1.96.0",
-                "solana": "solana-cli 4.0.1",
-                "quasar": "quasar 0.0.0",
-                "init_command": "quasar init factory-quasar-proof --yes --toolchain solana --test-language rust --rust-framework quasar-svm --template minimal --no-git",
-                "build_command": "quasar build",
-                "test_command": "quasar test",
-                "build_status": "PASS",
-                "test_status": "PASS",
-                "evidence_refs": [".tmp/factory-runs/quasar-real-proof/quasar-source-proof-result.json"],
-            },
+            "quasar_toolchain_proof": valid_quasar_toolchain_proof(),
             "findings": [],
             "waivers": [],
         }
@@ -890,20 +889,11 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(factoryctl.validate_auditor_result(complete), [])
 
     def test_auditor_code_audit_rejects_unpinned_quasar_crates_io_proof(self) -> None:
-        proof = {
-            "install_source": "crates.io:quasar-cli",
-            "source_head": "",
-            "rustc": "rustc 1.96.0",
-            "cargo": "cargo 1.96.0",
-            "solana": "solana-cli 4.0.1",
-            "quasar": "quasar 0.0.0",
-            "init_command": "quasar init factory-quasar-proof --toolchain solana --framework quasarsvm-rust --template minimal",
-            "build_command": "quasar build",
-            "test_command": "quasar test",
-            "build_status": "PASS",
-            "test_status": "PASS",
-            "evidence_refs": [".tmp/factory-runs/quasar-real-proof/quasar-crates-proof-result.json"],
-        }
+        proof = valid_quasar_toolchain_proof(
+            install_source="crates.io:quasar-cli",
+            source_head="",
+            evidence_refs=[".tmp/factory-runs/quasar-real-proof/quasar-crates-proof-result.json"],
+        )
 
         errors = factoryctl.validate_quasar_toolchain_proof(proof)
 
@@ -911,6 +901,23 @@ class FactoryCtlTest(unittest.TestCase):
             "auditor_result quasar_toolchain_proof cannot rely on crates.io quasar-cli without a source_head pin",
             errors,
         )
+
+    def test_auditor_code_audit_rejects_moving_quasar_toolchain_inputs(self) -> None:
+        proof = valid_quasar_toolchain_proof(
+            source_head="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            source_head_matches=False,
+            container_image="rust:latest",
+            solana_install_url="https://release.anza.xyz/stable/install",
+        )
+
+        errors = factoryctl.validate_quasar_toolchain_proof(proof)
+
+        self.assertIn("auditor_result quasar_toolchain_proof source_head must match source_head_expected", errors)
+        self.assertIn("auditor_result quasar_toolchain_proof source_head_matches must be true", errors)
+        self.assertIn("auditor_result quasar_toolchain_proof container_image must not use latest", errors)
+        self.assertIn("auditor_result quasar_toolchain_proof container_image must be digest-pinned", errors)
+        self.assertIn("auditor_result quasar_toolchain_proof solana_install_url must not use stable", errors)
+        self.assertIn("auditor_result quasar_toolchain_proof solana_install_url must use an explicit release", errors)
 
     def test_real_auditor_worker_result_uses_deep_validation(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -52,6 +52,33 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         errors = validator.validate_node(schema, {"result": "BLOCKED"}, "$")
         self.assertTrue(any("recovery_recommendation" in error for error in errors))
 
+    def test_quasar_runtime_schema_requires_pinned_head_only_for_pass(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["quasar-runtime-proof.schema.json"]
+        artifact = {
+            "$schema": "https://overkill-factory.dev/schemas/quasar-runtime-proof.schema.json",
+            "result": "FAIL",
+            "proof_kind": "containerized_product_like_quasar_build_test",
+            "install_source": "github:blueshift-gg/quasar",
+            "source_ref": "a89a9329f05740a20520607608b2b3b78c74f7c4",
+            "source_head_expected": "a89a9329f05740a20520607608b2b3b78c74f7c4",
+            "source_head": "",
+            "source_head_matches": False,
+            "container_image": "rust:1.91.0-bookworm@sha256:e187887ec511b3d93e45c0231d2f0fd59f1347526c58aa86343aa83c74f3e1a9",
+            "solana_release": "v4.0.2",
+            "solana_install_url": "https://release.anza.xyz/v4.0.2/install",
+            "policy_decision": "blocked until the pinned checkout resolves",
+        }
+
+        self.assertEqual(validator.validate_node(schema, artifact, "$", schemas=schemas, root_schema=schema), [])
+
+        artifact["result"] = "PASS"
+        errors = validator.validate_node(schema, artifact, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("source_head_matches" in error and "expected const True" in error for error in errors))
+        self.assertTrue(any("source_head" in error and "does not match pattern" in error for error in errors))
+
     def test_enforces_contains_used_by_review_authorization_schemas(self) -> None:
         validator = load_validator()
         schema = {"type": "array", "contains": {"const": "review"}}

--- a/tests/test_qvg_public_defaults.py
+++ b/tests/test_qvg_public_defaults.py
@@ -1,9 +1,12 @@
+import json
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from scripts import qvg_product_like_auditor_result as auditor_result
 from scripts import qvg_quasar_cu_fuzz_property_proof as property_proof
+from scripts import qvg_quasar_cu_svm_economic_proof as economic_proof
 from scripts import quasar_product_like_container_proof as container_proof
 
 
@@ -43,6 +46,90 @@ class QvgPublicDefaultsTests(unittest.TestCase):
         ):
             text = (ROOT / script).read_text(encoding="utf-8")
             self.assertNotIn(FORBIDDEN_HISTORICAL_PILOT, text, script)
+
+    def test_quasar_runtime_runners_pin_execution_inputs(self):
+        for module in (container_proof, economic_proof):
+            if module is economic_proof:
+                script = module.docker_script("qvg-public-validation-product", 200_000)
+            else:
+                script = module.docker_script("qvg-public-validation-product")
+
+            self.assertIn("@sha256:", module.RUST_CONTAINER_IMAGE)
+            self.assertNotIn(":latest", module.RUST_CONTAINER_IMAGE)
+            self.assertIn("/v4.0.2/install", module.SOLANA_INSTALL_URL)
+            self.assertNotIn("/stable/", module.SOLANA_INSTALL_URL)
+            self.assertIn('git fetch --depth 1 origin "$QUASAR_SOURCE_REF"', script)
+            self.assertIn('test "$resolved_quasar_head" = "$QUASAR_SOURCE_HEAD"', script)
+            self.assertNotIn("git clone --depth 1", script)
+            self.assertNotIn("stable/install", script)
+
+    def test_runtime_proof_fails_when_quasar_head_marker_does_not_match_declared_pin(self):
+        with TemporaryDirectory() as source_tmp, TemporaryDirectory() as work_tmp:
+            source_dir = Path(source_tmp)
+            (source_dir / "lib.rs").write_text("pub fn qvg() {}\n", encoding="utf-8")
+            work_dir = Path(work_tmp)
+            (work_dir / "build_status.txt").write_text("PASS", encoding="utf-8")
+            (work_dir / "test_status.txt").write_text("PASS", encoding="utf-8")
+            (work_dir / "quasar_head.txt").write_text("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", encoding="utf-8")
+            completed = subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
+
+            result = container_proof.build_result(
+                source_dir=source_dir,
+                out=work_dir / "proof.json",
+                work_dir=work_dir,
+                completed=completed,
+                started_at="2026-06-15T00:00:00+00:00",
+                ended_at="2026-06-15T00:00:01+00:00",
+                project_name="qvg-public-validation-product",
+                proof_kind="containerized_product_like_quasar_build_test",
+                evidence_boundary="test boundary",
+                policy_decision="test decision",
+            )
+
+        self.assertEqual(result["result"], "FAIL")
+        self.assertFalse(result["source_head_matches"])
+        self.assertEqual(result["source_head_expected"], container_proof.QUASAR_SOURCE_HEAD)
+
+    def test_auditor_result_does_not_pass_when_runtime_pin_did_not_match(self):
+        with TemporaryDirectory() as auditor_tmp, TemporaryDirectory() as proof_tmp:
+            auditor_dir = Path(auditor_tmp)
+            (auditor_dir / "01-checklist.md").write_text("known vector coverage\n", encoding="utf-8")
+            runtime_proof = {
+                "result": "PASS",
+                "source_head_matches": False,
+                "source_ref": container_proof.QUASAR_SOURCE_REF,
+                "source_head_expected": container_proof.QUASAR_SOURCE_HEAD,
+                "source_head": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "container_image": container_proof.RUST_CONTAINER_IMAGE,
+                "solana_release": container_proof.SOLANA_RELEASE,
+                "solana_install_url": container_proof.SOLANA_INSTALL_URL,
+                "install_source": container_proof.QUASAR_SOURCE,
+                "source_target": "products/qvg-public-validation-product/onchain/quasar/src",
+                "source_sha256": "1" * 64,
+                "rustc": "rustc 1.91.0",
+                "cargo": "cargo 1.91.0",
+                "solana": "solana-cli 4.0.2",
+                "quasar": "quasar 0.0.0",
+                "init_command": "quasar init qvg-public-validation-product",
+                "build_command": "quasar build",
+                "test_command": "quasar test",
+                "build_status": "PASS",
+                "test_status": "PASS",
+            }
+            runtime_path = Path(proof_tmp) / "runtime.json"
+            runtime_path.write_text(json.dumps(runtime_proof), encoding="utf-8")
+
+            result = auditor_result.build_result(
+                auditor_dir=auditor_dir,
+                runtime_proof_path=runtime_path,
+                property_proof_path=None,
+                card_path=auditor_result.PUBLIC_QVG_CARD,
+                report_path=Path(proof_tmp) / "report.md",
+            )
+
+        self.assertEqual(result["result"], "FAIL")
+        self.assertTrue(result["blocking_findings"])
+        self.assertFalse(result["quasar_toolchain_proof"]["source_head_matches"])
 
 
 if __name__ == "__main__":

--- a/tests/test_qvg_quasar_cu_svm_economic_proof.py
+++ b/tests/test_qvg_quasar_cu_svm_economic_proof.py
@@ -1,5 +1,8 @@
 import json
+import subprocess
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from scripts import qvg_quasar_cu_svm_economic_proof as proof
 
@@ -48,6 +51,56 @@ class QvgQuasarCuSvmEconomicProofTests(unittest.TestCase):
         self.assertIn("production_svm_success_and_failure_matrix", harness)
         self.assertIn("OF_SVM_CU review_vault_instruction", harness)
         json.dumps({"harness_sha256": proof.sha256_text(harness)})
+
+    def test_build_result_blocks_when_runtime_proof_source_hash_is_stale(self):
+        with TemporaryDirectory() as source_tmp, TemporaryDirectory() as work_tmp:
+            source_dir = Path(source_tmp)
+            (source_dir / "lib.rs").write_text("pub fn review() {}\n", encoding="utf-8")
+            runtime_proof = Path(work_tmp) / "runtime-proof.json"
+            runtime_proof.write_text(
+                json.dumps({"source_sha256": "0" * 64}),
+                encoding="utf-8",
+            )
+            work_dir = Path(work_tmp)
+            (work_dir / "build_status.txt").write_text("PASS", encoding="utf-8")
+            (work_dir / "svm_test_status.txt").write_text("PASS", encoding="utf-8")
+            (work_dir / "quasar_head.txt").write_text(proof.QUASAR_SOURCE_HEAD, encoding="utf-8")
+            (work_dir / "quasar_ref.txt").write_text(proof.QUASAR_SOURCE_REF, encoding="utf-8")
+            (work_dir / "svm-test.log").write_text(
+                "\n".join(
+                    [
+                        "OF_SVM_CU review_vault_instruction 1410",
+                        "OF_SVM_FLOW review_vault_instruction PASS",
+                        "OF_SVM_CU record_audit_receipt 1330",
+                        "OF_SVM_FLOW record_audit_receipt PASS",
+                        "OF_SVM_CU block_instruction 1180",
+                        "OF_SVM_FLOW block_instruction PASS",
+                        "OF_SVM_FLOW sequential_review_record_block PASS",
+                        "OF_SVM_NEGATIVE review_zero_hash PASS",
+                        "OF_SVM_NEGATIVE record_zero_hash PASS",
+                        "OF_SVM_NEGATIVE block_zero_reason PASS",
+                        "OF_SVM_ECONOMIC lamports_unchanged PASS",
+                        "OF_SVM_ECONOMIC pda_data_unchanged PASS",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
+
+            result = proof.build_result(
+                source_dir=source_dir,
+                runtime_proof_path=runtime_proof,
+                work_dir=work_dir,
+                completed=completed,
+                started_at="2026-06-15T00:00:00+00:00",
+                ended_at="2026-06-15T00:00:01+00:00",
+                project_name="qvg-public-validation-product",
+                compute_budget=200_000,
+            )
+
+        self.assertEqual(result["result"], "FAIL")
+        self.assertFalse(result["runtime_source_match"]["matches"])
+        self.assertTrue(result["runtime_source_match"]["blocking_for_this_proof"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #168

## Summary
- Pin Quasar proof Docker images by digest and Solana install URL by explicit Anza release.
- Require Quasar checkout by declared ref and fail when resolved HEAD differs from the expected commit.
- Propagate pin metadata through Auditor results and reject moving inputs in factoryctl validation.
- Harden public schemas/tests so PASS proofs cannot omit pinned toolchain evidence.

## Validation
- python -B -m unittest discover -s tests -q
- python -B scripts/public_safety_scan.py
- python -B scripts/secret_safety_scan.py
- python -B scripts/validate_public_json_artifacts.py
- python -B scripts/supply_chain_proof.py --check --no-write
- python -B scripts/release_integration_preflight.py
- python -B scripts/public_safety_scan.py --git-ref HEAD