### PR TITLE
Add factory SDLC lifecycle contract

### DIFF
--- a/schemas/factory-sdlc-lifecycle-state.schema.json
+++ b/schemas/factory-sdlc-lifecycle-state.schema.json
@@ -1,0 +1,429 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-sdlc-lifecycle-state.schema.json",
+  "title": "Overkill Factory SDLC Lifecycle State",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "lifecycle_id",
+    "created_at",
+    "factory_method_version",
+    "workflow_catalog_ref",
+    "subject",
+    "active_phase_id",
+    "delivery_state",
+    "phase_states",
+    "current_owner_worker",
+    "gate_predicate",
+    "evidence_refs",
+    "next_safe_action",
+    "lifecycle_acceptance",
+    "public_private_boundary",
+    "projection_policy"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-sdlc-lifecycle-state.schema.json"
+    },
+    "record_type": {
+      "const": "factory_sdlc_lifecycle_state"
+    },
+    "lifecycle_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "workflow_catalog_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "subject": {
+      "type": "object",
+      "required": [
+        "subject_type",
+        "subject_id",
+        "scope_type",
+        "source_ref"
+      ],
+      "properties": {
+        "subject_type": {
+          "enum": [
+            "product",
+            "run",
+            "slice",
+            "work_unit",
+            "release",
+            "factory_improvement"
+          ]
+        },
+        "subject_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "scope_type": {
+          "enum": [
+            "factory_execution",
+            "generated_product",
+            "mixed_with_explicit_boundary"
+          ]
+        },
+        "source_ref": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "active_phase_id": {
+      "type": "string",
+      "minLength": 2
+    },
+    "delivery_state": {
+      "enum": [
+        "local_only",
+        "committed",
+        "pr_open",
+        "merged_main",
+        "release_candidate",
+        "deployed",
+        "operational",
+        "blocked"
+      ]
+    },
+    "phase_states": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "phase_id",
+          "phase_name",
+          "status",
+          "owner_worker",
+          "gate_predicate",
+          "evidence_refs",
+          "next_safe_action",
+          "human_gate",
+          "recovery_route"
+        ],
+        "properties": {
+          "phase_id": {
+            "type": "string",
+            "minLength": 2
+          },
+          "phase_name": {
+            "type": "string",
+            "minLength": 3
+          },
+          "status": {
+            "enum": [
+              "PENDING",
+              "ACTIVE",
+              "PASSED",
+              "BLOCKED",
+              "WAIVED",
+              "STALE",
+              "SUPERSEDED",
+              "SKIPPED"
+            ]
+          },
+          "owner_worker": {
+            "type": "string",
+            "minLength": 3
+          },
+          "gate_predicate": {
+            "type": "object",
+            "required": [
+              "gate_id",
+              "result",
+              "predicate",
+              "evidence_refs"
+            ],
+            "properties": {
+              "gate_id": {
+                "type": "string",
+                "minLength": 3
+              },
+              "result": {
+                "enum": [
+                  "PASS",
+                  "BLOCK",
+                  "PENDING",
+                  "WAIVED",
+                  "STALE",
+                  "SUPERSEDED"
+                ]
+              },
+              "predicate": {
+                "type": "string",
+                "minLength": 6
+              },
+              "evidence_refs": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 3
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "next_safe_action": {
+            "type": "string",
+            "minLength": 6
+          },
+          "human_gate": {
+            "type": "object",
+            "required": [
+              "required",
+              "classification",
+              "authority_ref",
+              "factory_may_simulate"
+            ],
+            "properties": {
+              "required": {
+                "type": "boolean"
+              },
+              "classification": {
+                "enum": [
+                  "not_required",
+                  "required_real_human_gate"
+                ]
+              },
+              "authority_ref": {
+                "type": "string",
+                "minLength": 3
+              },
+              "factory_may_simulate": {
+                "const": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "recovery_route": {
+            "type": "object",
+            "required": [
+              "required",
+              "route_ref",
+              "factory_owned_repair_allowed",
+              "retry_policy"
+            ],
+            "properties": {
+              "required": {
+                "type": "boolean"
+              },
+              "route_ref": {
+                "type": "string",
+                "minLength": 3
+              },
+              "factory_owned_repair_allowed": {
+                "type": "boolean"
+              },
+              "retry_policy": {
+                "type": "object",
+                "required": [
+                  "max_attempts",
+                  "attempt_number",
+                  "stop_condition"
+                ],
+                "properties": {
+                  "max_attempts": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "attempt_number": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "stop_condition": {
+                    "type": "string",
+                    "minLength": 6
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "current_owner_worker": {
+      "type": "string",
+      "minLength": 3
+    },
+    "gate_predicate": {
+      "type": "object",
+      "required": [
+        "gate_id",
+        "result",
+        "predicate",
+        "evidence_refs"
+      ],
+      "properties": {
+        "gate_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "result": {
+          "enum": [
+            "PASS",
+            "BLOCK",
+            "PENDING",
+            "WAIVED",
+            "STALE",
+            "SUPERSEDED"
+          ]
+        },
+        "predicate": {
+          "type": "string",
+          "minLength": 6
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "next_safe_action": {
+      "type": "string",
+      "minLength": 6
+    },
+    "lifecycle_acceptance": {
+      "type": "object",
+      "required": [
+        "scope_completion_state",
+        "proof_level",
+        "implemented_by_contract",
+        "runtime_proven",
+        "production_ready_claimed",
+        "customer_ready_claimed"
+      ],
+      "properties": {
+        "scope_completion_state": {
+          "enum": [
+            "not_started",
+            "in_progress",
+            "scope_complete",
+            "production_complete",
+            "customer_ready",
+            "released",
+            "operational",
+            "blocked"
+          ]
+        },
+        "proof_level": {
+          "enum": [
+            "implemented_by_contract",
+            "static_or_schema_validated",
+            "runtime_proven",
+            "production_strict",
+            "customer_validated"
+          ]
+        },
+        "implemented_by_contract": {
+          "type": "boolean"
+        },
+        "runtime_proven": {
+          "type": "boolean"
+        },
+        "production_ready_claimed": {
+          "type": "boolean"
+        },
+        "customer_ready_claimed": {
+          "type": "boolean"
+        },
+        "limits": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "raw_private_evidence_embedded",
+        "public_safe_refs_only",
+        "private_runtime_evidence_stays_local"
+      ],
+      "properties": {
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "private_runtime_evidence_stays_local": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "projection_policy": {
+      "type": "object",
+      "required": [
+        "cockpit_is_source_of_truth",
+        "dashboard_visibility_is_evidence",
+        "consumer_role"
+      ],
+      "properties": {
+        "cockpit_is_source_of_truth": {
+          "const": false
+        },
+        "dashboard_visibility_is_evidence": {
+          "const": false
+        },
+        "consumer_role": {
+          "enum": [
+            "projection_only",
+            "operator_read_model",
+            "worker_context"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "linked_operational_evidence_bundle_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/operational-evidence-bundle.schema.json
+++ b/schemas/operational-evidence-bundle.schema.json
@@ -268,6 +268,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "factory_sdlc_lifecycle_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
     }
   },
   "additionalProperties": false,

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -153,6 +153,13 @@
         "$ref": "operational-evidence-bundle.schema.json"
       }
     },
+    "factory_sdlc_lifecycle_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
     "evidence_kind": {
       "enum": [
         "real",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4199,6 +4199,131 @@ def validate_operational_evidence_bundle(bundle: dict[str, Any]) -> list[str]:
     return errors
 
 
+def factory_workflow_catalog_phase_ids() -> set[str]:
+    if not DEFAULT_WORKFLOW_CATALOG.exists():
+        return set()
+    catalog = json.loads(DEFAULT_WORKFLOW_CATALOG.read_text(encoding="utf-8"))
+    phases = catalog.get("phases") if isinstance(catalog.get("phases"), list) else []
+    return {str(phase.get("phase_id") or "").strip() for phase in phases if isinstance(phase, dict)}
+
+
+def _validate_lifecycle_refs(refs: list[str], at: str, errors: list[str]) -> None:
+    for index, ref in enumerate(refs):
+        _, redaction = sanitize_public_ref(ref)
+        if redaction is not None:
+            errors.append(f"{at}[{index}] must be public-safe")
+
+
+def validate_factory_sdlc_lifecycle_state(state: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-sdlc-lifecycle-state.schema.json")
+    if not schema:
+        return ["factory_sdlc_lifecycle_state schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            state,
+            "factory_sdlc_lifecycle_state",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    catalog_phase_ids = factory_workflow_catalog_phase_ids()
+    active_phase_id = str(state.get("active_phase_id") or "").strip()
+    if catalog_phase_ids and active_phase_id not in catalog_phase_ids:
+        errors.append(f"factory_sdlc_lifecycle_state.active_phase_id unknown phase {active_phase_id!r}")
+
+    phase_states = state.get("phase_states") if isinstance(state.get("phase_states"), list) else []
+    active_phase_seen = False
+    for index, phase in enumerate(phase_states):
+        if not isinstance(phase, dict):
+            continue
+        phase_id = str(phase.get("phase_id") or "").strip()
+        if catalog_phase_ids and phase_id not in catalog_phase_ids:
+            errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}].phase_id unknown phase {phase_id!r}")
+        if phase_id == active_phase_id:
+            active_phase_seen = True
+
+        evidence_refs = _list_items(phase.get("evidence_refs"))
+        _validate_lifecycle_refs(evidence_refs, f"factory_sdlc_lifecycle_state.phase_states[{index}].evidence_refs", errors)
+        gate = phase.get("gate_predicate") if isinstance(phase.get("gate_predicate"), dict) else {}
+        _validate_lifecycle_refs(
+            _list_items(gate.get("evidence_refs")),
+            f"factory_sdlc_lifecycle_state.phase_states[{index}].gate_predicate.evidence_refs",
+            errors,
+        )
+
+        status = str(phase.get("status") or "").strip().upper()
+        human_gate = phase.get("human_gate") if isinstance(phase.get("human_gate"), dict) else {}
+        human_required = human_gate.get("required") is True
+        classification = str(human_gate.get("classification") or "").strip()
+        authority_ref = str(human_gate.get("authority_ref") or "").strip()
+        if human_required:
+            if classification != "required_real_human_gate":
+                errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] human gate classification is ambiguous")
+            if authority_ref != "human_gate_record" and not authority_ref.startswith("external:"):
+                errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] human gate requires real authority ref")
+        elif classification != "not_required":
+            errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] non-human phase must classify human gate as not_required")
+
+        recovery_route = phase.get("recovery_route") if isinstance(phase.get("recovery_route"), dict) else {}
+        if status == "BLOCKED" and not human_required:
+            if recovery_route.get("required") is not True:
+                errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] non-human BLOCKED state requires recovery_route.required=true")
+            if recovery_route.get("factory_owned_repair_allowed") is not True:
+                errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] non-human BLOCKED state requires factory-owned repair route")
+            if not _non_empty_text(recovery_route.get("route_ref")):
+                errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] blocked recovery route requires route_ref")
+            retry_policy = recovery_route.get("retry_policy") if isinstance(recovery_route.get("retry_policy"), dict) else {}
+            max_attempts = retry_policy.get("max_attempts")
+            if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or max_attempts < 1:
+                errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] blocked recovery route requires retry_policy.max_attempts")
+        if status == "BLOCKED" and human_required and recovery_route.get("factory_owned_repair_allowed") is True:
+            errors.append(f"factory_sdlc_lifecycle_state.phase_states[{index}] human gate cannot allow factory-owned repair")
+
+    if active_phase_id and not active_phase_seen:
+        errors.append("factory_sdlc_lifecycle_state.active_phase_id must appear in phase_states")
+
+    _validate_lifecycle_refs(_list_items(state.get("evidence_refs")), "factory_sdlc_lifecycle_state.evidence_refs", errors)
+    gate = state.get("gate_predicate") if isinstance(state.get("gate_predicate"), dict) else {}
+    _validate_lifecycle_refs(_list_items(gate.get("evidence_refs")), "factory_sdlc_lifecycle_state.gate_predicate.evidence_refs", errors)
+    _validate_lifecycle_refs(
+        _list_items(state.get("linked_operational_evidence_bundle_refs")),
+        "factory_sdlc_lifecycle_state.linked_operational_evidence_bundle_refs",
+        errors,
+    )
+
+    acceptance = state.get("lifecycle_acceptance") if isinstance(state.get("lifecycle_acceptance"), dict) else {}
+    proof_level = str(acceptance.get("proof_level") or "").strip()
+    scope_state = str(acceptance.get("scope_completion_state") or "").strip()
+    delivery_state = str(state.get("delivery_state") or "").strip()
+    production_claim = acceptance.get("production_ready_claimed") is True
+    customer_claim = acceptance.get("customer_ready_claimed") is True
+    production_states = {"production_complete", "released", "operational"}
+    customer_states = {"customer_ready", "released", "operational"}
+    production_delivery_claim = delivery_state in {"release_candidate", "deployed", "operational"}
+    if (
+        production_claim
+        or scope_state in production_states
+        or production_delivery_claim
+    ) and proof_level not in {"production_strict", "customer_validated"}:
+        errors.append("factory_sdlc_lifecycle_state production readiness requires production_strict or customer_validated proof")
+    if (customer_claim or scope_state in customer_states) and proof_level != "customer_validated":
+        errors.append("factory_sdlc_lifecycle_state customer readiness requires customer_validated proof")
+    if proof_level in {"implemented_by_contract", "static_or_schema_validated"} and acceptance.get("runtime_proven") is True:
+        errors.append("factory_sdlc_lifecycle_state runtime_proven cannot be true for contract/static proof")
+
+    projection = state.get("projection_policy") if isinstance(state.get("projection_policy"), dict) else {}
+    if projection.get("cockpit_is_source_of_truth") is not False:
+        errors.append("factory_sdlc_lifecycle_state cockpit must not be source of truth")
+    if projection.get("dashboard_visibility_is_evidence") is not False:
+        errors.append("factory_sdlc_lifecycle_state dashboard visibility must not be evidence")
+
+    return errors
+
+
 def _required_product_states(card: dict[str, Any]) -> list[str]:
     plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
     packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
@@ -8408,6 +8533,16 @@ def command_validate_evidence_bundle(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_sdlc_lifecycle(args: argparse.Namespace) -> int:
+    errors = validate_factory_sdlc_lifecycle_state(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_worker_packet(args: argparse.Namespace) -> int:
     card = load_json_like(args.card)
     if args.required_only and args.worker != "all":
@@ -8708,6 +8843,14 @@ def build_parser() -> argparse.ArgumentParser:
     validate_bundle_parser = sub.add_parser("validate-bundle")
     validate_bundle_parser.add_argument("path", type=Path)
     validate_bundle_parser.set_defaults(func=command_validate_evidence_bundle)
+
+    validate_sdlc_lifecycle_parser = sub.add_parser("validate-sdlc-lifecycle")
+    validate_sdlc_lifecycle_parser.add_argument("path", type=Path)
+    validate_sdlc_lifecycle_parser.set_defaults(func=command_validate_sdlc_lifecycle)
+
+    validate_lifecycle_parser = sub.add_parser("validate-lifecycle")
+    validate_lifecycle_parser.add_argument("path", type=Path)
+    validate_lifecycle_parser.set_defaults(func=command_validate_sdlc_lifecycle)
 
     worker_packet_parser = sub.add_parser("worker-packet")
     worker_packet_parser.add_argument("--worker", choices=[*WORKERS.keys(), "all"], required=True)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -474,6 +474,44 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                 errors.append(f"{at}: synthetic operational_evidence_bundle requires reusable_for_product=false")
             if not data.get("cannot_satisfy"):
                 errors.append(f"{at}: synthetic operational_evidence_bundle requires cannot_satisfy")
+    if data.get("record_type") == "factory_sdlc_lifecycle_state":
+        refs = data.get("evidence_refs") if isinstance(data.get("evidence_refs"), list) else []
+        for index, ref in enumerate(refs):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.evidence_refs[{index}]: {reason}")
+        gate = data.get("gate_predicate") if isinstance(data.get("gate_predicate"), dict) else {}
+        gate_refs = gate.get("evidence_refs") if isinstance(gate.get("evidence_refs"), list) else []
+        for index, ref in enumerate(gate_refs):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.gate_predicate.evidence_refs[{index}]: {reason}")
+        phase_states = data.get("phase_states") if isinstance(data.get("phase_states"), list) else []
+        for phase_index, phase in enumerate(phase_states):
+            if not isinstance(phase, dict):
+                continue
+            phase_refs = phase.get("evidence_refs") if isinstance(phase.get("evidence_refs"), list) else []
+            for index, ref in enumerate(phase_refs):
+                reason = public_artifact_ref_error(ref)
+                if reason:
+                    errors.append(f"{at}.phase_states[{phase_index}].evidence_refs[{index}]: {reason}")
+            phase_gate = phase.get("gate_predicate") if isinstance(phase.get("gate_predicate"), dict) else {}
+            phase_gate_refs = phase_gate.get("evidence_refs") if isinstance(phase_gate.get("evidence_refs"), list) else []
+            for index, ref in enumerate(phase_gate_refs):
+                reason = public_artifact_ref_error(ref)
+                if reason:
+                    errors.append(f"{at}.phase_states[{phase_index}].gate_predicate.evidence_refs[{index}]: {reason}")
+            status = str(phase.get("status") or "").strip().upper()
+            human_gate = phase.get("human_gate") if isinstance(phase.get("human_gate"), dict) else {}
+            recovery = phase.get("recovery_route") if isinstance(phase.get("recovery_route"), dict) else {}
+            if status == "BLOCKED" and human_gate.get("required") is not True and recovery.get("required") is not True:
+                errors.append(f"{at}.phase_states[{phase_index}]: non-human BLOCKED state requires recovery route")
+        acceptance = data.get("lifecycle_acceptance") if isinstance(data.get("lifecycle_acceptance"), dict) else {}
+        proof_level = str(acceptance.get("proof_level") or "")
+        if acceptance.get("production_ready_claimed") is True and proof_level not in {"production_strict", "customer_validated"}:
+            errors.append(f"{at}: production readiness requires production_strict or customer_validated proof")
+        if acceptance.get("customer_ready_claimed") is True and proof_level != "customer_validated":
+            errors.append(f"{at}: customer readiness requires customer_validated proof")
     if data.get("record_type") == "product_face_result" and data.get("reusable_for_product") is True:
         if not str(data.get("packet_ref") or "").strip():
             errors.append(f"{at}: reusable product_face_result requires packet_ref")

--- a/templates/factory-sdlc-lifecycle-state.json
+++ b/templates/factory-sdlc-lifecycle-state.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-sdlc-lifecycle-state.schema.json",
+  "record_type": "factory_sdlc_lifecycle_state",
+  "lifecycle_id": "lifecycle-public-template",
+  "created_at": "2026-06-16T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "workflow_catalog_ref": "docs/factory-workflow.catalog.json",
+  "subject": {
+    "subject_type": "factory_improvement",
+    "subject_id": "issue-247",
+    "scope_type": "factory_execution",
+    "source_ref": "https://github.com/felipegermano17/overkill-factory/issues/247"
+  },
+  "active_phase_id": "F11",
+  "delivery_state": "local_only",
+  "phase_states": [
+    {
+      "phase_id": "F11",
+      "phase_name": "Executable Plans",
+      "status": "ACTIVE",
+      "owner_worker": "decomposition-planner",
+      "gate_predicate": {
+        "gate_id": "sdlc-lifecycle-contract-gate",
+        "result": "PENDING",
+        "predicate": "Lifecycle contract exists and validates before consumers project it.",
+        "evidence_refs": [
+          "schemas/factory-sdlc-lifecycle-state.schema.json"
+        ]
+      },
+      "evidence_refs": [
+        "schemas/factory-sdlc-lifecycle-state.schema.json",
+        "tests/test_factory_sdlc_lifecycle.py"
+      ],
+      "next_safe_action": "Validate lifecycle state before any cockpit projection consumes it.",
+      "human_gate": {
+        "required": false,
+        "classification": "not_required",
+        "authority_ref": "not_required",
+        "factory_may_simulate": false
+      },
+      "recovery_route": {
+        "required": false,
+        "route_ref": "not_required",
+        "factory_owned_repair_allowed": false,
+        "retry_policy": {
+          "max_attempts": 1,
+          "attempt_number": 1,
+          "stop_condition": "No recovery route is active while the phase is not blocked."
+        }
+      }
+    }
+  ],
+  "current_owner_worker": "decomposition-planner",
+  "gate_predicate": {
+    "gate_id": "sdlc-lifecycle-template-gate",
+    "result": "PENDING",
+    "predicate": "Template is valid but does not claim production readiness.",
+    "evidence_refs": [
+      "templates/factory-sdlc-lifecycle-state.json"
+    ]
+  },
+  "evidence_refs": [
+    "schemas/factory-sdlc-lifecycle-state.schema.json",
+    "templates/factory-sdlc-lifecycle-state.json",
+    "tests/test_factory_sdlc_lifecycle.py"
+  ],
+  "next_safe_action": "Use factoryctl validate-sdlc-lifecycle before publishing or consuming lifecycle state.",
+  "lifecycle_acceptance": {
+    "scope_completion_state": "in_progress",
+    "proof_level": "static_or_schema_validated",
+    "implemented_by_contract": true,
+    "runtime_proven": false,
+    "production_ready_claimed": false,
+    "customer_ready_claimed": false,
+    "limits": [
+      "Template validates the contract shape only.",
+      "It does not prove product runtime, release or customer readiness."
+    ]
+  },
+  "public_private_boundary": {
+    "raw_private_evidence_embedded": false,
+    "public_safe_refs_only": true,
+    "private_runtime_evidence_stays_local": true
+  },
+  "projection_policy": {
+    "cockpit_is_source_of_truth": false,
+    "dashboard_visibility_is_evidence": false,
+    "consumer_role": "projection_only"
+  },
+  "linked_operational_evidence_bundle_refs": [
+    "templates/operational-evidence-bundle.json"
+  ]
+}

--- a/tests/test_factory_sdlc_lifecycle.py
+++ b/tests/test_factory_sdlc_lifecycle.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl", MODULE_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+def lifecycle_state(**overrides: object) -> dict:
+    state = {
+        "$schema": "https://overkill-factory.dev/schemas/factory-sdlc-lifecycle-state.schema.json",
+        "record_type": "factory_sdlc_lifecycle_state",
+        "lifecycle_id": "lifecycle-fixture-001",
+        "created_at": "2026-06-16T00:00:00+00:00",
+        "factory_method_version": "OVERKILL_VFINAL",
+        "workflow_catalog_ref": "docs/factory-workflow.catalog.json",
+        "subject": {
+            "subject_type": "factory_improvement",
+            "subject_id": "issue-247",
+            "scope_type": "factory_execution",
+            "source_ref": "https://github.com/felipegermano17/overkill-factory/issues/247"
+        },
+        "active_phase_id": "F11",
+        "delivery_state": "local_only",
+        "phase_states": [
+            {
+                "phase_id": "F11",
+                "phase_name": "Executable Plans",
+                "status": "ACTIVE",
+                "owner_worker": "decomposition-planner",
+                "gate_predicate": {
+                    "gate_id": "fixture-gate",
+                    "result": "PENDING",
+                    "predicate": "Fixture lifecycle is under validation.",
+                    "evidence_refs": ["schemas/factory-sdlc-lifecycle-state.schema.json"]
+                },
+                "evidence_refs": [
+                    "schemas/factory-sdlc-lifecycle-state.schema.json",
+                    "tests/test_factory_sdlc_lifecycle.py"
+                ],
+                "next_safe_action": "Validate lifecycle state before consumer projection.",
+                "human_gate": {
+                    "required": False,
+                    "classification": "not_required",
+                    "authority_ref": "not_required",
+                    "factory_may_simulate": False
+                },
+                "recovery_route": {
+                    "required": False,
+                    "route_ref": "not_required",
+                    "factory_owned_repair_allowed": False,
+                    "retry_policy": {
+                        "max_attempts": 1,
+                        "attempt_number": 1,
+                        "stop_condition": "No recovery route is active while the phase is not blocked."
+                    }
+                }
+            }
+        ],
+        "current_owner_worker": "decomposition-planner",
+        "gate_predicate": {
+            "gate_id": "fixture-lifecycle-gate",
+            "result": "PENDING",
+            "predicate": "Fixture lifecycle validates without production claim.",
+            "evidence_refs": ["templates/factory-sdlc-lifecycle-state.json"]
+        },
+        "evidence_refs": [
+            "schemas/factory-sdlc-lifecycle-state.schema.json",
+            "templates/factory-sdlc-lifecycle-state.json",
+            "tests/test_factory_sdlc_lifecycle.py"
+        ],
+        "next_safe_action": "Use factoryctl validate-sdlc-lifecycle before consumption.",
+        "lifecycle_acceptance": {
+            "scope_completion_state": "in_progress",
+            "proof_level": "static_or_schema_validated",
+            "implemented_by_contract": True,
+            "runtime_proven": False,
+            "production_ready_claimed": False,
+            "customer_ready_claimed": False,
+            "limits": ["Fixture does not prove runtime or production readiness."]
+        },
+        "public_private_boundary": {
+            "raw_private_evidence_embedded": False,
+            "public_safe_refs_only": True,
+            "private_runtime_evidence_stays_local": True
+        },
+        "projection_policy": {
+            "cockpit_is_source_of_truth": False,
+            "dashboard_visibility_is_evidence": False,
+            "consumer_role": "projection_only"
+        },
+        "linked_operational_evidence_bundle_refs": ["templates/operational-evidence-bundle.json"]
+    }
+    state.update(overrides)
+    return state
+
+
+class FactorySdlcLifecycleTest(unittest.TestCase):
+    def test_lifecycle_template_validates(self) -> None:
+        state = json.loads((ROOT / "templates" / "factory-sdlc-lifecycle-state.json").read_text(encoding="utf-8"))
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertEqual(errors, [])
+
+    def test_unknown_phase_is_rejected(self) -> None:
+        state = lifecycle_state(active_phase_id="F404")
+        state["phase_states"][0]["phase_id"] = "F404"
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("unknown phase" in error for error in errors), errors)
+
+    def test_unknown_status_is_rejected_by_schema(self) -> None:
+        state = lifecycle_state()
+        state["phase_states"][0]["status"] = "MAYBE"
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("status" in error and "not in enum" in error for error in errors), errors)
+
+    def test_missing_owner_gate_evidence_and_next_action_are_rejected(self) -> None:
+        state = lifecycle_state(current_owner_worker="", next_safe_action="", evidence_refs=[])
+        phase = state["phase_states"][0]
+        phase["owner_worker"] = ""
+        phase["evidence_refs"] = []
+        phase["next_safe_action"] = ""
+        phase["gate_predicate"]["evidence_refs"] = []
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("current_owner_worker" in error for error in errors), errors)
+        self.assertTrue(any("owner_worker" in error for error in errors), errors)
+        self.assertTrue(any("evidence_refs" in error for error in errors), errors)
+        self.assertTrue(any("next_safe_action" in error for error in errors), errors)
+
+    def test_non_human_blocked_state_requires_recovery_route(self) -> None:
+        state = lifecycle_state()
+        state["phase_states"][0]["status"] = "BLOCKED"
+        state["phase_states"][0]["gate_predicate"]["result"] = "BLOCK"
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("recovery_route.required=true" in error for error in errors), errors)
+        self.assertTrue(any("factory-owned repair route" in error for error in errors), errors)
+
+        state["phase_states"][0]["recovery_route"] = {
+            "required": True,
+            "route_ref": "schemas/factory-recovery-plan.schema.json",
+            "factory_owned_repair_allowed": True,
+            "retry_policy": {
+                "max_attempts": 3,
+                "attempt_number": 1,
+                "stop_condition": "Escalate after repeated failed factory-owned repair attempts."
+            }
+        }
+
+        self.assertEqual(factoryctl.validate_factory_sdlc_lifecycle_state(state), [])
+
+    def test_human_gate_boundary_rejects_factory_simulation(self) -> None:
+        state = lifecycle_state()
+        phase = state["phase_states"][0]
+        phase["status"] = "BLOCKED"
+        phase["gate_predicate"]["result"] = "BLOCK"
+        phase["human_gate"] = {
+            "required": True,
+            "classification": "not_required",
+            "authority_ref": "worker-result",
+            "factory_may_simulate": False
+        }
+        phase["recovery_route"]["factory_owned_repair_allowed"] = True
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("human gate classification is ambiguous" in error for error in errors), errors)
+        self.assertTrue(any("real authority ref" in error for error in errors), errors)
+        self.assertTrue(any("human gate cannot allow factory-owned repair" in error for error in errors), errors)
+
+    def test_private_or_transient_refs_are_rejected(self) -> None:
+        state = lifecycle_state(evidence_refs=[".tmp/factory-runs/private-lifecycle.json"])
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("evidence_refs[0] must be public-safe" in error for error in errors), errors)
+
+    def test_stale_and_superseded_states_validate_as_explicit_states(self) -> None:
+        stale = lifecycle_state()
+        stale["phase_states"][0]["status"] = "STALE"
+        stale["phase_states"][0]["gate_predicate"]["result"] = "STALE"
+        superseded = lifecycle_state()
+        superseded["phase_states"][0]["status"] = "SUPERSEDED"
+        superseded["phase_states"][0]["gate_predicate"]["result"] = "SUPERSEDED"
+
+        self.assertEqual(factoryctl.validate_factory_sdlc_lifecycle_state(stale), [])
+        self.assertEqual(factoryctl.validate_factory_sdlc_lifecycle_state(superseded), [])
+
+    def test_production_readiness_overclaim_is_rejected(self) -> None:
+        state = lifecycle_state(
+            delivery_state="deployed",
+            lifecycle_acceptance={
+                "scope_completion_state": "production_complete",
+                "proof_level": "implemented_by_contract",
+                "implemented_by_contract": True,
+                "runtime_proven": False,
+                "production_ready_claimed": True,
+                "customer_ready_claimed": False,
+                "limits": ["Contract-only proof."]
+            }
+        )
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("production readiness requires" in error for error in errors), errors)
+
+    def test_customer_readiness_overclaim_is_rejected(self) -> None:
+        acceptance = lifecycle_state()["lifecycle_acceptance"]
+        acceptance.update(
+            {
+                "scope_completion_state": "customer_ready",
+                "proof_level": "production_strict",
+                "runtime_proven": True,
+                "production_ready_claimed": True,
+                "customer_ready_claimed": True
+            }
+        )
+        state = lifecycle_state(lifecycle_acceptance=acceptance)
+
+        errors = factoryctl.validate_factory_sdlc_lifecycle_state(state)
+
+        self.assertTrue(any("customer readiness requires" in error for error in errors), errors)
+
+    def test_public_template_validates_with_schema_and_domain_rules(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        schema = schemas["factory-sdlc-lifecycle-state.schema.json"]
+        state = json.loads((ROOT / "templates" / "factory-sdlc-lifecycle-state.json").read_text(encoding="utf-8"))
+
+        schema_errors = public_json_validator.validate_node(schema, state, "$", schemas=schemas, root_schema=schema)
+        domain_errors = public_json_validator.validate_domain_rules(state, "$")
+
+        self.assertEqual(schema_errors + domain_errors, [])
+
+    def test_public_validator_rejects_private_lifecycle_ref(self) -> None:
+        state = lifecycle_state(evidence_refs=[".tmp/factory-runs/private-lifecycle.json"])
+
+        errors = public_json_validator.validate_domain_rules(state, "$")
+
+        self.assertTrue(any("$.evidence_refs[0]" in error for error in errors), errors)
+
+    def test_factoryctl_cli_validates_lifecycle_independently(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "lifecycle.json"
+            path.write_text(json.dumps(lifecycle_state()), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(["validate-sdlc-lifecycle", str(path)])
+
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a public-safe `factory_sdlc_lifecycle_state` schema and template that reference the existing workflow catalog instead of reinventing the factory map.
- Adds independent `factoryctl validate-sdlc-lifecycle` / `validate-lifecycle` validation.
- Enforces fail-closed lifecycle semantics: known catalog phases, closed statuses, owner/gate/evidence/next-action requirements, non-human BLOCKED recovery routes, real human-gate boundaries, public-safe refs, and no production/customer-readiness overclaim from contract/static proof.
- Lets worker results and operational evidence bundles reference lifecycle state without making it a substitute for Receipt Five, Evidence Graph, Product Face, Hermes Kanban or human gates.

Closes #247.

## Validation

- `python -m unittest tests.test_factory_sdlc_lifecycle tests.test_operational_evidence_bundle tests.test_public_json_artifact_validator -q`
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\factoryctl.py validate-sdlc-lifecycle templates\factory-sdlc-lifecycle-state.json`
- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest discover -s tests -q`
- `git diff --check`

## Boundaries

- Does not implement or modify the #84 cockpit UI.
- Does not touch local cockpit worktrees or `scripts/issue84/*`.
- Does not implement #244 async lanes or #245 automation run history here.
- Does not publish raw private/runtime evidence.
- Cockpit/dashboard visibility remains projection only, never source of truth or evidence.

## External research dedupe

Factory AI 2.0 / Software Factory and Hermes async-subagent signals were reviewed against current issues. No new issue is needed right now: #244 covers Hermes async lane reconciliation, #245 covers automation run targets/history, #246/#248 covers claim evidence bundles, and this PR covers #247 lifecycle control-plane state.
