### PR TITLE
[codex] Bound synthetic Product Face acceptance

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -187,6 +187,11 @@ That fallback is intentional. Static HTML metadata is not visual proof. It is a
 receipt that the Product Face worker tried to run and that the card must remain
 blocked until real browser evidence exists.
 
+Synthetic Product Face evidence is also bounded. It may support fixtures,
+smoke checks or validation cards only when `reusable_for_product=false` and the
+result carries a `product_acceptance_boundary` stating that it cannot satisfy
+product acceptance. Product-facing completion needs real Product Face proof.
+
 ## Current Boundary
 
 The repository documents the runner contract. Actual screenshots, state

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -545,6 +545,16 @@
     "reusable_for_product": {
       "type": "boolean"
     },
+    "product_acceptance_boundary": {
+      "type": "object",
+      "required": ["boundary", "cannot_satisfy_product_acceptance", "next_required_action"],
+      "properties": {
+        "boundary": { "type": "string", "minLength": 3 },
+        "cannot_satisfy_product_acceptance": { "type": "boolean" },
+        "next_required_action": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
     "next_action": {
       "type": "string"
     }
@@ -593,6 +603,27 @@
         "required": ["visual_artifacts"],
         "properties": {
           "visual_artifacts": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "result": { "const": "PASS" },
+          "evidence_kind": { "const": "synthetic" }
+        },
+        "required": ["result", "evidence_kind"]
+      },
+      "then": {
+        "required": ["reusable_for_product", "product_acceptance_boundary"],
+        "properties": {
+          "reusable_for_product": { "const": false },
+          "product_acceptance_boundary": {
+            "required": ["boundary", "cannot_satisfy_product_acceptance", "next_required_action"],
+            "properties": {
+              "cannot_satisfy_product_acceptance": { "const": true }
+            }
+          }
         }
       }
     }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4041,6 +4041,17 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     if str(result.get("result") or "").upper() not in {"PASS", "WAIVED"}:
         errors.append("product_face_result result must be PASS or WAIVED")
     is_pass = str(result.get("result") or "").upper() == "PASS"
+    evidence_kind = str(result.get("evidence_kind") or "").strip()
+    if evidence_kind and evidence_kind not in {"real", "synthetic", "waiver"}:
+        errors.append("product_face_result.evidence_kind must be real, synthetic or waiver")
+    if is_pass and evidence_kind == "synthetic" and result.get("reusable_for_product") is not False:
+        errors.append("product_face_result synthetic PASS must set reusable_for_product=false")
+    if is_pass and evidence_kind == "synthetic":
+        boundary = result.get("product_acceptance_boundary")
+        if not isinstance(boundary, dict) or not boundary:
+            errors.append("product_face_result synthetic PASS requires product_acceptance_boundary")
+        elif boundary.get("cannot_satisfy_product_acceptance") is not True:
+            errors.append("product_face_result synthetic PASS product_acceptance_boundary.cannot_satisfy_product_acceptance must be true")
     if is_pass and result.get("blocking_findings") is not False:
         errors.append("product_face_result PASS requires blocking_findings=false")
     if is_pass and _list_items(result.get("uncaptured_states")):
@@ -4214,6 +4225,8 @@ def validate_product_face_result_against_card(result: dict[str, Any], card: dict
         return errors
     if result_status != "PASS":
         return errors
+    if str(result.get("evidence_kind") or "").strip() == "synthetic":
+        errors.append("product_face_result synthetic evidence cannot satisfy product-facing completion")
 
     required_profiles = _expected_surface_evidence_profiles(card)
     declared_profiles = set(_declared_surface_evidence_profiles(result))
@@ -7080,6 +7093,12 @@ def build_worker_result(
                 },
             }
         )
