### PR TITLE
Resolve product delivery profile refs

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -1675,6 +1675,35 @@ def _has_ref_or_object(data: dict[str, Any], field: str) -> bool:
     return _has_contract(data, field)
 
 
+def _repo_local_json_ref_path(ref: Any) -> Path | None:
+    if not _non_empty_text(ref):
+        return None
+    value = str(ref).strip().split("#", 1)[0].strip()
+    if not value:
+        return None
+    normalized = value.replace("\\", "/")
+    if normalized.startswith(("external:", "repo://", "http://", "https://", "file://")):
+        return None
+    if Path(value).is_absolute() or ":" in normalized.split("/", 1)[0]:
+        return None
+    candidate = (ROOT / normalized).resolve()
+    try:
+        candidate.relative_to(ROOT.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def _load_repo_local_json_ref(ref: Any) -> dict[str, Any]:
+    path = _repo_local_json_ref_path(ref)
+    if path is None or not path.is_file():
+        return {}
+    try:
+        return load_json_like(path)
+    except Exception:
+        return {}
+
+
 def _product_planning_required(card: dict[str, Any]) -> bool:
     request_type = str(card.get("request_type") or "").strip()
     scope_intent = str(card.get("scope_intent") or "").strip()
@@ -1838,6 +1867,7 @@ def validate_product_creation_readiness_contract(card: dict[str, Any]) -> list[s
                         errors.append(f"product_creation_plan.work_units[{index}].{field} must be non-empty")
                 if not _non_empty_text(unit.get("expected_result")):
                     errors.append(f"product_creation_plan.work_units[{index}].expected_result is required")
+    errors.extend(_product_delivery_quality_profile_ref_errors(card))
     profile = _product_delivery_quality_profile(card)
     if profile:
         errors.extend(validate_product_delivery_quality_profile(profile))
@@ -2368,12 +2398,65 @@ def validate_product_delivery_quality_profile(profile: dict[str, Any]) -> list[s
 
 
 def _product_delivery_quality_profile(card: dict[str, Any]) -> dict[str, Any]:
-    profile = card.get("product_delivery_quality_profile")
-    if isinstance(profile, dict):
-        return profile
-    plan = card.get("product_creation_plan") if isinstance(card.get("product_creation_plan"), dict) else {}
-    profile = plan.get("product_delivery_quality_profile")
-    return profile if isinstance(profile, dict) else {}
+    containers: list[dict[str, Any]] = [card]
+    for field in (
+        "product_creation_plan",
+        "product_implementation_readiness",
+        "product_experience_plan",
+        "product_face_packet",
+    ):
+        value = card.get(field)
+        if isinstance(value, dict):
+            containers.append(value)
+    for container in containers:
+        profile = container.get("product_delivery_quality_profile")
+        if isinstance(profile, dict):
+            return profile
+    for container in containers:
+        profile = _load_repo_local_json_ref(container.get("product_delivery_quality_profile_ref"))
+        if profile:
+            return profile
+    return {}
+
+
+def _product_delivery_quality_profile_ref_errors(card: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    refs: list[tuple[str, str]] = []
+    containers: list[tuple[str, dict[str, Any]]] = [("card", card)]
+    for field in (
+        "product_creation_plan",
+        "product_implementation_readiness",
+        "product_experience_plan",
+        "product_face_packet",
+    ):
+        value = card.get(field)
+        if isinstance(value, dict):
+            containers.append((field, value))
+    for label, container in containers:
+        ref = container.get("product_delivery_quality_profile_ref")
+        if _non_empty_text(ref):
+            refs.append((label, str(ref).strip()))
+
+    seen: set[str] = set()
+    for label, ref in refs:
+        if ref in seen:
+            continue
+        seen.add(ref)
+        path = _repo_local_json_ref_path(ref)
+        if path is None:
+            continue
+        if not path.is_file():
+            errors.append(f"{label}.product_delivery_quality_profile_ref does not resolve to a repo-local file: {ref}")
+            continue
+        try:
+            profile = load_json_like(path)
+        except Exception as exc:
+            errors.append(
+                f"{label}.product_delivery_quality_profile_ref could not be loaded as JSON object: {type(exc).__name__}"
+            )
+            continue
+        errors.extend(validate_product_delivery_quality_profile(profile))
+    return errors
 
 
 def _delivery_profile_required_proof_ids(profile: dict[str, Any], phase: str) -> list[str]:
@@ -2985,6 +3068,7 @@ def _required_product_proofs(card: dict[str, Any]) -> list[str]:
 
 def validate_product_face_result_against_card(result: dict[str, Any], card: dict[str, Any]) -> list[str]:
     errors = validate_product_face_result(result)
+    errors.extend(_product_delivery_quality_profile_ref_errors(card))
     if str(result.get("result") or "").upper() != "PASS":
         return errors
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -645,6 +645,28 @@ class FactoryCtlTest(unittest.TestCase):
             errors,
         )
 
+    def test_product_face_completion_resolves_profile_ref_for_domain_proof_coverage(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_delivery_quality_profile_ref"] = "templates/product-delivery-quality-profile.json"
+
+        errors = factoryctl.validate_product_face_result_against_card(product_face_result_fixture(), card)
+
+        self.assertIn(
+            "product_face_result.domain_proof_coverage missing product delivery proof coverage for required proof ids: generic.operator-usability",
+            errors,
+        )
+
+    def test_product_face_completion_fails_closed_for_missing_profile_ref(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_delivery_quality_profile_ref"] = "templates/missing-product-delivery-quality-profile.json"
+
+        errors = factoryctl.validate_product_face_result_against_card(product_face_result_fixture(), card)
+
+        self.assertIn(
+            "card.product_delivery_quality_profile_ref does not resolve to a repo-local file: templates/missing-product-delivery-quality-profile.json",
+            errors,
+        )
+
     def test_product_face_completion_accepts_required_domain_proof_coverage(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
         card["product_delivery_quality_profile"] = product_delivery_quality_profile_fixture()

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -128,6 +128,32 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             factoryctl.validate_card(card),
         )
 
+    def test_product_delivery_quality_profile_ref_requires_readiness_proof_coverage(self) -> None:
+        card = self.vfinal_card()
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+        card["product_implementation_readiness"].pop("delivery_profile_proof_coverage")
+
+        self.assertIn(
+            "product_implementation_readiness.delivery_profile_proof_coverage missing product delivery proof coverage for required proof ids: generic.scope-fit",
+            factoryctl.validate_card(card),
+        )
+
+    def test_missing_repo_local_product_delivery_quality_profile_ref_fails_closed(self) -> None:
+        card = self.vfinal_card()
+        card["product_delivery_quality_profile_ref"] = "templates/missing-product-delivery-quality-profile.json"
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+
+        self.assertIn(
+            "card.product_delivery_quality_profile_ref does not resolve to a repo-local file: templates/missing-product-delivery-quality-profile.json",
+            factoryctl.validate_card(card),
+        )
+
     def test_worker_packet_carries_product_context_and_research_refs(self) -> None:
         card = self.vfinal_card()
 


### PR DESCRIPTION
## Summary

Closes #190.

This makes repo-local `product_delivery_quality_profile_ref` values an active validation gear instead of passive documentation:

- safely resolves repo-local product delivery profile refs from the card and product planning objects;
- fails closed when a repo-local profile ref is missing or malformed;
- applies required delivery proof IDs to Product Implementation Readiness and Product Face completion even when the profile is referenced instead of embedded;
- adds regression tests for ref-only readiness, ref-only Product Face completion, and missing refs.

#84/local cockpit remains untouched and out of scope.

## Validation

- `python -m unittest tests.test_product_method_sot_planning tests.test_factoryctl -q`
- `python -m unittest discover tests -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/release_integration_preflight.py`
