### PR TITLE
Add operational evidence bundle contract

### DIFF
--- a/schemas/operational-evidence-bundle.schema.json
+++ b/schemas/operational-evidence-bundle.schema.json
@@ -1,0 +1,347 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/operational-evidence-bundle.schema.json",
+  "title": "Overkill Factory Operational Evidence Bundle",
+  "type": "object",
+  "required": [
+    "record_type",
+    "bundle_id",
+    "claim_id",
+    "claim_text",
+    "claim_scope",
+    "materiality",
+    "verification_method",
+    "steps_executed",
+    "expected_result",
+    "observed_result",
+    "artifacts",
+    "verdict",
+    "evidence_kind",
+    "confidence_boundary",
+    "freshness",
+    "private_evidence_policy",
+    "reusable_for_product",
+    "next_safe_action"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 3
+    },
+    "record_type": {
+      "const": "operational_evidence_bundle"
+    },
+    "bundle_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "claim_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "claim_text": {
+      "type": "string",
+      "minLength": 12
+    },
+    "claim_scope": {
+      "enum": [
+        "product",
+        "work_unit",
+        "gate",
+        "runtime",
+        "security",
+        "release",
+        "ux",
+        "data",
+        "docs",
+        "research",
+        "external_source"
+      ]
+    },
+    "materiality": {
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "verification_method": {
+      "enum": [
+        "static_check",
+        "schema_validation",
+        "unit_test",
+        "integration_test",
+        "browser_check",
+        "visual_review",
+        "manual_review",
+        "runtime_probe",
+        "external_research",
+        "security_scan",
+        "performance_probe",
+        "other"
+      ]
+    },
+    "steps_executed": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 4
+      }
+    },
+    "expected_result": {
+      "type": "string",
+      "minLength": 6
+    },
+    "observed_result": {
+      "type": "string",
+      "minLength": 6
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "artifact_ref",
+          "artifact_type",
+          "public_safe",
+          "basis"
+        ],
+        "properties": {
+          "artifact_ref": {
+            "type": "string",
+            "minLength": 3
+          },
+          "artifact_type": {
+            "enum": [
+              "repo_file",
+              "schema_validation",
+              "test_output_ref",
+              "receipt_ref",
+              "report_ref",
+              "screenshot_ref",
+              "text_snapshot",
+              "external_ref",
+              "other"
+            ]
+          },
+          "public_safe": {
+            "const": true
+          },
+          "basis": {
+            "type": "string",
+            "minLength": 6
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "verdict": {
+      "enum": [
+        "CONFIRMED",
+        "REFUTED",
+        "INCONCLUSIVE",
+        "BLOCKED",
+        "WAIVED"
+      ]
+    },
+    "evidence_kind": {
+      "enum": [
+        "real",
+        "synthetic",
+        "waiver"
+      ]
+    },
+    "confidence_boundary": {
+      "type": "string",
+      "minLength": 12
+    },
+    "freshness": {
+      "type": "object",
+      "required": [
+        "checked_at",
+        "source_ref"
+      ],
+      "properties": {
+        "checked_at": {
+          "type": "string",
+          "minLength": 10
+        },
+        "source_ref": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "additionalProperties": true
+    },
+    "private_evidence_policy": {
+      "type": "object",
+      "required": [
+        "contains_private_evidence",
+        "raw_private_evidence_embedded",
+        "public_safe_refs_only",
+        "redaction_policy"
+      ],
+      "properties": {
+        "contains_private_evidence": {
+          "type": "boolean"
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "redaction_policy": {
+          "type": "string",
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "reusable_for_product": {
+      "type": "boolean"
+    },
+    "accepted_by": {
+      "type": "string",
+      "minLength": 3
+    },
+    "reviewer_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "next_safe_action": {
+      "type": "string",
+      "minLength": 6
+    },
+    "cannot_satisfy": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 6
+      }
+    },
+    "waiver": {
+      "type": "object",
+      "required": [
+        "owner",
+        "reason",
+        "expires_at",
+        "reviewer_or_human_gate_ref",
+        "compensating_controls",
+        "evidence_refs"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 2
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 6
+        },
+        "expires_at": {
+          "type": "string",
+          "minLength": 10
+        },
+        "reviewer_or_human_gate_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "compensating_controls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "WAIVED"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "required": [
+          "waiver"
+        ],
+        "properties": {
+          "evidence_kind": {
+            "const": "waiver"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence_kind": {
+            "const": "synthetic"
+          }
+        },
+        "required": [
+          "evidence_kind"
+        ]
+      },
+      "then": {
+        "required": [
+          "cannot_satisfy"
+        ],
+        "properties": {
+          "reusable_for_product": {
+            "const": false
+          },
+          "cannot_satisfy": {
+            "type": "array",
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "enum": [
+              "INCONCLUSIVE",
+              "BLOCKED"
+            ]
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "properties": {
+          "next_safe_action": {
+            "type": "string",
+            "minLength": 12
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -140,6 +140,19 @@
         "type": "string"
       }
     },
+    "operational_evidence_bundle_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "operational_evidence_bundles": {
+      "type": "array",
+      "items": {
+        "$ref": "operational-evidence-bundle.schema.json"
+      }
+    },
     "evidence_kind": {
       "enum": [
         "real",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4115,6 +4115,90 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_operational_evidence_bundle(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("operational-evidence-bundle.schema.json")
+    if not schema:
+        return ["operational_evidence_bundle schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            bundle,
+            "operational_evidence_bundle",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    verdict = str(bundle.get("verdict") or "").strip().upper()
+    evidence_kind = str(bundle.get("evidence_kind") or "").strip().lower()
+    artifacts = bundle.get("artifacts") if isinstance(bundle.get("artifacts"), list) else []
+    artifact_refs: list[str] = []
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        artifact_ref = str(artifact.get("artifact_ref") or "").strip()
+        artifact_refs.append(artifact_ref)
+        sanitized_ref, redaction = sanitize_public_ref(artifact_ref)
+        if redaction is not None:
+            errors.append(
+                "operational_evidence_bundle.artifacts"
+                f"[{index}].artifact_ref must be public-safe; got {sanitized_ref}"
+            )
+        if artifact.get("public_safe") is not True:
+            errors.append(f"operational_evidence_bundle.artifacts[{index}].public_safe must be true")
+
+    if verdict == "CONFIRMED":
+        for field in ("verification_method", "expected_result", "observed_result", "confidence_boundary"):
+            if not _non_empty_text(bundle.get(field)):
+                errors.append(f"operational_evidence_bundle CONFIRMED requires {field}")
+        if not _list_items(bundle.get("steps_executed")):
+            errors.append("operational_evidence_bundle CONFIRMED requires steps_executed")
+        if not artifact_refs:
+            errors.append("operational_evidence_bundle CONFIRMED requires artifact refs")
+
+    if verdict in {"INCONCLUSIVE", "BLOCKED"} and len(str(bundle.get("next_safe_action") or "").strip()) < 12:
+        errors.append(f"operational_evidence_bundle {verdict} requires the smallest safe next action")
+
+    waiver = bundle.get("waiver")
+    if verdict == "WAIVED":
+        if evidence_kind != "waiver":
+            errors.append("operational_evidence_bundle WAIVED requires evidence_kind=waiver")
+        if not isinstance(waiver, dict):
+            errors.append("operational_evidence_bundle WAIVED requires waiver object")
+        else:
+            for field in ("owner", "reason", "expires_at", "reviewer_or_human_gate_ref"):
+                if not _non_empty_text(waiver.get(field)):
+                    errors.append(f"operational_evidence_bundle.waiver missing {field}")
+            for index, ref in enumerate(_list_items(waiver.get("evidence_refs"))):
+                _, redaction = sanitize_public_ref(ref)
+                if redaction is not None:
+                    errors.append(
+                        "operational_evidence_bundle.waiver.evidence_refs"
+                        f"[{index}] must be public-safe"
+                    )
+    elif isinstance(waiver, dict):
+        errors.append("operational_evidence_bundle waiver object requires verdict=WAIVED")
+
+    if evidence_kind == "waiver" and verdict != "WAIVED":
+        errors.append("operational_evidence_bundle evidence_kind=waiver requires verdict=WAIVED")
+
+    if evidence_kind == "synthetic":
+        if bundle.get("reusable_for_product") is not False:
+            errors.append("operational_evidence_bundle synthetic evidence requires reusable_for_product=false")
+        if not _list_items(bundle.get("cannot_satisfy")):
+            errors.append("operational_evidence_bundle synthetic evidence requires cannot_satisfy")
+
+    policy = bundle.get("private_evidence_policy") if isinstance(bundle.get("private_evidence_policy"), dict) else {}
+    if policy.get("raw_private_evidence_embedded") is not False:
+        errors.append("operational_evidence_bundle must not embed raw private evidence")
+    if policy.get("public_safe_refs_only") is not True:
+        errors.append("operational_evidence_bundle requires public_safe_refs_only=true")
+
+    return errors
+
+
 def _required_product_states(card: dict[str, Any]) -> list[str]:
     plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
     packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
@@ -8314,6 +8398,16 @@ def command_validate_completion(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_evidence_bundle(args: argparse.Namespace) -> int:
+    errors = validate_operational_evidence_bundle(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_worker_packet(args: argparse.Namespace) -> int:
     card = load_json_like(args.card)
     if args.required_only and args.worker != "all":
@@ -8606,6 +8700,14 @@ def build_parser() -> argparse.ArgumentParser:
     validate_completion_parser.add_argument("--card", type=Path, required=True)
     validate_completion_parser.add_argument("--receipt", type=Path, required=True)
     validate_completion_parser.set_defaults(func=command_validate_completion)
+
+    validate_evidence_bundle_parser = sub.add_parser("validate-evidence-bundle")
+    validate_evidence_bundle_parser.add_argument("path", type=Path)
+    validate_evidence_bundle_parser.set_defaults(func=command_validate_evidence_bundle)
+
+    validate_bundle_parser = sub.add_parser("validate-bundle")
+    validate_bundle_parser.add_argument("path", type=Path)
+    validate_bundle_parser.set_defaults(func=command_validate_evidence_bundle)
 
     worker_packet_parser = sub.add_parser("worker-packet")
     worker_packet_parser.add_argument("--worker", choices=[*WORKERS.keys(), "all"], required=True)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -105,6 +105,36 @@ RAW_RESEARCH_FIELDS = {
     "private_capture_path",
 }
 
+
+def public_artifact_ref_error(ref: Any) -> str | None:
+    value = str(ref or "").strip()
+    normalized = value.replace("\\", "/")
+    if not value:
+        return "empty artifact ref"
+    if contains_private_kanban_task_marker(value):
+        return "raw Hermes Kanban task id"
+    if PRIVATE_MARKERS.search(value):
+        return "private local or runtime marker"
+    if value.startswith("external:"):
+        trusted_prefixes = (
+            "external:sanitized",
+            "external:operator",
+            "external:public",
+            "external:maintainer",
+            "external:source-card",
+            "external:memory",
+        )
+        if value.startswith(trusted_prefixes):
+            return None
+        return "untrusted external ref"
+    if value.startswith(("http://", "https://", "file://")):
+        return "absolute, URL, or private runtime ref"
+    if Path(value).is_absolute() or ":" in normalized.split("/", 1)[0]:
+        return "absolute, URL, or private runtime ref"
+    if normalized.startswith((".tmp/", "tmp/", "reports/private/", "private/", "run-evidence/")) or "/.tmp/" in normalized:
+        return "private or transient evidence location"
+    return None
+
 ANNOTATION_SCHEMA_KEYWORDS = {
     "$comment",
     "$id",
@@ -421,6 +451,29 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                         errors.append(f"{at}.waiver.{field}: expected non-empty array")
         if data.get("evidence_kind") == "waiver" and data.get("result") != "WAIVED":
             errors.append(f"{at}: evidence_kind=waiver requires result=WAIVED")
+    if data.get("record_type") == "operational_evidence_bundle":
+        artifacts = data.get("artifacts") if isinstance(data.get("artifacts"), list) else []
+        for index, artifact in enumerate(artifacts):
+            if not isinstance(artifact, dict):
+                continue
+            reason = public_artifact_ref_error(artifact.get("artifact_ref"))
+            if reason:
+                errors.append(f"{at}.artifacts[{index}].artifact_ref: {reason}")
+        waiver = data.get("waiver") if isinstance(data.get("waiver"), dict) else {}
+        waiver_refs = waiver.get("evidence_refs") if isinstance(waiver.get("evidence_refs"), list) else []
+        for index, ref in enumerate(waiver_refs):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.waiver.evidence_refs[{index}]: {reason}")
+        if data.get("verdict") == "WAIVED" and data.get("evidence_kind") != "waiver":
+            errors.append(f"{at}: WAIVED operational_evidence_bundle requires evidence_kind=waiver")
+        if data.get("evidence_kind") == "waiver" and data.get("verdict") != "WAIVED":
+            errors.append(f"{at}: evidence_kind=waiver requires verdict=WAIVED")
+        if data.get("evidence_kind") == "synthetic":
+            if data.get("reusable_for_product") is not False:
+                errors.append(f"{at}: synthetic operational_evidence_bundle requires reusable_for_product=false")
+            if not data.get("cannot_satisfy"):
+                errors.append(f"{at}: synthetic operational_evidence_bundle requires cannot_satisfy")
     if data.get("record_type") == "product_face_result" and data.get("reusable_for_product") is True:
         if not str(data.get("packet_ref") or "").strip():
             errors.append(f"{at}: reusable product_face_result requires packet_ref")

--- a/templates/operational-evidence-bundle.json
+++ b/templates/operational-evidence-bundle.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operational-evidence-bundle.schema.json",
+  "record_type": "operational_evidence_bundle",
+  "bundle_id": "bundle-schema-self-check",
+  "claim_id": "claim-operational-evidence-contract",
+  "claim_text": "The public operational evidence bundle contract can be independently validated.",
+  "claim_scope": "gate",
+  "materiality": "medium",
+  "verification_method": "schema_validation",
+  "steps_executed": [
+    "Validate this template against the public operational evidence bundle schema.",
+    "Run factoryctl validate-evidence-bundle against this template."
+  ],
+  "expected_result": "The template validates without embedding raw private evidence.",
+  "observed_result": "The template is public-safe and points only at repo-relative contract files.",
+  "artifacts": [
+    {
+      "artifact_ref": "schemas/operational-evidence-bundle.schema.json",
+      "artifact_type": "schema_validation",
+      "public_safe": true,
+      "basis": "Defines the enforced public bundle shape."
+    },
+    {
+      "artifact_ref": "tests/test_operational_evidence_bundle.py",
+      "artifact_type": "test_output_ref",
+      "public_safe": true,
+      "basis": "Covers verdict, waiver, synthetic and private-ref semantics."
+    }
+  ],
+  "verdict": "CONFIRMED",
+  "evidence_kind": "real",
+  "confidence_boundary": "This confirms the public contract shape, not a live production run.",
+  "freshness": {
+    "checked_at": "2026-06-16T00:00:00+00:00",
+    "source_ref": "repo:overkill-factory"
+  },
+  "private_evidence_policy": {
+    "contains_private_evidence": false,
+    "raw_private_evidence_embedded": false,
+    "public_safe_refs_only": true,
+    "redaction_policy": "Only repo-relative or explicitly sanitized refs are allowed."
+  },
+  "reusable_for_product": true,
+  "reviewer_ref": "external:public-contract-review",
+  "next_safe_action": "Attach bundles to worker results when a claim needs reusable proof."
+}

--- a/tests/test_operational_evidence_bundle.py
+++ b/tests/test_operational_evidence_bundle.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl", MODULE_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+def evidence_bundle(**overrides: object) -> dict:
+    bundle = {
+        "$schema": "https://overkill-factory.dev/schemas/operational-evidence-bundle.schema.json",
+        "record_type": "operational_evidence_bundle",
+        "bundle_id": "bundle-fixture-001",
+        "claim_id": "claim-fixture-001",
+        "claim_text": "The fixture claim has enough public-safe evidence to be checked.",
+        "claim_scope": "gate",
+        "materiality": "medium",
+        "verification_method": "schema_validation",
+        "steps_executed": [
+            "Load the operational evidence bundle fixture.",
+            "Validate schema and semantic factoryctl rules."
+        ],
+        "expected_result": "The bundle passes schema and semantic validation.",
+        "observed_result": "The bundle contains public-safe artifact references.",
+        "artifacts": [
+            {
+                "artifact_ref": "schemas/operational-evidence-bundle.schema.json",
+                "artifact_type": "schema_validation",
+                "public_safe": True,
+                "basis": "Public schema defines the accepted bundle shape."
+            }
+        ],
+        "verdict": "CONFIRMED",
+        "evidence_kind": "real",
+        "confidence_boundary": "This proves only the fixture claim, not production runtime behavior.",
+        "freshness": {
+            "checked_at": "2026-06-16T00:00:00+00:00",
+            "source_ref": "repo:overkill-factory"
+        },
+        "private_evidence_policy": {
+            "contains_private_evidence": False,
+            "raw_private_evidence_embedded": False,
+            "public_safe_refs_only": True,
+            "redaction_policy": "Raw private evidence stays outside public artifacts."
+        },
+        "reusable_for_product": True,
+        "reviewer_ref": "external:public-contract-review",
+        "next_safe_action": "Attach this bundle only to claims with matching scope."
+    }
+    bundle.update(overrides)
+    return bundle
+
+
+class OperationalEvidenceBundleTest(unittest.TestCase):
+    def test_confirmed_bundle_validates(self) -> None:
+        errors = factoryctl.validate_operational_evidence_bundle(evidence_bundle())
+
+        self.assertEqual(errors, [])
+
+    def test_refuted_bundle_validates_with_artifacts(self) -> None:
+        bundle = evidence_bundle(
+            verdict="REFUTED",
+            observed_result="The checked artifact contradicts the claim.",
+            next_safe_action="Repair the claim or rerun with corrected evidence."
+        )
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertEqual(errors, [])
+
+    def test_inconclusive_bundle_requires_next_action(self) -> None:
+        bundle = evidence_bundle(verdict="INCONCLUSIVE", next_safe_action="")
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertTrue(any("next_safe_action" in error for error in errors), errors)
+
+    def test_blocked_bundle_requires_next_action(self) -> None:
+        bundle = evidence_bundle(verdict="BLOCKED", next_safe_action="retry")
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertTrue(any("smallest safe next action" in error or "next_safe_action" in error for error in errors), errors)
+
+    def test_waived_bundle_requires_waiver_authority(self) -> None:
+        bundle = evidence_bundle(verdict="WAIVED", evidence_kind="waiver")
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertTrue(any("waiver" in error for error in errors), errors)
+
+        bundle["waiver"] = {
+            "owner": "risk-owner",
+            "reason": "Temporary documented exception for fixture validation.",
+            "expires_at": "2026-07-16T00:00:00+00:00",
+            "reviewer_or_human_gate_ref": "external:maintainer-human-gate",
+            "compensating_controls": ["manual review before promotion"],
+            "evidence_refs": ["external:public-waiver-review"]
+        }
+
+        self.assertEqual(factoryctl.validate_operational_evidence_bundle(bundle), [])
+
+    def test_synthetic_bundle_cannot_be_reused_for_product(self) -> None:
+        bundle = evidence_bundle(evidence_kind="synthetic", reusable_for_product=True)
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertTrue(any("reusable_for_product=false" in error for error in errors), errors)
+        self.assertTrue(any("cannot_satisfy" in error for error in errors), errors)
+
+        bundle["reusable_for_product"] = False
+        bundle["cannot_satisfy"] = ["customer acceptance", "release readiness"]
+
+        self.assertEqual(factoryctl.validate_operational_evidence_bundle(bundle), [])
+
+    def test_unsafe_private_artifact_ref_is_rejected(self) -> None:
+        bundle = evidence_bundle(
+            artifacts=[
+                {
+                    "artifact_ref": ".tmp/factory-runs/private/raw-log.txt",
+                    "artifact_type": "report_ref",
+                    "public_safe": True,
+                    "basis": "This should never be public."
+                }
+            ]
+        )
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertTrue(any("artifact_ref must be public-safe" in error for error in errors), errors)
+
+    def test_missing_claim_steps_artifacts_and_ambiguous_verdict_are_rejected(self) -> None:
+        bundle = evidence_bundle(claim_text="", steps_executed=[], artifacts=[], verdict="MAYBE")
+
+        errors = factoryctl.validate_operational_evidence_bundle(bundle)
+
+        self.assertTrue(any("claim_text" in error for error in errors), errors)
+        self.assertTrue(any("steps_executed" in error for error in errors), errors)
+        self.assertTrue(any("artifacts" in error for error in errors), errors)
+        self.assertTrue(any("verdict" in error for error in errors), errors)
+
+    def test_public_template_validates_with_schema_and_domain_rules(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        schema = schemas["operational-evidence-bundle.schema.json"]
+        template = json.loads((ROOT / "templates" / "operational-evidence-bundle.json").read_text(encoding="utf-8"))
+
+        schema_errors = public_json_validator.validate_node(schema, template, "$", schemas=schemas, root_schema=schema)
+        domain_errors = public_json_validator.validate_domain_rules(template, "$")
+
+        self.assertEqual(schema_errors + domain_errors, [])
+
+    def test_public_validator_rejects_private_artifact_ref(self) -> None:
+        bundle = evidence_bundle(
+            artifacts=[
+                {
+                    "artifact_ref": ".tmp/factory-runs/private/raw-log.json",
+                    "artifact_type": "report_ref",
+                    "public_safe": True,
+                    "basis": "Transient private run output."
+                }
+            ]
+        )
+
+        errors = public_json_validator.validate_domain_rules(bundle, "$")
+
+        self.assertTrue(any("$.artifacts[0].artifact_ref" in error for error in errors), errors)
+
+    def test_factoryctl_cli_validates_bundle_independently(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bundle.json"
+            path.write_text(json.dumps(evidence_bundle()), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(["validate-evidence-bundle", str(path)])
+
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a public-safe `operational_evidence_bundle` schema and template for claim-level proof.
- Adds independent `factoryctl validate-evidence-bundle` / `validate-bundle` validation with semantic checks for verdicts, waiver authority, synthetic evidence boundaries and private refs.
- Allows worker results to reference or embed operational evidence bundles without replacing Receipt Five, Evidence Graph or Product Face.
- Extends public JSON artifact validation so public bundle artifacts reject private/transient refs.

Closes #246.

## Validation

- `python -m unittest tests.test_operational_evidence_bundle -q`
- `python -m unittest tests.test_public_json_artifact_validator -q`
- `python -m unittest tests.test_factoryctl -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\factoryctl.py validate-evidence-bundle templates\operational-evidence-bundle.json`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python -m unittest discover -s tests -q`
- `git diff --check`

## Boundaries

- Does not touch #84 cockpit implementation or local HTML worktrees.
- Does not publish raw private/runtime evidence.
- Does not treat bundle existence as acceptance; owning gates still decide acceptance.
