### PR TITLE
[codex] Prevent Product Face state overclaims

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -76,8 +76,10 @@ python scripts/product_face_proof.py \
 Useful options:
 
 - `--viewport desktop=1440x900 --viewport mobile=390x844`
-- `--state loading --state error --state success`
-- `--journey "open target" --journey "inspect mobile viewport"`
+- `--state loading --state error --state success` to declare states that must
+  be proven before product acceptance.
+- `--journey "open target" --journey "inspect mobile viewport"` to declare
+  journeys that must be proven before product acceptance.
 - `--strict` to treat accessibility and overlap warnings as blocking.
 - `--force-fallback` to register bounded static evidence without a browser.
 - `--card` to bind the result to the exact factory card/slice that will later
@@ -97,6 +99,14 @@ performance note. Without Playwright, it writes a `WAIVED` result with
 `blocking_findings=true`, static file metadata, and an explicit note that no
 rendered screenshot, console, layout, accessibility tree or performance claim
 was captured.
+
+The repo runner does not drive arbitrary product states or user journeys by
+itself. It records requested states and journeys as `declared_states` and
+`declared_journeys`, but only the actually captured initial render/default
+browser journey can appear in `checked_states`, `user_journeys_checked`,
+`visual_artifacts` and `usage_evidence_matrix`. If extra states or journeys are
+declared without a state driver or separate proof artifact, the result is
+`WAIVED`, not a reusable Product Face PASS.
 
 For product-facing completion, Receipt Five must include `product_face_result`.
 A Product Face Packet is planning; a Product Face Result is proof. Browser

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -207,10 +207,43 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
     },
