### PR TITLE
[codex] Validate Product Face result refs

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3501,8 +3501,13 @@ def validate_card(data: dict[str, Any]) -> list[str]:
                 errors.extend(validate_professional_design_process(data["professional_design_process"]))
                 errors.extend(professional_design_process_gate_blockers(data["professional_design_process"]))
     phase = str(data.get("phase", "")).upper()
-    if product_experience_surface_required(data) and phase in {"F11", "F16", "F17"}:
-        if not isinstance(data.get("product_face_result"), dict) and not str(data.get("product_face_result_ref") or "").strip():
+    if product_face_result_required(data):
+        product_face_result = data.get("product_face_result")
+        if isinstance(product_face_result, dict):
+            errors.extend(validate_product_face_result_against_card(product_face_result, data))
+        elif str(data.get("product_face_result_ref") or "").strip():
+            errors.extend(validate_product_face_result_ref(data, str(data.get("product_face_result_ref") or "")))
+        else:
             errors.append("product_face_result or product_face_result_ref required before decomposition/release")
     runtime_contract = data.get("runtime_contract", {}) if isinstance(data.get("runtime_contract"), dict) else {}
     if runtime_contract.get("remote_proof_required") is True:
@@ -3877,6 +3882,53 @@ def validate_product_face_result_against_card(result: dict[str, Any], card: dict
         )
 
     return errors
+
+
+def _terminal_product_face_result_path_errors(ref: str) -> tuple[Path | None, list[str]]:
+    normalized = ref.strip().replace("\\", "/")
+    if normalized.startswith(("http://", "https://", "external:", "repo://")):
+        return (
+            None,
+            [
+                "product_face_result_ref external refs cannot satisfy full product acceptance "
+                "without an inline or validated local/sanitized product_face_result package"
+            ],
+        )
+    if normalized.startswith("file://") or Path(ref).is_absolute() or ":" in normalized.split("/", 1)[0]:
+        return None, [f"product_face_result_ref must be repo-relative or explicit bounded external ref: {ref}"]
+
+    candidate = (ROOT / normalized).resolve()
+    try:
+        candidate.relative_to(ROOT.resolve())
+    except ValueError:
+        return None, [f"product_face_result_ref escapes repo root: {ref}"]
+    if not candidate.exists():
+        return None, [f"product_face_result_ref does not exist: {ref}"]
+    if not candidate.is_file():
+        return None, [f"product_face_result_ref must point to a file: {ref}"]
+    return candidate, []
+
+
+def validate_product_face_result_ref(card: dict[str, Any], ref: str) -> list[str]:
+    ref = ref.strip()
+    if not ref:
+        return ["product_face_result_ref is required"]
+    path, errors = _terminal_product_face_result_path_errors(ref)
+    if errors:
+        return errors
+    assert path is not None
+    try:
+        result = load_json_like(path)
+    except json.JSONDecodeError as exc:
+        return [f"product_face_result_ref is not valid JSON: {ref}: {exc.msg}"]
+    except ValueError as exc:
+        return [f"product_face_result_ref must contain a JSON object: {ref}: {exc}"]
+
+    if not worker_result_is_active(result):
+        return [f"product_face_result_ref {ref}: referenced product_face_result is inactive or superseded"]
+
+    result_errors = validate_product_face_result_against_card(result, card)
+    return [f"product_face_result_ref {ref}: {error}" for error in result_errors]
 
 
 def _coverage_keys(coverage: object) -> list[str]:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import shutil
 import sys
 import tempfile
 import unittest
