### PR TITLE
Enforce product UI reference quality bars

### DIFF
--- a/schemas/reference-quality-packet.schema.json
+++ b/schemas/reference-quality-packet.schema.json
@@ -18,6 +18,9 @@
   "properties": {
     "record_type": { "const": "reference_quality_packet" },
     "experience_category": { "type": "string", "minLength": 3 },
+    "reference_domain": {
+      "enum": ["product_ui", "visual_design", "product_experience", "technical_domain", "documentation", "research"]
+    },
     "quality_bar": { "type": "string", "minLength": 3 },
     "anti_generic_criteria": {
       "type": "array",
@@ -51,6 +54,50 @@
       }
     },
     "design_rationale": { "type": "string", "minLength": 3 },
+    "rejected_references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source_id", "reason_rejected", "risk_prevented"],
+        "properties": {
+          "source_id": { "type": "string", "minLength": 2 },
+          "reason_rejected": { "type": "string", "minLength": 3 },
+          "risk_prevented": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "dimensional_synthesis": {
+      "type": "object",
+      "required": ["layout_hierarchy", "interaction_model", "visual_language", "content_density", "failure_modes"],
+      "properties": {
+        "layout_hierarchy": { "type": "string", "minLength": 3 },
+        "interaction_model": { "type": "string", "minLength": 3 },
+        "visual_language": { "type": "string", "minLength": 3 },
+        "content_density": { "type": "string", "minLength": 3 },
+        "failure_modes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "single_reference_waiver": {
+      "type": "object",
+      "required": ["owner", "reason", "expires_at", "forbidden_claims"],
+      "properties": {
+        "owner": { "type": "string", "minLength": 3 },
+        "reason": { "type": "string", "minLength": 3 },
+        "expires_at": { "type": "string", "minLength": 3 },
+        "forbidden_claims": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
     "component_expectations": { "type": "array", "items": { "type": "string" } },
     "interaction_expectations": { "type": "array", "items": { "type": "string" } },
     "visual_constraints": { "type": "array", "items": { "type": "string" } },
@@ -84,5 +131,32 @@
       "items": { "type": "string" }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "required": ["reference_domain"],
+        "properties": {
+          "reference_domain": { "enum": ["product_ui", "visual_design", "product_experience"] }
+        }
+      },
+      "then": {
+        "oneOf": [
+          {
+            "required": ["rejected_references", "dimensional_synthesis"],
+            "properties": {
+              "references": { "minItems": 3 },
+              "rejected_references": { "minItems": 2 }
+            }
+          },
+          {
+            "required": ["single_reference_waiver"],
+            "properties": {
+              "references": { "minItems": 1, "maxItems": 1 }
+            }
+          }
+        ]
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -406,6 +406,14 @@ REFERENCE_QUALITY_REQUIRED_FIELDS = (
     "performance_constraints",
     "acceptance_criteria",
 )
+PRODUCT_UI_REFERENCE_DOMAINS = {"product_ui", "visual_design", "product_experience"}
+REFERENCE_QUALITY_SYNTHESIS_DIMENSIONS = (
+    "layout_hierarchy",
+    "interaction_model",
+    "visual_language",
+    "content_density",
+    "failure_modes",
+)
 PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS = (
     "record_type",
     "surface_type",
@@ -2616,6 +2624,24 @@ def _validate_delivery_profile_proof_coverage(
     return errors
 
 
+def _is_product_ui_reference_packet(packet: dict[str, Any]) -> bool:
+    domain = str(packet.get("reference_domain") or "").strip().lower().replace("-", "_")
+    return domain in PRODUCT_UI_REFERENCE_DOMAINS
+
+
+def _single_reference_waiver_errors(packet: dict[str, Any]) -> list[str]:
+    waiver = packet.get("single_reference_waiver") if isinstance(packet.get("single_reference_waiver"), dict) else {}
+    errors: list[str] = []
+    if not waiver:
+        return ["reference_quality_packet.single_reference_waiver is required for single-reference product/UI packets"]
+    for field in ("owner", "reason", "expires_at"):
+        if not _non_empty_text(waiver.get(field)):
+            errors.append(f"reference_quality_packet.single_reference_waiver.{field} is required")
+    if not _list_items(waiver.get("forbidden_claims")):
+        errors.append("reference_quality_packet.single_reference_waiver.forbidden_claims must be a non-empty array")
+    return errors
+
+
 def validate_reference_quality_packet(packet: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     for field in REFERENCE_QUALITY_REQUIRED_FIELDS:
@@ -2632,7 +2658,8 @@ def validate_reference_quality_packet(packet: dict[str, Any]) -> list[str]:
     if packet.get("record_type") not in (None, "reference_quality_packet"):
         errors.append("reference_quality_packet.record_type must be reference_quality_packet")
 
-    for idx, ref in enumerate(packet.get("references", []) if isinstance(packet.get("references"), list) else []):
+    references = packet.get("references", []) if isinstance(packet.get("references"), list) else []
+    for idx, ref in enumerate(references):
         if not isinstance(ref, dict):
             errors.append(f"reference_quality_packet.references[{idx}] must be an object")
             continue
@@ -2647,6 +2674,46 @@ def validate_reference_quality_packet(packet: dict[str, Any]) -> list[str]:
             errors.append(f"reference_quality_packet.references[{idx}].license_or_terms_ref is required for copied code/assets")
         if str(ref.get("copy_policy") or "").strip().lower() in {"copy", "blind_copy"}:
             errors.append(f"reference_quality_packet.references[{idx}].copy_policy must not allow blind copying")
+
+    product_ui_packet = _is_product_ui_reference_packet(packet)
+    single_reference_waived = False
+    if product_ui_packet and len(references) == 1:
+        waiver_errors = _single_reference_waiver_errors(packet)
+        errors.extend(waiver_errors)
+        single_reference_waived = not waiver_errors
+
+    if product_ui_packet and not single_reference_waived:
+        if len(references) < 3:
+            errors.append("reference_quality_packet.references requires at least 3 sources for product/UI work")
+        source_types = {
+            str(ref.get("use_type") or "").strip()
+            for ref in references
+            if isinstance(ref, dict) and _non_empty_text(ref.get("use_type"))
+        }
+        if len(source_types) < 2:
+            errors.append("reference_quality_packet.references requires at least 2 source types for product/UI work")
+
+        rejected = packet.get("rejected_references") if isinstance(packet.get("rejected_references"), list) else []
+        if len(rejected) < 2:
+            errors.append("reference_quality_packet.rejected_references requires at least 2 rejected candidates for product/UI work")
+        for idx, rejected_ref in enumerate(rejected):
+            if not isinstance(rejected_ref, dict):
+                errors.append(f"reference_quality_packet.rejected_references[{idx}] must be an object")
+                continue
+            for field in ("source_id", "reason_rejected", "risk_prevented"):
+                if not _non_empty_text(rejected_ref.get(field)):
+                    errors.append(f"reference_quality_packet.rejected_references[{idx}].{field} is required")
+
+        synthesis = packet.get("dimensional_synthesis") if isinstance(packet.get("dimensional_synthesis"), dict) else {}
+        if not synthesis:
+            errors.append("reference_quality_packet.dimensional_synthesis is required for product/UI work")
+        for dimension in REFERENCE_QUALITY_SYNTHESIS_DIMENSIONS:
+            value = synthesis.get(dimension)
+            if isinstance(value, list):
+                if not _list_items(value):
+                    errors.append(f"reference_quality_packet.dimensional_synthesis.{dimension} must be a non-empty array")
+            elif not _non_empty_text(value):
+                errors.append(f"reference_quality_packet.dimensional_synthesis.{dimension} is required")
 
     reuse = packet.get("reuse_policy") if isinstance(packet.get("reuse_policy"), dict) else {}
     forbidden = " ".join(_list_items(reuse.get("forbidden"))).lower()

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -131,6 +131,7 @@ SUPPORTED_SCHEMA_KEYWORDS = ANNOTATION_SCHEMA_KEYWORDS | {
     "minItems",
     "minLength",
     "minProperties",
+    "oneOf",
     "pattern",
     "properties",
     "required",
@@ -140,7 +141,7 @@ SUPPORTED_SCHEMA_KEYWORDS = ANNOTATION_SCHEMA_KEYWORDS | {
 }
 SCHEMA_MAP_CHILDREN = {"$defs", "properties"}
 SCHEMA_OBJECT_CHILDREN = {"additionalProperties", "contains", "else", "if", "items", "then"}
-SCHEMA_ARRAY_CHILDREN = {"allOf"}
+SCHEMA_ARRAY_CHILDREN = {"allOf", "oneOf"}
 
 
 def load_json(path: Path) -> Any:
@@ -279,6 +280,20 @@ def validate_node(
         for index, subschema in enumerate(schema["allOf"]):
             if isinstance(subschema, dict):
                 errors.extend(validate_node(subschema, value, f"{at}.allOf[{index}]", schemas=schemas, root_schema=root, seen_refs=seen))
+    if isinstance(schema.get("oneOf"), list):
+        match_count = 0
+        for subschema in schema["oneOf"]:
+            if isinstance(subschema, dict) and schema_matches(
+                subschema,
+                value,
+                at,
+                schemas=schemas,
+                root_schema=root,
+                seen_refs=seen,
+            ):
+                match_count += 1
+        if match_count != 1:
+            errors.append(f"{at}: expected exactly one oneOf schema match, got {match_count}")
     if "if" in schema and isinstance(schema["if"], dict):
         if schema_matches(schema["if"], value, at, schemas=schemas, root_schema=root, seen_refs=seen):
             then_schema = schema.get("then")

--- a/templates/reference-quality-packet.json
+++ b/templates/reference-quality-packet.json
@@ -2,6 +2,7 @@
   "$schema": "https://overkill-factory.dev/schemas/reference-quality-packet.schema.json",
   "record_type": "reference_quality_packet",
   "experience_category": "web product surface",
+  "reference_domain": "product_ui",
   "quality_bar": "Specific, product-fit experience that avoids generic generated UI.",
   "anti_generic_criteria": [
     "The output must reflect the product job, not a generic landing-page template.",
@@ -16,9 +17,46 @@
       "copy_policy": "do_not_copy",
       "license_or_terms_ref": "operator must verify current terms before reuse",
       "public_safety_notes": "Use as a benchmark reference, not as copied content."
+    },
+    {
+      "source_id": "operator-approved-flow-benchmark",
+      "source_url_or_ref": "external:operator-approved-flow-benchmark",
+      "use_type": "benchmark",
+      "what_to_learn": ["flow density", "state visibility"],
+      "copy_policy": "do_not_copy",
+      "license_or_terms_ref": "not_applicable_for_benchmark_only",
+      "public_safety_notes": "Replace with a public-safe or operator-approved benchmark before execution."
+    },
+    {
+      "source_id": "operator-approved-component-pattern",
+      "source_url_or_ref": "external:operator-approved-component-pattern",
+      "use_type": "inspiration",
+      "what_to_learn": ["component hierarchy", "empty and blocked states"],
+      "copy_policy": "do_not_copy",
+      "license_or_terms_ref": "not_applicable_for_inspiration_only",
+      "public_safety_notes": "Use only to describe patterns; do not copy layout, text, code or assets."
     }
   ],
   "design_rationale": "References establish the quality baseline before generation.",
+  "rejected_references": [
+    {
+      "source_id": "generic-dashboard-template",
+      "reason_rejected": "Too generic for a product-specific job-to-be-done.",
+      "risk_prevented": "Avoids polished but interchangeable AI-dashboard output."
+    },
+    {
+      "source_id": "marketing-landing-page-only",
+      "reason_rejected": "Optimized for persuasion rather than repeated product operation.",
+      "risk_prevented": "Prevents hero-page styling from replacing the actual product workflow."
+    }
+  ],
+  "dimensional_synthesis": {
+    "layout_hierarchy": "The primary user job, status, evidence and next action must be visually ordered before decorative content.",
+    "interaction_model": "States, transitions, disabled actions and recovery paths must be visible before implementation.",
+    "visual_language": "Use a product-fit visual system derived from references without copying source assets or layouts.",
+    "content_density": "Match density to the operator task instead of defaulting to sparse marketing composition.",
+    "failure_modes": ["generic AI-dashboard look", "unclear blocked state", "reference copying"]
+  },
   "component_expectations": ["components must match the job-to-be-done"],
   "interaction_expectations": ["states and transitions must be observable"],
   "visual_constraints": ["avoid stock/generic composition"],

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -293,6 +293,7 @@
     "$schema": "https://overkill-factory.dev/schemas/reference-quality-packet.schema.json",
     "record_type": "reference_quality_packet",
     "experience_category": "software product surface",
+    "reference_domain": "product_ui",
     "quality_bar": "Specific, product-fit experience that avoids generic generated UI.",
     "anti_generic_criteria": [
       "The output must reflect the product job, not a generic demo.",
@@ -307,9 +308,46 @@
         "copy_policy": "do_not_copy",
         "license_or_terms_ref": "not_applicable_for_benchmark_only",
         "public_safety_notes": "Benchmark only; no copied text, code or assets."
+      },
+      {
+        "source_id": "operator-approved-flow-benchmark",
+        "source_url_or_ref": "external:operator-approved-flow-benchmark",
+        "use_type": "style_reference",
+        "what_to_learn": ["flow density", "visual hierarchy"],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "not_applicable_for_benchmark_only",
+        "public_safety_notes": "Benchmark only; replace with a public-safe or operator-approved source before execution."
+      },
+      {
+        "source_id": "operator-approved-state-pattern",
+        "source_url_or_ref": "external:operator-approved-state-pattern",
+        "use_type": "inspiration",
+        "what_to_learn": ["empty state", "blocked state", "recovery action"],
+        "copy_policy": "do_not_copy",
+        "license_or_terms_ref": "not_applicable_for_inspiration_only",
+        "public_safety_notes": "Pattern reference only; no copied text, code, layout or assets."
       }
     ],
     "design_rationale": "The reference packet feeds Product Experience and Product Face before implementation.",
+    "rejected_references": [
+      {
+        "source_id": "generic-ai-dashboard",
+        "reason_rejected": "Looks plausible but does not encode the product job, status or evidence hierarchy.",
+        "risk_prevented": "Prevents generic generated UI from becoming the quality baseline."
+      },
+      {
+        "source_id": "marketing-only-landing-page",
+        "reason_rejected": "Prioritizes hero copy over repeated product operation.",
+        "risk_prevented": "Prevents a landing page aesthetic from replacing a usable product surface."
+      }
+    ],
+    "dimensional_synthesis": {
+      "layout_hierarchy": "Primary job, current state, evidence and next action must be visible before decorative content.",
+      "interaction_model": "Required states, blocked states and recovery actions must be designed before implementation.",
+      "visual_language": "Use a product-fit direction derived from benchmarks without copying source layouts, text, code or assets.",
+      "content_density": "Density must match the operator task and surface type instead of defaulting to sparse marketing composition.",
+      "failure_modes": ["generic AI-dashboard look", "missing blocked state", "reference copying"]
+    },
     "component_expectations": ["components fit the job-to-be-done"],
     "interaction_expectations": ["states and transitions are observable"],
     "visual_constraints": ["avoid generic generated composition"],

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -118,6 +118,50 @@ class FactorySelfImprovementTest(unittest.TestCase):
 
         self.assertIn("reference_quality_packet.references[0].license_or_terms_ref is required for copied code/assets", errors)
 
+    def test_product_ui_reference_quality_rejects_single_weak_reference(self) -> None:
+        packet = json.loads(json.dumps(vfinal_card()["reference_quality_packet"]))
+        packet["references"] = packet["references"][:1]
+        packet.pop("rejected_references")
+        packet.pop("dimensional_synthesis")
+
+        errors = factoryctl.validate_reference_quality_packet(packet)
+
+        self.assertIn(
+            "reference_quality_packet.single_reference_waiver is required for single-reference product/UI packets",
+            errors,
+        )
+        self.assertIn("reference_quality_packet.references requires at least 3 sources for product/UI work", errors)
+        self.assertIn(
+            "reference_quality_packet.rejected_references requires at least 2 rejected candidates for product/UI work",
+            errors,
+        )
+        self.assertIn("reference_quality_packet.dimensional_synthesis is required for product/UI work", errors)
+
+    def test_product_ui_reference_quality_allows_bounded_single_reference_waiver(self) -> None:
+        packet = json.loads(json.dumps(vfinal_card()["reference_quality_packet"]))
+        packet["references"] = packet["references"][:1]
+        packet.pop("rejected_references")
+        packet.pop("dimensional_synthesis")
+        packet["single_reference_waiver"] = {
+            "owner": "product-owner",
+            "reason": "Only one authoritative source exists for this bounded visual decision.",
+            "expires_at": "before-product-face-pass",
+            "forbidden_claims": ["full product quality benchmark", "best-in-class visual comparison"],
+        }
+
+        self.assertEqual(factoryctl.validate_reference_quality_packet(packet), [])
+
+    def test_reference_quality_does_not_force_visual_bar_for_technical_domain(self) -> None:
+        packet = json.loads(json.dumps(vfinal_card()["reference_quality_packet"]))
+        packet["reference_domain"] = "technical_domain"
+        packet["experience_category"] = "database migration safety"
+        packet["references"] = packet["references"][:1]
+        packet.pop("rejected_references")
+        packet.pop("dimensional_synthesis")
+        packet.pop("product_experience_fields_informed")
+
+        self.assertEqual(factoryctl.validate_reference_quality_packet(packet), [])
+
     def test_worker_packet_carries_reasoning_and_reference_contracts(self) -> None:
         card_path = ROOT / "templates" / "vfinal-factory-card.json"
         card = vfinal_card()

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -97,11 +97,29 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
 
         self.assertTrue(any("does not contain" in error for error in errors))
 
+    def test_enforces_one_of_used_by_reference_quality_schema(self) -> None:
+        validator = load_validator()
+        schema = {
+            "oneOf": [
+                {"required": ["strong_bar"], "properties": {"mode": {"const": "strong"}}},
+                {"required": ["waiver"], "properties": {"mode": {"const": "waived"}}},
+            ]
+        }
+
+        self.assertEqual(validator.validate_node(schema, {"mode": "strong", "strong_bar": True}, "$"), [])
+        self.assertEqual(validator.validate_node(schema, {"mode": "waived", "waiver": True}, "$"), [])
+        self.assertTrue(any("expected exactly one oneOf" in error for error in validator.validate_node(schema, {}, "$")))
+        self.assertTrue(
+            any(
+                "expected exactly one oneOf" in error
+                for error in validator.validate_node(schema, {"strong_bar": True, "waiver": True}, "$")
+            )
+        )
+
     def test_schema_keyword_audit_rejects_unsupported_validation_keywords(self) -> None:
         validator = load_validator()
         schema = {
             "type": "object",
-            "oneOf": [{"required": ["mode"]}],
             "properties": {
                 "not": {"type": "string"},
                 "gate": {"not": {"const": "bypass"}},
@@ -110,7 +128,6 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
 
         errors = validator.validate_schema_keywords(schema)
 
-        self.assertTrue(any("unsupported JSON Schema keyword 'oneOf'" in error for error in errors))
         self.assertTrue(any("unsupported JSON Schema keyword 'not'" in error for error in errors))
         self.assertFalse(any("$/properties/not:" in error for error in errors))
 


### PR DESCRIPTION
## Summary

Closes #199.

This makes Reference Quality Packet a real quality bar for product/UI work instead of allowing a single loose reference to drive generation.

## Changes

- Adds `reference_domain` to Reference Quality Packet so Product/UI, technical/domain, docs and research references are distinguishable.
- Requires Product/UI RQPs to use either:
  - at least 3 references, at least 2 reference types, rejected candidates and dimensional synthesis; or
  - a bounded single-reference waiver with owner, reason, expiry and forbidden claims.
- Strengthens the public RQP templates with multi-source references, rejected references and dimensional synthesis.
- Adds minimal `oneOf` support to the public JSON artifact validator so the schema rule is enforceable by the repo's dependency-free validator.
- Leaves legacy untagged RQPs compatible, including work outside this PR's scope, while new public templates use `reference_domain: product_ui`.

## Validation

- `python -m unittest tests.test_factory_self_improvement tests.test_public_json_artifact_validator -q`
- `python -m unittest discover tests -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/release_integration_preflight.py`

## Notes

This PR does not touch #84. The validator intentionally relies on explicit `reference_domain` for Product/UI enforcement so older cards are not silently migrated in this PR.