### PR TITLE
Sanitize public CLI path output

### DIFF
--- a/scripts/control_tower_approval_registration_smoke.py
+++ b/scripts/control_tower_approval_registration_smoke.py
@@ -13,7 +13,7 @@ import json
 import re
 import sys
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
@@ -148,6 +148,10 @@ def assert_public_safe(payload: dict[str, Any]) -> None:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except (OSError, ValueError):

--- a/scripts/control_tower_approval_registration_smoke.py
+++ b/scripts/control_tower_approval_registration_smoke.py
@@ -147,6 +147,13 @@ def assert_public_safe(payload: dict[str, Any]) -> None:
         raise AssertionError(f"private-looking text in public smoke: {match.group(0)}")
 
 
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except (OSError, ValueError):
+        return f"external:{path.name or fallback}"
+
+
 def build_receipt(created_at: str | None = None) -> dict[str, Any]:
     timestamp = created_at or utc_now()
     approval = pending_approval(timestamp)
@@ -276,9 +283,10 @@ def main() -> int:
     args = parser.parse_args()
 
     receipt = build_receipt()
-    args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
-    print(f"Wrote {args.out.relative_to(ROOT).as_posix()}")
+    out_path = args.out if args.out.is_absolute() else ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {public_path_ref(out_path)}")
     return 0
 
 

--- a/scripts/control_tower_readonly_smoke.py
+++ b/scripts/control_tower_readonly_smoke.py
@@ -225,6 +225,13 @@ def assert_public_safe(payload: dict[str, Any]) -> None:
         raise AssertionError(f"private-looking text in public smoke: {match.group(0)}")
 
 
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except (OSError, ValueError):
+        return f"external:{path.name or fallback}"
+
+
 def build_receipt(created_at: str | None = None) -> dict[str, Any]:
     timestamp = created_at or utc_now()
     before = synthetic_runtime_snapshot(timestamp)
@@ -303,7 +310,7 @@ def main() -> int:
     receipt = build_receipt()
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
-    print(f"Wrote {out_path.relative_to(ROOT).as_posix()}")
+    print(f"Wrote {public_path_ref(out_path)}")
     return 0
 
 

--- a/scripts/control_tower_readonly_smoke.py
+++ b/scripts/control_tower_readonly_smoke.py
@@ -14,7 +14,7 @@ import json
 import re
 import sys
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
@@ -226,6 +226,10 @@ def assert_public_safe(payload: dict[str, Any]) -> None:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except (OSError, ValueError):

--- a/scripts/factory_battery.py
+++ b/scripts/factory_battery.py
@@ -20,7 +20,7 @@ BATTERY_SCHEMA = "https://overkill-factory.dev/schemas/factory-battery-result.sc
 def load_factoryctl() -> Any:
     spec = importlib.util.spec_from_file_location("battery_factoryctl", FACTORYCTL)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load factoryctl from {FACTORYCTL}")
+        raise RuntimeError("cannot load factoryctl from scripts/factoryctl.py")
     module = importlib.util.module_from_spec(spec)
     sys.modules["battery_factoryctl"] = module
     spec.loader.exec_module(module)
@@ -30,6 +30,13 @@ def load_factoryctl() -> Any:
 def write_json(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except (OSError, ValueError):
+        return f"external:{path.name or fallback}"
 
 
 def scenario_pass(name: str, *, expected: dict[str, Any], observed: dict[str, Any]) -> dict[str, Any]:
@@ -257,7 +264,7 @@ def main() -> int:
         "using public examples only.\n",
         encoding="utf-8",
     )
-    print(json.dumps({"out": str(args.out), "failed_count": result["failed_count"]}, indent=2))
+    print(json.dumps({"out": public_path_ref(args.out), "failed_count": result["failed_count"]}, indent=2))
     return 0 if result["failed_count"] == 0 else 1
 
 

--- a/scripts/factory_battery.py
+++ b/scripts/factory_battery.py
@@ -8,7 +8,7 @@ import importlib.util
 import json
 import sys
 import tempfile
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
@@ -33,6 +33,10 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except (OSError, ValueError):

