### PR TITLE
Route Product Face across vFinal surfaces

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -5,13 +5,18 @@ backend or architecture.
 
 ## When It Runs
 
-Run for any card with surfaces:
+Run for any vFinal card with Product Experience surfaces, including:
 
-- `ux`
-- `frontend`
-- `mobile`
-- `wallet-ui`
-- `product-face`
+- web/app UI: `ux`, `frontend`, `web_app`, `website`, `screen`,
+  `component`;
+- device/app UI: `mobile`, `desktop`, `extension`, `browser-extension`;
+- product interaction surfaces: `wallet-ui`, `ai_interface`,
+  `agentic_interface`, `design_system`;
+- product support surfaces: `docs`, `documentation`, `onboarding`;
+- game-like surfaces: `game`, `gameplay`, `2d`, `3d`.
+
+Legacy cards keep their existing narrower Product Face triggers unless they
+explicitly set `product_face_result_required=true`.
 
 ## Required Evidence
 

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -227,6 +227,37 @@ V2_APPROVAL_KEYS = [
 ]
 
 PRODUCT_FACE_SURFACES = {"ux", "frontend", "mobile", "wallet-ui", "product-face"}
+PRODUCT_EXPERIENCE_SURFACES = PRODUCT_FACE_SURFACES | {
+    "web",
+    "web-app",
+    "web_app",
+    "website",
+    "site",
+    "landing",
+    "landing-page",
+    "screen",
+    "component",
+    "desktop",
+    "desktop-app",
+    "cli",
+    "tui",
+    "extension",
+    "browser-extension",
+    "ai-interface",
+    "ai_interface",
+    "chat-ui",
+    "agentic-interface",
+    "agentic_interface",
+    "design-system",
+    "design_system",
+    "docs",
+    "documentation",
+    "onboarding",
+    "game",
+    "gameplay",
+    "2d",
+    "3d",
+}
 FRONTEND_BUILD_SURFACES = {"frontend", "mobile", "wallet-ui", "ux", "product-face", "screen", "component", "browser"}
 BACKEND_BUILD_SURFACES = {"backend", "api", "auth", "server", "service", "session"}
 DATA_BUILD_SURFACES = {"data", "database", "schema", "migration", "storage", "rls", "persistence"}
@@ -2281,6 +2312,15 @@ def strict_product_experience_required(card: dict[str, Any]) -> bool:
     return card.get("factory_method_version") == "OVERKILL_VFINAL" or isinstance(card.get("product_experience_plan"), dict)
 
 
+def product_experience_surface_required(card: dict[str, Any]) -> bool:
+    surfaces = normalized_surfaces(card)
+    if surfaces & PRODUCT_FACE_SURFACES:
+        return True
+    if card.get("factory_method_version") == "OVERKILL_VFINAL" and surfaces & PRODUCT_EXPERIENCE_SURFACES:
+        return True
+    return card.get("product_face_result_required") is True
+
+
 def validate_product_face_packet(packet: dict[str, Any], *, strict: bool) -> list[str]:
     errors: list[str] = []
     if not strict:
@@ -2890,7 +2930,7 @@ def validate_card(data: dict[str, Any]) -> list[str]:
         errors.extend(validate_parallel_lane_contract(lane, at=f"parallel_lane_contracts[{index}]"))
     if data.get("executor_identity") == data.get("reviewer_identity"):
         errors.append("executor_identity and reviewer_identity must differ")
-    product_facing = bool(surfaces & PRODUCT_FACE_SURFACES)
+    product_facing = product_experience_surface_required(data)
     strict_experience = product_facing and strict_product_experience_required(data)
     if product_facing and not isinstance(data.get("product_face_packet"), dict):
         errors.append("product_face_packet required for product-facing surfaces")
@@ -2919,7 +2959,7 @@ def validate_card(data: dict[str, Any]) -> list[str]:
             else:
                 errors.extend(validate_professional_design_process(data["professional_design_process"]))
     phase = str(data.get("phase", "")).upper()
-    if surfaces & PRODUCT_FACE_SURFACES and phase in {"F11", "F16", "F17"}:
+    if product_experience_surface_required(data) and phase in {"F11", "F16", "F17"}:
         if not isinstance(data.get("product_face_result"), dict) and not str(data.get("product_face_result_ref") or "").strip():
             errors.append("product_face_result or product_face_result_ref required before decomposition/release")
     runtime_contract = data.get("runtime_contract", {}) if isinstance(data.get("runtime_contract"), dict) else {}
@@ -3250,9 +3290,8 @@ def validate_auditor_result(result: dict[str, Any]) -> list[str]:
 
 
 def product_face_result_required(card: dict[str, Any]) -> bool:
-    surfaces = normalized_surfaces(card)
     phase = str(card.get("phase", "")).upper()
-    return bool(surfaces & PRODUCT_FACE_SURFACES) and (
+    return product_experience_surface_required(card) and (
         phase in PRODUCT_FACE_RESULT_PHASES or card.get("product_face_result_required") is True
     )
 
@@ -3501,7 +3540,7 @@ def worker_required(worker_id: str, card: dict[str, Any]) -> tuple[bool, str]:
         reason = "onchain/Solana/Quasar surface detected" if required else "no onchain surface detected"
         return required, reason
     if worker_id == "product-face":
-        required = bool(surfaces & PRODUCT_FACE_SURFACES)
+        required = product_experience_surface_required(card)
         reason = "visible product surface detected" if required else "no visible product surface detected"
         return required, reason
     if worker_id == "independent-reviewer":

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -524,6 +524,30 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_packet.surface is required", errors)
         self.assertIn("product_face_packet.design_direction is required", errors)
 
+    def test_vfinal_product_experience_surfaces_route_to_product_face(self) -> None:
+        for surface in ("website", "desktop", "extension", "docs", "agentic_interface", "ai_interface", "design_system"):
+            with self.subTest(surface=surface):
+                card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+                card["surfaces"] = [surface]
+                card["capability_pack_contract"] = dict(card["capability_pack_contract"])
+                card["capability_pack_contract"]["covered_surfaces"] = [surface]
+                card.pop("product_experience_plan", None)
+                card.pop("product_face_packet", None)
+
+                errors = factoryctl.validate_card(card)
+
+                self.assertIn("product_experience_plan required for vFinal product-facing surfaces", errors)
+                self.assertIn("product_face_packet required for product-facing surfaces", errors)
+                required, reason = factoryctl.worker_required("product-face", card)
+                self.assertTrue(required, reason)
+
+    def test_legacy_docs_surface_does_not_implicitly_require_product_face(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "factory-card.json")
+
+        required, reason = factoryctl.worker_required("product-face", card)
+
+        self.assertFalse(required, reason)
+
     def test_vfinal_product_surface_accepts_product_experience_os_contract(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
         card["surfaces"] = ["frontend", "product-face"]


### PR DESCRIPTION
## Summary

Closes #192.

This expands Product Face routing from the old short trigger list to a vFinal Product Experience surface matrix:

- keeps legacy cards on the old narrow triggers unless they explicitly request Product Face;
- routes vFinal surfaces such as website, desktop, extension, docs/onboarding, AI/agentic interfaces and design systems to Product Experience/Product Face;
- keeps Product Face result requirements tied to phase/explicit flag;
- updates the public proof-runner doc so schema/docs/runtime no longer teach different surface coverage.

#84/local cockpit remains untouched and out of scope.

## Validation

- `python -m unittest tests.test_factoryctl -q`
- `python scripts/factoryctl.py validate-card templates/factory-card.json`
- `python -m unittest discover tests -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/release_integration_preflight.py`