+    "declared_states": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "captured_states": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "uncaptured_states": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
     "user_journeys_checked": {
       "type": "array",
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
+    },
+    "declared_journeys": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "captured_journeys": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "uncaptured_journeys": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "state_capture_policy": {
+      "type": "object",
+      "properties": {
+        "mode": { "type": "string", "minLength": 3 },
+        "cannot_claim_uncaptured_states": { "type": "boolean" },
+        "basis": { "type": "string" }
+      },
+      "additionalProperties": true
     },
     "a11y": {
       "type": "object",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3802,6 +3802,10 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     is_pass = str(result.get("result") or "").upper() == "PASS"
     if is_pass and result.get("blocking_findings") is not False:
         errors.append("product_face_result PASS requires blocking_findings=false")
+    if is_pass and _list_items(result.get("uncaptured_states")):
+        errors.append("product_face_result PASS cannot include uncaptured_states")
+    if is_pass and _list_items(result.get("uncaptured_journeys")):
+        errors.append("product_face_result PASS cannot include uncaptured_journeys")
     for field in ("screenshots", "viewports", "checked_states", "user_journeys_checked", "evidence_refs"):
         if not _non_empty_string_list(result.get(field)):
             errors.append(f"product_face_result {field} must be a non-empty string array")

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -37,6 +37,16 @@ REFERENCE_COMPARISON_DIMENSIONS = (
     "visual_language",
     "density_spacing",
 )
+BROWSER_CAPTURED_STATE_ALIASES = {
+    "initial-render",
+    "initial render",
+    "initial_render",
+    "initial",
+    "loaded",
+    "page-loaded",
+    "page loaded",
+}
+BROWSER_CAPTURED_JOURNEYS = ("open target", "inspect configured viewports")
 
 
 class PlaywrightUnavailable(RuntimeError):
@@ -157,7 +167,7 @@ def build_visual_artifacts(
                 "state": state,
                 "captured_at": captured_at,
                 "freshness_status": "fresh",
-                "basis": "Screenshot captured by the Product Face proof runner for this target, viewport and declared state.",
+                "basis": "Screenshot captured by the Product Face proof runner for this target, viewport and captured state.",
             }
             path = _repo_ref_path(screenshot_ref)
             if path is not None and path.is_file():
@@ -173,6 +183,89 @@ def build_visual_artifacts(
                 )
             artifacts.append(artifact)
     return artifacts
+
+
+def _unique_non_empty(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for item in items:
+        text = str(item or "").strip()
+        key = text.lower()
+        if text and key not in seen:
+            seen.add(key)
+            output.append(text)
+    return output
+
+
+def _normalized_label(value: str) -> str:
+    return str(value or "").strip().lower().replace("_", " ").replace("-", " ")
+
+
+def browser_capture_scope(*, states: list[str], journeys: list[str]) -> dict[str, Any]:
+    declared_states = _unique_non_empty(states) or ["initial-render"]
+    declared_journeys = _unique_non_empty(journeys) or list(BROWSER_CAPTURED_JOURNEYS)
+    captured_states = [
+        state
+        for state in declared_states
+        if state.strip().lower() in BROWSER_CAPTURED_STATE_ALIASES
+        or _normalized_label(state) in BROWSER_CAPTURED_STATE_ALIASES
+    ]
+    if not captured_states:
+        captured_states = ["initial-render"]
+    captured_journeys = [
+        journey
+        for journey in declared_journeys
+        if _normalized_label(journey) in {_normalized_label(item) for item in BROWSER_CAPTURED_JOURNEYS}
+    ]
+    if not captured_journeys:
+        captured_journeys = ["open target"]
+    captured_state_keys = {_normalized_label(state) for state in captured_states}
+    captured_journey_keys = {_normalized_label(journey) for journey in captured_journeys}
+    return {
+        "mode": "browser_initial_render_only",
+        "declared_states": declared_states,
+        "declared_journeys": declared_journeys,
+        "captured_states": captured_states,
+        "captured_journeys": captured_journeys,
+        "uncaptured_states": [state for state in declared_states if _normalized_label(state) not in captured_state_keys],
+        "uncaptured_journeys": [journey for journey in declared_journeys if _normalized_label(journey) not in captured_journey_keys],
+        "basis": (
+            "The repository Product Face proof runner opens the target and captures rendered viewport evidence. "
+            "It does not drive arbitrary state transitions or user journeys unless a future state driver records them."
+        ),
+    }
+
+
+def apply_capture_scope(result: dict[str, Any], scope: dict[str, Any]) -> None:
+    result["declared_states"] = list(scope.get("declared_states") or [])
+    result["declared_journeys"] = list(scope.get("declared_journeys") or [])
+    result["captured_states"] = list(scope.get("captured_states") or [])
+    result["captured_journeys"] = list(scope.get("captured_journeys") or [])
+    result["uncaptured_states"] = list(scope.get("uncaptured_states") or [])
+    result["uncaptured_journeys"] = list(scope.get("uncaptured_journeys") or [])
+    result["state_capture_policy"] = {
+        "mode": str(scope.get("mode") or "browser_initial_render_only"),
+        "cannot_claim_uncaptured_states": True,
+        "basis": str(scope.get("basis") or ""),
+    }
+    if result["uncaptured_states"] or result["uncaptured_journeys"]:
+        missing_bits = []
+        if result["uncaptured_states"]:
+            missing_bits.append("states: " + ", ".join(result["uncaptured_states"]))
+        if result["uncaptured_journeys"]:
+            missing_bits.append("journeys: " + ", ".join(result["uncaptured_journeys"]))
+        result["result"] = "WAIVED"
+        result["blocking_findings"] = True
+        result["findings_summary"] = (
+            str(result.get("findings_summary") or "Product Face proof captured.")
+            + " Declared Product Face coverage was not executed by this runner: "
+            + "; ".join(missing_bits)
+            + "."
+        )
+        result["next_action"] = (
+            "Provide Product Face state/journey drivers or separate proof artifacts for uncaptured coverage, "
+            "then rerun before product acceptance."
+        )
 
 
 def repo_ref(path: Path) -> str:
@@ -787,6 +880,9 @@ def run_playwright(
     except ImportError as exc:
         raise PlaywrightUnavailable("python Playwright package is not installed") from exc
 
+    capture_scope = browser_capture_scope(states=states, journeys=journeys)
+    captured_states = list(capture_scope["captured_states"])
+    captured_journeys = list(capture_scope["captured_journeys"])
     screenshots: list[str] = []
     console_messages: list[dict[str, str]] = []
     page_errors: list[str] = []
@@ -857,8 +953,8 @@ def run_playwright(
     result = base_result(
         target_ref=target_ref,
         viewports=viewports,
-        states=states,
-        journeys=journeys,
+        states=captured_states,
+        journeys=captured_journeys,
         tool_or_profile="playwright-static-product-face-proof",
         card_ref=card_ref,
     )
@@ -875,7 +971,7 @@ def run_playwright(
             "visual_artifacts": build_visual_artifacts(
                 target_ref=target_ref,
                 viewports=viewports,
-                states=states,
+                states=captured_states,
                 screenshot_refs=screenshots,
                 captured_at=captured_at,
             ),
@@ -910,8 +1006,8 @@ def run_playwright(
             "evidence_refs": [repo_ref(state_path), repo_ref(console_path), *screenshots],
             "usage_evidence_matrix": build_usage_evidence_matrix(
                 viewports=viewports,
-                states=states,
-                journeys=journeys,
+                states=captured_states,
+                journeys=captured_journeys,
                 evidence_refs=[repo_ref(state_path), repo_ref(console_path), *screenshots],
                 data_condition="browser-local rendered state fixture",
                 a11y_status="warn" if a11y_issues else "pass",
@@ -924,6 +1020,7 @@ def run_playwright(
             ),
         }
     )
+    apply_capture_scope(result, capture_scope)
     return result
 
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1390,6 +1390,17 @@ class FactoryCtlTest(unittest.TestCase):
             errors,
         )
 
+    def test_product_face_pass_rejects_uncaptured_state_or_journey_overclaim(self) -> None:
+        result = product_face_result_fixture(
+            uncaptured_states=["loading"],
+            uncaptured_journeys=["checkout happy path"],
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn("product_face_result PASS cannot include uncaptured_states", errors)
+        self.assertIn("product_face_result PASS cannot include uncaptured_journeys", errors)
+
     def test_product_face_pass_accepts_resolvable_visual_artifact_with_hash(self) -> None:
         artifact_ref, artifact_hash = self.write_temp_visual_artifact()
         viewports = ["desktop 1440x900"]

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -167,6 +167,57 @@ class ProductFaceProofTest(unittest.TestCase):
         self.assertEqual(result["evidence_kind"], "real")
         self.assertFalse(result["reusable_for_product"])
 
+    def test_browser_capture_scope_does_not_claim_uncaptured_declared_states(self) -> None:
+        scope = product_face_proof.browser_capture_scope(
+            states=["initial-render", "loading", "error"],
+            journeys=["open target", "checkout happy path"],
+        )
+
+        self.assertEqual(scope["declared_states"], ["initial-render", "loading", "error"])
+        self.assertEqual(scope["captured_states"], ["initial-render"])
+        self.assertEqual(scope["uncaptured_states"], ["loading", "error"])
+        self.assertEqual(scope["captured_journeys"], ["open target"])
+        self.assertEqual(scope["uncaptured_journeys"], ["checkout happy path"])
+
+    def test_capture_scope_turns_declared_overclaim_into_waived_result(self) -> None:
+        scope = product_face_proof.browser_capture_scope(
+            states=["loading", "success"],
+            journeys=["purchase flow"],
+        )
+        result = product_face_proof.base_result(
+            target_ref="examples/minimal-hermes-project",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=scope["captured_states"],
+            journeys=scope["captured_journeys"],
+            tool_or_profile="unit-test",
+        )
+
+        product_face_proof.apply_capture_scope(result, scope)
+
+        self.assertEqual(result["result"], "WAIVED")
+        self.assertTrue(result["blocking_findings"])
+        self.assertEqual(result["checked_states"], ["initial-render"])
+        self.assertEqual(result["user_journeys_checked"], ["open target"])
+        self.assertEqual(result["uncaptured_states"], ["loading", "success"])
+        self.assertEqual(result["uncaptured_journeys"], ["purchase flow"])
+        self.assertIn("state/journey drivers", result["next_action"])
+
+    def test_visual_artifacts_are_emitted_only_for_captured_states(self) -> None:
+        scope = product_face_proof.browser_capture_scope(
+            states=["initial-render", "loading"],
+            journeys=["open target"],
+        )
+
+        artifacts = product_face_proof.build_visual_artifacts(
+            target_ref="examples/minimal-hermes-project",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=scope["captured_states"],
+            screenshot_refs=["external:desktop-proof.png"],
+            captured_at="2026-06-16T00:00:00+00:00",
+        )
+
+        self.assertEqual([artifact["state"] for artifact in artifacts], ["initial-render"])
+
     def test_reusable_for_product_requires_pass_result(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
             html_path = Path(tmp) / "prototype.html"


### PR DESCRIPTION
## Summary
- Split declared Product Face state/journey coverage from actually captured browser proof coverage.
- Make the repo Product Face runner emit `declared_*`, `captured_*`, `uncaptured_*` and a `state_capture_policy` instead of pretending declared states were executed.
- Reject Product Face PASS results that carry uncaptured states or journeys.
- Document that `--state` and `--journey` are declarations unless backed by a future state driver or separate proof artifact.

## Why
The runner opened the target once per viewport, then reused the same screenshot and matrix for every declared state/journey. That allowed loading/error/success or custom journeys to look proven when the browser proof had only captured the initial/default render.

## Validation
- `python -m unittest tests.test_product_face_proof`
- `python -m py_compile scripts/product_face_proof.py tests/test_product_face_proof.py`
- `python scripts/validate_public_json_artifacts.py`
- `python -m unittest tests.test_factoryctl tests.test_public_json_artifact_validator`
- `git diff --check`
- `python -m unittest tests.test_product_face_proof tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_uncaptured_state_or_journey_overclaim`
- `python -m py_compile scripts/product_face_proof.py scripts/factoryctl.py tests/test_product_face_proof.py tests/test_factoryctl.py`
- `python -m unittest discover -s tests -p 'test*.py'`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`

Closes #228