@@ -438,6 +439,25 @@ PRIVATE_PATH_RE = re.compile(
 
 
 class FactoryCtlTest(unittest.TestCase):
+    def terminal_product_face_ref_card(self) -> dict:
+        card = dict(factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md"))
+        card["phase"] = "F16"
+        card["product_face_result_required"] = True
+        card.pop("product_face_result", None)
+        return card
+
+    def write_temp_product_face_result(self, payload: object, name: str = "product-face-result.json") -> str:
+        tmp_root = ROOT / ".tmp" / "test-product-face-result-refs"
+        tmp_root.mkdir(parents=True, exist_ok=True)
+        directory = Path(tempfile.mkdtemp(dir=tmp_root))
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        path = directory / name
+        if isinstance(payload, str):
+            path.write_text(payload, encoding="utf-8")
+        else:
+            path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return path.relative_to(ROOT).as_posix()
+
     def test_local_web_cockpit_card_routes_without_discord_bridge(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "local-web-cockpit-factory-slice" / "card.md")
         card["product_experience_plan"] = {
@@ -695,6 +715,86 @@ class FactoryCtlTest(unittest.TestCase):
             factoryctl.validate_card(card),
         )
 
+    def test_terminal_product_face_result_ref_missing_fails_closed(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        card["product_face_result_ref"] = "reports/product-face/missing-result.json"
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("product_face_result_ref does not exist: reports/product-face/missing-result.json", errors)
+
+    def test_terminal_product_face_empty_inline_result_fails_closed(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        card["product_face_result"] = {}
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("product_face_result missing result, tool_or_profile, executed_by, performance_note, next_action", errors)
+
+    def test_terminal_product_face_result_ref_missing_fails_in_all_result_phases(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        card["phase"] = "F13"
+        card["product_face_result_ref"] = "reports/product-face/missing-result.json"
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("product_face_result_ref does not exist: reports/product-face/missing-result.json", errors)
+
+    def test_terminal_product_face_result_ref_malformed_json_fails_closed(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        ref = self.write_temp_product_face_result("{not valid json")
+        card["product_face_result_ref"] = ref
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertTrue(
+            any(error.startswith(f"product_face_result_ref is not valid JSON: {ref}:") for error in errors),
+            errors,
+        )
+
+    def test_terminal_product_face_result_ref_weak_pass_fails_closed(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        weak_result = product_face_result_fixture(screenshots=["not-captured: fake"])
+        ref = self.write_temp_product_face_result(weak_result)
+        card["product_face_result_ref"] = ref
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn(
+            f"product_face_result_ref {ref}: product_face_result screenshots must reference captured artifacts",
+            errors,
+        )
+
+    def test_terminal_product_face_result_ref_stale_result_fails_closed(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        stale_result = product_face_result_fixture(active=False, superseded_by="new-product-face-result.json")
+        ref = self.write_temp_product_face_result(stale_result)
+        card["product_face_result_ref"] = ref
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn(
+            f"product_face_result_ref {ref}: referenced product_face_result is inactive or superseded",
+            errors,
+        )
+
+    def test_terminal_product_face_result_ref_valid_result_passes(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        ref = self.write_temp_product_face_result(product_face_result_fixture())
+        card["product_face_result_ref"] = ref
+
+        self.assertEqual(factoryctl.validate_card(card), [])
+
+    def test_terminal_product_face_result_ref_external_cannot_claim_full_acceptance(self) -> None:
+        card = self.terminal_product_face_ref_card()
+        card["product_face_result_ref"] = "external:operator-owned-product-face-result"
+
+        self.assertIn(
+            "product_face_result_ref external refs cannot satisfy full product acceptance "
+            "without an inline or validated local/sanitized product_face_result package",
+            factoryctl.validate_card(card),
+        )
+
     def test_vfinal_product_surface_requires_product_experience_os_contract(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
         card["surfaces"] = ["frontend", "product-face"]
@@ -742,7 +842,20 @@ class FactoryCtlTest(unittest.TestCase):
         card["method_contract"]["required_plans"] = ["software_development_plan", "product_experience_plan"]
         card["product_experience_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-experience-plan.json")
         card["product_face_packet"] = factoryctl.load_json_like(ROOT / "templates" / "product-face-packet.json")
-        card["product_face_result_ref"] = ".tmp/factory-runs/product-face/product-face-result.json"
+        journeys = ["primary happy path", "empty/loading/error path", "primary user flow", "blocked/error recovery flow"]
+        states = ["empty", "loading", "success", "error"]
+        viewports = ["desktop 1440x900", "mobile 390x844"]
+        card["product_face_result_ref"] = self.write_temp_product_face_result(
+            product_face_result_fixture(
+                checked_states=states,
+                user_journeys_checked=journeys,
+                usage_evidence_matrix=usage_evidence_matrix_fixture(
+                    journeys=journeys,
+                    states=states,
+                    viewports=viewports,
+                ),
+            )
+        )
 
         self.assertEqual(factoryctl.validate_card(card), [])
 


### PR DESCRIPTION
## What changed

- Dereferences `product_face_result_ref` during terminal Product Face card validation instead of accepting a non-empty string as proof.
- Validates referenced Product Face result JSON with the same `validate_product_face_result_against_card` path used for inline proof.
- Fails closed for missing, malformed, external-only, inactive/superseded, weak PASS, and empty inline Product Face result evidence.
- Updates the vFinal Product Experience positive test so it supplies a real temporary Product Face result instead of a dead `.tmp` placeholder ref.

## Why

`validate-card` and `gate-report` could pass a product-facing terminal phase with a dead `product_face_result_ref`. That broke the factory gear invariant: a gate was treating the pointer as evidence instead of loading and validating the evidence.

This is intentionally narrower than #196. It validates the referenced Product Face result package, but does not claim screenshot freshness/hash/viewport artifact integrity. That remains in #196.

Closes #195.

## Validation

- `python -m unittest discover -s tests -p "test*.py"` - 523 tests passing
- `python -m py_compile scripts/factoryctl.py tests/test_factoryctl.py`
- `git diff --check`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_public_json_artifacts.py`