+        if evidence_kind == "synthetic":
+            payload["product_acceptance_boundary"] = {
+                "boundary": "synthetic_smoke_only",
+                "cannot_satisfy_product_acceptance": True,
+                "next_required_action": "run real Product Face proof before product-facing completion",
+            }
     if worker_id == "remote-proof-runner":
         payload.update(
             {

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1534,6 +1534,48 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertEqual(factoryctl.validate_product_face_result(result), [])
 
+    def test_product_face_pass_rejects_synthetic_reusable_product_claim(self) -> None:
+        result = product_face_result_fixture(evidence_kind="synthetic", reusable_for_product=True)
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn("product_face_result synthetic PASS must set reusable_for_product=false", errors)
+
+    def test_product_face_pass_allows_non_reusable_synthetic_smoke_record(self) -> None:
+        result = product_face_result_fixture(
+            evidence_kind="synthetic",
+            reusable_for_product=False,
+            product_acceptance_boundary={
+                "boundary": "synthetic_smoke_only",
+                "cannot_satisfy_product_acceptance": True,
+                "next_required_action": "run real Product Face proof before product-facing completion",
+            },
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result(result), [])
+
+    def test_product_face_completion_rejects_synthetic_pass_even_when_non_reusable(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        result = product_face_result_fixture(
+            evidence_kind="synthetic",
+            reusable_for_product=False,
+            product_acceptance_boundary={
+                "boundary": "synthetic_smoke_only",
+                "cannot_satisfy_product_acceptance": True,
+                "next_required_action": "run real Product Face proof before product-facing completion",
+            },
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn("product_face_result synthetic evidence cannot satisfy product-facing completion", errors)
+
+    def test_product_face_completion_accepts_real_pass_boundary(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
+        result = product_face_result_fixture(evidence_kind="real", reusable_for_product=True)
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
+
     def test_product_face_pass_rejects_state_viewport_artifact_mismatch(self) -> None:
         result = product_face_result_fixture()
         result["visual_artifacts"] = [dict(result["visual_artifacts"][0], state="success")]
@@ -2661,6 +2703,35 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("user_journeys_checked", product_face_result)
         self.assertIn("a11y", product_face_result)
         self.assertIn("overlap_check", product_face_result)
+        self.assertEqual(product_face_result["product_acceptance_boundary"]["boundary"], "synthetic_smoke_only")
+        self.assertTrue(product_face_result["product_acceptance_boundary"]["cannot_satisfy_product_acceptance"])
+
+    def test_product_face_worker_result_validation_rejects_synthetic_completion(self) -> None:
+        card = load_card("v35_valid_product_face.md")
+        card["source_refs"] = [*card.get("source_refs", []), "synthetic validation fixture"]
+        result = factoryctl.build_worker_result(
+            "product-face",
+            card,
+            result="PASS",
+            tool_or_profile="product-face-proof",
+            executed_by="product-face",
+            evidence_refs=["README.md"],
+            blocking_findings=False,
+            findings_summary="Synthetic Product Face smoke.",
+            next_action="run browser proof for real product",
+            evidence_kind="synthetic",
+            reusable_for_product=False,
+        )
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="product_face_result",
+            expected_worker_id="product-face",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn("product_face_result synthetic evidence cannot satisfy product-facing completion", errors)
 
     def test_product_face_worker_result_binds_external_visual_manifest(self) -> None:
         card = load_card("v35_valid_product_face.md")
@@ -2675,7 +2746,7 @@ class FactoryCtlTest(unittest.TestCase):
             blocking_findings=False,
             findings_summary="External visual proof package.",
             next_action="ready for independent review",
-            evidence_kind="browser",
+            evidence_kind="real",
             reusable_for_product=True,
         )
 


### PR DESCRIPTION
## What changed

This closes the synthetic Product Face acceptance gap.

- `validate_product_face_result(...)` now rejects Product Face `PASS` with `evidence_kind=synthetic` unless it is explicitly non-reusable and carries a `product_acceptance_boundary`.
- `validate_product_face_result_against_card(...)` rejects synthetic Product Face evidence for product-facing completion.
- `build_worker_result(...)` marks synthetic Product Face output as `synthetic_smoke_only` and explicitly says it cannot satisfy product acceptance.
- The Product Face Result schema now encodes the synthetic PASS boundary.
- Product Face runner docs now state that synthetic Product Face evidence is only for fixtures/smoke/validation cards.

## Why

Issue #239 identified that the base Product Face result validator could accept `PASS` with `evidence_kind=synthetic`. Synthetic proof is useful as a fixture, but it must not be confused with real Product Face proof for customer/product completion.

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_rejects_synthetic_reusable_product_claim tests.test_factoryctl.FactoryCtlTest.test_product_face_pass_allows_non_reusable_synthetic_smoke_record tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_rejects_synthetic_pass_even_when_non_reusable tests.test_factoryctl.FactoryCtlTest.test_product_face_completion_accepts_real_pass_boundary tests.test_factoryctl.FactoryCtlTest.test_product_face_worker_result_validation_rejects_synthetic_completion tests.test_factoryctl.FactoryCtlTest.test_worker_result_builder_uses_specialized_bound_schema`
- `python -m py_compile scripts/factoryctl.py tests/test_factoryctl.py`
- `python -m unittest tests.test_factoryctl tests.test_product_face_proof`
- `python scripts/validate_public_json_artifacts.py`
- `git diff --check`
- `python -m unittest discover -s tests -p 'test*.py'`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`

Closes #239
