### PR TITLE
[codex] Require external Product Face manifests

### DIFF
--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -76,6 +76,51 @@
         "additionalProperties": true
       }
     },
+    "external_visual_artifact_manifests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "manifest_ref",
+          "target",
+          "captured_at",
+          "expires_at",
+          "bounded_acceptance",
+          "sanitized",
+          "artifacts"
+        ],
+        "properties": {
+          "manifest_ref": { "type": "string", "minLength": 1 },
+          "target": { "type": "string", "minLength": 1 },
+          "captured_at": { "type": "string", "minLength": 10 },
+          "expires_at": { "type": "string", "minLength": 10 },
+          "bounded_acceptance": { "type": "boolean" },
+          "sanitized": { "type": "boolean" },
+          "owner": { "type": "string" },
+          "reviewer": { "type": "string" },
+          "artifacts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["evidence_ref", "viewport", "state"],
+              "properties": {
+                "evidence_ref": { "type": "string", "minLength": 1 },
+                "viewport": { "type": "string", "minLength": 1 },
+                "state": { "type": "string", "minLength": 1 },
+                "sha256": {
+                  "type": "string",
+                  "pattern": "^(sha256:)?[a-fA-F0-9]{64}$"
+                },
+                "captured_at": { "type": "string", "minLength": 10 }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
     "surface_evidence_profile": {
       "$ref": "#/$defs/surface_evidence_profile"
     },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import sysconfig
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path, PureWindowsPath
 from typing import Any, Callable
 
@@ -3702,6 +3702,66 @@ def _repo_local_artifact_path(ref: str) -> Path | None:
     return _repo_local_json_ref_path(ref)
 
 
+def _external_visual_artifact_manifests(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    manifests = result.get("external_visual_artifact_manifests")
+    if not isinstance(manifests, list):
+        return {}
+    by_ref: dict[str, dict[str, Any]] = {}
+    for manifest in manifests:
+        if not isinstance(manifest, dict):
+            continue
+        manifest_ref = str(manifest.get("manifest_ref") or "").strip()
+        if manifest_ref:
+            by_ref[manifest_ref] = manifest
+    return by_ref
+
+
+def _validate_external_visual_artifact_manifest(
+    manifest: dict[str, Any],
+    *,
+    package_ref: str,
+    record: dict[str, Any],
+    at: str,
+) -> list[str]:
+    errors: list[str] = []
+    manifest_at = f"{at}.external_manifest[{package_ref}]"
+    for field in ("manifest_ref", "target", "captured_at", "expires_at"):
+        if not _non_empty_text(manifest.get(field)):
+            errors.append(f"{manifest_at}.{field} is required")
+    if manifest.get("bounded_acceptance") is not True:
+        errors.append(f"{manifest_at}.bounded_acceptance=true is required")
+    if manifest.get("sanitized") is not True:
+        errors.append(f"{manifest_at}.sanitized=true is required")
+    if _non_empty_text(manifest.get("target")) and _non_empty_text(record.get("target")) and manifest.get("target") != record.get("target"):
+        errors.append(f"{manifest_at}.target must match visual_artifacts target")
+    captured_at = _parse_artifact_timestamp(manifest.get("captured_at"))
+    if manifest.get("captured_at") and captured_at is None:
+        errors.append(f"{manifest_at}.captured_at must be an ISO timestamp")
+    expires_at = _parse_artifact_timestamp(manifest.get("expires_at"))
+    if manifest.get("expires_at") and expires_at is None:
+        errors.append(f"{manifest_at}.expires_at must be an ISO timestamp")
+    elif expires_at is not None and expires_at <= datetime.now(timezone.utc):
+        errors.append(f"{manifest_at} is stale; expires_at is in the past")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        errors.append(f"{manifest_at}.artifacts must be a non-empty array")
+        return errors
+    evidence_ref = str(record.get("evidence_ref") or "").strip()
+    state = _normalized_usage_value(record.get("state"))
+    viewport_family = _usage_viewport_family(record.get("viewport"))
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        if (
+            str(artifact.get("evidence_ref") or "").strip() == evidence_ref
+            and _normalized_usage_value(artifact.get("state")) == state
+            and _usage_viewport_family(artifact.get("viewport")) == viewport_family
+        ):
+            return errors
+    errors.append(f"{manifest_at}.artifacts must include evidence_ref/state/viewport binding for {evidence_ref}")
+    return errors
+
+
 def validate_visual_artifact_records(result: dict[str, Any], *, is_pass: bool) -> list[str]:
     errors: list[str] = []
     records_value = result.get("visual_artifacts")
@@ -3716,6 +3776,7 @@ def validate_visual_artifact_records(result: dict[str, Any], *, is_pass: bool) -
     checked_states = {_normalized_usage_value(state) for state in _list_items(result.get("checked_states"))}
     viewport_families = {_usage_viewport_family(viewport) for viewport in _list_items(result.get("viewports"))}
     records_by_ref: dict[str, list[dict[str, Any]]] = {}
+    external_manifests = _external_visual_artifact_manifests(result)
 
     for index, record in enumerate(records):
         at = f"product_face_result.visual_artifacts[{index}]"
@@ -3750,6 +3811,20 @@ def validate_visual_artifact_records(result: dict[str, Any], *, is_pass: bool) -
                     errors.append(f"{at}.sanitized=true is required for external visual evidence")
                 if not _non_empty_text(record.get("external_package_ref")):
                     errors.append(f"{at}.external_package_ref is required for external visual evidence")
+                package_ref = str(record.get("external_package_ref") or "").strip()
+                if is_pass and package_ref:
+                    manifest = external_manifests.get(package_ref)
+                    if not isinstance(manifest, dict):
+                        errors.append(f"{at}.external_package_ref must resolve to external_visual_artifact_manifests entry: {package_ref}")
+                    else:
+                        errors.extend(
+                            _validate_external_visual_artifact_manifest(
+                                manifest,
+                                package_ref=package_ref,
+                                record=record,
+                                at=at,
+                            )
+                        )
             else:
                 ref_errors = _evidence_ref_errors([evidence_ref], ROOT)
                 errors.extend(f"{at}: {error}" for error in ref_errors)
@@ -6690,13 +6765,16 @@ def build_worker_result(
         product_face_viewports = ["synthetic-desktop", "synthetic-mobile"] if evidence_kind == "synthetic" else ["desktop 1440x900"]
         product_face_states = ["default", "empty", "loading", "error", "success"]
         product_face_journeys = ["open target", "inspect states"]
+        product_face_target = source_card_ref(Path("<memory>"))
+        product_face_captured_at = utc_now()
+        product_face_external_refs = [ref for ref in evidence_refs if _is_explicit_external_ref(ref)]
         product_face_visual_artifacts = [
             {
                 "evidence_ref": ref,
-                "target": source_card_ref(Path("<memory>")),
+                "target": product_face_target,
                 "viewport": viewport,
                 "state": state,
-                "captured_at": utc_now(),
+                "captured_at": product_face_captured_at,
                 "freshness_status": "bounded_external" if _is_explicit_external_ref(ref) else "fresh",
                 "bounded_acceptance": True,
                 "sanitized": True,
@@ -6707,6 +6785,34 @@ def build_worker_result(
             for viewport in product_face_viewports
             for state in product_face_states
         ]
+        product_face_external_manifests = []
+        if product_face_external_refs:
+            product_face_external_expires_at = (
+                datetime.now(timezone.utc) + timedelta(days=14)
+            ).isoformat(timespec="seconds")
+            product_face_external_manifests.append(
+                {
+                    "manifest_ref": "external:product-face-worker-result-package",
+                    "target": product_face_target,
+                    "captured_at": product_face_captured_at,
+                    "expires_at": product_face_external_expires_at,
+                    "bounded_acceptance": True,
+                    "sanitized": True,
+                    "owner": "product-face-validator",
+                    "reviewer": "product-face-validator",
+                    "artifacts": [
+                        {
+                            "evidence_ref": ref,
+                            "viewport": viewport,
+                            "state": state,
+                            "captured_at": product_face_captured_at,
+                        }
+                        for ref in product_face_external_refs
+                        for viewport in product_face_viewports
+                        for state in product_face_states
+                    ],
+                }
+            )
         payload.update(
             {
                 "screenshots": evidence_refs,
@@ -6731,6 +6837,7 @@ def build_worker_result(
                     for viewport in product_face_viewports
                 ],
                 "visual_artifacts": product_face_visual_artifacts,
+                "external_visual_artifact_manifests": product_face_external_manifests,
                 "accessibility": {"checked": True, "mode": evidence_kind},
                 "a11y": {"status": "pass" if not blocking_findings else "fail", "mode": evidence_kind},
                 "overlap": {"checked": True, "mode": evidence_kind},

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -396,11 +396,46 @@ def visual_artifacts_fixture(
     return artifacts
 
 
+def external_visual_artifact_manifest_fixture(
+    *,
+    manifest_ref: str = "external:product-face-fixture-package",
+    target: str,
+    viewports: list[str],
+    states: list[str],
+    screenshots: list[str],
+    captured_at: str = "2026-06-16T00:00:00+00:00",
+    expires_at: str = "2099-01-01T00:00:00+00:00",
+) -> list[dict]:
+    return [
+        {
+            "manifest_ref": manifest_ref,
+            "target": target,
+            "captured_at": captured_at,
+            "expires_at": expires_at,
+            "bounded_acceptance": True,
+            "sanitized": True,
+            "owner": "product-face-fixture-owner",
+            "reviewer": "product-face-fixture-reviewer",
+            "artifacts": [
+                {
+                    "evidence_ref": screenshot,
+                    "viewport": viewport,
+                    "state": state,
+                    "captured_at": captured_at,
+                }
+                for viewport, screenshot in zip(viewports, screenshots)
+                for state in states
+            ],
+        }
+    ]
+
+
 def product_face_result_fixture(**overrides: object) -> dict:
     overrides = dict(overrides)
     viewports = ["desktop 1440x900", "mobile 390x844"]
     states = ["empty", "loading", "pending", "success", "error"]
     journeys = ["pilot status review", "review evidence inspection"]
+    target = "external:product-face-fixture-target"
     viewports = list(overrides.pop("viewports", viewports))  # type: ignore[arg-type]
     states = list(overrides.pop("checked_states", states))  # type: ignore[arg-type]
     journeys = list(overrides.pop("user_journeys_checked", journeys))  # type: ignore[arg-type]
@@ -412,7 +447,16 @@ def product_face_result_fixture(**overrides: object) -> dict:
     visual_artifacts = overrides.pop(
         "visual_artifacts",
         visual_artifacts_fixture(
-            target="external:product-face-fixture-target",
+            target=target,
+            viewports=viewports,
+            states=states,
+            screenshots=screenshots,
+        ),
+    )
+    external_visual_artifact_manifests = overrides.pop(
+        "external_visual_artifact_manifests",
+        external_visual_artifact_manifest_fixture(
+            target=target,
             viewports=viewports,
             states=states,
             screenshots=screenshots,
@@ -440,6 +484,7 @@ def product_face_result_fixture(**overrides: object) -> dict:
         "user_journeys_checked": journeys,
         "usage_evidence_matrix": usage_matrix,
         "visual_artifacts": visual_artifacts,
+        "external_visual_artifact_manifests": external_visual_artifact_manifests,
         "a11y": {"status": "pass", "keyboard": "pass", "labels": "pass", "contrast": "pass"},
         "overlap_check": {"status": "pass", "desktop": "pass", "mobile": "pass"},
         "console": {"status": "pass"},
@@ -1378,6 +1423,43 @@ class FactoryCtlTest(unittest.TestCase):
         errors = factoryctl.validate_product_face_result(result)
 
         self.assertIn("product_face_result.visual_artifacts[0].freshness_status must be fresh or bounded_external", errors)
+
+    def test_product_face_pass_rejects_external_visual_artifact_without_manifest(self) -> None:
+        result = product_face_result_fixture(external_visual_artifact_manifests=[])
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.visual_artifacts[0].external_package_ref must resolve to external_visual_artifact_manifests entry: external:product-face-fixture-package",
+            errors,
+        )
+
+    def test_product_face_pass_rejects_stale_external_visual_manifest(self) -> None:
+        result = product_face_result_fixture()
+        result["external_visual_artifact_manifests"][0]["expires_at"] = "2026-01-01T00:00:00+00:00"
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertTrue(
+            any("external_manifest[external:product-face-fixture-package] is stale" in error for error in errors),
+            errors,
+        )
+
+    def test_product_face_pass_rejects_external_visual_manifest_state_viewport_mismatch(self) -> None:
+        result = product_face_result_fixture()
+        result["external_visual_artifact_manifests"][0]["artifacts"][0]["state"] = "unrelated-state"
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.visual_artifacts[0].external_manifest[external:product-face-fixture-package].artifacts must include evidence_ref/state/viewport binding for external:product-face-fixture-desktop.png",
+            errors,
+        )
+
+    def test_product_face_pass_accepts_external_visual_manifest_binding(self) -> None:
+        result = product_face_result_fixture()
+
+        self.assertEqual(factoryctl.validate_product_face_result(result), [])
 
     def test_product_face_pass_rejects_state_viewport_artifact_mismatch(self) -> None:
         result = product_face_result_fixture()
@@ -2506,6 +2588,32 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("user_journeys_checked", product_face_result)
         self.assertIn("a11y", product_face_result)
         self.assertIn("overlap_check", product_face_result)
+
+    def test_product_face_worker_result_binds_external_visual_manifest(self) -> None:
+        card = load_card("v35_valid_product_face.md")
+
+        result = factoryctl.build_worker_result(
+            "product-face",
+            card,
+            result="PASS",
+            tool_or_profile="product-face-proof",
+            executed_by="product-face",
+            evidence_refs=["external:product-face-fixture-desktop.png"],
+            blocking_findings=False,
+            findings_summary="External visual proof package.",
+            next_action="ready for independent review",
+            evidence_kind="browser",
+            reusable_for_product=True,
+        )
+
+        manifests = result["external_visual_artifact_manifests"]
+        self.assertEqual(len(manifests), 1)
+        manifest = manifests[0]
+        self.assertEqual(manifest["manifest_ref"], "external:product-face-worker-result-package")
+        self.assertEqual(manifest["bounded_acceptance"], True)
+        self.assertEqual(manifest["sanitized"], True)
+        self.assertNotEqual(manifest["expires_at"], "2099-01-01T00:00:00+00:00")
+        self.assertEqual(factoryctl.validate_product_face_result(result), [])
 
     def test_human_approval_requires_evidence(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")


### PR DESCRIPTION
## What changed

This closes the remaining trust-on-string path for Product Face external visual evidence.

- Adds `external_visual_artifact_manifests` to the Product Face result schema.
- Requires PASS Product Face external visual artifacts to resolve to a bounded, sanitized manifest.
- Validates manifest freshness, target binding, and evidence/state/viewport binding.
- Emits a bounded external manifest from `factoryctl worker-result` for Product Face external refs.
- Adds tests for missing manifests, stale manifests, mismatched bindings, valid bindings, and generated worker-result manifests.

## Why

Issue #227 identified that repo-local visual evidence was strong, but `external:*` screenshots could still be accepted through metadata alone. That allowed a Product Face PASS to depend on strings like `bounded_acceptance=true` and `sanitized=true` without proving the external package contract.

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_product_face_worker_result_binds_external_visual_manifest tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_external_visual_artifact_without_manifest tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_stale_external_visual_manifest tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_external_visual_manifest_state_viewport_mismatch tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_accepts_external_visual_manifest_binding`
- `python -m py_compile scripts/factoryctl.py tests/test_factoryctl.py`
- `python -m unittest discover -s tests -p 'test*.py'`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_public_json_artifacts.py`
- `git diff --check`

Closes #227
