### PR TITLE
[codex] Bind delivery proof coverage to quality profile

### DIFF
--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -354,6 +354,13 @@
             "items": { "type": "string", "minLength": 3 }
           },
           "reviewer": { "type": "string" },
+          "reviewer_role": { "type": "string" },
+          "evidence_kind": {
+            "enum": ["contract", "runtime", "review", "domain", "human_gate"]
+          },
+          "human_gate_ref": { "type": "string" },
+          "human_gate_bounded_acceptance": { "type": "boolean" },
+          "human_gate_sanitized": { "type": "boolean" },
           "basis": { "type": "string", "minLength": 3 },
           "waiver_owner": { "type": "string" },
           "waiver_reason": { "type": "string" }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2872,6 +2872,12 @@ def _validate_delivery_profile_proof_coverage(
         errors.append(f"{at} missing product delivery proof coverage for required proof ids: " + ", ".join(required_proof_ids))
         return errors
 
+    required_set = set(required_proof_ids)
+    required_by_id = {
+        str(proof.get("proof_id") or "").strip(): proof
+        for proof in profile.get("required_proofs", [])
+        if isinstance(proof, dict) and str(proof.get("proof_id") or "").strip() in required_set
+    }
     by_id: dict[str, dict[str, Any]] = {}
     for index, item in enumerate(coverage):
         if not isinstance(item, dict):
@@ -2889,6 +2895,28 @@ def _validate_delivery_profile_proof_coverage(
             errors.append(f"{at}[{index}].evidence_refs must be non-empty")
         if not _non_empty_text(item.get("basis")):
             errors.append(f"{at}[{index}].basis is required")
+        proof_requirement = required_by_id.get(proof_id)
+        if proof_requirement and status == "PASS":
+            expected_reviewer_role = str(proof_requirement.get("reviewer_role") or "").strip()
+            actual_reviewer_role = str(item.get("reviewer_role") or item.get("reviewer") or "").strip()
+            if expected_reviewer_role and actual_reviewer_role != expected_reviewer_role:
+                errors.append(f"{at}[{index}].reviewer_role must match required proof reviewer_role {expected_reviewer_role!r}")
+            expected_evidence_kind = str(proof_requirement.get("evidence_kind") or "").strip()
+            actual_evidence_kind = str(item.get("evidence_kind") or "").strip()
+            if expected_evidence_kind and actual_evidence_kind != expected_evidence_kind:
+                errors.append(f"{at}[{index}].evidence_kind must match required proof evidence_kind {expected_evidence_kind!r}")
+            if proof_requirement.get("human_gate_required") is True:
+                human_gate_ref = str(item.get("human_gate_ref") or "").strip()
+                if not human_gate_ref:
+                    errors.append(f"{at}[{index}].human_gate_ref is required when required proof declares human_gate_required=true")
+                else:
+                    ref_errors = _evidence_ref_errors([human_gate_ref], ROOT)
+                    errors.extend(f"{at}[{index}].human_gate_ref: {error}" for error in ref_errors)
+                    if _is_explicit_external_ref(human_gate_ref):
+                        if item.get("human_gate_bounded_acceptance") is not True:
+                            errors.append(f"{at}[{index}].human_gate_bounded_acceptance=true is required for external human gate refs")
+                        if item.get("human_gate_sanitized") is not True:
+                            errors.append(f"{at}[{index}].human_gate_sanitized=true is required for external human gate refs")
         if status == "WAIVED":
             waiver = profile.get("waiver_policy") if isinstance(profile.get("waiver_policy"), dict) else {}
             if waiver.get("allowed") is not True:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -262,6 +262,40 @@ def product_delivery_quality_profile_fixture() -> dict:
     }
 
 
+def human_gated_product_delivery_quality_profile_fixture() -> dict:
+    return {
+        "record_type": "product_delivery_quality_profile",
+        "profile_id": "human-gated-product-v1",
+        "archetype": "human-gated product",
+        "applies_to_surfaces": ["frontend"],
+        "quality_dimensions": [
+            {
+                "dimension_id": "human-accepted-operator-usability",
+                "bar": "Operator usability proof is accepted by the declared human reviewer.",
+                "block_when": ["Proof is reviewed by the wrong role or lacks a human gate record."]
+            }
+        ],
+        "required_proofs": [
+            {
+                "proof_id": "generic.operator-usability",
+                "name": "Human accepted operator usability proof",
+                "required_at": ["before_completion"],
+                "owner_worker": "qa-verification-worker",
+                "reviewer_role": "human-product-owner",
+                "evidence_kind": "human_gate",
+                "human_gate_required": True,
+            }
+        ],
+        "waiver_policy": {
+            "allowed": False,
+            "requires_owner": True,
+            "requires_reason": True,
+            "cannot_claim_full_acceptance": True,
+        },
+        "evidence_refs": ["templates/product-delivery-quality-profile.json"],
+    }
+
+
 def activated_game_contract_fixture() -> dict:
     return {
         "record_type": "capability_pack_contract",
@@ -442,6 +476,8 @@ def product_face_result_fixture(**overrides: object) -> dict:
                 "status": "PASS",
                 "evidence_refs": ["reports/product-face/operator-usability.json"],
                 "reviewer": "product-face-reviewer",
+                "reviewer_role": "independent-reviewer",
+                "evidence_kind": "review",
                 "basis": "Operator can understand current state, evidence and next action.",
             }
         ],
