### PR TITLE
[codex] Control design gates and readiness concerns

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -106,6 +106,12 @@ packet comparison, source-promise coverage, design-fit review and
 `visual_quality_result` recorded as acceptable by a reviewer empowered to block
 visually unacceptable UI.
 
+`templates/professional-design-process.json` is a starter contract. Its gates
+are intentionally `PENDING`; copying that template into a card is not
+professional design approval. Product-specific implementation can proceed only
+after the card's Professional Design Process gates are `PASS`, or it remains on
+the controlled blocker path named by the gate.
+
 Reusable product example:
 
 ```bash

--- a/schemas/product-implementation-readiness.schema.json
+++ b/schemas/product-implementation-readiness.schema.json
@@ -50,6 +50,53 @@
       }
     },
     "artifact_alignment_result": { "enum": ["PASS", "CONCERNS", "FAIL", "BLOCKED"] },
+    "concern_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "concern_id",
+          "severity",
+          "owner",
+          "impact",
+          "allowed_actions",
+          "forbidden_actions",
+          "allowed_ready_work_units",
+          "expiry",
+          "next_action",
+          "evidence_refs"
+        ],
+        "properties": {
+          "concern_id": { "type": "string", "minLength": 3 },
+          "severity": { "enum": ["LOW", "MEDIUM", "HIGH", "BLOCKING"] },
+          "owner": { "type": "string", "minLength": 3 },
+          "impact": { "type": "string", "minLength": 3 },
+          "allowed_actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "forbidden_actions": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "allowed_ready_work_units": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "expiry": { "type": "string", "minLength": 3 },
+          "next_action": { "type": "string", "minLength": 3 },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
     "requirements_trace": { "type": "array", "minItems": 1, "items": { "type": "object" } },
     "cross_slice_decision_coverage": { "type": "array", "items": { "type": "string" } },
     "experience_trace": { "type": "array", "items": { "type": "string" } },
@@ -70,5 +117,21 @@
       "items": { "type": "string", "minLength": 3 }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "artifact_alignment_result": { "const": "CONCERNS" }
+        },
+        "required": ["artifact_alignment_result"]
+      },
+      "then": {
+        "required": ["concern_items"],
+        "properties": {
+          "concern_items": { "minItems": 1 }
+        }
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/schemas/professional-design-process.schema.json
+++ b/schemas/professional-design-process.schema.json
@@ -264,17 +264,38 @@
     },
     "wireframe_gate": {
       "type": "object",
-      "required": ["status", "reviewer", "artifact_refs", "basis"],
+      "required": ["status"],
       "properties": {
-        "status": { "const": "PASS" },
+        "status": { "enum": ["PASS", "BLOCKED", "NEEDS_REWORK", "PENDING"] },
         "reviewer": { "type": "string", "minLength": 3 },
         "artifact_refs": {
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
-        "basis": { "type": "string", "minLength": 3 }
+        "basis": { "type": "string", "minLength": 3 },
+        "blocker_id": { "type": "string", "minLength": 3 },
+        "owner": { "type": "string", "minLength": 3 },
+        "next_action": { "type": "string", "minLength": 3 },
+        "proof_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
       },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "PASS" } }, "required": ["status"] },
+          "then": { "required": ["reviewer", "artifact_refs", "basis"] }
+        },
+        {
+          "if": {
+            "properties": { "status": { "enum": ["BLOCKED", "NEEDS_REWORK", "PENDING"] } },
+            "required": ["status"]
+          },
+          "then": { "required": ["blocker_id", "owner", "next_action", "basis", "proof_refs"] }
+        }
+      ],
       "additionalProperties": true
     },
     "visual_direction": {
@@ -295,9 +316,9 @@
     },
     "prototype_gate": {
       "type": "object",
-      "required": ["status", "reviewer", "artifact_refs", "basis", "real_data_states"],
+      "required": ["status"],
       "properties": {
-        "status": { "const": "PASS" },
+        "status": { "enum": ["PASS", "BLOCKED", "NEEDS_REWORK", "PENDING"] },
         "reviewer": { "type": "string", "minLength": 3 },
         "artifact_refs": {
           "type": "array",
@@ -309,8 +330,29 @@
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
+        },
+        "blocker_id": { "type": "string", "minLength": 3 },
+        "owner": { "type": "string", "minLength": 3 },
+        "next_action": { "type": "string", "minLength": 3 },
+        "proof_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
         }
       },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "PASS" } }, "required": ["status"] },
+          "then": { "required": ["reviewer", "artifact_refs", "basis", "real_data_states"] }
+        },
+        {
+          "if": {
+            "properties": { "status": { "enum": ["BLOCKED", "NEEDS_REWORK", "PENDING"] } },
+            "required": ["status"]
+          },
+          "then": { "required": ["blocker_id", "owner", "next_action", "basis", "proof_refs"] }
+        }
+      ],
       "additionalProperties": true
     },
     "design_qa_plan": {
@@ -351,9 +393,9 @@
     },
     "comparative_review_gate": {
       "type": "object",
-      "required": ["status", "reviewer_role", "must_compare_to_reference_packet", "basis", "block_when"],
+      "required": ["status"],
       "properties": {
-        "status": { "const": "PASS" },
+        "status": { "enum": ["PASS", "BLOCKED", "NEEDS_REWORK", "PENDING"] },
         "reviewer_role": { "type": "string", "minLength": 3 },
         "must_compare_to_reference_packet": { "const": true },
         "basis": { "type": "string", "minLength": 3 },
@@ -361,8 +403,29 @@
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
+        },
+        "blocker_id": { "type": "string", "minLength": 3 },
+        "owner": { "type": "string", "minLength": 3 },
+        "next_action": { "type": "string", "minLength": 3 },
+        "proof_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
         }
       },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "PASS" } }, "required": ["status"] },
+          "then": { "required": ["reviewer_role", "must_compare_to_reference_packet", "basis", "block_when"] }
+        },
+        {
+          "if": {
+            "properties": { "status": { "enum": ["BLOCKED", "NEEDS_REWORK", "PENDING"] } },
+            "required": ["status"]
+          },
+          "then": { "required": ["blocker_id", "owner", "next_action", "basis", "proof_refs"] }
+        }
+      ],
       "additionalProperties": true
     },
     "handoff_requirements": {

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -442,6 +442,23 @@ PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS = (
     "comparative_review_gate",
     "handoff_requirements",
 )
+PROFESSIONAL_DESIGN_GATE_ALLOWED_STATUSES = {"PASS", "BLOCKED", "NEEDS_REWORK", "PENDING"}
+PROFESSIONAL_DESIGN_GATE_BLOCKING_STATUSES = {"BLOCKED", "NEEDS_REWORK", "PENDING"}
+PROFESSIONAL_DESIGN_BLOCKER_REQUIRED_FIELDS = (
+    "blocker_id",
+    "owner",
+    "next_action",
+    "basis",
+)
+IMPLEMENTATION_CONCERN_ALLOWED_SEVERITIES = {"LOW", "MEDIUM", "HIGH", "BLOCKING"}
+IMPLEMENTATION_CONCERN_REQUIRED_FIELDS = (
+    "concern_id",
+    "severity",
+    "owner",
+    "impact",
+    "expiry",
+    "next_action",
+)
 PRODUCT_DELIVERY_QUALITY_PROFILE_REQUIRED_FIELDS = (
     "record_type",
     "profile_id",
@@ -2023,6 +2040,45 @@ def validate_specialist_research_contract(card: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_product_implementation_concerns(readiness: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    result = str(readiness.get("artifact_alignment_result") or "").strip().upper()
+    if result != "CONCERNS":
+        return errors
+
+    concerns = readiness.get("concern_items")
+    if not isinstance(concerns, list) or not concerns:
+        return ["product_implementation_readiness.CONCERNS requires concern_items"]
+
+    ready_work_units = _list_items(readiness.get("ready_work_units"))
+    for index, concern in enumerate(concerns):
+        if not isinstance(concern, dict):
+            errors.append(f"product_implementation_readiness.concern_items[{index}] must be an object")
+            continue
+        for field in IMPLEMENTATION_CONCERN_REQUIRED_FIELDS:
+            if not _non_empty_text(concern.get(field)):
+                errors.append(f"product_implementation_readiness.concern_items[{index}].{field} is required")
+        severity = str(concern.get("severity") or "").strip().upper()
+        if severity and severity not in IMPLEMENTATION_CONCERN_ALLOWED_SEVERITIES:
+            errors.append(
+                f"product_implementation_readiness.concern_items[{index}].severity must be LOW, MEDIUM, HIGH or BLOCKING"
+            )
+        if not _non_empty_string_list(concern.get("allowed_actions")):
+            errors.append(f"product_implementation_readiness.concern_items[{index}].allowed_actions must be non-empty")
+        if not _non_empty_string_list(concern.get("forbidden_actions")):
+            errors.append(f"product_implementation_readiness.concern_items[{index}].forbidden_actions must be non-empty")
+        if not _non_empty_string_list(concern.get("evidence_refs")):
+            errors.append(f"product_implementation_readiness.concern_items[{index}].evidence_refs must be non-empty")
+        allowed_units = _list_items(concern.get("allowed_ready_work_units"))
+        missing_ready_units = [unit for unit in ready_work_units if unit not in allowed_units]
+        if missing_ready_units:
+            errors.append(
+                "product_implementation_readiness.CONCERNS ready_work_units must be covered by "
+                f"concern_items[{index}].allowed_ready_work_units: " + ", ".join(missing_ready_units)
+            )
+    return errors
+
+
 def validate_product_creation_readiness_contract(card: dict[str, Any]) -> list[str]:
     if card.get("factory_method_version") != "OVERKILL_VFINAL":
         return []
@@ -2073,6 +2129,7 @@ def validate_product_creation_readiness_contract(card: dict[str, Any]) -> list[s
             errors.append("product_implementation_readiness.artifact_alignment_result blocks material implementation")
         if result == "PASS" and not _non_empty_string_list(readiness.get("ready_work_units")):
             errors.append("product_implementation_readiness PASS requires ready_work_units")
+        errors.extend(validate_product_implementation_concerns(readiness))
         required_readiness_proofs = _required_domain_proof_ids(card, "before_implementation")
         if required_readiness_proofs:
             proof_profile = profile or {
@@ -2939,6 +2996,43 @@ def _strict_plan_gate_enabled(plan: dict[str, Any]) -> bool:
     return str(plan.get("gate_enforcement") or "").strip().lower() in {"strict", "production"}
 
 
+def _validate_professional_design_gate(gate: dict[str, Any], *, at: str, reviewer_field: str) -> list[str]:
+    errors: list[str] = []
+    status = str(gate.get("status") or "").strip().upper()
+    if status not in PROFESSIONAL_DESIGN_GATE_ALLOWED_STATUSES:
+        errors.append(f"{at}.status must be PASS, BLOCKED, NEEDS_REWORK or PENDING")
+        return errors
+
+    if status == "PASS":
+        if not _non_empty_text(gate.get(reviewer_field)):
+            errors.append(f"{at}.{reviewer_field} is required")
+        if not _list_items(gate.get("artifact_refs")) and reviewer_field != "reviewer_role":
+            errors.append(f"{at}.artifact_refs must be a non-empty array")
+        if not _non_empty_text(gate.get("basis")):
+            errors.append(f"{at}.basis is required")
+        return errors
+
+    for field in PROFESSIONAL_DESIGN_BLOCKER_REQUIRED_FIELDS:
+        if not _non_empty_text(gate.get(field)):
+            errors.append(f"{at}.{field} is required when status is {status}")
+    if not _non_empty_string_list(gate.get("proof_refs")):
+        errors.append(f"{at}.proof_refs must be a non-empty array when status is {status}")
+    return errors
+
+
+def professional_design_process_gate_blockers(process: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    for field in ("wireframe_gate", "prototype_gate", "comparative_review_gate"):
+        gate = process.get(field) if isinstance(process.get(field), dict) else {}
+        status = str(gate.get("status") or "").strip().upper()
+        if status in PROFESSIONAL_DESIGN_GATE_BLOCKING_STATUSES:
+            next_action = str(gate.get("next_action") or "complete the controlled design gate repair").strip()
+            blockers.append(
+                f"professional_design_process.{field}.status {status} blocks product-facing implementation: {next_action}"
+            )
+    return blockers
+
+
 def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     for field in PROFESSIONAL_DESIGN_PROCESS_REQUIRED_FIELDS:
@@ -3093,14 +3187,13 @@ def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
 
     for field in ("wireframe_gate", "prototype_gate"):
         gate = process.get(field) if isinstance(process.get(field), dict) else {}
-        if gate.get("status") != "PASS":
-            errors.append(f"professional_design_process.{field}.status must be PASS before product-facing implementation")
-        if not _non_empty_text(gate.get("reviewer")):
-            errors.append(f"professional_design_process.{field}.reviewer is required")
-        if not _list_items(gate.get("artifact_refs")):
-            errors.append(f"professional_design_process.{field}.artifact_refs must be a non-empty array")
-        if not _non_empty_text(gate.get("basis")):
-            errors.append(f"professional_design_process.{field}.basis is required")
+        errors.extend(
+            _validate_professional_design_gate(
+                gate,
+                at=f"professional_design_process.{field}",
+                reviewer_field="reviewer",
+            )
+        )
 
     visual_direction = process.get("visual_direction") if isinstance(process.get("visual_direction"), dict) else {}
     for field in ("typography", "spacing", "color_semantics", "component_model", "anti_generic_commitments"):
@@ -3120,17 +3213,19 @@ def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
             errors.append(f"professional_design_process.design_qa_plan.{field} must be true")
 
     comparative = process.get("comparative_review_gate") if isinstance(process.get("comparative_review_gate"), dict) else {}
-    if comparative.get("status") != "PASS":
-        errors.append("professional_design_process.comparative_review_gate.status must be PASS")
-    if comparative.get("must_compare_to_reference_packet") is not True:
+    errors.extend(
+        _validate_professional_design_gate(
+            comparative,
+            at="professional_design_process.comparative_review_gate",
+            reviewer_field="reviewer_role",
+        )
+    )
+    comparative_status = str(comparative.get("status") or "").strip().upper()
+    if comparative_status == "PASS" and comparative.get("must_compare_to_reference_packet") is not True:
         errors.append("professional_design_process.comparative_review_gate.must_compare_to_reference_packet must be true")
-    if not _non_empty_text(comparative.get("reviewer_role")):
-        errors.append("professional_design_process.comparative_review_gate.reviewer_role is required")
-    elif "independent" not in str(comparative.get("reviewer_role") or "").strip().lower():
+    if comparative_status == "PASS" and _non_empty_text(comparative.get("reviewer_role")) and "independent" not in str(comparative.get("reviewer_role") or "").strip().lower():
         errors.append("professional_design_process.comparative_review_gate.reviewer_role must identify an independent design/Product Face reviewer")
-    if not _non_empty_text(comparative.get("basis")):
-        errors.append("professional_design_process.comparative_review_gate.basis is required")
-    if not _list_items(comparative.get("block_when")):
+    if comparative_status == "PASS" and not _list_items(comparative.get("block_when")):
         errors.append("professional_design_process.comparative_review_gate.block_when must be a non-empty array")
 
     return errors
@@ -3287,6 +3382,7 @@ def validate_card(data: dict[str, Any]) -> list[str]:
                 errors.append("professional_design_process required for vFinal product-facing surfaces")
             else:
                 errors.extend(validate_professional_design_process(data["professional_design_process"]))
+                errors.extend(professional_design_process_gate_blockers(data["professional_design_process"]))
     phase = str(data.get("phase", "")).upper()
     if product_experience_surface_required(data) and phase in {"F11", "F16", "F17"}:
         if not isinstance(data.get("product_face_result"), dict) and not str(data.get("product_face_result_ref") or "").strip():

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -78,6 +78,9 @@ REFERENCE_COMPARISON_DIMENSIONS = (
     "visual_language",
     "density_spacing",
 )
+PROFESSIONAL_DESIGN_GATE_ALLOWED_STATUSES = {"PASS", "BLOCKED", "NEEDS_REWORK", "PENDING"}
+PROFESSIONAL_DESIGN_GATE_BLOCKING_STATUSES = {"BLOCKED", "NEEDS_REWORK", "PENDING"}
+PROFESSIONAL_DESIGN_BLOCKER_FIELDS = ("blocker_id", "owner", "next_action", "basis")
 PRIVATE_USERS_PATH = "C:" + r"[\\/]+" + "Users"
 PRIVATE_SYNC_ROOT = "One" + "Drive"
 PRIVATE_MARKERS = re.compile(
@@ -514,10 +517,18 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                 errors.append(f"{at}.reference_research.reference_evidence_policy.{field}: must be true")
         for gate_name in ("wireframe_gate", "prototype_gate", "comparative_review_gate"):
             gate = data.get(gate_name) if isinstance(data.get(gate_name), dict) else {}
-            if gate.get("status") != "PASS":
-                errors.append(f"{at}: professional_design_process {gate_name}.status must be PASS")
+            status = str(gate.get("status") or "").strip().upper()
+            if status not in PROFESSIONAL_DESIGN_GATE_ALLOWED_STATUSES:
+                errors.append(f"{at}: professional_design_process {gate_name}.status must be PASS, BLOCKED, NEEDS_REWORK or PENDING")
+            elif status in PROFESSIONAL_DESIGN_GATE_BLOCKING_STATUSES:
+                for field in PROFESSIONAL_DESIGN_BLOCKER_FIELDS:
+                    if not str(gate.get(field) or "").strip():
+                        errors.append(f"{at}: professional_design_process {gate_name}.{field} is required when status is {status}")
+                if not gate.get("proof_refs"):
+                    errors.append(f"{at}: professional_design_process {gate_name}.proof_refs is required when status is {status}")
         reviewer_role = str((data.get("comparative_review_gate") or {}).get("reviewer_role") or "").lower()
-        if "independent" not in reviewer_role:
+        comparative_status = str((data.get("comparative_review_gate") or {}).get("status") or "").strip().upper()
+        if comparative_status == "PASS" and "independent" not in reviewer_role:
             errors.append(f"{at}: professional_design_process comparative_review_gate requires an independent reviewer")
     if data.get("record_type") == "factory_learning_proposal":
         serialized_refs = "\n".join(str(ref) for ref in data.get("source_evidence_refs", []))

--- a/templates/product-implementation-readiness.json
+++ b/templates/product-implementation-readiness.json
@@ -20,6 +20,20 @@
     }
   ],
   "artifact_alignment_result": "CONCERNS",
+  "concern_items": [
+    {
+      "concern_id": "scope-fit-bounded-slice",
+      "severity": "MEDIUM",
+      "owner": "factory-orchestrator",
+      "impact": "The first work unit may execute, but it cannot claim complete-product acceptance until the remaining Product SOT scope is proven.",
+      "allowed_actions": ["execute work-unit-001 within Product SOT scope"],
+      "forbidden_actions": ["claim complete product done from one bounded slice"],
+      "allowed_ready_work_units": ["work-unit-001"],
+      "expiry": "until Product SOT scope coverage changes",
+      "next_action": "execute work-unit-001 and preserve the complete-product scope gate for later units",
+      "evidence_refs": ["templates/full-product-sot-scope-coverage.json"]
+    }
+  ],
   "requirements_trace": [
     {
       "requirement_ref": "product-sot#scope-in-001",

--- a/templates/professional-design-process.json
+++ b/templates/professional-design-process.json
@@ -333,12 +333,16 @@
     "density_rationale": "Use dense, quiet, repeatable product-tool layout for operators instead of a landing page or generic analytics dashboard."
   },
   "wireframe_gate": {
-    "status": "PASS",
+    "status": "PENDING",
+    "blocker_id": "wireframe-review-pending",
+    "owner": "product-face",
+    "next_action": "Run product-specific wireframe review against this surface's task map and UX architecture.",
     "reviewer": "product-face",
     "artifact_refs": [
       "templates/professional-design-process.json#ux_architecture"
     ],
-    "basis": "Layout separates source, state, work queue and inspector before visual styling."
+    "basis": "Starter template records the expected wireframe review path, but it is not product-specific approval.",
+    "proof_refs": ["templates/professional-design-process.json#ux_architecture"]
   },
   "visual_direction": {
     "typography": "Compact system UI scale; no hero-scale type inside product tools.",
@@ -352,12 +356,16 @@
     ]
   },
   "prototype_gate": {
-    "status": "PASS",
+    "status": "PENDING",
+    "blocker_id": "prototype-review-pending",
+    "owner": "product-face",
+    "next_action": "Run product-specific prototype review with real states before implementation approval.",
     "reviewer": "product-face",
     "artifact_refs": [
       "templates/professional-design-process.json"
     ],
-    "basis": "Prototype must cover real state categories and unhappy paths before implementation.",
+    "basis": "Starter template names the prototype review requirements, but it is not product-specific approval.",
+    "proof_refs": ["templates/professional-design-process.json#design_qa_plan"],
     "real_data_states": [
       "long dense data",
       "blocked gate",
@@ -392,10 +400,14 @@
     "overlap_check_required": true
   },
   "comparative_review_gate": {
-    "status": "PASS",
+    "status": "PENDING",
+    "blocker_id": "comparative-review-pending",
+    "owner": "independent-product-face-reviewer",
+    "next_action": "Compare the implemented product surface side-by-side against selected references and record product-specific evidence.",
     "reviewer_role": "independent-product-face-reviewer",
     "must_compare_to_reference_packet": true,
-    "basis": "Independent Product Face reviewer must compare the implemented surface side-by-side against selected references, the pattern synthesis, task model and Product Face packet before approval.",
+    "basis": "Starter template defines the comparative review gate; PASS requires product-specific side-by-side evidence.",
+    "proof_refs": ["templates/professional-design-process.json#reference_research"],
     "block_when": [
       "The result resembles a generic dashboard rather than the product's task model.",
       "Reference research exists but did not affect layout, hierarchy, controls or state treatment.",

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -61,7 +61,10 @@ class FactorySelfImprovementTest(unittest.TestCase):
         process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
         process["reference_research"]["sources"] = process["reference_research"]["sources"][:1]
         process["reference_research"]["sources"][0]["extracted_patterns"] = ["single pattern is too weak"]
-        process["wireframe_gate"]["status"] = "BLOCK"
+        process["wireframe_gate"] = {
+            "status": "BLOCKED",
+            "basis": "Wireframe review found a product-specific blocker.",
+        }
 
         errors = factoryctl.validate_professional_design_process(process)
 
@@ -70,8 +73,56 @@ class FactorySelfImprovementTest(unittest.TestCase):
             "professional_design_process.reference_research.sources[0].extracted_patterns requires at least 2 items",
             errors,
         )
+        self.assertIn("professional_design_process.wireframe_gate.blocker_id is required when status is BLOCKED", errors)
+        self.assertIn("professional_design_process.wireframe_gate.owner is required when status is BLOCKED", errors)
+        self.assertIn("professional_design_process.wireframe_gate.next_action is required when status is BLOCKED", errors)
+        self.assertIn("professional_design_process.wireframe_gate.proof_refs must be a non-empty array when status is BLOCKED", errors)
+
+    def test_professional_design_process_accepts_controlled_blocking_gates_as_records(self) -> None:
+        process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
+        process["wireframe_gate"] = {
+            "status": "BLOCKED",
+            "blocker_id": "wireframe-state-map-missing",
+            "owner": "product-face",
+            "next_action": "Add explicit blocked and error state wireframes.",
+            "basis": "The current wireframe does not map blocked/error states.",
+            "proof_refs": ["external:wireframe-review"],
+        }
+        process["prototype_gate"] = {
+            "status": "NEEDS_REWORK",
+            "blocker_id": "prototype-real-data-missing",
+            "owner": "product-face",
+            "next_action": "Replay prototype with dense and empty data states.",
+            "basis": "Prototype review did not include realistic data states.",
+            "proof_refs": ["external:prototype-review"],
+        }
+        process["comparative_review_gate"] = {
+            "status": "PENDING",
+            "blocker_id": "comparative-review-not-run",
+            "owner": "independent-product-face-reviewer",
+            "next_action": "Run side-by-side reference comparison.",
+            "basis": "Comparative review has not executed yet.",
+            "proof_refs": ["external:comparative-review-request"],
+        }
+
+        self.assertEqual(factoryctl.validate_professional_design_process(process), [])
+
+    def test_controlled_design_gate_blocks_product_facing_implementation(self) -> None:
+        card = vfinal_card()
+        card["surfaces"] = ["frontend"]
+        card["professional_design_process"]["wireframe_gate"] = {
+            "status": "BLOCKED",
+            "blocker_id": "wireframe-state-map-missing",
+            "owner": "product-face",
+            "next_action": "Add explicit blocked and error state wireframes.",
+            "basis": "The current wireframe does not map blocked/error states.",
+            "proof_refs": ["external:wireframe-review"],
+        }
+
+        errors = factoryctl.validate_card(card)
+
         self.assertIn(
-            "professional_design_process.wireframe_gate.status must be PASS before product-facing implementation",
+            "professional_design_process.wireframe_gate.status BLOCKED blocks product-facing implementation: Add explicit blocked and error state wireframes.",
             errors,
         )
 

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -219,6 +219,44 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             factoryctl.validate_card(card),
         )
 
+    def test_product_implementation_concerns_require_structured_items(self) -> None:
+        card = self.vfinal_card()
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+        card["product_implementation_readiness"].pop("concern_items")
+
+        self.assertIn(
+            "product_implementation_readiness.CONCERNS requires concern_items",
+            factoryctl.validate_card(card),
+        )
+
+    def test_product_implementation_concerns_must_cover_ready_work_units(self) -> None:
+        card = self.vfinal_card()
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+        card["product_implementation_readiness"]["concern_items"][0]["allowed_ready_work_units"] = ["other-unit"]
+
+        self.assertIn(
+            "product_implementation_readiness.CONCERNS ready_work_units must be covered by concern_items[0].allowed_ready_work_units: work-unit-001",
+            factoryctl.validate_card(card),
+        )
+
+    def test_product_implementation_concerns_accept_controlled_ready_units(self) -> None:
+        card = self.vfinal_card()
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertNotIn("product_implementation_readiness.CONCERNS requires concern_items", errors)
+        self.assertFalse(any("allowed_ready_work_units" in error for error in errors), errors)
+
     def test_activated_capability_pack_proofs_block_readiness_when_missing(self) -> None:
         card = self.vfinal_card()
         card["surfaces"] = ["game", "3d", "asset-pipeline"]

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -229,6 +229,40 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         errors = validator.validate_node(schema, invalid_packet, "$", schemas=schemas)
         self.assertTrue(any("$.surface" in error and "not in enum" in error for error in errors))
 
+    def test_product_implementation_readiness_schema_requires_concerns(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["product-implementation-readiness.schema.json"]
+        readiness = json.loads((ROOT / "templates" / "product-implementation-readiness.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, readiness, "$", schemas=schemas, root_schema=schema), [])
+
+        invalid = json.loads(json.dumps(readiness))
+        invalid.pop("concern_items")
+        errors = validator.validate_node(schema, invalid, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("concern_items" in error for error in errors), errors)
+
+    def test_professional_design_process_schema_accepts_controlled_blocked_gate(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["professional-design-process.schema.json"]
+        process = json.loads((ROOT / "templates" / "professional-design-process.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, process, "$", schemas=schemas, root_schema=schema), [])
+
+        invalid = json.loads(json.dumps(process))
+        invalid["wireframe_gate"] = {
+            "status": "BLOCKED",
+            "basis": "Wireframe gate is blocked but lacks a controlled repair route.",
+        }
+        errors = validator.validate_node(schema, invalid, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("$.wireframe_gate" in error and "blocker_id" in error for error in errors), errors)
+        self.assertTrue(any("$.wireframe_gate" in error and "owner" in error for error in errors), errors)
+        self.assertTrue(any("$.wireframe_gate" in error and "next_action" in error for error in errors), errors)
+        self.assertTrue(any("$.wireframe_gate" in error and "proof_refs" in error for error in errors), errors)
+
     def test_resolves_internal_defs_refs(self) -> None:
         validator = load_validator()
         schema = {


### PR DESCRIPTION
## Summary
- Adds structured `concern_items` for Product Implementation Readiness `CONCERNS`, including owner, severity, allowed/forbidden actions, expiry, next action, evidence refs and explicit ready work unit coverage.
- Allows Professional Design Process gates to be valid structured `BLOCKED`, `NEEDS_REWORK` or `PENDING` records, while still blocking product-facing implementation until gates become `PASS`.
- Converts the public professional design process starter template from fake `PASS` to controlled `PENDING`, and aligns public schema/domain validators and docs.

## Root Cause
The factory had two soft spots in the gear model: `CONCERNS` could behave like an implicit pass, and design gates could only be modeled as `PASS` or invalid. That encouraged artificial approval instead of precise blocker loops.

## Validation
- `python -m unittest tests.test_factory_self_improvement tests.test_product_method_sot_planning tests.test_public_json_artifact_validator -q`
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py tests\test_factory_self_improvement.py tests\test_product_method_sot_planning.py tests\test_public_json_artifact_validator.py`
- `python scripts\validate_public_json_artifacts.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\factoryctl.py doctor --json`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\quickstart_smoke.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\validate_document_governance.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\factoryctl.py run minimal --out .tmp\issue198-minimal-result.json --packets-out .tmp\issue198-minimal-packets`
- `git diff --check`

Closes #198