### PR TITLE
Require independent review result for handoff consumption

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4609,7 +4609,7 @@ def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evide
     review_worker_id = _declared_review_worker_id(data)
     required_review_field = WORKERS[review_worker_id].output_field
     reviewer_result = str(data.get("reviewer_result") or "").strip().upper()
-    status = "satisfied" if reviewer_result == "PASS" else "pending"
+    status = "pending"
     requirement_ref = evidence_ref or f"external:{record_type}"
     recovery_route_refs = string_list(data.get("recovery_route_refs"))
     recovery_route_digests = recovery_route_digest_list(data.get("recovery_route_digests"))
@@ -4628,9 +4628,7 @@ def declared_graph_requirements(record_type: str, data: dict[str, Any], *, evide
         "reviewer_result": reviewer_result or "missing",
         "downstream_scope": ["implementation", "done", "release"],
         "review_authorized_scope": ["review"],
-        "producer_handoff_state": "implementation_ready_for_review"
-        if status == "pending"
-        else "review_satisfied",
+        "producer_handoff_state": "implementation_ready_for_review",
         "runtime_authority": "hermes_kanban",
         "local_state_authority": False,
     }

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1625,6 +1625,26 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(closure["unsatisfied_graph_requirements"][0]["requirement_type"], "review_before_consumption")
         self.assertEqual(closure["unsatisfied_graph_requirements"][0]["review_worker_id"], "independent-reviewer")
 
+    def test_worker_closure_ignores_inline_reviewer_pass_on_producer_handoff(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        handoff = worker_result(
+            "handoff_packet_result",
+            source_card=card,
+            reviewer_required=True,
+            reviewer_result="PASS",
+        )
+
+        closure = factoryctl.build_worker_closure(card, {"handoff_packet_result": handoff}, None)
+
+        handoff_row = closure["workers"]["handoff-packer"]
+        self.assertTrue(handoff_row["valid"])
+        self.assertFalse(handoff_row["consumable"])
+        self.assertFalse(handoff_row["satisfied"])
+        self.assertEqual(closure["graph_requirements"][0]["status"], "pending")
+        self.assertEqual(closure["graph_requirements"][0]["reviewer_result"], "PASS")
+        self.assertEqual(closure["unsatisfied_graph_requirements"][0]["review_worker_id"], "independent-reviewer")
+
     def test_transition_plan_blocks_declared_handoff_review_before_downstream_consumption(self) -> None:
         card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
         card = factoryctl.load_json_like(card_path)


### PR DESCRIPTION
## Summary
- Prevent a producer handoff from satisfying its own review requirement with inline `reviewer_result=PASS`.
- Keep review-required worker outputs valid but non-consumable until a separate matching review worker result satisfies the graph requirement.
- Add regression coverage for the inline reviewer PASS bypass.

## Scope
- Refs #134.
- Does not touch #84/cockpit.
- Does not add historical/audit artifacts or private evidence to the public repo.

## Validation
- `python -B -m unittest tests.test_factoryctl.FactoryCtlTest.test_worker_closure_ignores_inline_reviewer_pass_on_producer_handoff tests.test_factoryctl.FactoryCtlTest.test_worker_closure_satisfies_handoff_review_from_independent_review_result -q`
- `python -B -m unittest tests.test_factoryctl tests.test_hermes_live_kanban_adapter tests.test_hermes_transition_hook -q`
- `python -B -m unittest discover -s tests -q`
- `python -B scripts\public_safety_scan.py`
- `python -B scripts\secret_safety_scan.py`
- `python -B scripts\validate_public_json_artifacts.py`
- `python -B scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`
- `python -B scripts\release_integration_preflight.py`
- `python -B scripts\public_safety_scan.py --git-ref HEAD`