--- a/scripts/factory_concierge_discord_bridge.py
+++ b/scripts/factory_concierge_discord_bridge.py
@@ -808,11 +808,14 @@ def write_json(path: Path | None, data: dict[str, Any]) -> None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote {public_path_ref(path)}")
+
+
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
     try:
-        rel = path.relative_to(ROOT)
-        print(f"Wrote {rel.as_posix()}")
-    except ValueError:
-        print(f"Wrote {path}")
+        return path.resolve().relative_to(ROOT).as_posix()
+    except (OSError, ValueError):
+        return f"external:{path.name or fallback}"
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/factory_concierge_discord_bridge.py
+++ b/scripts/factory_concierge_discord_bridge.py
@@ -24,7 +24,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Protocol
 
 
@@ -812,6 +812,10 @@ def write_json(path: Path | None, data: dict[str, Any]) -> None:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except (OSError, ValueError):

--- a/scripts/factory_self_improvement.py
+++ b/scripts/factory_self_improvement.py
@@ -78,7 +78,14 @@ def write_json(path: Path | None, data: Any) -> None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
-    print(f"Wrote {path}")
+    print(f"Wrote {public_path_ref(path)}")
+
+
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except (OSError, ValueError):
+        return f"external:{path.name or fallback}"
 
 
 def clean_public_text(value: Any) -> str:

--- a/scripts/factory_self_improvement.py
+++ b/scripts/factory_self_improvement.py
@@ -12,7 +12,7 @@ import argparse
 import json
 import re
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
@@ -82,6 +82,10 @@ def write_json(path: Path | None, data: Any) -> None:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except (OSError, ValueError):

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -73,7 +73,7 @@ DEFAULT_READINESS_LEDGER_OUT = ROOT / ".tmp" / "factory-runs" / "readiness" / "r
 DEFAULT_HERMES_EVIDENCE_OUT = ROOT / ".tmp" / "factory-runs" / "hermes-evidence" / "sanitized-package.json"
 DEFAULT_PREPILOT_CHECKLIST_OUT = ROOT / ".tmp" / "factory-runs" / "prepilot" / "loose-end-checklist.json"
 PRIVATE_RUNTIME_REF_RE = re.compile(
-    r"([A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
+    r"((?<![A-Za-z])[A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
     re.IGNORECASE,
 )
 
@@ -884,7 +884,7 @@ def load_json_like(path: Path) -> dict[str, Any]:
             text = "\n".join(lines[1:-1]).strip()
     data = json.loads(text)
     if not isinstance(data, dict):
-        raise ValueError(f"{path} must contain a JSON object")
+        raise ValueError(f"{public_path_ref(path)} must contain a JSON object")
     return data
 
 
@@ -1110,7 +1110,7 @@ def write_json(path: Path | None, data: dict[str, Any]) -> None:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
-    print(f"Wrote {path}")
+    print(f"Wrote {public_path_ref(path)}")
 
 
 def source_card_ref(source_path: Path) -> str:
@@ -1131,6 +1131,14 @@ def source_card_ref(source_path: Path) -> str:
         if windows_path.is_absolute() or (len(raw_normalized) >= 2 and raw_normalized[1] == ":"):
             return f"external:{windows_path.name or 'source-card'}"
         return f"external:{source_path.name or 'source-card'}"
+
+
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except (OSError, ValueError):
+        name = path.name or fallback
+        return f"external:{name}"
 
 
 def classify_artifact_ref(ref: Any) -> dict[str, Any]:
@@ -1178,7 +1186,7 @@ def sanitize_slug(value: Any, *, fallback: str = "item") -> str:
 
 def redact_private_text(value: Any) -> str:
     text = str(value or "")
-    text = re.sub(r"[A-Za-z]:[\\/][^ \];,\"]+", "[redacted-private-ref]", text)
+    text = re.sub(r"(?<![A-Za-z])[A-Za-z]:[\\/][^ \];,\"]+", "[redacted-private-ref]", text)
     text = re.sub(r"/(?:home|Users|srv|var)/[^ \];,\"]+", "[redacted-private-ref]", text)
     text = PRIVATE_RUNTIME_REF_RE.sub("[redacted-private-marker]", text)
     text = public_safe_kanban_ref(text) or ""
