### PR TITLE
Add strict Data/Metrics and Docs/Onboarding gates

### DIFF
--- a/schemas/data-metrics-plan.schema.json
+++ b/schemas/data-metrics-plan.schema.json
@@ -16,76 +16,101 @@
     "instrumentation_proof"
   ],
   "properties": {
+    "gate_enforcement": { "enum": ["strict", "production", "advisory"] },
     "success_metrics": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "events": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "owners": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "privacy_limits": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "dashboards": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "evidence_refs": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "risk_metrics": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "logs": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "alerts": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "personal_data": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "visibility": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "instrumentation_proof": {
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     }
   },

--- a/schemas/user-docs-onboarding-plan.schema.json
+++ b/schemas/user-docs-onboarding-plan.schema.json
@@ -5,11 +5,12 @@
   "type": "object",
   "required": ["audience", "first_success_path", "tasks_covered", "proof_required"],
   "properties": {
+    "gate_enforcement": { "enum": ["strict", "production", "advisory"] },
     "audience": { "type": "string", "minLength": 3 },
     "first_success_path": { "type": "string", "minLength": 3 },
-    "tasks_covered": { "type": "array", "items": { "type": "string" } },
-    "proof_required": { "type": "array", "items": { "type": "string" } },
-    "evidence_refs": { "type": "array", "items": { "type": "string" } }
+    "tasks_covered": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "proof_required": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
   },
   "additionalProperties": true
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -414,6 +414,19 @@ REFERENCE_QUALITY_SYNTHESIS_DIMENSIONS = (
     "content_density",
     "failure_modes",
 )
