### PR TITLE
Require recovery route closure before downstream unblock

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -873,10 +873,24 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
                 for auth in auths
                 if str(auth.get("review_evidence_ref") or "").strip()
             ]
+            recovery_route_refs = [
+                str(route_ref or "").strip()
+                for auth in auths
+                for route_ref in auth.get("recovery_route_refs") or []
+                if str(route_ref or "").strip()
+            ]
+            recovery_route_digests = [
+                str(route_digest or "").strip()
+                for auth in auths
+                for route_digest in auth.get("recovery_route_digests") or []
+                if str(route_digest or "").strip()
+            ]
             readback_markers = [
                 f"authorized_worker_id={worker_id}",
                 *[f"requirement_id={requirement_id}" for requirement_id in requirement_ids],
                 *[f"review_evidence_ref={review_ref}" for review_ref in review_refs],
+                *[f"recovery_route_ref={route_ref}" for route_ref in recovery_route_refs],
+                *[f"recovery_route_digest={route_digest}" for route_digest in recovery_route_digests],
             ]
             unblock_task(
                 hermes_bin=args.hermes_bin,

--- a/schemas/hermes-transition-plan.schema.json
+++ b/schemas/hermes-transition-plan.schema.json
@@ -219,6 +219,14 @@
             "type": "array",
             "items": { "type": "string", "minLength": 3 }
           },
+          "recovery_route_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "recovery_route_digests": {
+            "type": "array",
+            "items": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+          },
           "runtime_authority": { "const": "hermes_kanban" },
           "local_state_authority": { "const": false }
         },

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -193,6 +193,22 @@
       "type": "array",
       "items": { "type": "string", "minLength": 3 }
     },
