### PR TITLE
Match fresh reviews to recovery requirements

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4434,7 +4434,9 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
         active = [candidate for candidate in candidates if candidate.get("active")]
         ordered = sorted(active or candidates, key=_worker_record_sort_key, reverse=True)
         if ordered:
-            records[record_type] = ordered[0]
+            selected = dict(ordered[0])
+            selected["candidate_records"] = ordered
+            records[record_type] = selected
     return records
 
 
@@ -4644,25 +4646,55 @@ def apply_record_consumption_state(record: dict[str, Any]) -> None:
     record["review_task_authorizations"] = [review_task_authorization(requirement) for requirement in pending]
 
 
+def candidate_records_for_field(fields: dict[str, dict[str, Any]], field: str) -> list[dict[str, Any]]:
+    record = fields.get(field)
+    if not isinstance(record, dict):
+        return []
+    candidates = [record]
+    for candidate in record.get("candidate_records", []):
+        if isinstance(candidate, dict):
+            candidates.append(candidate)
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for candidate in candidates:
+        key = (
+            str(candidate.get("created_at") or ""),
+            str(candidate.get("evidence_ref") or ""),
+        )
+        if key not in seen:
+            deduped.append(candidate)
+            seen.add(key)
+    return deduped
+
+
 def resolve_graph_requirements(fields: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
     requirements: list[dict[str, Any]] = []
     for record in fields.values():
         for requirement in record.get("graph_requirements", []):
             requirement = dict(requirement)
-            review_record = fields.get(str(requirement.get("required_review_field") or ""))
-            if requirement.get("status") != "satisfied" and review_record:
-                if (
-                    review_record.get("valid")
-                    and str(review_record.get("result") or "").strip().upper() == "PASS"
-                    and review_record_matches_requirement(review_record, requirement)
-                ):
+            review_candidates = candidate_records_for_field(
+                fields,
+                str(requirement.get("required_review_field") or ""),
+            )
+            if requirement.get("status") != "satisfied" and review_candidates:
+                matching_review = next(
+                    (
+                        candidate
+                        for candidate in review_candidates
+                        if candidate.get("valid")
+                        and str(candidate.get("result") or "").strip().upper() == "PASS"
+                        and review_record_matches_requirement(candidate, requirement)
+                    ),
+                    None,
+                )
+                if matching_review:
                     requirement["status"] = "satisfied"
                     requirement["reviewer_result"] = "PASS"
-                    requirement["review_evidence_ref"] = review_record.get("evidence_ref") or "receipt:review"
+                    requirement["review_evidence_ref"] = matching_review.get("evidence_ref") or "receipt:review"
                     authorized_worker_ids = registered_nonhuman_worker_ids(
-                        review_record.get("authorized_downstream_worker_ids")
-                        or review_record.get("authorized_next_worker_ids")
-                        or review_record.get("downstream_worker_ids")
+                        matching_review.get("authorized_downstream_worker_ids")
+                        or matching_review.get("authorized_next_worker_ids")
+                        or matching_review.get("downstream_worker_ids")
                     )
                     if authorized_worker_ids:
                         requirement["authorized_downstream_worker_ids"] = authorized_worker_ids

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1820,6 +1820,41 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(closure["graph_requirements"][0]["status"], "pending")
         self.assertEqual(closure["unsatisfied_graph_requirements"][0]["producer_field"], "handoff_packet_result")
 
+    def test_worker_closure_uses_matching_review_candidate_not_newest_unrelated_review(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmpdir:
+            results_dir = Path(tmpdir)
+            handoff_path = results_dir / "handoff.json"
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            requirement_id = factoryctl.declared_graph_requirements(
+                "handoff_packet_result",
+                handoff,
+                evidence_ref=factoryctl.source_card_ref(handoff_path),
+            )[0]["requirement_id"]
+
+            matching_review = worker_result("independent_review_result", source_card=card)
+            matching_review["created_at"] = "2026-06-06T00:01:00+00:00"
+            matching_review["graph_requirement_refs"] = [requirement_id]
+            matching_review["authorized_downstream_worker_ids"] = ["qa-verification-worker"]
+            (results_dir / "matching-review.json").write_text(json.dumps(matching_review), encoding="utf-8")
+
+            unrelated_review = worker_result("independent_review_result", source_card=card)
+            unrelated_review["created_at"] = "2026-06-06T00:02:00+00:00"
+            unrelated_review["findings_summary"] = "Fresh, but for a different dependency."
+            (results_dir / "z-unrelated-review.json").write_text(json.dumps(unrelated_review), encoding="utf-8")
+
+            closure = factoryctl.build_worker_closure(card, {}, results_dir)
+
+        requirement = closure["graph_requirements"][0]
+        self.assertEqual(requirement["status"], "satisfied")
+        self.assertTrue(requirement["review_evidence_ref"].endswith("/matching-review.json"))
+        self.assertEqual(requirement["authorized_downstream_worker_ids"], ["qa-verification-worker"])
+        self.assertEqual(closure["unsatisfied_graph_requirements"], [])
+        self.assertTrue(closure["workers"]["handoff-packer"]["satisfied"])
+
     def test_transition_plan_done_blocks_missing_required_worker_results(self) -> None:
         card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         card = factoryctl.load_json_like(card_path)


### PR DESCRIPTION
## Summary
- preserve all active worker-result candidates for a record type while still selecting a default current row
- resolve review-before-consumption requirements against the candidate review that actually references the requirement/producer, not merely the newest review result of that type
- add regression coverage for stale dependency replacement when a newer unrelated independent review exists beside the matching fresh PASS review

Refs #134.

## Validation
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_worker_closure_uses_matching_review_candidate_not_newest_unrelated_review tests.test_factoryctl.FactoryCtlTest.test_worker_closure_satisfies_handoff_review_from_independent_review_result tests.test_factoryctl.FactoryCtlTest.test_transition_plan_downstream_authorization_requires_explicit_review_worker_ids -q`
- `python -B -m unittest discover -s tests -q`
- `python -B scripts/public_safety_scan.py`
- `python -B scripts/secret_safety_scan.py`
- `python -B scripts/validate_public_json_artifacts.py`
- `python -B scripts/supply_chain_proof.py --check --no-write`
- `python -B scripts/release_integration_preflight.py`
- `python -B scripts/public_safety_scan.py --git-ref HEAD`