@@ -1467,6 +1503,8 @@ class FactoryCtlTest(unittest.TestCase):
                     "status": "PASS",
                     "evidence_refs": ["reports/domain-proof/generic.operator-usability.json"],
                     "reviewer": "domain-proof-reviewer",
+                    "reviewer_role": "independent-reviewer",
+                    "evidence_kind": "review",
                     "basis": "Operator usability proof passed with structured evidence.",
                 }
             ]
@@ -1519,7 +1557,105 @@ class FactoryCtlTest(unittest.TestCase):
                     "status": "PASS",
                     "evidence_refs": ["reports/game/playable-smoke.md"],
                     "reviewer": "game-qa-specialist",
+                    "reviewer_role": "game-qa-specialist",
+                    "evidence_kind": "runtime",
                     "basis": "Playable smoke covered input, feedback and completion feedback.",
+                }
+            ]
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
+
+    def test_product_face_completion_rejects_domain_proof_wrong_reviewer_role(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_delivery_quality_profile"] = human_gated_product_delivery_quality_profile_fixture()
+        result = product_face_result_fixture(
+            domain_proof_coverage=[
+                {
+                    "proof_id": "generic.operator-usability",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/domain-proof/operator-usability.json"],
+                    "reviewer_role": "domain-proof-reviewer",
+                    "evidence_kind": "human_gate",
+                    "human_gate_ref": "external:product-owner-approval",
+                    "human_gate_bounded_acceptance": True,
+                    "human_gate_sanitized": True,
+                    "basis": "Wrong reviewer role should not satisfy the human-gated profile.",
+                }
+            ]
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.domain_proof_coverage[0].reviewer_role must match required proof reviewer_role 'human-product-owner'",
+            errors,
+        )
+
+    def test_product_face_completion_rejects_domain_proof_wrong_evidence_kind(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_delivery_quality_profile"] = human_gated_product_delivery_quality_profile_fixture()
+        result = product_face_result_fixture(
+            domain_proof_coverage=[
+                {
+                    "proof_id": "generic.operator-usability",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/domain-proof/operator-usability.json"],
+                    "reviewer_role": "human-product-owner",
+                    "evidence_kind": "review",
+                    "human_gate_ref": "external:product-owner-approval",
+                    "human_gate_bounded_acceptance": True,
+                    "human_gate_sanitized": True,
+                    "basis": "Wrong evidence kind should not satisfy the human-gated profile.",
+                }
+            ]
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.domain_proof_coverage[0].evidence_kind must match required proof evidence_kind 'human_gate'",
+            errors,
+        )
+
+    def test_product_face_completion_requires_human_gate_ref_for_human_gated_domain_proof(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_delivery_quality_profile"] = human_gated_product_delivery_quality_profile_fixture()
+        result = product_face_result_fixture(
+            domain_proof_coverage=[
+                {
+                    "proof_id": "generic.operator-usability",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/domain-proof/operator-usability.json"],
+                    "reviewer_role": "human-product-owner",
+                    "evidence_kind": "human_gate",
+                    "basis": "Missing human gate ref should fail closed.",
+                }
+            ]
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.domain_proof_coverage[0].human_gate_ref is required when required proof declares human_gate_required=true",
+            errors,
+        )
+
+    def test_product_face_completion_accepts_human_gated_domain_proof_binding(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        card["product_delivery_quality_profile"] = human_gated_product_delivery_quality_profile_fixture()
+        result = product_face_result_fixture(
+            domain_proof_coverage=[
+                {
+                    "proof_id": "generic.operator-usability",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/domain-proof/operator-usability.json"],
+                    "reviewer_role": "human-product-owner",
+                    "evidence_kind": "human_gate",
+                    "human_gate_ref": "external:product-owner-approval",
+                    "human_gate_bounded_acceptance": True,
+                    "human_gate_sanitized": True,
+                    "basis": "Human product owner approved the operator usability proof.",
                 }
             ]
         )


### PR DESCRIPTION
## Summary
- Bind Product Face `domain_proof_coverage` to the declared `product_delivery_quality_profile.required_proofs` reviewer role and evidence kind.
- Require a bounded/dereferenced human gate ref when a required proof declares `human_gate_required=true`.
- Add regressions for wrong reviewer role, wrong evidence kind, missing human gate, and a valid human-gated proof.

## Why
A final delivery proof could previously PASS by matching only `proof_id`, `status`, `evidence_refs`, and `basis`. That bypassed the authority model declared by the Product Delivery Quality Profile.

## Validation
- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_accepts_required_domain_proof_coverage tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_accepts_activated_pack_domain_proofs tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_rejects_domain_proof_wrong_reviewer_role tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_rejects_domain_proof_wrong_evidence_kind tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_requires_human_gate_ref_for_human_gated_domain_proof tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_accepts_human_gated_domain_proof_binding`
- `python -m py_compile scripts/factoryctl.py tests/test_factoryctl.py`
- `python -m unittest tests.test_factoryctl`
- `python scripts/validate_public_json_artifacts.py`
- `git diff --check`
- `python -m unittest discover -s tests -p 'test*.py'`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`

Closes #225