+    "recovery_route_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "recovery_route_digests": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+    },
+    "reviewed_recovery_route_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "reviewed_recovery_route_digests": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+    },
     "review_required_handoff": {
       "type": "object",
       "required": [

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -10,6 +10,7 @@ specialist worker still has to run and attach real evidence.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import re
@@ -76,6 +77,15 @@ PRIVATE_RUNTIME_REF_RE = re.compile(
     r"((?<![A-Za-z])[A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
     re.IGNORECASE,
 )
+CONTRACT_DIGEST_ALGORITHM = "sha256"
+VOLATILE_CONTRACT_KEYS = {
+    "checked_at",
+    "created_at",
+    "generated_at",
+    "last_checked_at",
+    "timestamp",
+    "updated_at",
+}
 
 CARD_REQUIRED = {
     "factory_method_version",
@@ -4090,6 +4100,40 @@ def string_list(value: Any) -> list[str]:
     return [item for item in value if isinstance(item, str) and item.strip()]
 
 
+def stable_contract_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): stable_contract_value(item)
+            for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
+            if str(key) not in VOLATILE_CONTRACT_KEYS
+        }
+    if isinstance(value, list):
+        return [stable_contract_value(item) for item in value]
+    return value
+
+
+def contract_digest(value: Any) -> str:
+    stable_value = stable_contract_value(value)
+    if isinstance(stable_value, str):
+        payload = stable_value
+    else:
+        payload = json.dumps(stable_value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def recovery_route_digest(route: dict[str, Any]) -> str:
+    return f"{CONTRACT_DIGEST_ALGORITHM}:{contract_digest(route)}"
+
+
+def recovery_route_digest_list(value: Any) -> list[str]:
+    digests: list[str] = []
+    for item in string_list(value):
+        digest = item.strip()
+        if re.fullmatch(r"sha256:[0-9a-f]{64}", digest) and digest not in digests:
+            digests.append(digest)
+    return digests
+
+
 def _worker_id_for_output_field(output_field: str) -> str | None:
     for worker_id, worker in WORKERS.items():
         if worker.output_field == output_field:
@@ -4412,6 +4456,14 @@ def collect_worker_result_fields(card: dict[str, Any], results_dir: Path | None)
             "reviewed_requirement_refs": string_list(data.get("reviewed_requirement_refs")),
             "reviewed_producer_refs": string_list(data.get("reviewed_producer_refs")),
             "producer_refs_reviewed": string_list(data.get("producer_refs_reviewed")),
+            "recovery_route_refs": string_list(data.get("recovery_route_refs")),
+            "recovery_route_digests": recovery_route_digest_list(data.get("recovery_route_digests")),
+            "reviewed_recovery_route_refs": string_list(
+                data.get("reviewed_recovery_route_refs") or data.get("recovery_route_refs_reviewed")
+            ),
+            "reviewed_recovery_route_digests": recovery_route_digest_list(
+                data.get("reviewed_recovery_route_digests") or data.get("recovery_route_digests_reviewed")
+            ),
             "authorized_downstream_worker_ids": registered_nonhuman_worker_ids(
                 data.get("authorized_downstream_worker_ids")
                 or data.get("authorized_next_worker_ids")
@@ -4482,6 +4534,14 @@ def receipt_result_fields(
                 "reviewed_requirement_refs": string_list(value.get("reviewed_requirement_refs")),
                 "reviewed_producer_refs": string_list(value.get("reviewed_producer_refs")),
                 "producer_refs_reviewed": string_list(value.get("producer_refs_reviewed")),
+                "recovery_route_refs": string_list(value.get("recovery_route_refs")),
+                "recovery_route_digests": recovery_route_digest_list(value.get("recovery_route_digests")),
+                "reviewed_recovery_route_refs": string_list(
+                    value.get("reviewed_recovery_route_refs") or value.get("recovery_route_refs_reviewed")
+                ),
+                "reviewed_recovery_route_digests": recovery_route_digest_list(
+                    value.get("reviewed_recovery_route_digests") or value.get("recovery_route_digests_reviewed")
+                ),
                 "authorized_downstream_worker_ids": registered_nonhuman_worker_ids(
                     value.get("authorized_downstream_worker_ids")
                     or value.get("authorized_next_worker_ids")
@@ -4551,28 +4611,35 @@ def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evide
     reviewer_result = str(data.get("reviewer_result") or "").strip().upper()
     status = "satisfied" if reviewer_result == "PASS" else "pending"
     requirement_ref = evidence_ref or f"external:{record_type}"
+    recovery_route_refs = string_list(data.get("recovery_route_refs"))
+    recovery_route_digests = recovery_route_digest_list(data.get("recovery_route_digests"))
+    requirement = {
+        "requirement_type": "review_before_consumption",
+        "requirement_id": (
+            f"review-before-consumption:{sanitize_slug(record_type, fallback='record')}:"
+            f"{sanitize_slug(requirement_ref, fallback='evidence')}"
+        ),
+        "producer_field": record_type,
+        "producer_ref": requirement_ref,
+        "review_worker_id": review_worker_id,
+        "required_review_field": required_review_field,
+        "required_result": "PASS",
+        "status": status,
+        "reviewer_result": reviewer_result or "missing",
+        "downstream_scope": ["implementation", "done", "release"],
+        "review_authorized_scope": ["review"],
+        "producer_handoff_state": "implementation_ready_for_review"
+        if status == "pending"
+        else "review_satisfied",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+    }
+    if recovery_route_refs:
+        requirement["recovery_route_refs"] = recovery_route_refs
+    if recovery_route_digests:
+        requirement["recovery_route_digests"] = recovery_route_digests
     return [
-        {
-            "requirement_type": "review_before_consumption",
-            "requirement_id": (
-                f"review-before-consumption:{sanitize_slug(record_type, fallback='record')}:"
-                f"{sanitize_slug(requirement_ref, fallback='evidence')}"
-            ),
-            "producer_field": record_type,
-            "producer_ref": requirement_ref,
-            "review_worker_id": review_worker_id,
-            "required_review_field": required_review_field,
-            "required_result": "PASS",
-            "status": status,
-            "reviewer_result": reviewer_result or "missing",
-            "downstream_scope": ["implementation", "done", "release"],
-            "review_authorized_scope": ["review"],
-            "producer_handoff_state": "implementation_ready_for_review"
-            if status == "pending"
-            else "review_satisfied",
-            "runtime_authority": "hermes_kanban",
-            "local_state_authority": False,
-        }
+        requirement
     ]
 
 
@@ -4601,6 +4668,22 @@ def review_task_authorization(requirement: dict[str, Any]) -> dict[str, Any]:
 def review_record_matches_requirement(review_record: dict[str, Any], requirement: dict[str, Any]) -> bool:
     requirement_id = str(requirement.get("requirement_id") or "").strip()
     producer_ref = str(requirement.get("producer_ref") or "").strip()
+    required_route_refs = set(string_list(requirement.get("recovery_route_refs")))
+    required_route_digests = set(recovery_route_digest_list(requirement.get("recovery_route_digests")))
+    if required_route_refs:
+        reviewed_route_refs = set(
+            string_list(review_record.get("reviewed_recovery_route_refs"))
+            + string_list(review_record.get("recovery_route_refs_reviewed"))
+        )
+        if not required_route_refs.issubset(reviewed_route_refs):
+            return False
+    if required_route_digests:
+        reviewed_route_digests = set(
+            recovery_route_digest_list(review_record.get("reviewed_recovery_route_digests"))
+            + recovery_route_digest_list(review_record.get("recovery_route_digests_reviewed"))
+        )
+        if not required_route_digests.issubset(reviewed_route_digests):
+            return False
     explicit_refs = set(string_list(review_record.get("graph_requirement_refs")))
     explicit_refs.update(string_list(review_record.get("review_requirement_refs")))
     explicit_refs.update(string_list(review_record.get("reviewed_requirement_refs")))
@@ -4737,7 +4820,9 @@ def downstream_task_authorization(requirement: dict[str, Any], worker_tasks: lis
     if not authorized_worker_ids:
         return None
     requirement_id = str(requirement.get("requirement_id") or "").strip()
-    return {
+    recovery_route_refs = string_list(requirement.get("recovery_route_refs"))
+    recovery_route_digests = recovery_route_digest_list(requirement.get("recovery_route_digests"))
+    authorization = {
         "authorization_type": "fresh_review_downstream_task",
         "authorization_state": "worker_task_ready",
         "requirement_id": requirement_id,
@@ -4753,6 +4838,11 @@ def downstream_task_authorization(requirement: dict[str, Any], worker_tasks: lis
         "runtime_authority": "hermes_kanban",
         "local_state_authority": False,
     }
+    if recovery_route_refs:
+        authorization["recovery_route_refs"] = recovery_route_refs
+    if recovery_route_digests:
+        authorization["recovery_route_digests"] = recovery_route_digests
+    return authorization
 
 
 def downstream_task_authorizations(

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1801,6 +1801,58 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("handoff-packer", authorization["forbidden_worker_ids"])
         self.assertIn("independent-reviewer", authorization["forbidden_worker_ids"])
 
+    def test_recovery_route_review_must_close_route_before_downstream_authorization(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        route_ref = "recovery:val-solana-quasar-r3:review-block:handoff"
+        route_digest = "sha256:" + ("1" * 64)
+        handoff = worker_result("handoff_packet_result", source_card=card, reviewer_required=True)
+        handoff["recovery_route_refs"] = [route_ref]
+        handoff["recovery_route_digests"] = [route_digest]
+        requirement_id = factoryctl.declared_graph_requirements(
+            "handoff_packet_result",
+            handoff,
+            evidence_ref="receipt:handoff_packet_result",
+        )[0]["requirement_id"]
+        review = worker_result("independent_review_result", source_card=card)
+        review["graph_requirement_refs"] = [requirement_id]
+        review["authorized_downstream_worker_ids"] = ["qa-verification-worker"]
+        receipt = {
+            "handoff_packet_result": handoff,
+            "independent_review_result": review,
+            "orchestration_result": worker_result("orchestration_result", source_card=card),
+            "source_ledger_result": worker_result("source_ledger_result", source_card=card),
+            "security_orchestration_result": worker_result("security_orchestration_result", source_card=card),
+            "supply_chain_result": worker_result("supply_chain_result", source_card=card),
+        }
+
+        generic_pass = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="review",
+            to_status="ready",
+            receipt=receipt,
+        )
+
+        self.assertEqual(generic_pass["downstream_task_authorizations"], [])
+        self.assertEqual(generic_pass["graph_requirements"][0]["status"], "pending")
+
+        review["reviewed_recovery_route_refs"] = [route_ref]
+        review["reviewed_recovery_route_digests"] = [route_digest]
+        route_closed = factoryctl.build_transition_plan(
+            card,
+            card_path,
+            from_status="review",
+            to_status="ready",
+            receipt=receipt,
+        )
+
+        authorization = route_closed["downstream_task_authorizations"][0]
+        self.assertEqual(authorization["authorized_worker_ids"], ["qa-verification-worker"])
+        self.assertEqual(authorization["recovery_route_refs"], [route_ref])
+        self.assertEqual(authorization["recovery_route_digests"], [route_digest])
+
     def test_worker_closure_does_not_satisfy_handoff_review_with_generic_review_result(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -360,6 +360,16 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         self.assertEqual(fake.tasks[task_id]["status"], "ready")
 
+    def test_recovery_route_digest_matches_factoryctl_contract(self) -> None:
+        route = {
+            "recovery_route_id": "recovery:card:review-block",
+            "created_at": "2026-06-06T00:00:00+00:00",
+            "repair_owner_worker": "handoff-packer",
+            "fresh_review_required": True,
+        }
+
+        self.assertEqual(adapter.recovery_route_digest(route), factoryctl.recovery_route_digest(route))
+
     def test_dispatch_reports_tasks_that_entered_running_even_when_native_spawned_is_empty(self) -> None:
         fake = FakeDispatchHermes(native_spawned=False)
         args = adapter.build_parser().parse_args(["dispatch", "--board", TEST_BOARD])
@@ -888,6 +898,10 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             reviewer_required=True,
             reviewer_result="PENDING",
         )
+        route_ref = "recovery:val-solana-quasar-r3:review-block:handoff"
+        route_digest = "sha256:" + ("2" * 64)
+        handoff["recovery_route_refs"] = [route_ref]
+        handoff["recovery_route_digests"] = [route_digest]
         requirement = factoryctl.declared_graph_requirements(
             "handoff_packet_result",
             handoff,
@@ -905,6 +919,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             next_action="continue downstream",
         )
         review["graph_requirement_refs"] = [requirement["requirement_id"]]
+        review["reviewed_recovery_route_refs"] = [route_ref]
+        review["reviewed_recovery_route_digests"] = [route_digest]
         review["authorized_downstream_worker_ids"] = [
             "qa-verification-worker",
             "human-gate-clerk",
@@ -1009,6 +1025,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 and "authorized_worker_id=qa-verification-worker" in call[6]
                 and f"requirement_id={requirement['requirement_id']}" in call[6]
                 and "review_evidence_ref=receipt:review" in call[6]
+                and f"recovery_route_ref={route_ref}" in call[6]
+                and f"recovery_route_digest={route_digest}" in call[6]
                 for call in unblock_calls
             )
         )

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -37,6 +37,15 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         self.assertEqual(validator.validate_node(schema, "a" * 64, "$"), [])
         self.assertTrue(any("does not match pattern" in error for error in validator.validate_node(schema, "not-a-sha", "$")))
 
+    def test_worker_result_schema_types_recovery_route_digests(self) -> None:
+        validator = load_validator()
+        schema = validator.load_schemas()["worker-result.schema.json"]["properties"]["reviewed_recovery_route_digests"]
+
+        self.assertEqual(validator.validate_node(schema, ["sha256:" + ("a" * 64)], "$"), [])
+        self.assertTrue(
+            any("does not match pattern" in error for error in validator.validate_node(schema, ["not-a-sha"], "$"))
+        )
+
     def test_enforces_conditional_required_fields_used_by_worker_result_schema(self) -> None:
         validator = load_validator()
         schema = {


### PR DESCRIPTION
## Summary
- Require recovery-aware fresh reviews to close the exact recovery route refs/digests before they can satisfy a graph requirement.
- Carry recovery route refs/digests into downstream task authorizations and Hermes unblock readback markers.
- Add public schema fields and regressions so a generic PASS cannot unblock a post-recovery downstream worker.

## Scope
- Refs #134.
- Does not touch #84/cockpit.
- Does not create a scheduler, dispatcher, dependency engine, dashboard source of truth, or private artifact surface.

## Validation
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_recovery_route_review_must_close_route_before_downstream_authorization tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_materialize_promotes_downstream_workers_after_fresh_review_pass tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_recovery_route_digest_matches_factoryctl_contract tests.test_public_json_artifact_validator.PublicJsonArtifactValidatorTest.test_worker_result_schema_types_recovery_route_digests -q`
- `python -B -m unittest tests.test_factoryctl tests.test_hermes_live_kanban_adapter tests.test_hermes_transition_hook tests.test_public_json_artifact_validator -q`
- `python -B -m unittest discover -s tests -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\release_integration_preflight.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`