### PR TITLE
Require Hermes unblock readback markers

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -339,12 +339,18 @@ def task_has_blocked_event(payload: dict[str, Any]) -> bool:
     return False
 
 
-def task_has_unblocked_event(payload: dict[str, Any]) -> bool:
+def task_has_unblocked_event(payload: dict[str, Any], required_markers: list[str] | None = None) -> bool:
     if str(payload.get("status") or "").strip().lower() == "blocked":
         return False
+    markers = [marker.strip().lower() for marker in (required_markers or []) if marker.strip()]
     events = payload.get("events") or payload.get("history") or payload.get("timeline") or []
     if isinstance(events, list):
-        return any("unblock" in str(event).lower() for event in events)
+        for event in events:
+            text = str(event).lower()
+            if "unblock" not in text:
+                continue
+            if all(marker in text for marker in markers):
+                return True
     return False
 
 
@@ -462,6 +468,7 @@ def unblock_task(
     board: str,
     task_id: str,
     reason: str,
+    required_readback_markers: list[str] | None = None,
     runner: Runner = default_runner,
 ) -> None:
     run_checked(hermes_kanban(hermes_bin, board, "unblock", task_id, reason), runner)
@@ -470,7 +477,7 @@ def unblock_task(
         payload = json.loads(shown.stdout or "{}")
     except json.JSONDecodeError as exc:
         raise RuntimeError("Hermes show --json did not return JSON while verifying unblock event") from exc
-    if not isinstance(payload, dict) or not task_has_unblocked_event(payload):
+    if not isinstance(payload, dict) or not task_has_unblocked_event(payload, required_readback_markers):
         raise RuntimeError(f"Hermes task {task_id} is not durably unblocked after unblock command")
 
 
@@ -839,6 +846,13 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                     "Factory-owned recovery route authorized repair task; downstream remains gated until "
                     f"{fresh_review_ref} passes."
                 ),
+                required_readback_markers=[
+                    RECOVERY_ATTEMPT_MARKER,
+                    f"route_id={route_id}",
+                    f"route_digest={route_digest}",
+                    f"attempt_number={attempt_number}",
+                    f"max_attempts={max_attempts}",
+                ],
                 runner=runner,
             )
             recovery_promoted_worker_task_ids[worker_id] = task_id
@@ -859,6 +873,11 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 for auth in auths
                 if str(auth.get("review_evidence_ref") or "").strip()
             ]
+            readback_markers = [
+                f"authorized_worker_id={worker_id}",
+                *[f"requirement_id={requirement_id}" for requirement_id in requirement_ids],
+                *[f"review_evidence_ref={review_ref}" for review_ref in review_refs],
+            ]
             unblock_task(
                 hermes_bin=args.hermes_bin,
                 board=args.board,
@@ -866,8 +885,11 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 reason=(
                     "Fresh PASS review authorized exact downstream worker "
                     f"{worker_id}; requirement(s): {', '.join(requirement_ids)}; "
-                    f"review ref(s): {', '.join(review_refs)}; main gate remains blocked."
+                    f"review ref(s): {', '.join(review_refs)}; "
+                    f"readback_markers: {' '.join(readback_markers)}; "
+                    "main gate remains blocked."
                 ),
+                required_readback_markers=readback_markers,
                 runner=runner,
             )
             downstream_promoted_worker_task_ids[worker_id] = task_id

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -333,6 +333,33 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             )
         )
 
+    def test_unblock_task_requires_readback_markers_when_provided(self) -> None:
+        fake = FakeHermes()
+        task_id = "t_" + "marker01"
+        fake.tasks[task_id] = {"status": "blocked", "events": []}
+
+        with self.assertRaisesRegex(RuntimeError, "not durably unblocked"):
+            adapter.unblock_task(
+                hermes_bin="hermes",
+                board=TEST_BOARD,
+                task_id=task_id,
+                reason="unblock without required marker",
+                required_readback_markers=["route_id=recovery:card:worker"],
+                runner=fake,
+            )
+
+        fake.tasks[task_id] = {"status": "blocked", "events": []}
+        adapter.unblock_task(
+            hermes_bin="hermes",
+            board=TEST_BOARD,
+            task_id=task_id,
+            reason="factory_recovery_attempt route_id=recovery:card:worker",
+            required_readback_markers=["factory_recovery_attempt", "route_id=recovery:card:worker"],
+            runner=fake,
+        )
+
+        self.assertEqual(fake.tasks[task_id]["status"], "ready")
+
     def test_dispatch_reports_tasks_that_entered_running_even_when_native_spawned_is_empty(self) -> None:
         fake = FakeDispatchHermes(native_spawned=False)
         args = adapter.build_parser().parse_args(["dispatch", "--board", TEST_BOARD])
@@ -979,6 +1006,9 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             any(
                 call[5] == qa_task["runtime_refs"]["hermes_task_ref"]
                 and "Fresh PASS review authorized exact downstream worker" in call[6]
+                and "authorized_worker_id=qa-verification-worker" in call[6]
+                and f"requirement_id={requirement['requirement_id']}" in call[6]
+                and "review_evidence_ref=receipt:review" in call[6]
                 for call in unblock_calls
             )
         )


### PR DESCRIPTION
## Summary
- Require Hermes unblock readback to include the exact markers that authorized the transition.
- Factory-owned recovery unblocks must read back route id, route digest, attempt number and retry ceiling from Hermes event history.
- Fresh review downstream unblocks must read back authorized worker id, requirement id(s), and review evidence ref(s), so a generic unblock event cannot masquerade as a valid graph transition.

## Scope
- Refs #134.
- Does not touch #84/cockpit.
- Does not add a scheduler, dispatcher, dependency engine, dashboard source of truth, or private artifact surface.

## Validation
- `python -B -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_unblock_task_requires_readback_markers_when_provided tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_materialize_promotes_factory_owned_recovery_repair_task tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_materialize_promotes_downstream_workers_after_fresh_review_pass -q`
- `python -B -m unittest tests.test_hermes_live_kanban_adapter tests.test_hermes_transition_hook tests.test_factoryctl -q`
- `python -B -m unittest discover -s tests -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\release_integration_preflight.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`