### PR TITLE
Reconcile capability pack proofs into delivery gates

### DIFF
--- a/docs/agents/capability-packs.md
+++ b/docs/agents/capability-packs.md
@@ -86,6 +86,7 @@ A template pack becomes executable only when the card includes a
 - eval path;
 - activation evidence refs;
 - smoke and eval evidence refs;
+- structured proof ids required by the registry pack;
 - missing capabilities, if any;
 - an execution rule.
 
@@ -103,7 +104,11 @@ public-safe smoke and eval refs replace the placeholders.
    smoke and eval evidence.
 4. Keep `missing_capabilities` non-empty and `lifecycle_state` below
    `activated` until smoke and eval evidence exist.
-5. Run `factoryctl validate-card`. Material execution may start only after the
+5. Mirror every `structured_proofs_required` id from the registry pack into the
+   activation contract. Once activated, those proof ids become required
+   delivery proof: readiness must cover or waive them, and Product Face/product
+   completion must pass them before full acceptance.
+6. Run `factoryctl validate-card`. Material execution may start only after the
    contract is activated, complete and every requested surface is covered.
 
 ## Important Boundary

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -1022,6 +1022,10 @@ def _activated_capability_pack_ids(contract: Any) -> set[str]:
     return ids
 
 
+def _pack_structured_proof_ids(pack: dict[str, Any]) -> list[str]:
+    return sorted({item for item in _list_items(pack.get("structured_proofs_required")) if item})
+
+
 def validate_activated_capability_contract(
     contract: Any,
     *,
@@ -1040,6 +1044,7 @@ def validate_activated_capability_contract(
     activation_refs = _list_items(contract.get("activation_evidence_refs"))
     tool_refs = _list_items(contract.get("tool_refs"))
     missing_capabilities = _list_items(contract.get("missing_capabilities"))
+    contract_structured_proofs = _list_items(contract.get("structured_proofs_required"))
 
     if status not in CAPABILITY_ACTIVATED_STATES:
         errors.append("capability_pack_contract.status must be ready or activated")
@@ -1064,6 +1069,19 @@ def validate_activated_capability_contract(
         errors.append("capability_pack_contract.tool_refs must name the activated tools or commands")
     if missing_capabilities:
         errors.append("capability_pack_contract.missing_capabilities must be empty before material execution")
+    packs = load_capability_packs()
+    required_pack_proofs: set[str] = set()
+    for pack_id in contract_pack_ids.intersection(candidate_pack_ids):
+        required_pack_proofs.update(_pack_structured_proof_ids(packs.get(pack_id, {})))
+    if required_pack_proofs:
+        if not contract_structured_proofs:
+            errors.append("capability_pack_contract.structured_proofs_required must mirror activated registry proof ids")
+        missing_proofs = sorted(required_pack_proofs - set(contract_structured_proofs))
+        if missing_proofs:
+            errors.append(
+                "capability_pack_contract.structured_proofs_required missing registry proof ids: "
+                + ", ".join(missing_proofs)
+            )
 
     profile_binding_refs = contract.get("profile_binding_refs")
     if not isinstance(profile_binding_refs, dict) or not profile_binding_refs:
@@ -1912,15 +1930,24 @@ def validate_product_creation_readiness_contract(card: dict[str, Any]) -> list[s
             errors.append("product_implementation_readiness.artifact_alignment_result blocks material implementation")
         if result == "PASS" and not _non_empty_string_list(readiness.get("ready_work_units")):
             errors.append("product_implementation_readiness PASS requires ready_work_units")
-        if profile:
+        required_readiness_proofs = _required_domain_proof_ids(card, "before_implementation")
+        if required_readiness_proofs:
+            proof_profile = profile or {
+                "waiver_policy": {
+                    "allowed": True,
+                    "requires_owner": True,
+                    "requires_reason": True,
+                    "cannot_claim_full_acceptance": True,
+                }
+            }
             if not _non_empty_string_list(readiness.get("product_delivery_quality_profile_trace")):
                 errors.append("product_implementation_readiness.product_delivery_quality_profile_trace must be non-empty")
             errors.extend(
                 _validate_delivery_profile_proof_coverage(
                     readiness.get("delivery_profile_proof_coverage"),
-                    _delivery_profile_required_proof_ids(profile, "before_implementation"),
+                    required_readiness_proofs,
                     at="product_implementation_readiness.delivery_profile_proof_coverage",
-                    profile=profile,
+                    profile=proof_profile,
                     full_acceptance=False,
                 )
             )
@@ -2509,11 +2536,27 @@ def _delivery_profile_required_proof_ids(profile: dict[str, Any], phase: str) ->
     return sorted(set(proof_ids))
 
 
+def _activated_capability_pack_structured_proof_ids(card: dict[str, Any]) -> list[str]:
+    contract = card.get("capability_pack_contract")
+    if not isinstance(contract, dict):
+        return []
+    if str(contract.get("status") or "").strip().lower() != "activated":
+        return []
+
+    proof_ids: set[str] = set(_list_items(contract.get("structured_proofs_required")))
+    packs = load_capability_packs()
+    for pack_id in _activated_capability_pack_ids(contract):
+        proof_ids.update(_pack_structured_proof_ids(packs.get(pack_id, {})))
+    return sorted(proof_id for proof_id in proof_ids if proof_id)
+
+
 def _required_domain_proof_ids(card: dict[str, Any], phase: str) -> list[str]:
     proof_ids: list[str] = []
     profile = _product_delivery_quality_profile(card)
     if profile:
         proof_ids.extend(_delivery_profile_required_proof_ids(profile, phase))
+    if phase in {"before_implementation", "before_completion", "before_promotion"}:
+        proof_ids.extend(_activated_capability_pack_structured_proof_ids(card))
     plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
     packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
     if phase == "before_completion":
@@ -3875,6 +3918,8 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
                 if isinstance(card.get("product_implementation_readiness"), dict)
                 else None
             ),
+            "required_structured_proofs": _activated_capability_pack_structured_proof_ids(card),
+            "required_completion_proofs": _required_domain_proof_ids(card, "before_completion"),
             "specialist_research_plan_ref": card.get("specialist_research_plan_ref")
             or ("card.specialist_research_plan" if isinstance(card.get("specialist_research_plan"), dict) else None),
             "specialist_decision_packet_ref": card.get("specialist_decision_packet_ref")

--- a/tests/test_capability_packs.py
+++ b/tests/test_capability_packs.py
@@ -43,6 +43,13 @@ def activated_game_contract() -> dict:
         "permission_class": "bounded-worker",
         "missing_capabilities": [],
         "execution_rule": "Game execution is allowed only after playable smoke, performance budget and game QA proof exist.",
+        "structured_proofs_required": [
+            "game.design-packet",
+            "game.performance-budget",
+            "game.playable-smoke",
+            "game.playtest-review",
+            "game.runtime-choice",
+        ],
         "worker_mapping": {
             "runtime": ["game-runtime-builder"],
             "design": ["game-design-specialist"],
@@ -179,6 +186,22 @@ class CapabilityPacksTest(unittest.TestCase):
         self.assertIn("capability_pack_contract.profile_binding_refs must map each specialist worker to a profile binding ref", errors)
         self.assertIn("capability_pack_contract.smoke_evidence_ref is required for activated packs", errors)
         self.assertIn("capability_pack_contract.eval_path is required for activated packs", errors)
+
+    def test_activated_pack_requires_registry_structured_proofs(self) -> None:
+        card = base_card()
+        card["surfaces"] = ["game", "3d", "asset-pipeline"]
+        card["capability_pack_contract"] = activated_game_contract()
+        card["capability_pack_contract"]["structured_proofs_required"] = [
+            "game.design-packet",
+            "game.playable-smoke",
+        ]
+
+        errors = factoryctl.validate_capability_coverage(card)
+
+        self.assertIn(
+            "capability_pack_contract.structured_proofs_required missing registry proof ids: game.performance-budget, game.playtest-review, game.runtime-choice",
+            errors,
+        )
 
     def test_activation_example_stays_blocked_until_real_evidence_replaces_placeholders(self) -> None:
         example = json.loads((ROOT / "templates" / "capability-pack-activation-example.json").read_text(encoding="utf-8"))

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -260,6 +260,43 @@ def product_delivery_quality_profile_fixture() -> dict:
     }
 
 
+def activated_game_contract_fixture() -> dict:
+    return {
+        "record_type": "capability_pack_contract",
+        "pack_id": "game-product-pack",
+        "status": "activated",
+        "lifecycle_state": "activated",
+        "covered_surfaces": ["game", "3d", "asset-pipeline"],
+        "specialist_workers": ["game-runtime-builder", "game-design-specialist", "game-qa-specialist"],
+        "activation_evidence_refs": ["external:game-pack-activation"],
+        "tool_refs": ["external:game-runtime-tool"],
+        "local_smoke_path": "external:playable-game-smoke-command",
+        "eval_path": "external:game-eval-command",
+        "smoke_evidence_ref": "external:playable-game-smoke",
+        "eval_evidence_ref": "external:game-eval",
+        "profile_binding_refs": {
+            "game-runtime-builder": "external:game-runtime-profile-binding",
+            "game-design-specialist": "external:game-design-profile-binding",
+            "game-qa-specialist": "external:game-qa-profile-binding",
+        },
+        "permission_class": "bounded-worker",
+        "missing_capabilities": [],
+        "execution_rule": "Game execution is allowed only after playable smoke, performance budget and game QA proof exist.",
+        "structured_proofs_required": [
+            "game.design-packet",
+            "game.performance-budget",
+            "game.playable-smoke",
+            "game.playtest-review",
+            "game.runtime-choice",
+        ],
+        "worker_mapping": {
+            "runtime": ["game-runtime-builder"],
+            "design": ["game-design-specialist"],
+            "qa": ["game-qa-specialist"],
+        },
+    }
+
+
 def product_face_result_fixture(**overrides: object) -> dict:
     result = {
         "result": "PASS",
@@ -399,6 +436,25 @@ class FactoryCtlTest(unittest.TestCase):
                 factoryctl.build_worker_packet("codex-security", card, card_path)
         finally:
             factoryctl.PROFILE_BINDINGS_PATH = original_path
+
+    def test_worker_packet_carries_activated_pack_structured_proofs(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+        card["surfaces"] = ["game", "3d", "asset-pipeline"]
+        card["capability_pack_contract"] = activated_game_contract_fixture()
+
+        packet = factoryctl.build_worker_packet("implementation-worker", card, card_path)
+
+        self.assertEqual(
+            packet["input_contract"]["required_structured_proofs"],
+            [
+                "game.design-packet",
+                "game.performance-budget",
+                "game.playable-smoke",
+                "game.playtest-review",
+                "game.runtime-choice",
+            ],
+        )
 
     def test_worker_packet_schema_allows_every_registered_worker(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
@@ -668,6 +724,35 @@ class FactoryCtlTest(unittest.TestCase):
             "product_face_result.domain_proof_coverage missing product delivery proof coverage for required proof ids: game.playable-smoke",
             errors,
         )
+
+    def test_product_face_completion_requires_activated_pack_domain_proofs(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["capability_pack_contract"] = activated_game_contract_fixture()
+
+        errors = factoryctl.validate_product_face_result_against_card(product_face_result_fixture(), card)
+
+        self.assertIn(
+            "product_face_result.domain_proof_coverage missing product delivery proof coverage for required proof ids: game.design-packet, game.performance-budget, game.playable-smoke, game.playtest-review, game.runtime-choice",
+            errors,
+        )
+
+    def test_product_face_completion_accepts_activated_pack_domain_proofs(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["capability_pack_contract"] = activated_game_contract_fixture()
+        result = product_face_result_fixture(
+            domain_proof_coverage=[
+                {
+                    "proof_id": proof_id,
+                    "status": "PASS",
+                    "evidence_refs": [f"reports/domain-proof/{proof_id}.json"],
+                    "reviewer": "domain-proof-reviewer",
+                    "basis": f"{proof_id} passed with structured evidence.",
+                }
+                for proof_id in card["capability_pack_contract"]["structured_proofs_required"]
+            ]
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
 
     def test_product_face_completion_resolves_profile_ref_for_domain_proof_coverage(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -21,6 +21,71 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
     def vfinal_card(self) -> dict:
         return factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
 
+    def activated_game_contract(self) -> dict:
+        return {
+            "record_type": "capability_pack_contract",
+            "pack_id": "game-product-pack",
+            "status": "activated",
+            "lifecycle_state": "activated",
+            "covered_surfaces": ["game", "3d", "asset-pipeline"],
+            "specialist_workers": ["game-runtime-builder", "game-design-specialist", "game-qa-specialist"],
+            "activation_evidence_refs": ["external:game-pack-activation"],
+            "tool_refs": ["external:game-runtime-tool"],
+            "local_smoke_path": "external:playable-game-smoke-command",
+            "eval_path": "external:game-eval-command",
+            "smoke_evidence_ref": "external:playable-game-smoke",
+            "eval_evidence_ref": "external:game-eval",
+            "profile_binding_refs": {
+                "game-runtime-builder": "external:game-runtime-profile-binding",
+                "game-design-specialist": "external:game-design-profile-binding",
+                "game-qa-specialist": "external:game-qa-profile-binding",
+            },
+            "permission_class": "bounded-worker",
+            "missing_capabilities": [],
+            "execution_rule": "Game execution is allowed only after playable smoke, performance budget and game QA proof exist.",
+            "structured_proofs_required": [
+                "game.design-packet",
+                "game.performance-budget",
+                "game.playable-smoke",
+                "game.playtest-review",
+                "game.runtime-choice",
+            ],
+            "worker_mapping": {
+                "runtime": ["game-runtime-builder"],
+                "design": ["game-design-specialist"],
+                "qa": ["game-qa-specialist"],
+            },
+        }
+
+    def activated_registry_pack_contract(self, pack_id: str, surfaces: list[str]) -> dict:
+        proofs = factoryctl.load_capability_packs()[pack_id]["structured_proofs_required"]
+        return {
+            "record_type": "capability_pack_contract",
+            "pack_id": pack_id,
+            "status": "activated",
+            "lifecycle_state": "activated",
+            "covered_surfaces": surfaces,
+            "specialist_workers": ["domain-builder", "domain-qa-specialist"],
+            "activation_evidence_refs": [f"external:{pack_id}-activation"],
+            "tool_refs": [f"external:{pack_id}-tool"],
+            "local_smoke_path": f"external:{pack_id}-smoke-command",
+            "eval_path": f"external:{pack_id}-eval-command",
+            "smoke_evidence_ref": f"external:{pack_id}-smoke",
+            "eval_evidence_ref": f"external:{pack_id}-eval",
+            "profile_binding_refs": {
+                "domain-builder": f"external:{pack_id}-builder-profile",
+                "domain-qa-specialist": f"external:{pack_id}-qa-profile",
+            },
+            "permission_class": "bounded-worker",
+            "missing_capabilities": [],
+            "execution_rule": f"{pack_id} execution is allowed only after its structured proofs exist.",
+            "structured_proofs_required": proofs,
+            "worker_mapping": {
+                "build": ["domain-builder"],
+                "qa": ["domain-qa-specialist"],
+            },
+        }
+
     def test_vfinal_template_passes_complete_product_planning_gate(self) -> None:
         self.assertEqual(factoryctl.validate_card(self.vfinal_card()), [])
 
@@ -153,6 +218,44 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             "card.product_delivery_quality_profile_ref does not resolve to a repo-local file: templates/missing-product-delivery-quality-profile.json",
             factoryctl.validate_card(card),
         )
+
+    def test_activated_capability_pack_proofs_block_readiness_when_missing(self) -> None:
+        card = self.vfinal_card()
+        card["surfaces"] = ["game", "3d", "asset-pipeline"]
+        card["capability_pack_contract"] = self.activated_game_contract()
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn(
+            "product_implementation_readiness.delivery_profile_proof_coverage missing required product delivery proof ids: game.design-packet, game.performance-budget, game.playable-smoke, game.playtest-review, game.runtime-choice",
+            errors,
+        )
+
+    def test_specialized_pack_proofs_block_readiness_across_product_domains(self) -> None:
+        cases = [
+            ("game-product-pack", ["game"], "game.playable-smoke"),
+            ("mobile-app-pack", ["ios"], "mobile.device-smoke"),
+            ("data-analytics-pack", ["analytics"], "analytics.lineage"),
+            ("fintech-payments-pack", ["payment"], "fintech.reconciliation-proof"),
+            ("browser-extension-pack", ["extension"], "extension.service-worker-content-script"),
+        ]
+        for pack_id, surfaces, expected_proof in cases:
+            with self.subTest(pack_id=pack_id):
+                card = self.vfinal_card()
+                card["surfaces"] = surfaces
+                card["capability_pack_contract"] = self.activated_registry_pack_contract(pack_id, surfaces)
+                card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+                card["product_implementation_readiness"] = factoryctl.load_json_like(
+                    ROOT / "templates" / "product-implementation-readiness.json"
+                )
+
+                errors = factoryctl.validate_card(card)
+
+                self.assertIn(expected_proof, "\n".join(errors))
 
     def test_worker_packet_carries_product_context_and_research_refs(self) -> None:
         card = self.vfinal_card()


### PR DESCRIPTION
## Summary

Closes #193.

This PR makes activated capability packs operationally binding instead of descriptive:

- requires activated pack contracts to mirror the registry `structured_proofs_required` ids;
- folds activated pack proof ids into readiness and Product Face/product completion proof coverage;
- passes required structured/completion proofs through worker packets;
- documents the activation rule for external operators.

Issue #84/local cockpit is intentionally untouched.

## Validation

- `python -m unittest tests.test_capability_packs tests.test_product_method_sot_planning tests.test_factoryctl -q`
- `python -m unittest discover tests -q`
- `python scripts/public_safety_scan.py`
- `python scripts/public_safety_scan.py --git-ref HEAD`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/release_integration_preflight.py`