### PR TITLE
[codex] Align Product Experience runtime validation

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -29,6 +29,7 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from public_refs import contains_private_kanban_task_marker, public_safe_kanban_ref, sanitize_public_refs  # noqa: E402
+from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
 
 
 def installed_asset_root() -> Path | None:
@@ -379,7 +380,17 @@ PRODUCT_EXPERIENCE_REQUIRED_FIELDS = (
     "reviewers_required",
     "done_definition",
     "human_gate",
+    "prototype_decision",
+    "device_or_viewport_scope",
+    "accessibility_scope",
+    "performance_scope",
+    "data_context",
+    "docs_onboarding",
+    "experience_qa",
+    "product_face_result_required",
 )
+PRODUCT_EXPERIENCE_BOOLEAN_FIELDS = {"product_face_result_required"}
+PRODUCT_EXPERIENCE_SCHEMA_NAME = "product-experience-plan.schema.json"
 PRODUCT_FACE_PACKET_REQUIRED_FIELDS = (
     "surface",
     "mode",
@@ -1062,6 +1073,26 @@ def load_json_like(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"{public_path_ref(path)} must contain a JSON object")
     return data
+
+
+_BUNDLED_SCHEMAS: dict[str, dict[str, Any]] | None = None
+
+
+def bundled_schemas() -> dict[str, dict[str, Any]]:
+    global _BUNDLED_SCHEMAS
+    if _BUNDLED_SCHEMAS is None:
+        schemas = load_schemas()
+        schema_dir = ROOT / "schemas"
+        if schema_dir.exists():
+            for path in sorted(schema_dir.glob("*.json")):
+                schema = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(schema, dict):
+                    schemas[path.name] = schema
+                    schema_id = str(schema.get("$id") or "")
+                    if schema_id:
+                        schemas[schema_id.rsplit("/", 1)[-1]] = schema
+        _BUNDLED_SCHEMAS = schemas
+    return _BUNDLED_SCHEMAS
 
 
 def load_profile_bindings() -> dict[str, dict[str, Any]]:
@@ -2616,12 +2647,34 @@ def validate_product_face_packet(packet: dict[str, Any], *, strict: bool) -> lis
     return errors
 
 
+def _format_product_experience_schema_error(error: str) -> str:
+    missing = re.fullmatch(r"(product_experience_plan(?:\.[^:]+)?): missing required field ([A-Za-z0-9_]+)", error)
+    if missing:
+        return f"{missing.group(1)}.{missing.group(2)} is required"
+    expected_type = re.fullmatch(r"(product_experience_plan(?:\.[^:]+)?): expected type ([A-Za-z0-9_]+)", error)
+    if expected_type:
+        return f"{expected_type.group(1)} must be {expected_type.group(2)}"
+    return error
+
+
+def validate_product_experience_plan_schema(plan: dict[str, Any]) -> list[str]:
+    schemas = bundled_schemas()
+    schema = schemas.get(PRODUCT_EXPERIENCE_SCHEMA_NAME)
+    if not isinstance(schema, dict):
+        return [f"{PRODUCT_EXPERIENCE_SCHEMA_NAME} is unavailable for product_experience_plan validation"]
+    errors = validate_node(schema, plan, "product_experience_plan", schemas=schemas, root_schema=schema)
+    return [_format_product_experience_schema_error(error) for error in errors]
+
+
 def validate_product_experience_plan(plan: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
+    errors: list[str] = validate_product_experience_plan_schema(plan)
     errors.extend(_validate_surface_evidence_profile_declarations(plan, at="product_experience_plan"))
     for field in PRODUCT_EXPERIENCE_REQUIRED_FIELDS:
         value = plan.get(field)
-        if isinstance(value, list):
+        if field in PRODUCT_EXPERIENCE_BOOLEAN_FIELDS:
+            if not isinstance(value, bool):
+                errors.append(f"product_experience_plan.{field} must be boolean")
+        elif isinstance(value, list):
             if not _list_items(value):
                 errors.append(f"product_experience_plan.{field} must be a non-empty array")
         elif isinstance(value, dict):
@@ -2643,7 +2696,9 @@ def validate_product_experience_plan(plan: dict[str, Any]) -> list[str]:
         if human_gate.get("required") is True and not _non_empty_text(human_gate.get("approver")):
             errors.append("product_experience_plan.human_gate.approver is required when human gate is required")
 
-    return errors
+    return list(dict.fromkeys(errors))
+
+
 
 
 def validate_product_delivery_quality_profile(profile: dict[str, Any]) -> list[str]:

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -871,6 +871,14 @@
     "reviewers_required": ["product-face", "qa-verification-worker", "independent-reviewer"],
     "done_definition": ["experience evidence exists", "states are checked", "visual_quality_result is PASS or PASS_WITH_RESIDUALS with reviewer basis"],
     "human_gate": {"required": false, "approver": "", "reason": "No material human product decision in this template."},
+    "prototype_decision": "prototype_required_when product uncertainty or interaction risk remains before implementation",
+    "device_or_viewport_scope": ["primary desktop or command viewport", "secondary narrow/mobile viewport when user-facing"],
+    "accessibility_scope": ["labels", "keyboard path or command help", "contrast/readability basics"],
+    "performance_scope": ["basic render or command responsiveness", "no blocking interaction latency in primary flow"],
+    "data_context": "Use realistic empty, loading, success, blocked, error and sensitive-data-safe states.",
+    "docs_onboarding": ["first-success path for the produced surface", "operator/user handoff notes when needed"],
+    "experience_qa": ["state coverage", "viewport/device coverage", "accessibility basics", "performance note"],
+    "product_face_result_required": true,
     "evidence_refs": ["templates/vfinal-factory-card.json"]
   },
   "product_face_packet": {

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -440,6 +440,10 @@ PRIVATE_PATH_RE = re.compile(
 class FactoryCtlTest(unittest.TestCase):
     def test_local_web_cockpit_card_routes_without_discord_bridge(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "local-web-cockpit-factory-slice" / "card.md")
+        card["product_experience_plan"] = {
+            **factoryctl.load_json_like(ROOT / "templates" / "product-experience-plan.json"),
+            **card["product_experience_plan"],
+        }
         report = factoryctl.build_gate_report(card)
 
         self.assertEqual(report["card_validation_errors"], [])
@@ -741,6 +745,66 @@ class FactoryCtlTest(unittest.TestCase):
         card["product_face_result_ref"] = ".tmp/factory-runs/product-face/product-face-result.json"
 
         self.assertEqual(factoryctl.validate_card(card), [])
+
+    def test_product_experience_runtime_enforces_schema_required_fields(self) -> None:
+        schema = factoryctl.load_json_like(ROOT / "schemas" / "product-experience-plan.schema.json")
+        required_fields = schema["required"]
+
+        for field in required_fields:
+            with self.subTest(field=field):
+                card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+                card["surfaces"] = ["frontend", "product-face"]
+                card["capability_pack_contract"] = dict(card["capability_pack_contract"])
+                card["capability_pack_contract"]["covered_surfaces"] = ["frontend", "product-face"]
+                card["method_contract"] = dict(card["method_contract"])
+                card["method_contract"]["required_plans"] = ["software_development_plan", "product_experience_plan"]
+                card["product_experience_plan"] = factoryctl.load_json_like(
+                    ROOT / "templates" / "product-experience-plan.json"
+                )
+                card["product_experience_plan"].pop(field, None)
+
+                errors = factoryctl.validate_card(card)
+
+                self.assertTrue(
+                    any(error.startswith(f"product_experience_plan.{field}") for error in errors),
+                    errors,
+                )
+
+    def test_product_experience_runtime_enforces_schema_field_shapes(self) -> None:
+        cases = [
+            (
+                "product_face_result_required",
+                lambda plan: plan.__setitem__("product_face_result_required", "true"),
+                "product_experience_plan.product_face_result_required must be boolean",
+            ),
+            (
+                "human_gate_reason",
+                lambda plan: plan.__setitem__("human_gate", {"required": False, "approver": ""}),
+                "product_experience_plan.human_gate.reason is required",
+            ),
+            (
+                "visual_quality_bar_required_fields",
+                lambda plan: plan.__setitem__("visual_quality_bar", {"reference_quality_bar": "Professional bar"}),
+                "product_experience_plan.visual_quality_bar.anti_generic_criteria is required",
+            ),
+        ]
+
+        for name, mutate, expected_error in cases:
+            with self.subTest(name=name):
+                card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+                card["surfaces"] = ["frontend", "product-face"]
+                card["capability_pack_contract"] = dict(card["capability_pack_contract"])
+                card["capability_pack_contract"]["covered_surfaces"] = ["frontend", "product-face"]
+                card["method_contract"] = dict(card["method_contract"])
+                card["method_contract"]["required_plans"] = ["software_development_plan", "product_experience_plan"]
+                card["product_experience_plan"] = factoryctl.load_json_like(
+                    ROOT / "templates" / "product-experience-plan.json"
+                )
+                mutate(card["product_experience_plan"])
+
+                errors = factoryctl.validate_card(card)
+
+                self.assertIn(expected_error, errors)
 
     def test_data_metrics_plan_rejects_prose_only_or_empty_delivery_proof(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")


### PR DESCRIPTION
## Summary

Closes #194.

This aligns the Product Experience runtime gate with the public `product-experience-plan.schema.json` contract.

## What changed

- `factoryctl validate-card` now validates inline `product_experience_plan` objects against the bundled Product Experience schema before applying domain-specific rules.
- Schema loading now works both from a repository checkout and from the installed package asset root.
- The vFinal card template now includes the Product Experience fields that the schema already required: prototype decision, viewport/device scope, accessibility, performance, data context, onboarding, QA and Product Face result requirement.
- Tests now prove Product Experience fails closed when required top-level fields are removed and when schema-shaped fields are malformed, including boolean/string mismatch, missing `human_gate.reason`, and incomplete `visual_quality_bar`.

## Scope guard

- Did not touch #84 or the local-first cockpit card implementation.
- Did not dereference `product_face_result_ref` and did not enforce screenshot freshness/hash/existence here. Those remain #195/#196 territory.
- No historical audit artifacts or private evidence were added to the public repo.

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_product_experience_runtime_enforces_schema_required_fields tests.test_factoryctl.FactoryCtlTest.test_product_experience_runtime_enforces_schema_field_shapes tests.test_factoryctl.FactoryCtlTest.test_vfinal_product_surface_accepts_product_experience_os_contract tests.test_factoryctl.FactoryCtlTest.test_local_web_cockpit_card_routes_without_discord_bridge -q`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/validate_public_json_artifacts.py`
- `python -m unittest tests.test_factoryctl tests.test_public_json_artifact_validator -q`
- `python -m unittest discover -s tests -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m compileall -q scripts tests`
- `git diff --check`
- Installed-package smoke outside checkout: `factoryctl --help`, `factoryctl doctor --json`, `factoryctl run minimal`, and `overkill-quickstart`