@@ -1549,7 +1557,7 @@ def build_doctor_report(hermes_home: Path | None = None) -> dict[str, Any]:
 
 def write_operator_workspace(target: Path, project_name: str, hermes_home: Path | None, force: bool = False) -> None:
     if target.exists() and any(target.iterdir()) and not force:
-        raise ValueError(f"{target} is not empty; use --force to write into it")
+        raise ValueError(f"{public_path_ref(target, fallback='workspace')} is not empty; use --force to write into it")
     target.mkdir(parents=True, exist_ok=True)
     for rel in ["cards", "worker-packets", "receipts", "worker-results", "reports"]:
         directory = target / rel
@@ -6786,7 +6794,7 @@ def command_init(args: argparse.Namespace) -> int:
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    print(f"Initialized Overkill Factory workspace at {args.out}")
+    print(f"Initialized Overkill Factory workspace at {public_path_ref(args.out, fallback='workspace')}")
     return 0
 
 
@@ -6972,7 +6980,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    return int(args.func(args))
+    try:
+        return int(args.func(args))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(redact_private_text(str(exc)), file=sys.stderr)
+        return 1
 
 
 def main_with_args_for_test(argv: list[str]) -> int:

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -1134,6 +1134,10 @@ def source_card_ref(source_path: Path) -> str:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
     try:
         return path.resolve().relative_to(ROOT).as_posix()
     except (OSError, ValueError):

--- a/scripts/managed_remote_proof_probe.py
+++ b/scripts/managed_remote_proof_probe.py
@@ -48,14 +48,20 @@ def utc_now() -> str:
 
 def repo_ref(path: Path) -> str:
     try:
-        return path.relative_to(ROOT).as_posix()
+        return path.resolve().relative_to(ROOT).as_posix()
     except ValueError:
         return f"external:{path.name}"
 
 
 def redact(text: str) -> str:
     text = URL_RE.sub("<url-redacted>", text)
