### PR TITLE
[codex] Require Product Face comparison artifacts

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -89,6 +89,12 @@ Useful options:
   product approval alignment.
 - `--visual-quality-status`, `--visual-quality-reviewer` and
   `--visual-quality-basis` to record the professional visual quality verdict.
+- `--reference-quality-ref`, `--reference-quality-comparison-basis`,
+  `--compared-reference-id`, `--reference-comparison-dimension` and
+  `--reference-comparison-artifact` to record the material reference/design
+  comparison used by the reviewer. The artifact may be a side-by-side capture,
+  reference snapshot, design-system/component ref, comparison manifest or
+  bounded equivalent.
 - `--reusable-for-product` only after the three alignment fields above are
   recorded as `pass` and `visual_quality_result` is `PASS` or
   `PASS_WITH_RESIDUALS`.
@@ -114,7 +120,9 @@ screenshots, no console errors, no overflow, accessibility basics and state
 coverage are necessary but insufficient. A reusable product approval also needs
 packet comparison, source-promise coverage, design-fit review and
 `visual_quality_result` recorded as acceptable by a reviewer empowered to block
-visually unacceptable UI.
+visually unacceptable UI. Reference/design comparison cannot be prose-only:
+`reference_quality_comparison` must bind the compared source ids to material
+comparison artifacts or to a bounded sanitized comparison manifest.
 
 `templates/professional-design-process.json` is a starter contract. Its gates
 are intentionally `PENDING`; copying that template into a card is not
@@ -137,6 +145,19 @@ python scripts/product_face_proof.py \
   --packet-comparison-basis "Screens, states and viewports match the Product Face Packet." \
   --source-promise-coverage-basis "The checked journey covers the stated product promise." \
   --design-fit-review-basis "The reviewer confirmed fit to the requested product direction." \