+DATA_METRICS_REQUIRED_FIELDS = (
+    "success_metrics",
+    "events",
+    "owners",
+    "privacy_limits",
+    "risk_metrics",
+    "logs",
+    "alerts",
+    "personal_data",
+    "visibility",
+    "instrumentation_proof",
+)
+DATA_METRICS_RUNTIME_REQUIRED_FIELDS = DATA_METRICS_REQUIRED_FIELDS + ("dashboards", "evidence_refs")
 PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS = (
     "record_type",
     "surface_type",
@@ -2724,6 +2737,49 @@ def validate_reference_quality_packet(packet: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_data_metrics_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in DATA_METRICS_RUNTIME_REQUIRED_FIELDS:
+        if not _list_items(plan.get(field)):
+            errors.append(f"data_metrics_plan.{field} must be a non-empty array")
+
+    for idx, event in enumerate(_list_items(plan.get("events"))):
+        if " " in event.strip():
+            errors.append(f"data_metrics_plan.events[{idx}] must be a stable event id, not prose")
+
+    proof_text = " ".join(_list_items(plan.get("instrumentation_proof")) + _list_items(plan.get("evidence_refs"))).lower()
+    if not any(term in proof_text for term in ("test", "dashboard", "log", "report", "trace", "artifact", "receipt")):
+        errors.append("data_metrics_plan.instrumentation_proof must name test, dashboard, log, report, trace, artifact or receipt evidence")
+    return errors
+
+
+def validate_user_docs_onboarding_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    audience = plan.get("audience")
+    if isinstance(audience, list):
+        if not _list_items(audience):
+            errors.append("user_docs_onboarding_plan.audience must be a non-empty string or array")
+    elif not _non_empty_text(audience):
+        errors.append("user_docs_onboarding_plan.audience is required")
+
+    for field in ("first_success_path",):
+        if not _non_empty_text(plan.get(field)):
+            errors.append(f"user_docs_onboarding_plan.{field} is required")
+
+    for field in ("tasks_covered", "proof_required", "evidence_refs"):
+        if not _list_items(plan.get(field)):
+            errors.append(f"user_docs_onboarding_plan.{field} must be a non-empty array")
+
+    proof_text = " ".join(_list_items(plan.get("proof_required")) + _list_items(plan.get("evidence_refs"))).lower()
+    if not any(term in proof_text for term in ("first", "reader", "link", "test", "smoke", "review", "artifact")):
+        errors.append("user_docs_onboarding_plan.proof_required must name reader, first-success, link, test, smoke, review or artifact evidence")
+    return errors
+
+
+def _strict_plan_gate_enabled(plan: dict[str, Any]) -> bool:
+    return str(plan.get("gate_enforcement") or "").strip().lower() in {"strict", "production"}
+
+
 def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     for field in PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS:
@@ -2985,6 +3041,10 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_product_creation_readiness_contract(data))
     errors.extend(validate_production_promotion_ladder_contract(data))
     errors.extend(validate_user_facing_autonomy_contract(data))
+    if isinstance(data.get("data_metrics_plan"), dict) and _strict_plan_gate_enabled(data["data_metrics_plan"]):
+        errors.extend(validate_data_metrics_plan(data["data_metrics_plan"]))
+    if isinstance(data.get("user_docs_onboarding_plan"), dict) and _strict_plan_gate_enabled(data["user_docs_onboarding_plan"]):
+        errors.extend(validate_user_docs_onboarding_plan(data["user_docs_onboarding_plan"]))
     return errors
 
 

--- a/templates/data-metrics-plan.json
+++ b/templates/data-metrics-plan.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/data-metrics-plan.schema.json",
+  "gate_enforcement": "strict",
   "success_metrics": [
     "activation rate",
     "task completion"

--- a/templates/user-docs-onboarding-plan.json
+++ b/templates/user-docs-onboarding-plan.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/user-docs-onboarding-plan.schema.json",
+  "gate_enforcement": "strict",
   "audience": "new user",
   "first_success_path": "user completes the first useful task without external help",
   "tasks_covered": ["setup", "first action", "troubleshooting"],

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -909,14 +909,19 @@
   },
   "data_metrics_plan": {
     "$schema": "https://overkill-factory.dev/schemas/data-metrics-plan.schema.json",
+    "gate_enforcement": "strict",
     "success_metrics": ["observable success signal"],
     "risk_metrics": ["observable risk signal"],
     "events": ["factory.card.transition"],
+    "owners": ["product-owner"],
+    "privacy_limits": ["no private source material or sensitive payloads in public metrics"],
     "dashboards": ["Project Projection"],
     "logs": ["runtime gate output"],
     "alerts": ["blocked material transition"],
-    "privacy_notes": ["no private source material in public receipts"],
-    "instrumentation_proof": ["gate report artifact"]
+    "personal_data": ["none in the public template, or explicitly named data classes with limits"],
+    "visibility": ["operator and authorized reviewers only before public release"],
+    "instrumentation_proof": ["gate report artifact", "dashboard/report test"],
+    "evidence_refs": ["templates/vfinal-factory-card.json#data_metrics_plan"]
   },
   "agent_eval_plan": {
     "$schema": "https://overkill-factory.dev/schemas/agent-eval-plan.schema.json",
@@ -1058,10 +1063,12 @@
   },
   "user_docs_onboarding_plan": {
     "$schema": "https://overkill-factory.dev/schemas/user-docs-onboarding-plan.schema.json",
-    "audience": ["operator", "external contributor"],
-    "docs_required": ["quickstart", "validation and release", "troubleshooting"],
-    "acceptance": ["another agent can continue from docs"],
-    "public_safety": ["no private paths or raw private source"]
+    "gate_enforcement": "strict",
+    "audience": "operator and external contributor",
+    "first_success_path": "new operator reaches the first validated local factory check without private context",
+    "tasks_covered": ["setup", "first validation command", "troubleshooting blocked evidence"],
+    "proof_required": ["fresh-reader review", "broken-link check", "first-success smoke artifact"],
+    "evidence_refs": ["templates/vfinal-factory-card.json#user_docs_onboarding_plan"]
   },
   "project_projection": {
     "$schema": "https://overkill-factory.dev/schemas/project-projection.schema.json",

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -617,6 +617,50 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertEqual(factoryctl.validate_card(card), [])
 
+    def test_data_metrics_plan_rejects_prose_only_or_empty_delivery_proof(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["data_metrics_plan"] = {
+            "$schema": "https://overkill-factory.dev/schemas/data-metrics-plan.schema.json",
+            "gate_enforcement": "strict",
+            "success_metrics": [],
+            "events": ["looks good"],
+            "owners": [],
+            "privacy_limits": [],
+            "risk_metrics": [],
+            "logs": [],
+            "alerts": [],
+            "personal_data": [],
+            "visibility": [],
+            "instrumentation_proof": ["nice dashboard someday"],
+            "dashboards": [],
+            "evidence_refs": [],
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("data_metrics_plan.success_metrics must be a non-empty array", errors)
+        self.assertIn("data_metrics_plan.events[0] must be a stable event id, not prose", errors)
+        self.assertIn("data_metrics_plan.dashboards must be a non-empty array", errors)
+        self.assertIn("data_metrics_plan.evidence_refs must be a non-empty array", errors)
+
+    def test_user_docs_onboarding_plan_rejects_missing_first_success_and_proof(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["user_docs_onboarding_plan"] = {
+            "$schema": "https://overkill-factory.dev/schemas/user-docs-onboarding-plan.schema.json",
+            "gate_enforcement": "strict",
+            "audience": "",
+            "tasks_covered": [],
+            "proof_required": ["someone reads it eventually"],
+            "evidence_refs": [],
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("user_docs_onboarding_plan.audience is required", errors)
+        self.assertIn("user_docs_onboarding_plan.first_success_path is required", errors)
+        self.assertIn("user_docs_onboarding_plan.tasks_covered must be a non-empty array", errors)
+        self.assertIn("user_docs_onboarding_plan.evidence_refs must be a non-empty array", errors)
+
     def test_product_face_completion_requires_visual_result(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
         card["product_face_result_required"] = True


### PR DESCRIPTION
## Summary

Progresses #204.

This adds executable strict gates for Data/Metrics and Docs/Onboarding plans so production-style product delivery cannot rely on empty arrays or prose-only promises when those plans opt into strict enforcement.

## Changes

- Adds `gate_enforcement` to Data/Metrics and Docs/Onboarding schemas.
- Tightens schema arrays with `minItems` and item `minLength`.
- Adds `factoryctl` validators for strict Data/Metrics plans:
  - success/risk metrics
  - events
  - owners
  - privacy limits
  - logs/alerts/personal data/visibility
  - dashboards and evidence refs
  - instrumentation proof with concrete evidence kind
- Adds `factoryctl` validators for strict Docs/Onboarding plans:
  - audience
  - first success path
  - covered tasks
  - proof requirements
  - evidence refs
- Updates public templates to `gate_enforcement: strict`.
- Adds regression tests for weak strict plans.

## Validation

- `python -m unittest tests.test_factoryctl tests.test_canonical_runtime_enforcement tests.test_public_json_artifact_validator -q`
- `python -m unittest discover tests -q`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/release_integration_preflight.py`

## Scope note

This PR intentionally does not touch #84. Legacy cards that do not declare `gate_enforcement: strict` remain compatible; new public templates now opt into strict enforcement. A follow-up can decide whether/how to migrate older cards without mixing that with this methodology gate.