-    return SECRETISH_RE.sub("<redacted>", text)
+    text = SECRETISH_RE.sub("<redacted>", text)
+    text = text.replace(str(ROOT), "<repo-root>").replace(str(ROOT).replace("\\", "/"), "<repo-root>")
+    text = text.replace(str(Path.home()), "<home>").replace(str(Path.home()).replace("\\", "/"), "<home>")
+    text = re.sub(r"<home>[\\/][^\s\"')<]+", "<home>", text)
+    text = re.sub(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", "<redacted-local-path>", text)
+    text = re.sub(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+", "<redacted-local-path>", text)
+    return text
 
 
 def run_probe_command(argv: list[str], timeout: int = 20) -> dict[str, Any]:

--- a/scripts/production_release_gate.py
+++ b/scripts/production_release_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -61,9 +62,22 @@ def source_sha256(path: Path = PRODUCT_SOURCE) -> str:
 
 def repo_ref(path: Path) -> str:
     try:
-        return path.relative_to(ROOT).as_posix()
+        return path.resolve().relative_to(ROOT).as_posix()
     except ValueError:
         return f"external:{path.name}"
+
+
+def redact_public_text(text: str) -> str:
+    redacted = text
+    replacements = {
+        str(ROOT): "<repo>",
+        str(ROOT).replace("\\", "/"): "<repo>",
+    }
+    for before, after in replacements.items():
+        redacted = redacted.replace(before, after)
+    redacted = re.sub(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", "<redacted-local-path>", redacted)
+    redacted = re.sub(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+", "<redacted-local-path>", redacted)
+    return redacted
 
 
 def run_command(argv: list[str]) -> dict[str, Any]:
@@ -76,10 +90,10 @@ def run_command(argv: list[str]) -> dict[str, Any]:
         timeout=120,
     )
     return {
-        "command": " ".join(argv),
+        "command": redact_public_text(" ".join(argv)),
         "exit_code": completed.returncode,
-        "stdout_tail": completed.stdout[-2000:].replace(str(ROOT), "<repo>"),
-        "stderr_tail": completed.stderr[-2000:].replace(str(ROOT), "<repo>"),
+        "stdout_tail": redact_public_text(completed.stdout[-2000:]),
+        "stderr_tail": redact_public_text(completed.stderr[-2000:]),
     }
 
 
@@ -280,8 +294,14 @@ def main(argv: list[str] | None = None) -> int:
     created_at = utc_now()
     try:
         human_gate = load_human_gate_record(args.human_gate_record)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        print(f"human gate record rejected: {exc}", file=sys.stderr)
+    except OSError:
+        print(f"human gate record rejected: {repo_ref(args.human_gate_record)}", file=sys.stderr)
+        return 1
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(
+            f"human gate record rejected: {repo_ref(args.human_gate_record)}: {redact_public_text(str(exc))}",
+            file=sys.stderr,
+        )
         return 1
     validation = [run_command(command) for command in validation_commands(no_write=args.no_write)]
     release_ops = build_release_ops(

--- a/scripts/quasar_product_like_container_proof.py
+++ b/scripts/quasar_product_like_container_proof.py
@@ -51,6 +51,8 @@ def redact_text(text: str, source_dir: Path, work_dir: Path) -> str:
     }
     for before, after in replacements.items():
         redacted = redacted.replace(before, after)
+    redacted = re.sub(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", "<redacted-local-path>", redacted)
+    redacted = re.sub(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+", "<redacted-local-path>", redacted)
     return redacted
 
 
@@ -234,7 +236,7 @@ def main(argv: list[str] | None = None) -> int:
     source_dir = args.source_dir if args.source_dir.is_absolute() else ROOT / args.source_dir
     source_dir = source_dir.resolve()
     if not source_dir.exists():
-        raise SystemExit(f"source dir does not exist: {source_dir}")
+        raise SystemExit(f"source dir does not exist: {repo_ref(source_dir)}")
     if not PROJECT_NAME_RE.fullmatch(args.project_name):
         raise SystemExit("--project-name must be 3-64 chars of lowercase letters, numbers or hyphens")
     out = args.out if args.out.is_absolute() else ROOT / args.out

--- a/scripts/qvg_quasar_cu_fuzz_property_proof.py
+++ b/scripts/qvg_quasar_cu_fuzz_property_proof.py
@@ -246,7 +246,17 @@ def main(argv: list[str] | None = None) -> int:
     source_dir = args.source_dir if args.source_dir.is_absolute() else ROOT / args.source_dir
     runtime_proof = args.runtime_proof if args.runtime_proof.is_absolute() else ROOT / args.runtime_proof
     out = args.out if args.out.is_absolute() else ROOT / args.out
-    result = build_result(source_dir.resolve(), runtime_proof.resolve())
+    source_dir = source_dir.resolve()
+    runtime_proof = runtime_proof.resolve()
+    if not source_dir.exists():
+        raise SystemExit(f"source dir does not exist: {repo_ref(source_dir)}")
+    if not runtime_proof.exists():
+        raise SystemExit(f"runtime proof does not exist: {repo_ref(runtime_proof)}")
+    try:
+        result = build_result(source_dir, runtime_proof)
+    except (OSError, json.JSONDecodeError) as exc:
+        target = runtime_proof if isinstance(exc, json.JSONDecodeError) else source_dir
+        raise SystemExit(f"proof input rejected: {repo_ref(target)}") from None
     write_json(out, result)
     print(json.dumps({"result": result["result"], "out": repo_ref(out), "total_cases": result["property_fuzz_coverage"]["total_cases"]}, indent=2))
     return 0 if result["result"] == "PASS" else 1

--- a/scripts/qvg_quasar_cu_svm_economic_proof.py
+++ b/scripts/qvg_quasar_cu_svm_economic_proof.py
@@ -83,6 +83,8 @@ def redact_text(text: str, source_dir: Path, work_dir: Path) -> str:
     }
     for before, after in replacements.items():
         redacted = redacted.replace(before, after)
+    redacted = re.sub(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", "<redacted-local-path>", redacted)
+    redacted = re.sub(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+", "<redacted-local-path>", redacted)
     return redacted
 
 
@@ -711,9 +713,9 @@ def main(argv: list[str] | None = None) -> int:
     report_out = args.report_out if args.report_out.is_absolute() else ROOT / args.report_out
     source_dir = source_dir.resolve()
     if not source_dir.exists():
-        raise SystemExit(f"source dir does not exist: {source_dir}")
+        raise SystemExit(f"source dir does not exist: {repo_ref(source_dir)}")
     if not runtime_proof.exists():
-        raise SystemExit(f"runtime proof does not exist: {runtime_proof}")
+        raise SystemExit(f"runtime proof does not exist: {repo_ref(runtime_proof)}")
 
     started_at = utc_now()
     with tempfile.TemporaryDirectory(prefix="of-quasar-svm-economic-") as tmp:

--- a/scripts/remote_proof_smoke.py
+++ b/scripts/remote_proof_smoke.py
@@ -19,6 +19,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PRIVATE_OUTPUT_PATTERNS = [
     re.compile(r"C:[/\\]+Users[/\\]+", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", re.IGNORECASE),
+    re.compile(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+"),
     re.compile("/srv/" + "hermes"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{30,}\b"),
     re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
@@ -69,8 +71,13 @@ def run_command(command: str, cwd: Path, timeout: int) -> dict[str, object]:
 
 
 def redact_output(text: str) -> str:
-    redacted = text.replace(str(Path.home()), "<home>").replace(str(Path.home()).replace("\\", "\\\\"), "<home>")
+    redacted = text.replace(str(ROOT), "<repo>").replace(str(ROOT).replace("\\", "/"), "<repo>")
+    redacted = redacted.replace(str(Path.home()), "<home>").replace(str(Path.home()).replace("\\", "/"), "<home>")
+    redacted = redacted.replace(str(Path.home()).replace("\\", "\\\\"), "<home>")
+    redacted = re.sub(r"<home>[\\/][^\s\"')<]+", "<home>", redacted)
     redacted = re.sub(r"C:[/\\]+Users[/\\]+[^\s\"')<]+", "<redacted-local-path>", redacted, flags=re.IGNORECASE)
+    redacted = re.sub(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", "<redacted-local-path>", redacted, flags=re.IGNORECASE)
+    redacted = re.sub(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+", "<redacted-local-path>", redacted)
     redacted = re.sub(r"<home>\\AppData\\Local\\Temp\\[^\s\\]+", "<temp>", redacted)
     redacted = re.sub(r"/" + r"tmp/[^\s/]+", "<temp>", redacted)
     redacted = re.sub(r"\bgh[pousr]_[A-Za-z0-9_]{10,}\b", "<redacted-token>", redacted)

--- a/scripts/whimsical_mcp.py
+++ b/scripts/whimsical_mcp.py
@@ -10,7 +10,7 @@ import json
 import re
 import urllib.parse
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
@@ -108,8 +108,11 @@ def validate_endpoint(endpoint: str) -> urllib.parse.ParseResult:
 
 
 def public_path_ref(path: Path, fallback: str = "artifact") -> str:
-    name = path.name or fallback
-    return f"external:{name}"
+    raw = str(path)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() or (len(raw) >= 2 and raw[1] == ":"):
+        return f"external:{windows_path.name or fallback}"
+    return f"external:{path.name or fallback}"
 
 
 def redact(value: Any, *, include_private_content: bool = True) -> Any:

--- a/scripts/whimsical_mcp.py
+++ b/scripts/whimsical_mcp.py
@@ -23,6 +23,10 @@ PRIVATE_PATTERNS = [
     (re.compile(r"C:[/\\]+Users[/\\]+[^\s\"<>]+", re.IGNORECASE), "<local-path>"),
     (re.compile(r"(?i)\b[a-z0-9._%+-]*" + "fel" + "ipe" + r"[a-z0-9._%+-]*\b"), "<user>"),
 ]
+PRIVATE_PATH_PATTERNS = [
+    (re.compile(r"(?<![A-Za-z])[A-Za-z]:[\\/][^\s\"')<]+", re.IGNORECASE), "<local-path>"),
+    (re.compile(r"/(?:Users|home|srv|tmp)/[^\s\"')<]+"), "<local-path>"),
+]
 
 
 @dataclass(frozen=True)
@@ -103,16 +107,24 @@ def validate_endpoint(endpoint: str) -> urllib.parse.ParseResult:
     return parsed
 
 
-def redact(value: Any) -> Any:
+def public_path_ref(path: Path, fallback: str = "artifact") -> str:
+    name = path.name or fallback
+    return f"external:{name}"
+
+
+def redact(value: Any, *, include_private_content: bool = True) -> Any:
     if isinstance(value, str):
         redacted = value
-        for pattern, replacement in PRIVATE_PATTERNS:
+        patterns = [*PRIVATE_PATH_PATTERNS]
+        if include_private_content:
+            patterns.extend(PRIVATE_PATTERNS)
+        for pattern, replacement in patterns:
             redacted = pattern.sub(replacement, redacted)
         return redacted
     if isinstance(value, list):
-        return [redact(item) for item in value]
+        return [redact(item, include_private_content=include_private_content) for item in value]
     if isinstance(value, dict):
-        return {key: redact(item) for key, item in value.items()}
+        return {key: redact(item, include_private_content=include_private_content) for key, item in value.items()}
     return value
 
 
@@ -138,7 +150,7 @@ def build_health(initialize_response: dict[str, Any], tools_response: dict[str, 
 
 
 def print_json(data: Any, *, should_redact: bool) -> None:
-    safe = redact(data) if should_redact else data
+    safe = redact(data, include_private_content=should_redact)
     print(json.dumps(safe, indent=2, sort_keys=True, ensure_ascii=True))
 
 
@@ -217,7 +229,7 @@ def run_snapshot(args: argparse.Namespace, client: McpClient, should_redact: boo
         {
             "status": "PASS",
             "metadata": text_blocks,
-            "output": str(out_path),
+            "output": public_path_ref(out_path),
             "bytes": out_path.stat().st_size,
         },
         should_redact=should_redact,

--- a/tests/test_cli_public_stdout_hygiene.py
+++ b/tests/test_cli_public_stdout_hygiene.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str) -> Any:
+    path = ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CliPublicStdoutHygieneTests(unittest.TestCase):
+    def assert_no_private_path(self, text: str, private_path: Path | None = None) -> None:
+        if private_path is not None:
+            self.assertNotIn(str(private_path), text)
+            self.assertNotIn(str(private_path).replace("\\", "/"), text)
+        self.assertNotIn("C:\\Users", text)
+        self.assertNotIn("OneDrive", text)
+        self.assertNotIn("/Users/", text)
+        self.assertNotIn("/home/", text)
+        self.assertNotIn("/srv/", text)
+        self.assertNotIn("/tmp/", text)
+
+    def test_write_helpers_print_public_refs_for_external_outputs(self) -> None:
+        factoryctl = load_script("factoryctl")
+        self_improvement = load_script("factory_self_improvement")
+        bridge = load_script("factory_concierge_discord_bridge")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            private_out = Path(tmp) / "private-output.json"
+            for module in (factoryctl, self_improvement, bridge):
+                with self.subTest(module=module.__name__):
+                    stdout = io.StringIO()
+                    with contextlib.redirect_stdout(stdout):
+                        module.write_json(private_out, {"result": "PASS"})
+
+                    printed = stdout.getvalue()
+                    self.assertIn("Wrote external:private-output.json", printed)
+                    self.assert_no_private_path(printed, private_out)
+
+    def test_factory_battery_summary_uses_public_output_ref(self) -> None:
+        battery = load_script("factory_battery")
+        readonly = load_script("control_tower_readonly_smoke")
+        approval = load_script("control_tower_approval_registration_smoke")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            private_out = Path(tmp) / "battery.json"
+
+            self.assertEqual(battery.public_path_ref(private_out), "external:battery.json")
+            self.assertEqual(readonly.public_path_ref(private_out), "external:battery.json")
+            self.assertEqual(approval.public_path_ref(private_out), "external:battery.json")
+
+    def test_factoryctl_init_error_uses_public_workspace_ref(self) -> None:
+        factoryctl = load_script("factoryctl")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "operator-workspace"
+            workspace.mkdir()
+            (workspace / "already-here.txt").write_text("busy", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                exit_code = factoryctl.main_with_args_for_test(
+                    ["init", "--out", str(workspace), "--project-name", "private-product"]
+                )
+
+            printed = stderr.getvalue()
+            self.assertEqual(exit_code, 1)
+            self.assertIn("external:operator-workspace is not empty", printed)
+            self.assert_no_private_path(printed, workspace)
+
+    def test_quasar_missing_inputs_use_public_refs(self) -> None:
+        container = load_script("quasar_product_like_container_proof")
+        svm = load_script("qvg_quasar_cu_svm_economic_proof")
+        fuzz = load_script("qvg_quasar_cu_fuzz_property_proof")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_source = Path(tmp) / "missing-source"
+            missing_runtime = Path(tmp) / "missing-runtime.json"
+            existing_source = Path(tmp) / "src"
+            existing_source.mkdir()
+
+            for module, argv, expected in (
+                (container, ["--source-dir", str(missing_source)], "source dir does not exist: external:missing-source"),
+                (svm, ["--source-dir", str(missing_source)], "source dir does not exist: external:missing-source"),
+                (
+                    fuzz,
+                    ["--source-dir", str(existing_source), "--runtime-proof", str(missing_runtime)],
+                    "runtime proof does not exist: external:missing-runtime.json",
+                ),
+            ):
+                with self.subTest(module=module.__name__):
+                    with self.assertRaises(SystemExit) as raised:
+                        module.main(argv)
+                    message = str(raised.exception)
+                    self.assertIn(expected, message)
+                    self.assert_no_private_path(message, missing_source)
+                    self.assert_no_private_path(message, missing_runtime)
+
+    def test_subprocess_tail_redactors_remove_private_paths(self) -> None:
+        release_gate = load_script("production_release_gate")
+        remote_probe = load_script("managed_remote_proof_probe")
+        remote_smoke = load_script("remote_proof_smoke")
+        whimsical = load_script("whimsical_mcp")
+
+        drive_path = "C:" + "\\Users\\example\\Workspace\\file.txt"
+        temp_path = "/" + "tmp" + "/workspace/file.txt"
+        home_path = "/" + "home" + "/example/workspace.txt"
+        service_path = "/" + "srv" + "/runtime/x"
+        sample = f"{drive_path} {temp_path} {home_path} {service_path}"
+
+        redacted_samples = [
+            release_gate.redact_public_text(sample),
+            remote_probe.redact(sample),
+            remote_smoke.redact_output(sample),
+            whimsical.redact(sample),
+            whimsical.redact(sample, include_private_content=False),
+        ]
+        for redacted in redacted_samples:
+            self.assert_no_private_path(str(redacted))
+
+        self.assertEqual(whimsical.public_path_ref(Path("C:" + "\\Users\\example\\shot.png")), "external:shot.png")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- sanitize public CLI success and error output so absolute local paths become repo-relative refs or `external:<name>`
- harden subprocess evidence tails for release, remote proof, Quasar, and Whimsical helpers
- add regression coverage for public stdout/stderr path hygiene and missing-input errors

Closes #169.

## Validation
- `python -B -m unittest discover -s tests -q`
- `python -B scripts/public_safety_scan.py`
- `python -B scripts/secret_safety_scan.py`
- `python -B scripts/validate_public_json_artifacts.py`
- `python -B scripts/supply_chain_proof.py --check --no-write`
- `python -B scripts/release_integration_preflight.py`
- `python -B scripts/public_safety_scan.py --git-ref HEAD`