### PR TITLE
[codex] Require Product Face visual artifacts

### DIFF
--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -44,6 +44,38 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
     },
+    "visual_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "evidence_ref",
+          "target",
+          "viewport",
+          "state",
+          "captured_at",
+          "freshness_status"
+        ],
+        "properties": {
+          "evidence_ref": { "type": "string", "minLength": 1 },
+          "target": { "type": "string", "minLength": 1 },
+          "viewport": { "type": "string", "minLength": 1 },
+          "state": { "type": "string", "minLength": 1 },
+          "captured_at": { "type": "string", "minLength": 10 },
+          "freshness_status": { "enum": ["fresh", "bounded_external"] },
+          "sha256": {
+            "type": "string",
+            "pattern": "^(sha256:)?[a-fA-F0-9]{64}$"
+          },
+          "bounded_acceptance": { "type": "boolean" },
+          "sanitized": { "type": "boolean" },
+          "external_package_ref": { "type": "string", "minLength": 1 },
+          "expires_at": { "type": "string", "minLength": 10 },
+          "basis": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
     "surface_evidence_profile": {
       "$ref": "#/$defs/surface_evidence_profile"
     },
@@ -412,5 +444,21 @@
       "additionalProperties": true
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "result": { "const": "PASS" }
+        },
+        "required": ["result"]
+      },
+      "then": {
+        "required": ["visual_artifacts"],
+        "properties": {
+          "visual_artifacts": { "minItems": 1 }
+        }
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3643,6 +3643,125 @@ def validate_usage_evidence_matrix(result: dict[str, Any], *, is_pass: bool) -> 
     return errors
 
 
+def _is_explicit_external_ref(ref: str) -> bool:
+    normalized = ref.strip().replace("\\", "/")
+    return normalized.startswith(("http://", "https://", "external:", "repo://"))
+
+
+def _parse_artifact_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _visual_artifact_records(result: dict[str, Any]) -> list[dict[str, Any]]:
+    records = result.get("visual_artifacts")
+    if not isinstance(records, list):
+        return []
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _repo_local_artifact_path(ref: str) -> Path | None:
+    return _repo_local_json_ref_path(ref)
+
+
+def validate_visual_artifact_records(result: dict[str, Any], *, is_pass: bool) -> list[str]:
+    errors: list[str] = []
+    records_value = result.get("visual_artifacts")
+    records = _visual_artifact_records(result)
+    if is_pass and not records:
+        return ["product_face_result.visual_artifacts is required for PASS"]
+    if records_value is not None and not isinstance(records_value, list):
+        return ["product_face_result.visual_artifacts must be an array"]
+    if not records:
+        return errors
+
+    checked_states = {_normalized_usage_value(state) for state in _list_items(result.get("checked_states"))}
+    viewport_families = {_usage_viewport_family(viewport) for viewport in _list_items(result.get("viewports"))}
+    records_by_ref: dict[str, list[dict[str, Any]]] = {}
+
+    for index, record in enumerate(records):
+        at = f"product_face_result.visual_artifacts[{index}]"
+        for field in ("evidence_ref", "target", "viewport", "state", "captured_at", "freshness_status"):
+            if not _non_empty_text(record.get(field)):
+                errors.append(f"{at}.{field} is required")
+        evidence_ref = str(record.get("evidence_ref") or "").strip()
+        state = _normalized_usage_value(record.get("state"))
+        viewport_family = _usage_viewport_family(record.get("viewport"))
+        if state and checked_states and state not in checked_states:
+            errors.append(f"{at}.state must match checked_states")
+        if viewport_family and viewport_families and viewport_family not in viewport_families:
+            errors.append(f"{at}.viewport must match viewports")
+        captured_at = _parse_artifact_timestamp(record.get("captured_at"))
+        if record.get("captured_at") and captured_at is None:
+            errors.append(f"{at}.captured_at must be an ISO timestamp")
+        freshness_status = str(record.get("freshness_status") or "").strip().lower()
+        if freshness_status and freshness_status not in {"fresh", "bounded_external"}:
+            errors.append(f"{at}.freshness_status must be fresh or bounded_external")
+        expires_at = _parse_artifact_timestamp(record.get("expires_at"))
+        if record.get("expires_at") and expires_at is None:
+            errors.append(f"{at}.expires_at must be an ISO timestamp")
+        elif expires_at is not None and expires_at <= datetime.now(timezone.utc):
+            errors.append(f"{at} is stale; expires_at is in the past")
+
+        if evidence_ref:
+            records_by_ref.setdefault(evidence_ref, []).append(record)
+            if _is_explicit_external_ref(evidence_ref):
+                if record.get("bounded_acceptance") is not True:
+                    errors.append(f"{at}.bounded_acceptance=true is required for external visual evidence")
+                if record.get("sanitized") is not True:
+                    errors.append(f"{at}.sanitized=true is required for external visual evidence")
+                if not _non_empty_text(record.get("external_package_ref")):
+                    errors.append(f"{at}.external_package_ref is required for external visual evidence")
+            else:
+                ref_errors = _evidence_ref_errors([evidence_ref], ROOT)
+                errors.extend(f"{at}: {error}" for error in ref_errors)
+                path = _repo_local_artifact_path(evidence_ref)
+                sha256_value = str(record.get("sha256") or "").strip().removeprefix("sha256:")
+                if path is not None and path.is_file() and sha256_value:
+                    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+                    if actual != sha256_value:
+                        errors.append(f"{at}.sha256 does not match evidence_ref")
+
+    for screenshot in _list_items(result.get("screenshots")):
+        if screenshot and screenshot not in records_by_ref:
+            errors.append(f"product_face_result.screenshots entry lacks visual_artifacts record: {screenshot}")
+
+    matrix = result.get("usage_evidence_matrix")
+    if isinstance(matrix, list):
+        for index, entry in enumerate(matrix):
+            if not isinstance(entry, dict):
+                continue
+            entry_state = _normalized_usage_value(entry.get("state"))
+            entry_viewport = _usage_viewport_family(entry.get("viewport"))
+            entry_refs = _list_items(entry.get("evidence_refs"))
+            has_binding = False
+            for ref in entry_refs:
+                for record in records_by_ref.get(ref, []):
+                    if (
+                        _normalized_usage_value(record.get("state")) == entry_state
+                        and _usage_viewport_family(record.get("viewport")) == entry_viewport
+                    ):
+                        has_binding = True
+                        break
+                if has_binding:
+                    break
+            if not has_binding:
+                errors.append(
+                    f"product_face_result.usage_evidence_matrix[{index}] lacks visual_artifacts binding for state/viewport"
+                )
+    return errors
+
+
 def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     errors.extend(_validate_surface_evidence_profile_declarations(result, at="product_face_result"))
@@ -3706,6 +3825,7 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
             errors.append("product_face_result.professional_design_process_comparison.basis is required")
     errors.extend(validate_reference_quality_comparison(result.get("reference_quality_comparison"), is_pass=is_pass))
     errors.extend(validate_usage_evidence_matrix(result, is_pass=is_pass))
+    errors.extend(validate_visual_artifact_records(result, is_pass=is_pass))
     for profile_id in _declared_surface_evidence_profiles(result):
         errors.extend(validate_surface_evidence_profile_result(result, profile_id, is_pass=is_pass))
     return errors
@@ -6535,13 +6655,50 @@ def build_worker_result(
             }
         )
     if worker_id == "product-face":
