### PR TITLE
Add surface-specific Product Face evidence profiles

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -18,22 +18,31 @@ Run for any vFinal card with Product Experience surfaces, including:
 Legacy cards keep their existing narrower Product Face triggers unless they
 explicitly set `product_face_result_required=true`.
 
-## Required Evidence
+## Surface Evidence Profiles
 
-- desktop screenshot;
-- mobile screenshot;
-- important state matrix;
-- empty/loading/error/success states when applicable;
-- accessibility basics;
-- visual overlap check;
-- user-facing copy sanity;
-- wallet flow evidence when wallet UI exists;
-- performance budget note.
+Product Face proof is surface-specific. A result must declare the profile it
+proves, and completion validation compares that profile to the Product Face
+Packet or Product Experience Plan.
+
+- `web_visual_ui`: screenshots, viewports, important state matrix,
+  empty/loading/error/success states when applicable, accessibility basics,
+  visual overlap check, console status, copy sanity and performance note.
+- `cli_tui`: golden path transcript, help output, install/run path, error-state
+  transcript and cross-platform terminal evidence.
+- `docs_onboarding`: first-success replay, tasks covered, stale-link check,
+  public-safety check and reader success criteria.
+- `agentic_interface`: task transcript, state transitions, approval boundaries,
+  user control boundaries and recovery/error handling evidence.
+
+The repo runner in `scripts/product_face_proof.py` is a `web_visual_ui` runner.
+It should not be used to claim CLI/TUI, docs/onboarding or agentic-interface
+PASS without the matching profile evidence.
 
 ## Output
 
 `product_face_result` with:
 
+- surface evidence profile;
 - screenshots;
 - checked states;
 - viewport list;

--- a/schemas/product-experience-plan.schema.json
+++ b/schemas/product-experience-plan.schema.json
@@ -44,6 +44,16 @@
       "items": { "type": "string", "minLength": 3 },
       "uniqueItems": true
     },
