### PR TITLE
[codex] Enforce Product Face usage matrix

### DIFF
--- a/docs/concepts/operator-journey.md
+++ b/docs/concepts/operator-journey.md
@@ -173,7 +173,8 @@ Intake -> Source Ledger -> Source Resolution -> Outcome & Discovery
 -> Risk/Dependency/Access/Compliance/Budget Gates -> Security Architecture
 -> Software Plan -> Experience Plan -> Data Plan -> Evals Plan when relevant
 -> Spec Graph -> Loop Plan -> Autonomy Readiness -> Ready Gate
--> Runtime execution -> Verification -> Review -> Human Gate when required
+-> Runtime execution -> Verification -> Product Face Result when product-facing
+-> Experience Gate -> Review -> Human Gate when required
 -> Completion Audit -> Production Operations -> Release or Block
 -> Learnback -> Factory Maturity Audit
 ```

--- a/docs/factory-workflow.catalog.json
+++ b/docs/factory-workflow.catalog.json
@@ -178,6 +178,7 @@
         "product_experience_plan exists and names surface_pack",
         "product_face_packet exists and names required states and proof",
         "surface_evidence_profile or surface_evidence_profiles are declared",
+        "product_delivery_quality_profile_ref or product_delivery_quality_profile is declared",
         "professional_design_process exists before product-facing implementation"
       ],
       "operator_visible_summary": "Factory is defining the product surface, states, experience bar and proof before implementation.",
@@ -340,13 +341,16 @@
       "phase_name": "Verification",
       "entry_conditions": ["implementation or proof exists"],
       "required_artifacts": ["verification_plan", "verification_result"],
-      "optional_artifacts": ["qa_verification_plan"],
+      "optional_artifacts": ["qa_verification_plan", "product_face_result"],
       "required_gates": ["Verification Gate"],
       "required_workers": ["qa-verification-worker"],
       "allowed_next_actions": ["run named checks and record outputs"],
       "blocked_actions": ["claim done without command evidence"],
       "output_locations": ["card.verification_plan", "receipt.verification_commands"],
-      "completion_detection": ["verification commands and results are attached"],
+      "completion_detection": [
+        "verification commands and results are attached",
+        "product-facing work has product_face_result with usage_evidence_matrix before completion"
+      ],
       "operator_visible_summary": "Factory is proving the work with checks.",
       "maintainer_visible_details": "Verification is scoped to the card and cannot be implied.",
       "related_schema_refs": ["schemas/qa-verification-plan.schema.json"],
@@ -418,7 +422,10 @@
       "allowed_next_actions": ["reconcile receipt with evidence"],
       "blocked_actions": ["mark done without Receipt Five"],
       "output_locations": ["card.receipt_five", "receipt artifact"],
-      "completion_detection": ["changed, artifacts, commands, review and next action exist"],
+      "completion_detection": [
+        "changed, artifacts, commands, review and next action exist",
+        "product-facing receipts include Product Face result evidence refs"
+      ],
       "operator_visible_summary": "Factory is preparing the done receipt.",
       "maintainer_visible_details": "Receipt Five is the durable proof boundary.",
       "related_schema_refs": ["schemas/receipt-five.schema.json"],

--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -163,6 +163,8 @@ Full Product Face PASS requires:
 - mobile screenshot;
 - console check;
 - important UI-state coverage;
+- usage evidence matrix tying journey, state, viewport, data condition,
+  accessibility status, performance status and evidence refs together;
 - accessibility basics;
 - overlap/layout check;
 - performance note;

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -329,6 +329,39 @@
         "additionalProperties": true
       }
     },
+    "usage_evidence_matrix": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "journey",
+          "state",
+          "viewport",
+          "data_condition",
+          "evidence_refs",
+          "a11y_status",
+          "performance_status",
+          "reviewer",
+          "basis"
+        ],
+        "properties": {
+          "journey": { "type": "string", "minLength": 1 },
+          "state": { "type": "string", "minLength": 1 },
+          "viewport": { "type": "string", "minLength": 1 },
+          "data_condition": { "type": "string", "minLength": 1 },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "a11y_status": { "enum": ["pass", "warn", "fail"] },
+          "performance_status": { "enum": ["pass", "warn", "fail"] },
+          "reviewer": { "type": "string", "minLength": 3 },
+          "basis": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": true
+      }
+    },
     "blocking_findings": {
       "type": "boolean"
     },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -470,6 +470,17 @@ PRODUCT_FACE_RESULT_ALIGNMENT_FIELDS = (
     "professional_design_process_comparison",
     "reference_quality_comparison",
 )
+USAGE_EVIDENCE_MATRIX_REQUIRED_FIELDS = (
+    "journey",
+    "state",
+    "viewport",
+    "data_condition",
+    "a11y_status",
+    "performance_status",
+    "reviewer",
+    "basis",
+)
+USAGE_EVIDENCE_ALLOWED_STATUSES = {"pass", "warn", "fail"}
 VISUAL_QUALITY_ALLOWED_RESULTS = {"PASS", "PASS_WITH_RESIDUALS", "BLOCK"}
 DOMAIN_PROOF_ALLOWED_STATUSES = {"PASS", "WARN", "FAIL", "WAIVED"}
 REFERENCE_RESEARCH_SOURCE_TYPES = {
@@ -3364,6 +3375,56 @@ def validate_surface_evidence_profile_result(
     return errors
 
 
+def _usage_evidence_matrix_entries(result: dict[str, Any]) -> list[dict[str, Any]]:
+    matrix = result.get("usage_evidence_matrix")
+    if not isinstance(matrix, list):
+        return []
+    return [entry for entry in matrix if isinstance(entry, dict)]
+
+
+def _normalized_usage_value(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _usage_viewport_family(value: Any) -> str:
+    text = _normalized_usage_value(value)
+    if "mobile" in text or "390" in text or "375" in text or "360" in text:
+        return "mobile"
+    if "desktop" in text or "1440" in text or "1366" in text:
+        return "desktop"
+    if "tablet" in text or "768" in text:
+        return "tablet"
+    if "laptop" in text or "1280" in text:
+        return "laptop"
+    return text
+
+
+def validate_usage_evidence_matrix(result: dict[str, Any], *, is_pass: bool) -> list[str]:
+    errors: list[str] = []
+    matrix = result.get("usage_evidence_matrix")
+    if is_pass and (not isinstance(matrix, list) or not matrix):
+        return ["product_face_result.usage_evidence_matrix is required for PASS"]
+    if not isinstance(matrix, list):
+        return errors
+
+    for index, entry in enumerate(matrix):
+        if not isinstance(entry, dict):
+            errors.append(f"product_face_result.usage_evidence_matrix[{index}] must be an object")
+            continue
+        for field in USAGE_EVIDENCE_MATRIX_REQUIRED_FIELDS:
+            if not _non_empty_text(entry.get(field)):
+                errors.append(f"product_face_result.usage_evidence_matrix[{index}].{field} is required")
+        if not _non_empty_string_list(entry.get("evidence_refs")):
+            errors.append(f"product_face_result.usage_evidence_matrix[{index}].evidence_refs must be a non-empty string array")
+        for field in ("a11y_status", "performance_status"):
+            status = _normalized_usage_value(entry.get(field))
+            if status and status not in USAGE_EVIDENCE_ALLOWED_STATUSES:
+                errors.append(f"product_face_result.usage_evidence_matrix[{index}].{field} must be pass, warn or fail")
+            if is_pass and status == "fail":
+                errors.append(f"product_face_result PASS cannot include usage_evidence_matrix[{index}].{field}=fail")
+    return errors
+
+
 def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     errors.extend(_validate_surface_evidence_profile_declarations(result, at="product_face_result"))
@@ -3426,6 +3487,7 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
         elif not _non_empty_text(professional_comparison.get("basis")):
             errors.append("product_face_result.professional_design_process_comparison.basis is required")
     errors.extend(validate_reference_quality_comparison(result.get("reference_quality_comparison"), is_pass=is_pass))
+    errors.extend(validate_usage_evidence_matrix(result, is_pass=is_pass))
     for profile_id in _declared_surface_evidence_profiles(result):
         errors.extend(validate_surface_evidence_profile_result(result, profile_id, is_pass=is_pass))
     return errors
@@ -3442,6 +3504,14 @@ def _required_product_states(card: dict[str, Any]) -> list[str]:
     return sorted({state.lower() for state in states})
 
 
+def _required_product_journeys(card: dict[str, Any]) -> list[str]:
+    plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
+    packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
+    journeys = _list_items(plan.get("main_flows"))
+    journeys.extend(_list_items(packet.get("main_flows")))
+    return sorted({_normalized_usage_value(journey) for journey in journeys if _normalized_usage_value(journey)})
+
+
 def _required_product_proofs(card: dict[str, Any]) -> list[str]:
     plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
     packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
@@ -3449,6 +3519,79 @@ def _required_product_proofs(card: dict[str, Any]) -> list[str]:
     proofs.extend(_list_items(packet.get("proof_required")))
     proofs.extend(_list_items(packet.get("visual_evidence_plan")))
     return [proof.lower() for proof in proofs]
+
+
+def _format_usage_combinations(combinations: list[tuple[str, str, str]]) -> str:
+    sample = ["/".join(combination) for combination in combinations[:10]]
+    remaining = len(combinations) - len(sample)
+    suffix = f" (+{remaining} more)" if remaining > 0 else ""
+    return ", ".join(sample) + suffix
+
+
+def validate_usage_evidence_matrix_against_card(result: dict[str, Any], card: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    entries = _usage_evidence_matrix_entries(result)
+    if not entries:
+        return ["product_face_result.usage_evidence_matrix is required for product-facing completion"]
+
+    covered_journeys = {_normalized_usage_value(entry.get("journey")) for entry in entries}
+    covered_states = {_normalized_usage_value(entry.get("state")) for entry in entries}
+    covered_viewports = {_usage_viewport_family(entry.get("viewport")) for entry in entries}
+    covered_combinations = {
+        (
+            _normalized_usage_value(entry.get("journey")),
+            _normalized_usage_value(entry.get("state")),
+            _usage_viewport_family(entry.get("viewport")),
+        )
+        for entry in entries
+    }
+
+    result_journeys = [_normalized_usage_value(journey) for journey in _list_items(result.get("user_journeys_checked"))]
+    missing_result_journeys = [journey for journey in result_journeys if journey and journey not in covered_journeys]
+    if missing_result_journeys:
+        errors.append(
+            "product_face_result.usage_evidence_matrix missing checked journey coverage: "
+            + ", ".join(missing_result_journeys)
+        )
+
+    missing_planned_journeys = [journey for journey in _required_product_journeys(card) if journey not in covered_journeys]
+    if missing_planned_journeys:
+        errors.append(
+            "product_face_result.usage_evidence_matrix missing planned flow coverage: "
+            + ", ".join(missing_planned_journeys)
+        )
+
+    missing_states = [state for state in _required_product_states(card) if state not in covered_states]
+    if missing_states:
+        errors.append("product_face_result.usage_evidence_matrix missing state coverage: " + ", ".join(missing_states))
+
+    required_viewport_families = sorted(
+        {family for family in (_usage_viewport_family(viewport) for viewport in _list_items(result.get("viewports"))) if family}
+    )
+    missing_viewports = [viewport for viewport in required_viewport_families if viewport not in covered_viewports]
+    if missing_viewports:
+        errors.append(
+            "product_face_result.usage_evidence_matrix missing viewport coverage: "
+            + ", ".join(missing_viewports)
+        )
+
+    required_journeys = sorted({journey for journey in result_journeys if journey} | set(_required_product_journeys(card)))
+    required_states = _required_product_states(card) or [
+        state for state in (_normalized_usage_value(state) for state in _list_items(result.get("checked_states"))) if state
+    ]
+    missing_combinations = [
+        (journey, state, viewport)
+        for journey in required_journeys
+        for state in required_states
+        for viewport in required_viewport_families
+        if (journey, state, viewport) not in covered_combinations
+    ]
+    if missing_combinations:
+        errors.append(
+            "product_face_result.usage_evidence_matrix missing required journey/state/viewport combinations: "
+            + _format_usage_combinations(missing_combinations)
+        )
+    return errors
 
 
 def validate_product_face_result_against_card(result: dict[str, Any], card: dict[str, Any]) -> list[str]:
@@ -3483,6 +3626,7 @@ def validate_product_face_result_against_card(result: dict[str, Any], card: dict
     missing_states = [state for state in _required_product_states(card) if state not in checked_states]
     if missing_states:
         errors.append("product_face_result missing states promised by Product Face Packet/Experience Plan: " + ", ".join(missing_states))
+    errors.extend(validate_usage_evidence_matrix_against_card(result, card))
 
     proofs = _required_product_proofs(card)
     viewports = " ".join(_list_items(result.get("viewports"))).lower()

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -93,6 +93,37 @@ class StaticHtmlSummary(HTMLParser):
             self.title += data.strip()
 
 
+def build_usage_evidence_matrix(
+    *,
+    viewports: list[Viewport],
+    states: list[str],
+    journeys: list[str],
+    evidence_refs: list[str],
+    data_condition: str = "configured proof data",
+    a11y_status: str = "pass",
+    performance_status: str = "pass",
+    reviewer: str = "product-face-proof-runner",
+    basis: str = "Journey, state and viewport were checked together in this Product Face proof run.",
+) -> list[dict[str, Any]]:
+    refs = [ref for ref in evidence_refs if str(ref).strip()] or ["external:product-face-proof-run"]
+    return [
+        {
+            "journey": journey,
+            "state": state,
+            "viewport": viewport.label,
+            "data_condition": data_condition,
+            "evidence_refs": refs,
+            "a11y_status": a11y_status,
+            "performance_status": performance_status,
+            "reviewer": reviewer,
+            "basis": basis,
+        }
+        for journey in journeys
+        for state in states
+        for viewport in viewports
+    ]
+
+
 def repo_ref(path: Path) -> str:
     try:
         return path.resolve().relative_to(ROOT).as_posix()
@@ -367,6 +398,13 @@ def base_result(
         "checked_states": states,
         "user_journeys_checked": journeys,
         "journeys": journeys,
+        "usage_evidence_matrix": build_usage_evidence_matrix(
+            viewports=viewports,
+            states=states,
+            journeys=journeys,
+            evidence_refs=[target_ref],
+            data_condition="configured proof target",
+        ),
         "a11y": {},
         "accessibility": {},
         "overlap_check": {},
@@ -811,6 +849,15 @@ def run_playwright(
             "performance_note": "; ".join(perf_notes)
             + "; browser-local static proof only, not a production performance benchmark",
             "evidence_refs": [repo_ref(state_path), repo_ref(console_path), *screenshots],
+            "usage_evidence_matrix": build_usage_evidence_matrix(
+                viewports=viewports,
+                states=states,
+                journeys=journeys,
+                evidence_refs=[repo_ref(state_path), repo_ref(console_path), *screenshots],
+                data_condition="browser-local rendered state fixture",
+                a11y_status="warn" if a11y_issues else "pass",
+                performance_status="pass",
+            ),
             "next_action": (
                 "Fix blocking browser findings and rerun Product Face proof."
                 if blocking

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -297,7 +297,37 @@ def activated_game_contract_fixture() -> dict:
     }
 
 
+def usage_evidence_matrix_fixture(
+    *,
+    journeys: list[str],
+    states: list[str],
+    viewports: list[str],
+) -> list[dict]:
+    entries: list[dict] = []
+    for journey in journeys:
+        for state in states:
+            for viewport in viewports:
+                evidence_ref = "reports/product-face/mobile.png" if "mobile" in viewport.lower() else "reports/product-face/desktop.png"
+                entries.append(
+                    {
+                        "journey": journey,
+                        "state": state,
+                        "viewport": viewport,
+                        "data_condition": f"{state} fixture",
+                        "evidence_refs": [evidence_ref],
+                        "a11y_status": "pass",
+                        "performance_status": "pass",
+                        "reviewer": "product-face-reviewer",
+                        "basis": f"{journey} was checked in {state} state on {viewport}.",
+                    }
+                )
+    return entries
+
+
 def product_face_result_fixture(**overrides: object) -> dict:
+    viewports = ["desktop 1440x900", "mobile 390x844"]
+    states = ["empty", "loading", "pending", "success", "error"]
+    journeys = ["pilot status review", "review evidence inspection"]
     result = {
         "result": "PASS",
         "tool_or_profile": "browser-proof-runner",
@@ -315,9 +345,10 @@ def product_face_result_fixture(**overrides: object) -> dict:
             }
         ],
         "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
-        "viewports": ["desktop 1440x900", "mobile 390x844"],
-        "checked_states": ["empty", "loading", "pending", "success", "error"],
-        "user_journeys_checked": ["dashboard to detail", "settings save"],
+        "viewports": viewports,
+        "checked_states": states,
+        "user_journeys_checked": journeys,
+        "usage_evidence_matrix": usage_evidence_matrix_fixture(journeys=journeys, states=states, viewports=viewports),
         "a11y": {"status": "pass", "keyboard": "pass", "labels": "pass", "contrast": "pass"},
         "overlap_check": {"status": "pass", "desktop": "pass", "mobile": "pass"},
         "console": {"status": "pass"},
@@ -814,9 +845,14 @@ class FactoryCtlTest(unittest.TestCase):
                 "surface_evidence_profile": surface_profile("web_visual_ui", "web_app"),
                 "surface_evidence_profiles": [surface_profile("web_visual_ui", "web_app")],
                 "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
-                "viewports": ["1440x900", "390x844"],
+                "viewports": ["desktop 1440x900", "mobile 390x844"],
                 "checked_states": ["empty", "loading", "pending", "success", "error"],
-                "user_journeys_checked": ["dashboard to detail", "settings save"],
+                "user_journeys_checked": ["pilot status review", "review evidence inspection"],
+                "usage_evidence_matrix": usage_evidence_matrix_fixture(
+                    journeys=["pilot status review", "review evidence inspection"],
+                    states=["empty", "loading", "pending", "success", "error"],
+                    viewports=["desktop 1440x900", "mobile 390x844"],
+                ),
                 "a11y": {"status": "pass", "keyboard": "pass", "labels": "pass", "contrast": "pass"},
                 "overlap_check": {"status": "pass", "desktop": "pass", "mobile": "pass"},
                 "performance_note": "static validation scenario only",
@@ -916,6 +952,68 @@ class FactoryCtlTest(unittest.TestCase):
             "product_face_result.domain_proof_coverage missing required product delivery proof ids: game.playable-smoke",
             errors,
         )
+
+    def test_product_face_completion_requires_usage_evidence_matrix(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        result = product_face_result_fixture(usage_evidence_matrix=[])
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn("product_face_result.usage_evidence_matrix is required for PASS", errors)
+        self.assertIn("product_face_result.usage_evidence_matrix is required for product-facing completion", errors)
+
+    def test_product_face_completion_requires_usage_matrix_planned_flow_coverage(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        result = product_face_result_fixture()
+        result["usage_evidence_matrix"] = [
+            entry for entry in result["usage_evidence_matrix"] if entry["journey"] != "review evidence inspection"
+        ]
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.usage_evidence_matrix missing checked journey coverage: review evidence inspection",
+            errors,
+        )
+        self.assertIn(
+            "product_face_result.usage_evidence_matrix missing planned flow coverage: review evidence inspection",
+            errors,
+        )
+
+    def test_product_face_completion_rejects_disconnected_usage_dimensions(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        result = product_face_result_fixture()
+        result["usage_evidence_matrix"] = [
+            entry
+            for entry in result["usage_evidence_matrix"]
+            if not (
+                entry["journey"] == "pilot status review"
+                and entry["state"] == "pending"
+                and "mobile" in entry["viewport"]
+            )
+        ]
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.usage_evidence_matrix missing required journey/state/viewport combinations: "
+            "pilot status review/pending/mobile",
+            errors,
+        )
+
+    def test_product_face_completion_requires_usage_matrix_state_and_viewport_coverage(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        result = product_face_result_fixture()
+        result["usage_evidence_matrix"] = [
+            entry
+            for entry in result["usage_evidence_matrix"]
+            if entry["state"] != "pending" and "mobile" not in entry["viewport"]
+        ]
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn("product_face_result.usage_evidence_matrix missing state coverage: pending", errors)
+        self.assertIn("product_face_result.usage_evidence_matrix missing viewport coverage: mobile", errors)
 
     def test_product_face_completion_requires_activated_pack_domain_proofs(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -100,6 +100,7 @@ class ProductFaceProofTest(unittest.TestCase):
             "viewports",
             "checked_states",
             "user_journeys_checked",
+            "usage_evidence_matrix",
             "a11y",
             "overlap_check",
             "performance_note",
@@ -118,6 +119,10 @@ class ProductFaceProofTest(unittest.TestCase):
         self.assertIn(result["result"], {"PASS", "WAIVED"})
         for field in ("screenshots", "viewports", "checked_states", "user_journeys_checked", "evidence_refs"):
             self.assertTrue(result[field])
+        self.assertTrue(result["usage_evidence_matrix"])
+        first_matrix_entry = result["usage_evidence_matrix"][0]
+        for field in ("journey", "state", "viewport", "data_condition", "evidence_refs", "a11y_status", "performance_status"):
+            self.assertIn(field, first_matrix_entry)
         self.assertTrue(result["a11y"])
         self.assertTrue(result["overlap_check"])
         self.assertIn(result["visual_quality_result"]["status"], {"BLOCK", "PASS", "PASS_WITH_RESIDUALS"})


### PR DESCRIPTION
## Summary
- Adds `usage_evidence_matrix` to Product Face results so UX proof ties journeys, states, viewports, data conditions, evidence refs, accessibility and performance together.
- Makes Product Face PASS/completion fail closed when required journey/state/viewport combinations are missing, instead of accepting disconnected checklist fields.
- Updates the Product Face proof runner and public workflow docs/catalog so generated proof and method guidance stay aligned.

## Root Cause
Product Face evidence had the right categories, but they were independent lists. That allowed a product to look covered while never proving the actual combinations a real user experiences.

## Validation
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\factoryctl.py doctor --json`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\quickstart_smoke.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\validate_document_governance.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\factoryctl.py run minimal --out .tmp\issue218-minimal-result.json --packets-out .tmp\issue218-minimal-packets`
- `git diff --check`

Closes #218