+        product_face_viewports = ["synthetic-desktop", "synthetic-mobile"] if evidence_kind == "synthetic" else ["desktop 1440x900"]
+        product_face_states = ["default", "empty", "loading", "error", "success"]
+        product_face_journeys = ["open target", "inspect states"]
+        product_face_visual_artifacts = [
+            {
+                "evidence_ref": ref,
+                "target": source_card_ref(Path("<memory>")),
+                "viewport": viewport,
+                "state": state,
+                "captured_at": utc_now(),
+                "freshness_status": "bounded_external" if _is_explicit_external_ref(ref) else "fresh",
+                "bounded_acceptance": True,
+                "sanitized": True,
+                "external_package_ref": "external:product-face-worker-result-package",
+                "basis": "Generated Product Face worker result binds evidence to declared viewport and state.",
+            }
+            for ref in evidence_refs
+            for viewport in product_face_viewports
+            for state in product_face_states
+        ]
         payload.update(
             {
                 "screenshots": evidence_refs,
-                "viewports": ["synthetic-desktop", "synthetic-mobile"] if evidence_kind == "synthetic" else [],
-                "checked_states": ["default", "empty", "loading", "error", "success"],
-                "journeys": ["open target", "inspect states"],
-                "user_journeys_checked": ["open target", "inspect states"],
+                "viewports": product_face_viewports,
+                "checked_states": product_face_states,
+                "journeys": product_face_journeys,
+                "user_journeys_checked": product_face_journeys,
+                "usage_evidence_matrix": [
+                    {
+                        "journey": journey,
+                        "state": state,
+                        "viewport": viewport,
+                        "data_condition": f"{state} fixture",
+                        "evidence_refs": evidence_refs,
+                        "a11y_status": "pass" if not blocking_findings else "fail",
+                        "performance_status": "pass" if not blocking_findings else "fail",
+                        "reviewer": "product-face-validator",
+                        "basis": "Generated Product Face result binds journey, state, viewport and evidence refs.",
+                    }
+                    for journey in product_face_journeys
+                    for state in product_face_states
+                    for viewport in product_face_viewports
+                ],
+                "visual_artifacts": product_face_visual_artifacts,
                 "accessibility": {"checked": True, "mode": evidence_kind},
                 "a11y": {"status": "pass" if not blocking_findings else "fail", "mode": evidence_kind},
                 "overlap": {"checked": True, "mode": evidence_kind},

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -124,6 +124,57 @@ def build_usage_evidence_matrix(
     ]
 
 
+def _repo_ref_path(ref: str) -> Path | None:
+    normalized = ref.strip().replace("\\", "/")
+    if normalized.startswith(("http://", "https://", "external:", "repo://", "file://")):
+        return None
+    if Path(ref).is_absolute() or ":" in normalized.split("/", 1)[0]:
+        return None
+    candidate = (ROOT / normalized).resolve()
+    try:
+        candidate.relative_to(ROOT)
+    except ValueError:
+        return None
+    return candidate
+
+
+def build_visual_artifacts(
+    *,
+    target_ref: str,
+    viewports: list[Viewport],
+    states: list[str],
+    screenshot_refs: list[str],
+    captured_at: str | None = None,
+) -> list[dict[str, Any]]:
+    captured_at = captured_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    artifacts: list[dict[str, Any]] = []
+    for viewport, screenshot_ref in zip(viewports, screenshot_refs):
+        for state in states:
+            artifact: dict[str, Any] = {
+                "evidence_ref": screenshot_ref,
+                "target": target_ref,
+                "viewport": viewport.label,
+                "state": state,
+                "captured_at": captured_at,
+                "freshness_status": "fresh",
+                "basis": "Screenshot captured by the Product Face proof runner for this target, viewport and declared state.",
+            }
+            path = _repo_ref_path(screenshot_ref)
+            if path is not None and path.is_file():
+                artifact["sha256"] = sha256_file(path)
+            else:
+                artifact.update(
+                    {
+                        "freshness_status": "bounded_external",
+                        "bounded_acceptance": True,
+                        "sanitized": True,
+                        "external_package_ref": "external:product-face-proof-package",
+                    }
+                )
+            artifacts.append(artifact)
+    return artifacts
+
+
 def repo_ref(path: Path) -> str:
     try:
         return path.resolve().relative_to(ROOT).as_posix()
@@ -768,6 +819,7 @@ def run_playwright(
         finally:
             browser.close()
 
+    captured_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     console_path = output_dir / "console.json"
     state_path = output_dir / "state.json"
     write_json(
@@ -820,6 +872,13 @@ def run_playwright(
                 else "Browser proof captured for screenshots, console, DOM state, a11y basics, overlap and performance note."
             ),
             "screenshots": screenshots,
+            "visual_artifacts": build_visual_artifacts(
+                target_ref=target_ref,
+                viewports=viewports,
+                states=states,
+                screenshot_refs=screenshots,
+                captured_at=captured_at,
+            ),
             "a11y": {
                 "status": "warn" if a11y_issues else "pass",
                 "issues": a11y_issues,

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import re
 import shutil
@@ -308,7 +309,7 @@ def usage_evidence_matrix_fixture(
     for journey in journeys:
         for state in states:
             for viewport in viewports:
-                evidence_ref = "reports/product-face/mobile.png" if "mobile" in viewport.lower() else "reports/product-face/desktop.png"
+                evidence_ref = product_face_screenshot_ref(viewport)
                 entries.append(
                     {
                         "journey": journey,
@@ -325,10 +326,64 @@ def usage_evidence_matrix_fixture(
     return entries
 
 
+def product_face_screenshot_ref(viewport: str) -> str:
+    return (
+        "external:product-face-fixture-mobile.png"
+        if "mobile" in viewport.lower()
+        else "external:product-face-fixture-desktop.png"
+    )
+
+
+def visual_artifacts_fixture(
+    *,
+    target: str,
+    viewports: list[str],
+    states: list[str],
+    screenshots: list[str],
+    captured_at: str = "2026-06-16T00:00:00+00:00",
+) -> list[dict]:
+    artifacts: list[dict] = []
+    for viewport, screenshot in zip(viewports, screenshots):
+        for state in states:
+            artifacts.append(
+                {
+                    "evidence_ref": screenshot,
+                    "target": target,
+                    "viewport": viewport,
+                    "state": state,
+                    "captured_at": captured_at,
+                    "freshness_status": "bounded_external",
+                    "bounded_acceptance": True,
+                    "sanitized": True,
+                    "external_package_ref": "external:product-face-fixture-package",
+                    "basis": "Sanitized fixture artifact bound to the declared viewport and state.",
+                }
+            )
+    return artifacts
+
+
 def product_face_result_fixture(**overrides: object) -> dict:
+    overrides = dict(overrides)
     viewports = ["desktop 1440x900", "mobile 390x844"]
     states = ["empty", "loading", "pending", "success", "error"]
     journeys = ["pilot status review", "review evidence inspection"]
+    viewports = list(overrides.pop("viewports", viewports))  # type: ignore[arg-type]
+    states = list(overrides.pop("checked_states", states))  # type: ignore[arg-type]
+    journeys = list(overrides.pop("user_journeys_checked", journeys))  # type: ignore[arg-type]
+    screenshots = list(overrides.pop("screenshots", [product_face_screenshot_ref(viewport) for viewport in viewports]))  # type: ignore[arg-type]
+    usage_matrix = overrides.pop(
+        "usage_evidence_matrix",
+        usage_evidence_matrix_fixture(journeys=journeys, states=states, viewports=viewports),
+    )
+    visual_artifacts = overrides.pop(
+        "visual_artifacts",
+        visual_artifacts_fixture(
+            target="external:product-face-fixture-target",
+            viewports=viewports,
+            states=states,
+            screenshots=screenshots,
+        ),
+    )
     result = {
         "result": "PASS",
         "tool_or_profile": "browser-proof-runner",
@@ -345,11 +400,12 @@ def product_face_result_fixture(**overrides: object) -> dict:
                 "evidence_kind": "visual_ui",
             }
         ],
-        "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
+        "screenshots": screenshots,
         "viewports": viewports,
         "checked_states": states,
         "user_journeys_checked": journeys,
-        "usage_evidence_matrix": usage_evidence_matrix_fixture(journeys=journeys, states=states, viewports=viewports),
+        "usage_evidence_matrix": usage_matrix,
+        "visual_artifacts": visual_artifacts,
         "a11y": {"status": "pass", "keyboard": "pass", "labels": "pass", "contrast": "pass"},
         "overlap_check": {"status": "pass", "desktop": "pass", "mobile": "pass"},
         "console": {"status": "pass"},
@@ -390,7 +446,7 @@ def product_face_result_fixture(**overrides: object) -> dict:
             }
         ],
         "blocking_findings": False,
-        "evidence_refs": ["reports/product-face.md"],
+        "evidence_refs": ["external:product-face-fixture-report"],
         "next_action": "independent review",
     }
     result.update(overrides)
@@ -457,6 +513,15 @@ class FactoryCtlTest(unittest.TestCase):
         else:
             path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return path.relative_to(ROOT).as_posix()
+
+    def write_temp_visual_artifact(self, name: str = "desktop.png") -> tuple[str, str]:
+        tmp_root = ROOT / ".tmp" / "test-product-face-visual-artifacts"
+        tmp_root.mkdir(parents=True, exist_ok=True)
+        directory = Path(tempfile.mkdtemp(dir=tmp_root))
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        path = directory / name
+        path.write_bytes(b"product-face-visual-artifact")
+        return path.relative_to(ROOT).as_posix(), hashlib.sha256(path.read_bytes()).hexdigest()
 
     def test_local_web_cockpit_card_routes_without_discord_bridge(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "local-web-cockpit-factory-slice" / "card.md")
@@ -1157,63 +1222,7 @@ class FactoryCtlTest(unittest.TestCase):
             },
             "independent_review_result": worker_result("independent_review_result", source_card=card),
             "receipt_five_reconciliation_result": worker_result("receipt_five_reconciliation_result", source_card=card),
-            "product_face_result": {
-                "result": "PASS",
-                "tool_or_profile": "browser-proof-runner",
-                "executed_by": "product-face-validator",
-                "surface_evidence_profile": surface_profile("web_visual_ui", "web_app"),
-                "surface_evidence_profiles": [surface_profile("web_visual_ui", "web_app")],
-                "screenshots": ["reports/product-face/desktop.png", "reports/product-face/mobile.png"],
-                "viewports": ["desktop 1440x900", "mobile 390x844"],
-                "checked_states": ["empty", "loading", "pending", "success", "error"],
-                "user_journeys_checked": ["pilot status review", "review evidence inspection"],
-                "usage_evidence_matrix": usage_evidence_matrix_fixture(
-                    journeys=["pilot status review", "review evidence inspection"],
-                    states=["empty", "loading", "pending", "success", "error"],
-                    viewports=["desktop 1440x900", "mobile 390x844"],
-                ),
-                "a11y": {"status": "pass", "keyboard": "pass", "labels": "pass", "contrast": "pass"},
-                "overlap_check": {"status": "pass", "desktop": "pass", "mobile": "pass"},
-                "performance_note": "static validation scenario only",
-                "packet_ref": "examples/cards/v35_valid_product_face.md#product_face_packet",
-                "packet_comparison": {
-                    "status": "pass",
-                    "basis": "All planned screens, states and viewports are covered."
-                },
-                "source_promise_coverage": {
-                    "status": "pass",
-                    "basis": "The result covers the visible SaaS validation promise in the card."
-                },
-                "design_fit_review": {
-                    "status": "pass",
-                    "basis": "The validator confirmed this bounded SaaS surface matches the Product Face packet."
-                },
-                "professional_design_process_ref": "examples/cards/v35_valid_product_face.md#professional_design_process",
-                "professional_design_process_comparison": {
-                    "status": "pass",
-                    "basis": "The validator confirmed the result satisfies the professional design process gates."
-                },
-                "reference_quality_comparison": reference_quality_comparison_fixture(),
-                "visual_quality_result": {
-                    "status": "PASS",
-                    "reviewer": "product-face-reviewer",
-                    "basis": "The surface meets the Product Face packet quality bar and does not show AI-generic UI symptoms.",
-                    "reference_quality_bar_checked": True,
-                    "ai_generic_symptoms": [],
-                },
-                "domain_proof_coverage": [
-                    {
-                        "proof_id": "generic.operator-usability",
-                        "status": "PASS",
-                        "evidence_refs": ["reports/product-face/operator-usability.json"],
-                        "reviewer": "product-face-reviewer",
-                        "basis": "Operator can understand current state, evidence and next action.",
-                    }
-                ],
-                "blocking_findings": False,
-                "evidence_refs": ["reports/product-face.md"],
-                "next_action": "independent review",
-            },
+            "product_face_result": product_face_result_fixture(),
         }
 
         self.assertEqual(factoryctl.validate_completion(card, receipt), [])
@@ -1280,6 +1289,109 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertIn("product_face_result.usage_evidence_matrix is required for PASS", errors)
         self.assertIn("product_face_result.usage_evidence_matrix is required for product-facing completion", errors)
+
+    def test_product_face_pass_requires_visual_artifact_records(self) -> None:
+        result = product_face_result_fixture(visual_artifacts=[])
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn("product_face_result.visual_artifacts is required for PASS", errors)
+
+    def test_product_face_pass_rejects_missing_repo_local_visual_artifact(self) -> None:
+        result = product_face_result_fixture(
+            screenshots=["reports/product-face/missing-desktop.png"],
+            viewports=["desktop 1440x900"],
+            checked_states=["success"],
+            user_journeys_checked=["pilot status review"],
+            usage_evidence_matrix=[
+                {
+                    "journey": "pilot status review",
+                    "state": "success",
+                    "viewport": "desktop 1440x900",
+                    "data_condition": "success fixture",
+                    "evidence_refs": ["reports/product-face/missing-desktop.png"],
+                    "a11y_status": "pass",
+                    "performance_status": "pass",
+                    "reviewer": "product-face-reviewer",
+                    "basis": "Missing artifact should fail closed.",
+                }
+            ],
+            visual_artifacts=[
+                {
+                    "evidence_ref": "reports/product-face/missing-desktop.png",
+                    "target": "examples/cards/v35_valid_product_face.md",
+                    "viewport": "desktop 1440x900",
+                    "state": "success",
+                    "captured_at": "2026-06-16T00:00:00+00:00",
+                    "freshness_status": "fresh",
+                }
+            ],
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.visual_artifacts[0]: evidence ref does not exist: reports/product-face/missing-desktop.png",
+            errors,
+        )
+
+    def test_product_face_pass_rejects_stale_visual_artifact(self) -> None:
+        result = product_face_result_fixture()
+        result["visual_artifacts"][0]["freshness_status"] = "stale"
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn("product_face_result.visual_artifacts[0].freshness_status must be fresh or bounded_external", errors)
+
+    def test_product_face_pass_rejects_state_viewport_artifact_mismatch(self) -> None:
+        result = product_face_result_fixture()
+        result["visual_artifacts"] = [dict(result["visual_artifacts"][0], state="success")]
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.usage_evidence_matrix[0] lacks visual_artifacts binding for state/viewport",
+            errors,
+        )
+
+    def test_product_face_pass_accepts_resolvable_visual_artifact_with_hash(self) -> None:
+        artifact_ref, artifact_hash = self.write_temp_visual_artifact()
+        viewports = ["desktop 1440x900"]
+        states = ["success"]
+        result = product_face_result_fixture(
+            screenshots=[artifact_ref],
+            viewports=viewports,
+            checked_states=states,
+            user_journeys_checked=["pilot status review"],
+            usage_evidence_matrix=[
+                {
+                    "journey": "pilot status review",
+                    "state": "success",
+                    "viewport": "desktop 1440x900",
+                    "data_condition": "success fixture",
+                    "evidence_refs": [artifact_ref],
+                    "a11y_status": "pass",
+                    "performance_status": "pass",
+                    "reviewer": "product-face-reviewer",
+                    "basis": "Repo-local visual artifact exists and is hash-bound.",
+                }
+            ],
+            visual_artifacts=[
+                {
+                    "evidence_ref": artifact_ref,
+                    "target": "examples/cards/v35_valid_product_face.md",
+                    "viewport": "desktop 1440x900",
+                    "state": "success",
+                    "captured_at": "2026-06-16T00:00:00+00:00",
+                    "freshness_status": "fresh",
+                    "sha256": artifact_hash,
+                }
+            ],
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertEqual(errors, [])
 
     def test_product_face_completion_requires_usage_matrix_planned_flow_coverage(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -61,6 +61,15 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         errors = validator.validate_node(schema, {"result": "BLOCKED"}, "$")
         self.assertTrue(any("recovery_recommendation" in error for error in errors))
 
+    def test_product_face_result_schema_requires_visual_artifacts_for_pass(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["product-face-result.schema.json"]
+
+        errors = validator.validate_node(schema, {"result": "PASS"}, "$", schemas=schemas, root_schema=schema)
+
+        self.assertTrue(any("visual_artifacts" in error for error in errors), errors)
+
     def test_quasar_runtime_schema_requires_pinned_head_only_for_pass(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary
- Require PASS Product Face results to carry `visual_artifacts` records, not only screenshot strings.
- Validate each visual artifact for target, viewport, state, timestamp/freshness, evidence ref binding, repo-local existence and optional sha256.
- Teach the Product Face proof runner and generated worker result to emit visual artifact records.

## Why
Product Face could previously pass with free-floating screenshot refs. That let visual evidence look complete while the factory could not prove whether artifacts existed, were fresh, or matched the declared state/viewport.

## Validation
- `python -m unittest tests.test_factoryctl tests.test_product_face_proof tests.test_public_json_artifact_validator`
- `python -m py_compile scripts/factoryctl.py scripts/product_face_proof.py tests/test_factoryctl.py tests/test_product_face_proof.py tests/test_public_json_artifact_validator.py`
- `python scripts/validate_public_json_artifacts.py`
- `git diff --check`
- `python -m unittest discover -s tests -p 'test*.py'`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`

Closes #196