+  --professional-design-process-ref examples/minimal-hermes-project/card.md#professional_design_process \
+  --professional-design-process-comparison-basis "The checked surface satisfies the professional design process." \
+  --reference-quality-ref examples/minimal-hermes-project/card.md#professional_design_process.reference_research \
+  --reference-quality-comparison-basis "The reviewer compared the surface against selected professional references." \
+  --compared-reference-id 21st-dev-components \
+  --compared-reference-id mobbin-workflow-patterns \
+  --compared-reference-id pageflows-review-approval \
+  --reference-comparison-dimension layout_hierarchy="Hierarchy matches the selected reference patterns." \
+  --reference-comparison-dimension interaction_model="Interactions match the selected reference patterns." \
+  --reference-comparison-dimension state_coverage="States match the selected reference patterns." \
+  --reference-comparison-dimension visual_language="Visual language matches the selected reference patterns." \
+  --reference-comparison-dimension density_spacing="Density and spacing match the selected reference patterns." \
+  --reference-comparison-artifact side_by_side_capture=external:product-face-reference-comparison \
   --visual-quality-status PASS \
   --visual-quality-reviewer product-face-reviewer \
   --visual-quality-basis "The UI meets the product-specific quality bar and does not show AI-generic symptoms." \

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -378,6 +378,58 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "reviewer_independent_from_implementation": { "type": "boolean" },
+        "reference_source_manifest": {
+          "type": "object",
+          "required": ["manifest_ref", "bounded_acceptance", "sanitized", "sources"],
+          "properties": {
+            "manifest_ref": { "type": "string", "minLength": 1 },
+            "bounded_acceptance": { "type": "boolean" },
+            "sanitized": { "type": "boolean" },
+            "sources": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["source_id"],
+                "properties": {
+                  "source_id": { "type": "string", "minLength": 1 },
+                  "source_ref": { "type": "string" },
+                  "source_type": { "type": "string" }
+                },
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        "comparison_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["artifact_ref", "artifact_type", "compared_source_ids", "basis"],
+            "properties": {
+              "artifact_ref": { "type": "string", "minLength": 1 },
+              "artifact_type": {
+                "enum": [
+                  "side_by_side_capture",
+                  "reference_snapshot",
+                  "design_system_component",
+                  "comparison_manifest",
+                  "bounded_equivalent"
+                ]
+              },
+              "compared_source_ids": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "basis": { "type": "string", "minLength": 3 },
+              "bounded_acceptance": { "type": "boolean" },
+              "sanitized": { "type": "boolean" }
+            },
+            "additionalProperties": true
+          }
+        },
         "dimensions": {
           "type": "object",
           "required": [

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -532,6 +532,13 @@ REFERENCE_COMPARISON_DIMENSIONS = (
     "visual_language",
     "density_spacing",
 )
+REFERENCE_COMPARISON_ARTIFACT_TYPES = {
+    "side_by_side_capture",
+    "reference_snapshot",
+    "design_system_component",
+    "comparison_manifest",
+    "bounded_equivalent",
+}
 SURFACE_EVIDENCE_PROFILES = {"web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"}
 SURFACE_EVIDENCE_PROFILE_BLOCKS = {
     "cli_tui": (
@@ -3580,7 +3587,8 @@ def validate_reference_quality_comparison(comparison: Any, *, is_pass: bool) -> 
         errors.append("product_face_result.reference_quality_comparison.basis is required")
     if not _non_empty_text(comparison.get("reference_set_ref")):
         errors.append("product_face_result.reference_quality_comparison.reference_set_ref is required")
-    if is_pass and len(_list_items(comparison.get("compared_source_ids"))) < 3:
+    compared_source_ids = _list_items(comparison.get("compared_source_ids"))
+    if is_pass and len(compared_source_ids) < 3:
         errors.append("product_face_result.reference_quality_comparison.compared_source_ids requires at least 3 references")
     if is_pass and comparison.get("reviewer_independent_from_implementation") is not True:
         errors.append("product_face_result.reference_quality_comparison.reviewer_independent_from_implementation must be true")
@@ -3594,6 +3602,164 @@ def validate_reference_quality_comparison(comparison: Any, *, is_pass: bool) -> 
             errors.append(f"product_face_result.reference_quality_comparison.dimensions.{dimension}.status must be pass")
         if not _non_empty_text(verdict.get("basis")):
             errors.append(f"product_face_result.reference_quality_comparison.dimensions.{dimension}.basis is required")
+    if is_pass:
+        errors.extend(_validate_reference_source_resolution(comparison, compared_source_ids))
+        errors.extend(_validate_reference_comparison_artifacts(comparison, compared_source_ids))
+    return errors
+
+
+def _fragment_node(data: Any, fragment: str) -> Any:
+    node = data
+    fragment = fragment.strip().lstrip("#")
+    if not fragment:
+        return node
+    for part in [item for item in fragment.split(".") if item]:
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+            continue
+        if isinstance(node, dict) and isinstance(node.get("sources"), list):
+            match = next(
+                (
+                    source
+                    for source in node["sources"]
+                    if isinstance(source, dict) and str(source.get("source_id") or "").strip() == part
+                ),
+                None,
+            )
+            if match is not None:
+                node = match
+                continue
+        if isinstance(node, list):
+            match = next(
+                (
+                    item
+                    for item in node
+                    if isinstance(item, dict) and str(item.get("source_id") or "").strip() == part
+                ),
+                None,
+            )
+            if match is not None:
+                node = match
+                continue
+        return None
+    return node
+
+
+def _collect_reference_source_ids(node: Any) -> set[str]:
+    ids: set[str] = set()
+    if isinstance(node, dict):
+        source_id = str(node.get("source_id") or "").strip()
+        if source_id:
+            ids.add(source_id)
+        for key in ("sources", "selected_sources", "reference_sources"):
+            ids.update(_collect_reference_source_ids(node.get(key)))
+        ids.update(_collect_reference_source_ids(node.get("reference_research")))
+    elif isinstance(node, list):
+        for item in node:
+            ids.update(_collect_reference_source_ids(item))
+    return ids
+
+
+def _reference_source_manifest_ids(manifest: Any) -> tuple[set[str], list[str]]:
+    errors: list[str] = []
+    if not isinstance(manifest, dict) or not manifest:
+        return set(), errors
+    if not _non_empty_text(manifest.get("manifest_ref")):
+        errors.append("product_face_result.reference_quality_comparison.reference_source_manifest.manifest_ref is required")
+    if manifest.get("bounded_acceptance") is not True:
+        errors.append("product_face_result.reference_quality_comparison.reference_source_manifest.bounded_acceptance=true is required")
+    if manifest.get("sanitized") is not True:
+        errors.append("product_face_result.reference_quality_comparison.reference_source_manifest.sanitized=true is required")
+    sources = manifest.get("sources")
+    if not isinstance(sources, list) or not sources:
+        errors.append("product_face_result.reference_quality_comparison.reference_source_manifest.sources must be a non-empty array")
+        return set(), errors
+    ids: set[str] = set()
+    for index, source in enumerate(sources):
+        if not isinstance(source, dict):
+            errors.append(f"product_face_result.reference_quality_comparison.reference_source_manifest.sources[{index}] must be an object")
+            continue
+        source_id = str(source.get("source_id") or "").strip()
+        if not source_id:
+            errors.append(f"product_face_result.reference_quality_comparison.reference_source_manifest.sources[{index}].source_id is required")
+        else:
+            ids.add(source_id)
+    return ids, errors
+
+
+def _repo_reference_source_ids(reference_set_ref: str) -> set[str]:
+    path = _repo_local_json_ref_path(reference_set_ref)
+    if path is None or not path.is_file():
+        return set()
+    try:
+        data = load_json_like(path)
+    except Exception:
+        return set()
+    fragment = reference_set_ref.split("#", 1)[1] if "#" in reference_set_ref else ""
+    return _collect_reference_source_ids(_fragment_node(data, fragment))
+
+
+def _validate_reference_source_resolution(comparison: dict[str, Any], compared_source_ids: list[str]) -> list[str]:
+    errors: list[str] = []
+    reference_set_ref = str(comparison.get("reference_set_ref") or "").strip()
+    source_ids = _repo_reference_source_ids(reference_set_ref)
+    manifest_ids, manifest_errors = _reference_source_manifest_ids(comparison.get("reference_source_manifest"))
+    errors.extend(manifest_errors)
+    source_ids.update(manifest_ids)
+    if compared_source_ids and not source_ids:
+        errors.append(
+            "product_face_result.reference_quality_comparison.reference_set_ref must resolve to repo-local reference sources "
+            "or reference_source_manifest"
+        )
+        return errors
+    unknown = [source_id for source_id in compared_source_ids if source_id not in source_ids]
+    if unknown:
+        errors.append(
+            "product_face_result.reference_quality_comparison.compared_source_ids not found in reference sources: "
+            + ", ".join(unknown)
+        )
+    return errors
+
+
+def _validate_reference_comparison_artifacts(comparison: dict[str, Any], compared_source_ids: list[str]) -> list[str]:
+    errors: list[str] = []
+    artifacts = comparison.get("comparison_artifacts")
+    at = "product_face_result.reference_quality_comparison.comparison_artifacts"
+    if not isinstance(artifacts, list) or not artifacts:
+        return [f"{at} must include material comparison artifacts for PASS"]
+    compared = set(compared_source_ids)
+    artifact_coverage: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        item_at = f"{at}[{index}]"
+        if not isinstance(artifact, dict):
+            errors.append(f"{item_at} must be an object")
+            continue
+        artifact_ref = str(artifact.get("artifact_ref") or "").strip()
+        if not artifact_ref:
+            errors.append(f"{item_at}.artifact_ref is required")
+        else:
+            if _is_explicit_external_ref(artifact_ref):
+                if artifact.get("bounded_acceptance") is not True:
+                    errors.append(f"{item_at}.bounded_acceptance=true is required for external comparison artifact")
+                if artifact.get("sanitized") is not True:
+                    errors.append(f"{item_at}.sanitized=true is required for external comparison artifact")
+            else:
+                errors.extend(f"{item_at}: {error}" for error in _evidence_ref_errors([artifact_ref], ROOT))
+        artifact_type = str(artifact.get("artifact_type") or "").strip()
+        if artifact_type not in REFERENCE_COMPARISON_ARTIFACT_TYPES:
+            errors.append(f"{item_at}.artifact_type must be one of " + ", ".join(sorted(REFERENCE_COMPARISON_ARTIFACT_TYPES)))
+        if not _non_empty_text(artifact.get("basis")):
+            errors.append(f"{item_at}.basis is required")
+        artifact_source_ids = set(_list_items(artifact.get("compared_source_ids")))
+        if not artifact_source_ids:
+            errors.append(f"{item_at}.compared_source_ids must be a non-empty string array")
+        extra_ids = sorted(artifact_source_ids - compared)
+        if extra_ids:
+            errors.append(f"{item_at}.compared_source_ids contains ids not declared in compared_source_ids: " + ", ".join(extra_ids))
+        artifact_coverage.update(artifact_source_ids & compared)
+    missing = [source_id for source_id in compared_source_ids if source_id not in artifact_coverage]
+    if missing:
+        errors.append(f"{at} missing material artifact coverage for compared_source_ids: " + ", ".join(missing))
     return errors
 
 
@@ -6868,6 +7034,30 @@ def build_worker_result(
                     "reference_set_ref": "card.professional_design_process.reference_research",
                     "compared_source_ids": ["design-library-reference", "component-registry-reference", "product-flow-reference"],
                     "reviewer_independent_from_implementation": not blocking_findings,
+                    "reference_source_manifest": {
+                        "manifest_ref": "external:product-face-worker-reference-source-manifest",
+                        "bounded_acceptance": True,
+                        "sanitized": True,
+                        "sources": [
+                            {"source_id": "design-library-reference"},
+                            {"source_id": "component-registry-reference"},
+                            {"source_id": "product-flow-reference"},
+                        ],
+                    },
+                    "comparison_artifacts": [
+                        {
+                            "artifact_ref": "external:product-face-worker-reference-comparison",
+                            "artifact_type": "bounded_equivalent",
+                            "compared_source_ids": [
+                                "design-library-reference",
+                                "component-registry-reference",
+                                "product-flow-reference",
+                            ],
+                            "basis": "Bounded worker-result package records sanitized material comparison across the selected references.",
+                            "bounded_acceptance": True,
+                            "sanitized": True,
+                        }
+                    ],
                     "dimensions": {
                         dimension: {
                             "status": "pass" if not blocking_findings else "fail",

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -37,6 +37,13 @@ REFERENCE_COMPARISON_DIMENSIONS = (
     "visual_language",
     "density_spacing",
 )
+REFERENCE_COMPARISON_ARTIFACT_TYPES = {
+    "side_by_side_capture",
+    "reference_snapshot",
+    "design_system_component",
+    "comparison_manifest",
+    "bounded_equivalent",
+}
 BROWSER_CAPTURED_STATE_ALIASES = {
     "initial-render",
     "initial render",
@@ -302,6 +309,30 @@ def parse_reference_dimension(raw: str) -> tuple[str, str]:
     if not basis:
         raise ValueError("--reference-comparison-dimension basis must be non-empty")
     return dimension, basis
+
+
+def parse_reference_comparison_artifact(raw: str, compared_source_ids: list[str]) -> dict[str, Any]:
+    if "=" in raw:
+        artifact_type, artifact_ref = raw.split("=", 1)
+    else:
+        artifact_type, artifact_ref = "side_by_side_capture", raw
+    artifact_type = artifact_type.strip()
+    artifact_ref = artifact_ref.strip()
+    if artifact_type not in REFERENCE_COMPARISON_ARTIFACT_TYPES:
+        allowed = ", ".join(sorted(REFERENCE_COMPARISON_ARTIFACT_TYPES))
+        raise ValueError(f"--reference-comparison-artifact type must be one of: {allowed}")
+    if not artifact_ref:
+        raise ValueError("--reference-comparison-artifact artifact ref must be non-empty")
+    artifact = {
+        "artifact_ref": artifact_ref,
+        "artifact_type": artifact_type,
+        "compared_source_ids": compared_source_ids,
+        "basis": "Material comparison artifact supplied with Product Face reference-quality review.",
+    }
+    if artifact_ref.startswith(("http://", "https://", "external:", "repo://")):
+        artifact["bounded_acceptance"] = True
+        artifact["sanitized"] = True
+    return artifact
 
 
 def resolve_target(target: str, *, allow_external_file: bool = False) -> tuple[str, Path | None]:
@@ -690,6 +721,33 @@ def reference_quality_passes(result: dict[str, Any]) -> bool:
             return False
         if not str(verdict.get("basis") or "").strip():
             return False
+    compared_source_ids = {str(item).strip() for item in comparison.get("compared_source_ids") or [] if str(item).strip()}
+    artifact_coverage: set[str] = set()
+    artifacts = comparison.get("comparison_artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        return False
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            return False
+        artifact_ref = str(artifact.get("artifact_ref") or "").strip()
+        if not artifact_ref:
+            return False
+        if artifact.get("artifact_type") not in REFERENCE_COMPARISON_ARTIFACT_TYPES:
+            return False
+        if not str(artifact.get("basis") or "").strip():
+            return False
+        if artifact_ref.startswith(("http://", "https://", "external:", "repo://")) and (
+            artifact.get("bounded_acceptance") is not True or artifact.get("sanitized") is not True
+        ):
+            return False
+        artifact_source_ids = {str(item).strip() for item in artifact.get("compared_source_ids") or [] if str(item).strip()}
+        if not artifact_source_ids:
+            return False
+        if artifact_source_ids - compared_source_ids:
+            return False
+        artifact_coverage.update(artifact_source_ids)
+    if compared_source_ids - artifact_coverage:
+        return False
     return True
 
 
@@ -706,6 +764,7 @@ def apply_product_alignment(
     reference_quality_comparison_basis: str | None,
     compared_reference_ids: list[str] | None,
     reference_quality_dimensions: dict[str, str] | None,
+    reference_comparison_artifacts: list[dict[str, Any]] | None = None,
 ) -> None:
     values = {
         "packet_ref": packet_ref,
@@ -722,6 +781,8 @@ def apply_product_alignment(
         supplied.add("compared_reference_ids")
     if reference_quality_dimensions:
         supplied.add("reference_quality_dimensions")
+    if reference_comparison_artifacts:
+        supplied.add("reference_comparison_artifacts")
     if not supplied:
         return
     missing = [field for field, value in values.items() if not str(value or "").strip()]
@@ -734,6 +795,8 @@ def apply_product_alignment(
     ]
     if missing_dimensions:
         missing.extend(f"reference_comparison_dimension:{dimension}" for dimension in missing_dimensions)
+    if not reference_comparison_artifacts:
+        missing.append("reference_comparison_artifacts")
     if missing:
         raise ValueError("Product Face alignment is incomplete: missing " + ", ".join(missing))
     result["packet_ref"] = str(packet_ref).strip()
@@ -760,6 +823,7 @@ def apply_product_alignment(
         "reference_set_ref": str(reference_quality_ref).strip(),
         "compared_source_ids": [str(item).strip() for item in compared_reference_ids or [] if str(item).strip()],
         "reviewer_independent_from_implementation": True,
+        "comparison_artifacts": reference_comparison_artifacts or [],
         "dimensions": {
             dimension: {
                 "status": "pass",
@@ -1156,6 +1220,7 @@ def build_product_face_proof(
     reference_quality_comparison_basis: str | None = None,
     compared_reference_ids: list[str] | None = None,
     reference_quality_dimensions: dict[str, str] | None = None,
+    reference_comparison_artifacts: list[dict[str, Any]] | None = None,
     visual_quality_status: str | None = None,
     visual_quality_reviewer: str | None = None,
     visual_quality_basis: str | None = None,
@@ -1224,6 +1289,7 @@ def build_product_face_proof(
         reference_quality_comparison_basis=reference_quality_comparison_basis,
         compared_reference_ids=compared_reference_ids,
         reference_quality_dimensions=reference_quality_dimensions,
+        reference_comparison_artifacts=reference_comparison_artifacts,
     )
     apply_visual_quality_review(
         result=result,
@@ -1289,6 +1355,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="append",
         help="Dimension comparison as DIMENSION=BASIS. Required dimensions: layout_hierarchy, interaction_model, state_coverage, visual_language, density_spacing.",
     )
+    parser.add_argument(
+        "--reference-comparison-artifact",
+        action="append",
+        help="Material comparison artifact as TYPE=REF. TYPE can be side_by_side_capture, reference_snapshot, design_system_component, comparison_manifest or bounded_equivalent.",
+    )
     parser.add_argument("--visual-quality-status", choices=["PASS", "BLOCK", "PASS_WITH_RESIDUALS"], help="Professional visual quality verdict.")
     parser.add_argument("--visual-quality-reviewer", help="Reviewer empowered to block visually unacceptable UI.")
     parser.add_argument("--visual-quality-basis", help="Why the surface meets or fails the product-specific quality bar.")
@@ -1306,6 +1377,11 @@ def main(argv: list[str] | None = None) -> int:
                 parse_reference_dimension(raw) for raw in args.reference_comparison_dimension or []
             )
         }
+        compared_ids = [str(item).strip() for item in args.compared_reference_id or [] if str(item).strip()]
+        reference_artifacts = [
+            parse_reference_comparison_artifact(raw, compared_ids)
+            for raw in args.reference_comparison_artifact or []
+        ]
         result = build_product_face_proof(
             target=args.target,
             out=Path(args.out),
@@ -1330,6 +1406,7 @@ def main(argv: list[str] | None = None) -> int:
             reference_quality_comparison_basis=args.reference_quality_comparison_basis,
             compared_reference_ids=args.compared_reference_id,
             reference_quality_dimensions=reference_dimensions,
+            reference_comparison_artifacts=reference_artifacts,
             visual_quality_status=args.visual_quality_status,
             visual_quality_reviewer=args.visual_quality_reviewer,
             visual_quality_basis=args.visual_quality_basis,

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -208,16 +208,27 @@ def human_gate_record(source_card: dict | None = None) -> dict:
 
 
 def reference_quality_comparison_fixture() -> dict:
+    compared_source_ids = [
+        "21st-dev-components",
+        "mobbin-workflow-patterns",
+        "pageflows-review-approval",
+    ]
     return {
         "status": "pass",
         "basis": "Independent reviewer compared the Product Face result against selected professional references.",
         "reference_set_ref": "examples/cards/v35_valid_product_face.md#professional_design_process.reference_research",
-        "compared_source_ids": [
-            "21st-dev-components",
-            "mobbin-workflow-patterns",
-            "pageflows-review-approval",
-        ],
+        "compared_source_ids": compared_source_ids,
         "reviewer_independent_from_implementation": True,
+        "comparison_artifacts": [
+            {
+                "artifact_ref": "external:product-face-fixture-reference-comparison",
+                "artifact_type": "side_by_side_capture",
+                "compared_source_ids": compared_source_ids,
+                "basis": "Sanitized side-by-side comparison covers all selected references.",
+                "bounded_acceptance": True,
+                "sanitized": True,
+            }
+        ],
         "dimensions": {
             dimension: {
                 "status": "pass",
@@ -1458,6 +1469,68 @@ class FactoryCtlTest(unittest.TestCase):
 
     def test_product_face_pass_accepts_external_visual_manifest_binding(self) -> None:
         result = product_face_result_fixture()
+
+        self.assertEqual(factoryctl.validate_product_face_result(result), [])
+
+    def test_product_face_pass_rejects_reference_quality_prose_only_comparison(self) -> None:
+        result = product_face_result_fixture()
+        result["reference_quality_comparison"].pop("comparison_artifacts")
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.reference_quality_comparison.comparison_artifacts must include material comparison artifacts for PASS",
+            errors,
+        )
+
+    def test_product_face_pass_rejects_unknown_compared_reference_id(self) -> None:
+        result = product_face_result_fixture()
+        result["reference_quality_comparison"]["compared_source_ids"] = [
+            "21st-dev-components",
+            "mobbin-workflow-patterns",
+            "unknown-design-reference",
+        ]
+        result["reference_quality_comparison"]["comparison_artifacts"][0]["compared_source_ids"] = [
+            "21st-dev-components",
+            "mobbin-workflow-patterns",
+            "unknown-design-reference",
+        ]
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.reference_quality_comparison.compared_source_ids not found in reference sources: unknown-design-reference",
+            errors,
+        )
+
+    def test_product_face_pass_rejects_missing_reference_comparison_artifact(self) -> None:
+        result = product_face_result_fixture()
+        result["reference_quality_comparison"]["comparison_artifacts"] = [
+            {
+                "artifact_ref": "reports/product-face/missing-reference-comparison.png",
+                "artifact_type": "side_by_side_capture",
+                "compared_source_ids": result["reference_quality_comparison"]["compared_source_ids"],
+                "basis": "Missing repo-local comparison artifact must fail closed.",
+            }
+        ]
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.reference_quality_comparison.comparison_artifacts[0]: evidence ref does not exist: reports/product-face/missing-reference-comparison.png",
+            errors,
+        )
+
+    def test_product_face_pass_accepts_external_reference_source_manifest(self) -> None:
+        result = product_face_result_fixture()
+        compared_source_ids = result["reference_quality_comparison"]["compared_source_ids"]
+        result["reference_quality_comparison"]["reference_set_ref"] = "external:product-face-reference-source-manifest"
+        result["reference_quality_comparison"]["reference_source_manifest"] = {
+            "manifest_ref": "external:product-face-reference-source-manifest",
+            "bounded_acceptance": True,
+            "sanitized": True,
+            "sources": [{"source_id": source_id} for source_id in compared_source_ids],
+        }
 
         self.assertEqual(factoryctl.validate_product_face_result(result), [])
 

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -262,6 +262,20 @@ class ProductFaceProofTest(unittest.TestCase):
                     "pageflows-review-approval",
                 ],
                 reference_quality_dimensions=reference_dimension_basis(),
+                reference_comparison_artifacts=[
+                    {
+                        "artifact_ref": "external:unit-reference-comparison",
+                        "artifact_type": "side_by_side_capture",
+                        "compared_source_ids": [
+                            "21st-dev-components",
+                            "mobbin-workflow-patterns",
+                            "pageflows-review-approval",
+                        ],
+                        "basis": "Unit fixture supplies a bounded material comparison artifact.",
+                        "bounded_acceptance": True,
+                        "sanitized": True,
+                    }
+                ],
             )
             product_face_proof.apply_visual_quality_review(
                 result=result,
@@ -284,6 +298,34 @@ class ProductFaceProofTest(unittest.TestCase):
         self.assertEqual(result["product_target"]["environment_class"], "production-like-static-artifact")
         self.assertEqual(result["product_target"]["target_sha256"], expected_sha256)
         self.assertIn("Product Face lane", result["product_target"]["approval_scope"])
+
+    def test_product_alignment_requires_reference_comparison_artifact(self) -> None:
+        result = product_face_proof.base_result(
+            target_ref="examples/minimal-hermes-project",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=["initial-render"],
+            journeys=["open target"],
+            tool_or_profile="unit-test",
+        )
+
+        with self.assertRaisesRegex(ValueError, "reference_comparison_artifacts"):
+            product_face_proof.apply_product_alignment(
+                result=result,
+                packet_ref="templates/product-face-packet.json",
+                packet_comparison_basis="Unit proof is explicitly matched to the packet.",
+                source_promise_coverage_basis="Unit proof covers the named product promise.",
+                design_fit_review_basis="Unit proof includes an explicit design-fit review.",
+                professional_design_process_ref="templates/professional-design-process.json",
+                professional_design_process_comparison_basis="Unit proof satisfies the professional design process gates.",
+                reference_quality_ref="templates/professional-design-process.json#reference_research",
+                reference_quality_comparison_basis="Unit proof compares against selected professional design references.",
+                compared_reference_ids=[
+                    "21st-dev-components",
+                    "mobbin-workflow-patterns",
+                    "pageflows-review-approval",
+                ],
+                reference_quality_dimensions=reference_dimension_basis(),
+            )
 
     def test_reusable_for_product_requires_packet_alignment(self) -> None:
         result = product_face_proof.base_result(


### PR DESCRIPTION
## What changed

This closes the prose-only Product Face design/reference comparison path.

- Adds material `comparison_artifacts` and optional sanitized `reference_source_manifest` to `reference_quality_comparison`.
- Resolves `compared_source_ids` against the declared repo-local reference set or a bounded sanitized source manifest.
- Requires Product Face PASS comparison artifacts to cover every compared reference id.
- Requires external comparison artifacts to be explicitly bounded and sanitized.
- Updates `product_face_proof.py` so reusable Product Face evidence cannot be produced without material comparison artifacts.
- Documents the new runner arguments and adds regression tests for prose-only comparison, unknown reference ids, missing artifacts and valid external manifests.

## Why

Issue #229 showed that Product Face could still accept a convincing reference/design comparison written as prose: three source ids, reviewer independence and dimension basis were enough, even if the source ids were unknown and no side-by-side/reference artifact existed.

That is unsafe for product delivery quality. Mechanical screenshots plus persuasive text cannot be the same thing as a material design comparison.

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_reference_quality_prose_only_comparison tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_unknown_compared_reference_id tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_missing_reference_comparison_artifact tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_accepts_external_reference_source_manifest tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_accepts_external_visual_manifest_binding`
- `python -m unittest tests.test_product_face_proof.ProductFaceProofTest.test_reusable_for_product_scope_adds_target_hash tests.test_product_face_proof.ProductFaceProofTest.test_product_alignment_requires_reference_comparison_artifact`
- `python -m py_compile scripts/factoryctl.py scripts/product_face_proof.py tests/test_factoryctl.py tests/test_product_face_proof.py`
- `python -m unittest tests.test_factoryctl tests.test_product_face_proof`
- `python scripts/validate_public_json_artifacts.py`
- `git diff --check`
- `python -m unittest discover -s tests -p 'test*.py'`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`

Closes #229