+    "surface_evidence_profile": {
+      "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+    },
+    "surface_evidence_profiles": {
+      "type": "array",
+      "items": {
+        "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+      },
+      "uniqueItems": true
+    },
     "states": {
       "type": "array",
       "items": {

--- a/schemas/product-face-packet.schema.json
+++ b/schemas/product-face-packet.schema.json
@@ -36,6 +36,16 @@
       "items": { "type": "string", "minLength": 3 },
       "uniqueItems": true
     },
+    "surface_evidence_profile": {
+      "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+    },
+    "surface_evidence_profiles": {
+      "type": "array",
+      "items": {
+        "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+      },
+      "uniqueItems": true
+    },
     "user": {
       "type": "string",
       "minLength": 3

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -44,6 +44,127 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
     },
+    "surface_evidence_profile": {
+      "$ref": "#/$defs/surface_evidence_profile"
+    },
+    "surface_evidence_profiles": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/surface_evidence_profile" }
+    },
+    "cli_tui_evidence": {
+      "type": "object",
+      "required": [
+        "golden_path_transcript_refs",
+        "help_output_refs",
+        "error_state_refs",
+        "install_run_refs",
+        "cross_platform_terminal_refs"
+      ],
+      "properties": {
+        "golden_path_transcript_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "help_output_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "error_state_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "install_run_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "cross_platform_terminal_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "docs_onboarding_evidence": {
+      "type": "object",
+      "required": [
+        "first_success_replay_refs",
+        "tasks_covered",
+        "stale_link_check_refs",
+        "public_safety_check_refs",
+        "reader_success_criteria"
+      ],
+      "properties": {
+        "first_success_replay_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "tasks_covered": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "stale_link_check_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "public_safety_check_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "reader_success_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "agentic_interface_evidence": {
+      "type": "object",
+      "required": [
+        "task_transcript_refs",
+        "state_transition_refs",
+        "approval_boundary_refs",
+        "user_control_refs",
+        "recovery_error_refs"
+      ],
+      "properties": {
+        "task_transcript_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "state_transition_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "approval_boundary_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "user_control_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "recovery_error_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
     "viewports": {
       "type": "array",
       "minItems": 1,
@@ -227,6 +348,27 @@
     }
   },
   "$defs": {
+    "surface_evidence_profile": {
+      "type": "object",
+      "required": ["profile_id", "surface"],
+      "properties": {
+        "profile_id": {
+          "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+        },
+        "surface": {
+          "type": "string",
+          "minLength": 2
+        },
+        "evidence_kind": {
+          "enum": ["visual_ui", "command_transcript", "reader_success", "task_transcript"]
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
     "reference_dimension_verdict": {
       "type": "object",
       "required": ["status", "basis"],

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -493,6 +493,68 @@ REFERENCE_COMPARISON_DIMENSIONS = (
     "visual_language",
     "density_spacing",
 )
+SURFACE_EVIDENCE_PROFILES = {"web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"}
+SURFACE_EVIDENCE_PROFILE_BLOCKS = {
+    "cli_tui": (
+        "cli_tui_evidence",
+        (
+            "golden_path_transcript_refs",
+            "help_output_refs",
+            "error_state_refs",
+            "install_run_refs",
+            "cross_platform_terminal_refs",
+        ),
+    ),
+    "docs_onboarding": (
+        "docs_onboarding_evidence",
+        (
+            "first_success_replay_refs",
+            "tasks_covered",
+            "stale_link_check_refs",
+            "public_safety_check_refs",
+            "reader_success_criteria",
+        ),
+    ),
+    "agentic_interface": (
+        "agentic_interface_evidence",
+        (
+            "task_transcript_refs",
+            "state_transition_refs",
+            "approval_boundary_refs",
+            "user_control_refs",
+            "recovery_error_refs",
+        ),
+    ),
+}
+CLI_TUI_SURFACE_TOKENS = {"cli", "tui", "terminal", "console", "command_line", "command-line"}
+DOCS_ONBOARDING_SURFACE_TOKENS = {"docs", "documentation", "onboarding", "quickstart", "guide"}
+AGENTIC_INTERFACE_SURFACE_TOKENS = {
+    "agentic_interface",
+    "agentic-interface",
+    "ai_interface",
+    "ai-interface",
+    "chat_ui",
+    "chat-ui",
+    "assistant",
+    "copilot",
+}
+VISUAL_UI_SURFACE_TOKENS = PRODUCT_FACE_SURFACES | {
+    "web",
+    "web-app",
+    "web_app",
+    "website",
+    "site",
+    "landing",
+    "landing-page",
+    "screen",
+    "component",
+    "desktop",
+    "desktop-app",
+    "extension",
+    "browser-extension",
+    "design-system",
+    "design_system",
+}
 
 
 @dataclass(frozen=True)
@@ -1734,6 +1796,42 @@ def _list_items(value: Any) -> list[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
+def _normalized_contract_token(value: Any) -> str:
+    return str(value or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _surface_evidence_profile_id(value: Any) -> str:
+    if isinstance(value, dict):
+        value = value.get("profile_id")
+    return _normalized_contract_token(value)
+
+
+def _declared_surface_evidence_profiles(data: dict[str, Any]) -> list[str]:
+    profile_ids: list[str] = []
+    single = _surface_evidence_profile_id(data.get("surface_evidence_profile"))
+    if single:
+        profile_ids.append(single)
+    raw_profiles = data.get("surface_evidence_profiles")
+    if isinstance(raw_profiles, list):
+        profile_ids.extend(_surface_evidence_profile_id(item) for item in raw_profiles)
+    return sorted({profile_id for profile_id in profile_ids if profile_id})
+
+
+def _validate_surface_evidence_profile_declarations(data: dict[str, Any], *, at: str) -> list[str]:
+    errors: list[str] = []
+    if "surface_evidence_profile" in data and not _surface_evidence_profile_id(data.get("surface_evidence_profile")):
+        errors.append(f"{at}.surface_evidence_profile.profile_id is required")
+    raw_profiles = data.get("surface_evidence_profiles")
+    if isinstance(raw_profiles, list):
+        for index, profile in enumerate(raw_profiles):
+            if not _surface_evidence_profile_id(profile):
+                errors.append(f"{at}.surface_evidence_profiles[{index}].profile_id is required")
+    for profile_id in _declared_surface_evidence_profiles(data):
+        if profile_id not in SURFACE_EVIDENCE_PROFILES:
+            errors.append(f"{at}.surface_evidence_profile must be one of " + ", ".join(sorted(SURFACE_EVIDENCE_PROFILES)))
+    return errors
+
+
 def _has_contract(data: dict[str, Any], field: str) -> bool:
     value = data.get(field)
     if isinstance(value, dict) and value:
@@ -2352,6 +2450,41 @@ def normalized_surfaces(card: dict[str, Any]) -> set[str]:
     return {str(value).strip().lower() for value in raw if str(value).strip()}
 
 
+def _surface_profile_tokens(card: dict[str, Any]) -> set[str]:
+    tokens = {_normalized_contract_token(surface) for surface in normalized_surfaces(card)}
+    packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
+    plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
+    for field in ("surface", "surface_type", "surface_pack"):
+        if _non_empty_text(packet.get(field)):
+            tokens.add(_normalized_contract_token(packet.get(field)))
+        if _non_empty_text(plan.get(field)):
+            tokens.add(_normalized_contract_token(plan.get(field)))
+    return {token for token in tokens if token}
+
+
+def _expected_surface_evidence_profiles(card: dict[str, Any]) -> list[str]:
+    profiles = set()
+    packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
+    plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
+    for source in (packet, plan):
+        profiles.update(_declared_surface_evidence_profiles(source))
+    if profiles:
+        return sorted(profile for profile in profiles if profile in SURFACE_EVIDENCE_PROFILES)
+
+    tokens = _surface_profile_tokens(card)
+    if tokens & {_normalized_contract_token(token) for token in CLI_TUI_SURFACE_TOKENS}:
+        profiles.add("cli_tui")
+    if tokens & {_normalized_contract_token(token) for token in DOCS_ONBOARDING_SURFACE_TOKENS}:
+        profiles.add("docs_onboarding")
+    if tokens & {_normalized_contract_token(token) for token in AGENTIC_INTERFACE_SURFACE_TOKENS}:
+        profiles.add("agentic_interface")
+    if tokens & {_normalized_contract_token(token) for token in VISUAL_UI_SURFACE_TOKENS}:
+        profiles.add("web_visual_ui")
+    if not profiles and product_experience_surface_required(card):
+        profiles.add("web_visual_ui")
+    return sorted(profiles)
+
+
 def risk(card: dict[str, Any]) -> str:
     return str(card.get("risk_effective", "")).strip().upper()
 
@@ -2373,6 +2506,7 @@ def validate_product_face_packet(packet: dict[str, Any], *, strict: bool) -> lis
     errors: list[str] = []
     if not strict:
         return errors
+    errors.extend(_validate_surface_evidence_profile_declarations(packet, at="product_face_packet"))
 
     for field in PRODUCT_FACE_PACKET_REQUIRED_FIELDS:
         value = packet.get(field)
@@ -2403,6 +2537,7 @@ def validate_product_face_packet(packet: dict[str, Any], *, strict: bool) -> lis
 
 def validate_product_experience_plan(plan: dict[str, Any]) -> list[str]:
     errors: list[str] = []
+    errors.extend(_validate_surface_evidence_profile_declarations(plan, at="product_experience_plan"))
     for field in PRODUCT_EXPERIENCE_REQUIRED_FIELDS:
         value = plan.get(field)
         if isinstance(value, list):
@@ -3192,8 +3327,33 @@ def validate_reference_quality_comparison(comparison: Any, *, is_pass: bool) -> 
     return errors
 
 
+def validate_surface_evidence_profile_result(
+    result: dict[str, Any],
+    profile_id: str,
+    *,
+    is_pass: bool,
+) -> list[str]:
+    errors: list[str] = []
+    if profile_id not in SURFACE_EVIDENCE_PROFILES:
+        errors.append("product_face_result.surface_evidence_profile must be one of " + ", ".join(sorted(SURFACE_EVIDENCE_PROFILES)))
+        return errors
+    if not is_pass or profile_id == "web_visual_ui":
+        return errors
+
+    block_name, required_fields = SURFACE_EVIDENCE_PROFILE_BLOCKS[profile_id]
+    evidence = result.get(block_name)
+    if not isinstance(evidence, dict) or not evidence:
+        errors.append(f"product_face_result.{block_name} is required for {profile_id} PASS")
+        return errors
+    for field in required_fields:
+        if not _list_items(evidence.get(field)):
+            errors.append(f"product_face_result.{block_name}.{field} must be a non-empty array for {profile_id} PASS")
+    return errors
+
+
 def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     errors: list[str] = []
+    errors.extend(_validate_surface_evidence_profile_declarations(result, at="product_face_result"))
     required_string = ["result", "tool_or_profile", "executed_by", "performance_note", "next_action"]
     missing_string = [field for field in required_string if not str(result.get(field) or "").strip()]
     if missing_string:
@@ -3253,6 +3413,8 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
         elif not _non_empty_text(professional_comparison.get("basis")):
             errors.append("product_face_result.professional_design_process_comparison.basis is required")
     errors.extend(validate_reference_quality_comparison(result.get("reference_quality_comparison"), is_pass=is_pass))
+    for profile_id in _declared_surface_evidence_profiles(result):
+        errors.extend(validate_surface_evidence_profile_result(result, profile_id, is_pass=is_pass))
     return errors
 
 
@@ -3281,6 +3443,17 @@ def validate_product_face_result_against_card(result: dict[str, Any], card: dict
     errors.extend(_product_delivery_quality_profile_ref_errors(card))
     if str(result.get("result") or "").upper() != "PASS":
         return errors
+
+    required_profiles = _expected_surface_evidence_profiles(card)
+    declared_profiles = set(_declared_surface_evidence_profiles(result))
+    missing_profiles = [profile for profile in required_profiles if profile not in declared_profiles]
+    if missing_profiles:
+        errors.append(
+            "product_face_result.surface_evidence_profiles missing required profile(s): "
+            + ", ".join(missing_profiles)
+        )
+    for profile_id in required_profiles:
+        errors.extend(validate_surface_evidence_profile_result(result, profile_id, is_pass=True))
 
     for field in PRODUCT_FACE_RESULT_ALIGNMENT_FIELDS:
         value = result.get(field)

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -350,6 +350,18 @@ def base_result(
         "findings_summary": "Product Face browser proof captured.",
         "tool_or_profile": tool_or_profile,
         "executed_by": "product-face-proof-runner",
+        "surface_evidence_profile": {
+            "profile_id": "web_visual_ui",
+            "surface": "web_app",
+            "evidence_kind": "visual_ui",
+        },
+        "surface_evidence_profiles": [
+            {
+                "profile_id": "web_visual_ui",
+                "surface": "web_app",
+                "evidence_kind": "visual_ui",
+            }
+        ],
         "screenshots": [],
         "viewports": [viewport.label for viewport in viewports],
         "checked_states": states,
@@ -1028,6 +1040,12 @@ def build_product_face_proof(
             approval_scope=approval_scope,
         )
     result["evidence_refs"] = [*result["evidence_refs"], repo_ref(report_path), repo_ref(result_path)]
+    profile_refs = result["evidence_refs"]
+    if isinstance(result.get("surface_evidence_profile"), dict):
+        result["surface_evidence_profile"]["evidence_refs"] = profile_refs
+    for profile in result.get("surface_evidence_profiles") or []:
+        if isinstance(profile, dict):
+            profile["evidence_refs"] = profile_refs
     if result.get("result") == "WAIVED":
         result["waiver"] = build_waiver(result)
     write_json(result_path, result)

--- a/templates/product-experience-plan.json
+++ b/templates/product-experience-plan.json
@@ -4,6 +4,7 @@
   "surface_pack": "web-app-surface-pack",
   "product_delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
   "domain_proof_required": ["generic.operator-usability"],
+  "surface_evidence_profile": "web_visual_ui",
   "experience_sot": "What the user must be able to understand and accomplish.",
   "user": "Primary user or operator who touches this surface.",
   "job_to_be_done": "The concrete job this surface must help the user complete.",

--- a/templates/product-face-packet.json
+++ b/templates/product-face-packet.json
@@ -4,6 +4,7 @@
   "mode": "greenfield",
   "product_delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
   "domain_proof_required": ["generic.operator-usability"],
+  "surface_evidence_profile": "web_visual_ui",
   "user": "Primary external or internal user.",
   "job_to_be_done": "What this user must understand or accomplish on the surface.",
   "main_flows": [

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -302,6 +302,18 @@ def product_face_result_fixture(**overrides: object) -> dict:
         "result": "PASS",
         "tool_or_profile": "browser-proof-runner",
         "executed_by": "product-face-validator",
+        "surface_evidence_profile": {
+            "profile_id": "web_visual_ui",
+            "surface": "web_app",
+            "evidence_kind": "visual_ui",
+        },
+        "surface_evidence_profiles": [
+            {
+                "profile_id": "web_visual_ui",
+                "surface": "web_app",
+                "evidence_kind": "visual_ui",
+            }
+        ],
         "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
         "viewports": ["desktop 1440x900", "mobile 390x844"],
         "checked_states": ["empty", "loading", "pending", "success", "error"],
@@ -342,6 +354,37 @@ def product_face_result_fixture(**overrides: object) -> dict:
     }
     result.update(overrides)
     return result
+
+
+def surface_profile(profile_id: str, surface: str) -> dict:
+    return {
+        "profile_id": profile_id,
+        "surface": surface,
+        "evidence_kind": {
+            "web_visual_ui": "visual_ui",
+            "cli_tui": "command_transcript",
+            "docs_onboarding": "reader_success",
+            "agentic_interface": "task_transcript",
+        }[profile_id],
+    }
+
+
+def product_surface_card_fixture(surface: str, profile_id: str) -> dict:
+    return {
+        "surfaces": [surface],
+        "product_face_packet": {
+            "surface": surface,
+            "surface_evidence_profile": profile_id,
+            "required_states": ["success", "error"],
+            "proof_required": [f"{surface} product proof"],
+        },
+        "product_experience_plan": {
+            "surface_type": surface,
+            "surface_evidence_profile": profile_id,
+            "required_states": ["success", "error"],
+            "proof_required": [f"{surface} product proof"],
+        },
+    }
 
 
 PRIVATE_NAME = "KA" + "XIS"
@@ -717,6 +760,8 @@ class FactoryCtlTest(unittest.TestCase):
                 "result": "PASS",
                 "tool_or_profile": "browser-proof-runner",
                 "executed_by": "product-face-validator",
+                "surface_evidence_profile": surface_profile("web_visual_ui", "web_app"),
+                "surface_evidence_profiles": [surface_profile("web_visual_ui", "web_app")],
                 "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
                 "viewports": ["1440x900", "390x844"],
                 "checked_states": ["empty", "loading", "pending", "success", "error"],
@@ -1118,6 +1163,63 @@ class FactoryCtlTest(unittest.TestCase):
             "product_face_result.reference_quality_comparison.reviewer_independent_from_implementation must be true",
             errors,
         )
+
+    def test_cli_tui_surface_cannot_pass_with_screenshot_only_product_face(self) -> None:
+        card = product_surface_card_fixture("cli", "cli_tui")
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("cli_tui", "cli"),
+            surface_evidence_profiles=[surface_profile("cli_tui", "cli")],
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn("product_face_result.cli_tui_evidence is required for cli_tui PASS", errors)
+
+    def test_cli_tui_surface_passes_with_command_profile_evidence(self) -> None:
+        card = product_surface_card_fixture("cli", "cli_tui")
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("cli_tui", "cli"),
+            surface_evidence_profiles=[surface_profile("cli_tui", "cli")],
+            cli_tui_evidence={
+                "golden_path_transcript_refs": ["reports/cli/golden-path.txt"],
+                "help_output_refs": ["reports/cli/help.txt"],
+                "error_state_refs": ["reports/cli/error-state.txt"],
+                "install_run_refs": ["reports/cli/install-run.txt"],
+                "cross_platform_terminal_refs": ["reports/cli/windows.txt", "reports/cli/linux.txt"],
+            },
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
+
+    def test_docs_onboarding_surface_cannot_pass_with_prose_only_product_face(self) -> None:
+        card = product_surface_card_fixture("docs", "docs_onboarding")
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("docs_onboarding", "docs"),
+            surface_evidence_profiles=[surface_profile("docs_onboarding", "docs")],
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.docs_onboarding_evidence is required for docs_onboarding PASS",
+            errors,
+        )
+
+    def test_agentic_surface_requires_task_state_control_and_recovery_evidence(self) -> None:
+        card = product_surface_card_fixture("agentic_interface", "agentic_interface")
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("agentic_interface", "agentic_interface"),
+            surface_evidence_profiles=[surface_profile("agentic_interface", "agentic_interface")],
+            agentic_interface_evidence={
+                "task_transcript_refs": ["reports/agentic/task-transcript.json"],
+                "state_transition_refs": ["reports/agentic/state-transitions.json"],
+                "approval_boundary_refs": ["reports/agentic/approval-boundaries.json"],
+                "user_control_refs": ["reports/agentic/user-control.json"],
+                "recovery_error_refs": ["reports/agentic/recovery-error.json"],
+            },
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
 
     def test_auditor_preflight_cannot_claim_pass(self) -> None:
         bad = {

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -154,6 +154,8 @@ class ProductFaceProofTest(unittest.TestCase):
 
         self.assertEqual(result["card_ref"]["card_id"], "CARD-001")
         self.assertEqual(result["card_ref"]["slice_id"], "SLICE-001")
+        self.assertEqual(result["surface_evidence_profile"]["profile_id"], "web_visual_ui")
+        self.assertEqual(result["surface_evidence_profiles"][0]["profile_id"], "web_visual_ui")
         self.assertEqual(result["journeys"], result["user_journeys_checked"])
         self.assertEqual(result["accessibility"], result["a11y"])
         self.assertEqual(result["overlap"], result["overlap_check"])


### PR DESCRIPTION
## Summary
- Adds surface-specific Product Face evidence profiles for `web_visual_ui`, `cli_tui`, `docs_onboarding`, and `agentic_interface`.
- Makes `factoryctl` derive required Product Face evidence profiles from the card/packet/experience plan and reject PASS when non-visual surfaces only provide visual/prose evidence.
- Marks the existing Product Face proof runner as an honest `web_visual_ui` runner instead of a universal proof mechanism.

Closes #205.

## Validation
- `python -m unittest tests.test_factoryctl tests.test_product_face_proof tests.test_public_json_artifact_validator -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_document_governance.py`
- `git diff --check`