### PR TITLE
Add factory automation run contracts

### DIFF
--- a/schemas/factory-automation-run-record.schema.json
+++ b/schemas/factory-automation-run-record.schema.json
@@ -1,0 +1,333 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-automation-run-record.schema.json",
+  "title": "Overkill Factory Automation Run Record",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "automation_id",
+    "run_id",
+    "started_at",
+    "trigger_observed",
+    "target_resolved",
+    "authority_level",
+    "status",
+    "allowed_actions_executed",
+    "actions_taken",
+    "required_preflight_checks",
+    "required_post_checks",
+    "checks_run",
+    "evidence_refs_public_safe",
+    "next_safe_action",
+    "residual_risk",
+    "public_artifact_policy"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-automation-run-record.schema.json"
+    },
+    "record_type": {
+      "const": "factory_automation_run_record"
+    },
+    "automation_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "started_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "completed_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "trigger_observed": {
+      "type": "object",
+      "required": [
+        "trigger_type",
+        "trigger_ref_public_safe",
+        "observed_at"
+      ],
+      "properties": {
+        "trigger_type": {
+          "enum": [
+            "schedule",
+            "heartbeat",
+            "github_event",
+            "hermes_event",
+            "manual_request",
+            "status_change",
+            "incident",
+            "learnback",
+            "external_signal"
+          ]
+        },
+        "trigger_ref_public_safe": {
+          "type": "string",
+          "minLength": 3
+        },
+        "observed_at": {
+          "type": "string",
+          "minLength": 10
+        }
+      },
+      "additionalProperties": false
+    },
+    "target_resolved": {
+      "type": "object",
+      "required": [
+        "target_kind",
+        "target_ref",
+        "scope_summary"
+      ],
+      "properties": {
+        "target_kind": {
+          "enum": [
+            "repo",
+            "card",
+            "project",
+            "product",
+            "worker_profile",
+            "capability_pack",
+            "release",
+            "external_research_track",
+            "factory_issue"
+          ]
+        },
+        "target_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "scope_summary": {
+          "type": "string",
+          "minLength": 12
+        }
+      },
+      "additionalProperties": false
+    },
+    "authority_level": {
+      "enum": [
+        "read_only",
+        "planning_only",
+        "bounded_edit",
+        "local_commit",
+        "github_pr",
+        "release_candidate",
+        "production_operation"
+      ]
+    },
+    "status": {
+      "enum": [
+        "skipped",
+        "running",
+        "blocked",
+        "failed",
+        "completed",
+        "superseded"
+      ]
+    },
+    "allowed_actions_executed": {
+      "type": "boolean"
+    },
+    "actions_taken": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "required_preflight_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "required_post_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "checks_run": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "check_id",
+          "phase",
+          "status",
+          "evidence_ref"
+        ],
+        "properties": {
+          "check_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "phase": {
+            "enum": [
+              "preflight",
+              "post",
+              "continuous"
+            ]
+          },
+          "status": {
+            "enum": [
+              "PASS",
+              "FAIL",
+              "BLOCKED",
+              "SKIPPED"
+            ]
+          },
+          "evidence_ref": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "evidence_refs_public_safe": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "git_state": {
+      "type": "object",
+      "required": [
+        "branch",
+        "head_sha",
+        "dirty_state",
+        "remote_state",
+        "publication_state"
+      ],
+      "properties": {
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "head_sha": {
+          "type": "string",
+          "minLength": 7
+        },
+        "dirty_state": {
+          "enum": [
+            "clean",
+            "dirty",
+            "unknown"
+          ]
+        },
+        "remote_state": {
+          "enum": [
+            "no_remote",
+            "local_only",
+            "pushed",
+            "diverged",
+            "unknown"
+          ]
+        },
+        "publication_state": {
+          "enum": [
+            "no_publication_attempted",
+            "local_only",
+            "pushed_branch",
+            "pr_open",
+            "merged_main",
+            "release_published"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "issues_created_or_updated": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "prs_created_or_updated": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "external_research_sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "source_url",
+          "source_type",
+          "public_safe_synthesis"
+        ],
+        "properties": {
+          "source_url": {
+            "type": "string",
+            "minLength": 10
+          },
+          "source_type": {
+            "enum": [
+              "official_docs",
+              "public_post",
+              "public_repo",
+              "public_article",
+              "public_release_note"
+            ]
+          },
+          "public_safe_synthesis": {
+            "type": "string",
+            "minLength": 12
+          },
+          "raw_capture_embedded": {
+            "const": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "blocked_reason": {
+      "type": "string",
+      "minLength": 6
+    },
+    "next_safe_action": {
+      "type": "string",
+      "minLength": 6
+    },
+    "residual_risk": {
+      "type": "string",
+      "minLength": 6
+    },
+    "public_artifact_policy": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "no_raw_screenshots_or_logs"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "no_raw_screenshots_or_logs": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-automation-run-target.schema.json
+++ b/schemas/factory-automation-run-target.schema.json
@@ -1,0 +1,259 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-automation-run-target.schema.json",
+  "title": "Overkill Factory Automation Run Target",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "automation_id",
+    "created_at",
+    "trigger",
+    "target",
+    "owner_worker",
+    "runtime_target_ref",
+    "profile_binding_ref",
+    "authority_level",
+    "allowed_actions",
+    "forbidden_actions",
+    "required_preflight_checks",
+    "required_post_checks",
+    "human_gate_triggers",
+    "public_artifact_policy",
+    "retry_policy",
+    "stop_condition",
+    "cleanup_policy",
+    "next_safe_action"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-automation-run-target.schema.json"
+    },
+    "record_type": {
+      "const": "factory_automation_run_target"
+    },
+    "automation_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "trigger": {
+      "type": "object",
+      "required": [
+        "trigger_type",
+        "trigger_ref_public_safe",
+        "trigger_contract"
+      ],
+      "properties": {
+        "trigger_type": {
+          "enum": [
+            "schedule",
+            "heartbeat",
+            "github_event",
+            "hermes_event",
+            "manual_request",
+            "status_change",
+            "incident",
+            "learnback",
+            "external_signal"
+          ]
+        },
+        "trigger_ref_public_safe": {
+          "type": "string",
+          "minLength": 3
+        },
+        "trigger_contract": {
+          "type": "string",
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "target": {
+      "type": "object",
+      "required": [
+        "target_kind",
+        "target_ref",
+        "scope_summary"
+      ],
+      "properties": {
+        "target_kind": {
+          "enum": [
+            "repo",
+            "card",
+            "project",
+            "product",
+            "worker_profile",
+            "capability_pack",
+            "release",
+            "external_research_track",
+            "factory_issue"
+          ]
+        },
+        "target_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "scope_summary": {
+          "type": "string",
+          "minLength": 12
+        }
+      },
+      "additionalProperties": false
+    },
+    "owner_worker": {
+      "type": "string",
+      "minLength": 3
+    },
+    "runtime_target_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "profile_binding_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "authority_level": {
+      "enum": [
+        "read_only",
+        "planning_only",
+        "bounded_edit",
+        "local_commit",
+        "github_pr",
+        "release_candidate",
+        "production_operation"
+      ]
+    },
+    "allowed_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "forbidden_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "required_preflight_checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "required_post_checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "human_gate_triggers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "public_artifact_policy": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "no_raw_screenshots_or_logs",
+        "allowed_ref_classes"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "no_raw_screenshots_or_logs": {
+          "const": true
+        },
+        "allowed_ref_classes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "repo_relative",
+              "external_public_url",
+              "external_sanitized_ref",
+              "github_public_ref"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "retry_policy": {
+      "type": "object",
+      "required": [
+        "max_attempts",
+        "retry_when",
+        "stop_condition"
+      ],
+      "properties": {
+        "max_attempts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "retry_when": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "stop_condition": {
+          "type": "string",
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "stop_condition": {
+      "type": "string",
+      "minLength": 6
+    },
+    "cleanup_policy": {
+      "type": "object",
+      "required": [
+        "temporary_artifacts_policy",
+        "branch_cleanup_required",
+        "private_evidence_cleanup_required"
+      ],
+      "properties": {
+        "temporary_artifacts_policy": {
+          "type": "string",
+          "minLength": 6
+        },
+        "branch_cleanup_required": {
+          "type": "boolean"
+        },
+        "private_evidence_cleanup_required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "next_safe_action": {
+      "type": "string",
+      "minLength": 6
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4324,6 +4324,212 @@ def validate_factory_sdlc_lifecycle_state(state: dict[str, Any]) -> list[str]:
     return errors
 
 
+AUTOMATION_GITHUB_AUTHORITIES = {"github_pr", "release_candidate", "production_operation"}
+AUTOMATION_REPO_BOUND_AUTHORITIES = {"bounded_edit", "local_commit", "github_pr", "release_candidate", "production_operation"}
+AUTOMATION_REPO_BOUND_TARGETS = {"repo", "factory_issue", "release"}
+AUTOMATION_REQUIRED_SAFETY_CHECKS = {"public_safety_scan", "secret_safety_scan"}
+AUTOMATION_RAW_RESEARCH_FIELDS = {
+    "raw_notes",
+    "paper_dump",
+    "source_dump",
+    "screenshot_path",
+    "conversation_history",
+    "local_capture_path",
+    "private_capture_path",
+}
+
+
+def _validate_automation_ref(ref: Any, at: str, errors: list[str]) -> None:
+    _, redaction = sanitize_public_ref(ref)
+    if redaction is not None:
+        errors.append(f"{at} must be public-safe")
+
+
+def _normalized_check_ids(items: Any) -> set[str]:
+    return {item.strip().lower() for item in _list_items(items)}
+
+
+def _passed_check_ids(checks: Any, *, phase: str | None = None) -> set[str]:
+    if not isinstance(checks, list):
+        return set()
+    passed: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        if phase is not None and str(check.get("phase") or "").strip().lower() != phase:
+            continue
+        if str(check.get("status") or "").strip().upper() == "PASS":
+            passed.add(str(check.get("check_id") or "").strip().lower())
+    return passed
+
+
+def _validate_automation_public_policy(policy: Any, at: str, errors: list[str]) -> None:
+    if not isinstance(policy, dict):
+        errors.append(f"{at} is required")
+        return
+    if policy.get("public_safe_refs_only") is not True:
+        errors.append(f"{at}.public_safe_refs_only must be true")
+    if policy.get("raw_private_evidence_embedded") is not False:
+        errors.append(f"{at}.raw_private_evidence_embedded must be false")
+    if policy.get("no_raw_screenshots_or_logs") is not True:
+        errors.append(f"{at}.no_raw_screenshots_or_logs must be true")
+
+
+def validate_factory_automation_run_target(target: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-automation-run-target.schema.json")
+    if not schema:
+        return ["factory_automation_run_target schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            target,
+            "factory_automation_run_target",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    trigger = target.get("trigger") if isinstance(target.get("trigger"), dict) else {}
+    target_obj = target.get("target") if isinstance(target.get("target"), dict) else {}
+    _validate_automation_ref(
+        trigger.get("trigger_ref_public_safe"),
+        "factory_automation_run_target.trigger.trigger_ref_public_safe",
+        errors,
+    )
+    _validate_automation_ref(target_obj.get("target_ref"), "factory_automation_run_target.target.target_ref", errors)
+    _validate_automation_ref(target.get("runtime_target_ref"), "factory_automation_run_target.runtime_target_ref", errors)
+    _validate_automation_ref(target.get("profile_binding_ref"), "factory_automation_run_target.profile_binding_ref", errors)
+
+    authority = str(target.get("authority_level") or "").strip()
+    preflight = _normalized_check_ids(target.get("required_preflight_checks"))
+    post = _normalized_check_ids(target.get("required_post_checks"))
+    if authority in AUTOMATION_GITHUB_AUTHORITIES:
+        missing_preflight = sorted(AUTOMATION_REQUIRED_SAFETY_CHECKS - preflight)
+        missing_post = sorted(AUTOMATION_REQUIRED_SAFETY_CHECKS - post)
+        if missing_preflight:
+            errors.append(
+                "factory_automation_run_target GitHub authority requires preflight checks: "
+                + ", ".join(missing_preflight)
+            )
+        if missing_post:
+            errors.append(
+                "factory_automation_run_target GitHub authority requires post checks: "
+                + ", ".join(missing_post)
+            )
+        if not _list_items(target.get("human_gate_triggers")):
+            errors.append("factory_automation_run_target GitHub authority requires human_gate_triggers")
+
+    if authority == "production_operation" and "production_human_gate" not in _normalized_check_ids(target.get("human_gate_triggers")):
+        errors.append("factory_automation_run_target production_operation requires production_human_gate trigger")
+
+    allowed = _normalized_check_ids(target.get("allowed_actions"))
+    forbidden = _normalized_check_ids(target.get("forbidden_actions"))
+    if allowed & forbidden:
+        errors.append("factory_automation_run_target allowed_actions and forbidden_actions overlap")
+
+    if target_obj.get("target_kind") == "external_research_track":
+        forbidden_text = " ".join(_list_items(target.get("forbidden_actions"))).lower()
+        if "raw" not in forbidden_text or "private" not in forbidden_text:
+            errors.append("factory_automation_run_target external research must forbid raw/private evidence publication")
+
+    _validate_automation_public_policy(target.get("public_artifact_policy"), "factory_automation_run_target.public_artifact_policy", errors)
+    return errors
+
+
+def validate_factory_automation_run_record(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-automation-run-record.schema.json")
+    if not schema:
+        return ["factory_automation_run_record schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            record,
+            "factory_automation_run_record",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    trigger = record.get("trigger_observed") if isinstance(record.get("trigger_observed"), dict) else {}
+    target_obj = record.get("target_resolved") if isinstance(record.get("target_resolved"), dict) else {}
+    _validate_automation_ref(
+        trigger.get("trigger_ref_public_safe"),
+        "factory_automation_run_record.trigger_observed.trigger_ref_public_safe",
+        errors,
+    )
+    _validate_automation_ref(target_obj.get("target_ref"), "factory_automation_run_record.target_resolved.target_ref", errors)
+    for index, ref in enumerate(_list_items(record.get("evidence_refs_public_safe"))):
+        _validate_automation_ref(ref, f"factory_automation_run_record.evidence_refs_public_safe[{index}]", errors)
+    for index, issue_ref in enumerate(_list_items(record.get("issues_created_or_updated"))):
+        _validate_automation_ref(issue_ref, f"factory_automation_run_record.issues_created_or_updated[{index}]", errors)
+    for index, pr_ref in enumerate(_list_items(record.get("prs_created_or_updated"))):
+        _validate_automation_ref(pr_ref, f"factory_automation_run_record.prs_created_or_updated[{index}]", errors)
+    checks = record.get("checks_run") if isinstance(record.get("checks_run"), list) else []
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            continue
+        _validate_automation_ref(check.get("evidence_ref"), f"factory_automation_run_record.checks_run[{index}].evidence_ref", errors)
+
+    authority = str(record.get("authority_level") or "").strip()
+    status = str(record.get("status") or "").strip().lower()
+    target_kind = str(target_obj.get("target_kind") or "").strip()
+    repo_bound = authority in AUTOMATION_REPO_BOUND_AUTHORITIES or target_kind in AUTOMATION_REPO_BOUND_TARGETS
+    if repo_bound:
+        git_state = record.get("git_state") if isinstance(record.get("git_state"), dict) else None
+        if git_state is None:
+            errors.append("factory_automation_run_record repo-bound run requires git_state")
+        elif not _non_empty_text(git_state.get("publication_state")):
+            errors.append("factory_automation_run_record git_state must distinguish local work from GitHub publication")
+
+    if status == "completed":
+        if not _non_empty_text(record.get("completed_at")):
+            errors.append("factory_automation_run_record completed status requires completed_at")
+        if not _list_items(record.get("checks_run")):
+            errors.append("factory_automation_run_record completed status requires checks_run")
+        if not _list_items(record.get("evidence_refs_public_safe")):
+            errors.append("factory_automation_run_record completed status requires evidence_refs_public_safe")
+        missing_post = sorted(_normalized_check_ids(record.get("required_post_checks")) - _passed_check_ids(checks, phase="post"))
+        if missing_post:
+            errors.append("factory_automation_run_record completed status requires passed post checks: " + ", ".join(missing_post))
+        if record.get("allowed_actions_executed") is not True:
+            errors.append("factory_automation_run_record completed status requires allowed_actions_executed=true")
+
+    if status in {"blocked", "failed"} and not _non_empty_text(record.get("blocked_reason")):
+        errors.append(f"factory_automation_run_record {status} status requires blocked_reason")
+
+    if authority in AUTOMATION_GITHUB_AUTHORITIES:
+        passed = _passed_check_ids(checks)
+        missing = sorted(AUTOMATION_REQUIRED_SAFETY_CHECKS - passed)
+        if missing:
+            errors.append("factory_automation_run_record GitHub authority requires passed safety checks: " + ", ".join(missing))
+
+    if target_kind == "external_research_track":
+        sources = record.get("external_research_sources") if isinstance(record.get("external_research_sources"), list) else []
+        if not sources:
+            errors.append("factory_automation_run_record external research requires external_research_sources")
+        serialized = json.dumps(record, sort_keys=True)
+        for field in AUTOMATION_RAW_RESEARCH_FIELDS:
+            if f'"{field}"' in serialized:
+                errors.append(f"factory_automation_run_record external research must not contain raw dump field {field}")
+        for index, source in enumerate(sources):
+            if not isinstance(source, dict):
+                continue
+            source_url = str(source.get("source_url") or "").strip()
+            if not source_url.startswith(("https://", "http://")):
+                errors.append(f"factory_automation_run_record.external_research_sources[{index}].source_url must be a public URL")
+            if source.get("raw_capture_embedded") is not False:
+                errors.append(f"factory_automation_run_record.external_research_sources[{index}].raw_capture_embedded must be false")
+            if not public_safe_text(source.get("public_safe_synthesis")):
+                errors.append(f"factory_automation_run_record.external_research_sources[{index}].public_safe_synthesis must be public-safe")
+
+    _validate_automation_public_policy(record.get("public_artifact_policy"), "factory_automation_run_record.public_artifact_policy", errors)
+    return errors
+
+
 def _required_product_states(card: dict[str, Any]) -> list[str]:
     plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
     packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
@@ -8543,6 +8749,26 @@ def command_validate_sdlc_lifecycle(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_automation_target(args: argparse.Namespace) -> int:
+    errors = validate_factory_automation_run_target(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+def command_validate_automation_record(args: argparse.Namespace) -> int:
+    errors = validate_factory_automation_run_record(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_worker_packet(args: argparse.Namespace) -> int:
     card = load_json_like(args.card)
     if args.required_only and args.worker != "all":
@@ -8851,6 +9077,22 @@ def build_parser() -> argparse.ArgumentParser:
     validate_lifecycle_parser = sub.add_parser("validate-lifecycle")
     validate_lifecycle_parser.add_argument("path", type=Path)
     validate_lifecycle_parser.set_defaults(func=command_validate_sdlc_lifecycle)
+
+    validate_automation_target_parser = sub.add_parser("validate-automation-target")
+    validate_automation_target_parser.add_argument("path", type=Path)
+    validate_automation_target_parser.set_defaults(func=command_validate_automation_target)
+
+    validate_automation_run_target_parser = sub.add_parser("validate-automation-run-target")
+    validate_automation_run_target_parser.add_argument("path", type=Path)
+    validate_automation_run_target_parser.set_defaults(func=command_validate_automation_target)
+
+    validate_automation_record_parser = sub.add_parser("validate-automation-record")
+    validate_automation_record_parser.add_argument("path", type=Path)
+    validate_automation_record_parser.set_defaults(func=command_validate_automation_record)
+
+    validate_automation_run_record_parser = sub.add_parser("validate-automation-run-record")
+    validate_automation_run_record_parser.add_argument("path", type=Path)
+    validate_automation_run_record_parser.set_defaults(func=command_validate_automation_record)
 
     worker_packet_parser = sub.add_parser("worker-packet")
     worker_packet_parser.add_argument("--worker", choices=[*WORKERS.keys(), "all"], required=True)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -104,6 +104,10 @@ RAW_RESEARCH_FIELDS = {
     "local_capture_path",
     "private_capture_path",
 }
+AUTOMATION_GITHUB_AUTHORITIES = {"github_pr", "release_candidate", "production_operation"}
+AUTOMATION_REPO_BOUND_AUTHORITIES = {"bounded_edit", "local_commit", "github_pr", "release_candidate", "production_operation"}
+AUTOMATION_REPO_BOUND_TARGETS = {"repo", "factory_issue", "release"}
+AUTOMATION_REQUIRED_SAFETY_CHECKS = {"public_safety_scan", "secret_safety_scan"}
 
 
 def public_artifact_ref_error(ref: Any) -> str | None:
@@ -134,6 +138,39 @@ def public_artifact_ref_error(ref: Any) -> str | None:
     if normalized.startswith((".tmp/", "tmp/", "reports/private/", "private/", "run-evidence/")) or "/.tmp/" in normalized:
         return "private or transient evidence location"
     return None
+
+
+def text_items(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def normalized_check_ids(value: Any) -> set[str]:
+    return {item.lower() for item in text_items(value)}
+
+
+def passed_check_ids(checks: Any, *, phase: str | None = None) -> set[str]:
+    if not isinstance(checks, list):
+        return set()
+    passed: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        if phase is not None and str(check.get("phase") or "").strip().lower() != phase:
+            continue
+        if str(check.get("status") or "").strip().upper() == "PASS":
+            passed.add(str(check.get("check_id") or "").strip().lower())
+    return passed
+
+
+def add_public_ref_errors(refs: Any, at: str, errors: list[str]) -> None:
+    for index, ref in enumerate(text_items(refs)):
+        reason = public_artifact_ref_error(ref)
+        if reason:
+            errors.append(f"{at}[{index}]: {reason}")
 
 ANNOTATION_SCHEMA_KEYWORDS = {
     "$comment",
@@ -512,6 +549,109 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: production readiness requires production_strict or customer_validated proof")
         if acceptance.get("customer_ready_claimed") is True and proof_level != "customer_validated":
             errors.append(f"{at}: customer readiness requires customer_validated proof")
+    if data.get("record_type") == "factory_automation_run_target":
+        trigger = data.get("trigger") if isinstance(data.get("trigger"), dict) else {}
+        target = data.get("target") if isinstance(data.get("target"), dict) else {}
+        for field, ref in (
+            ("trigger.trigger_ref_public_safe", trigger.get("trigger_ref_public_safe")),
+            ("target.target_ref", target.get("target_ref")),
+            ("runtime_target_ref", data.get("runtime_target_ref")),
+            ("profile_binding_ref", data.get("profile_binding_ref")),
+        ):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.{field}: {reason}")
+        authority = str(data.get("authority_level") or "").strip()
+        if authority in AUTOMATION_GITHUB_AUTHORITIES:
+            preflight_missing = sorted(AUTOMATION_REQUIRED_SAFETY_CHECKS - normalized_check_ids(data.get("required_preflight_checks")))
+            post_missing = sorted(AUTOMATION_REQUIRED_SAFETY_CHECKS - normalized_check_ids(data.get("required_post_checks")))
+            if preflight_missing:
+                errors.append(f"{at}: GitHub authority requires preflight checks: {', '.join(preflight_missing)}")
+            if post_missing:
+                errors.append(f"{at}: GitHub authority requires post checks: {', '.join(post_missing)}")
+            if not text_items(data.get("human_gate_triggers")):
+                errors.append(f"{at}: GitHub authority requires human_gate_triggers")
+        policy = data.get("public_artifact_policy") if isinstance(data.get("public_artifact_policy"), dict) else {}
+        if policy.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}.public_artifact_policy.public_safe_refs_only must be true")
+        if policy.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}.public_artifact_policy.raw_private_evidence_embedded must be false")
+        if policy.get("no_raw_screenshots_or_logs") is not True:
+            errors.append(f"{at}.public_artifact_policy.no_raw_screenshots_or_logs must be true")
+        if target.get("target_kind") == "external_research_track":
+            forbidden_text = " ".join(text_items(data.get("forbidden_actions"))).lower()
+            if "raw" not in forbidden_text or "private" not in forbidden_text:
+                errors.append(f"{at}: external research automation must forbid raw/private evidence publication")
+    if data.get("record_type") == "factory_automation_run_record":
+        trigger = data.get("trigger_observed") if isinstance(data.get("trigger_observed"), dict) else {}
+        target = data.get("target_resolved") if isinstance(data.get("target_resolved"), dict) else {}
+        for field, ref in (
+            ("trigger_observed.trigger_ref_public_safe", trigger.get("trigger_ref_public_safe")),
+            ("target_resolved.target_ref", target.get("target_ref")),
+        ):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.{field}: {reason}")
+        add_public_ref_errors(data.get("evidence_refs_public_safe"), f"{at}.evidence_refs_public_safe", errors)
+        add_public_ref_errors(data.get("issues_created_or_updated"), f"{at}.issues_created_or_updated", errors)
+        add_public_ref_errors(data.get("prs_created_or_updated"), f"{at}.prs_created_or_updated", errors)
+        checks = data.get("checks_run") if isinstance(data.get("checks_run"), list) else []
+        for index, check in enumerate(checks):
+            if not isinstance(check, dict):
+                continue
+            reason = public_artifact_ref_error(check.get("evidence_ref"))
+            if reason:
+                errors.append(f"{at}.checks_run[{index}].evidence_ref: {reason}")
+        authority = str(data.get("authority_level") or "").strip()
+        status = str(data.get("status") or "").strip().lower()
+        target_kind = str(target.get("target_kind") or "").strip()
+        if authority in AUTOMATION_REPO_BOUND_AUTHORITIES or target_kind in AUTOMATION_REPO_BOUND_TARGETS:
+            git_state = data.get("git_state") if isinstance(data.get("git_state"), dict) else None
+            if git_state is None:
+                errors.append(f"{at}: repo-bound automation run requires git_state")
+            elif not str(git_state.get("publication_state") or "").strip():
+                errors.append(f"{at}.git_state: publication_state must distinguish local work from GitHub publication")
+        if status == "completed":
+            missing_post = sorted(normalized_check_ids(data.get("required_post_checks")) - passed_check_ids(checks, phase="post"))
+            if missing_post:
+                errors.append(f"{at}: completed automation run requires passed post checks: {', '.join(missing_post)}")
+            if not data.get("completed_at"):
+                errors.append(f"{at}: completed automation run requires completed_at")
+            if not checks:
+                errors.append(f"{at}: completed automation run requires checks_run")
+            if not text_items(data.get("evidence_refs_public_safe")):
+                errors.append(f"{at}: completed automation run requires evidence_refs_public_safe")
+        if status in {"blocked", "failed"} and not str(data.get("blocked_reason") or "").strip():
+            errors.append(f"{at}: {status} automation run requires blocked_reason")
+        if authority in AUTOMATION_GITHUB_AUTHORITIES:
+            missing = sorted(AUTOMATION_REQUIRED_SAFETY_CHECKS - passed_check_ids(checks))
+            if missing:
+                errors.append(f"{at}: GitHub authority requires passed safety checks: {', '.join(missing)}")
+        if target_kind == "external_research_track":
+            sources = data.get("external_research_sources") if isinstance(data.get("external_research_sources"), list) else []
+            if not sources:
+                errors.append(f"{at}: external research automation run requires external_research_sources")
+            serialized = json.dumps(data, sort_keys=True)
+            present_raw_fields = sorted(field for field in RAW_RESEARCH_FIELDS if f'"{field}"' in serialized)
+            if present_raw_fields:
+                errors.append(f"{at}: external research automation run must not contain raw dump fields: {', '.join(present_raw_fields)}")
+            for index, source in enumerate(sources):
+                if not isinstance(source, dict):
+                    continue
+                source_url = str(source.get("source_url") or "").strip()
+                if not source_url.startswith(("https://", "http://")):
+                    errors.append(f"{at}.external_research_sources[{index}].source_url must be a public URL")
+                if PRIVATE_MARKERS.search(source_url):
+                    errors.append(f"{at}.external_research_sources[{index}].source_url contains private marker")
+                if source.get("raw_capture_embedded") is not False:
+                    errors.append(f"{at}.external_research_sources[{index}].raw_capture_embedded must be false")
+        policy = data.get("public_artifact_policy") if isinstance(data.get("public_artifact_policy"), dict) else {}
+        if policy.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}.public_artifact_policy.public_safe_refs_only must be true")
+        if policy.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}.public_artifact_policy.raw_private_evidence_embedded must be false")
+        if policy.get("no_raw_screenshots_or_logs") is not True:
+            errors.append(f"{at}.public_artifact_policy.no_raw_screenshots_or_logs must be true")
     if data.get("record_type") == "product_face_result" and data.get("reusable_for_product") is True:
         if not str(data.get("packet_ref") or "").strip():
             errors.append(f"{at}: reusable product_face_result requires packet_ref")

--- a/templates/factory-automation-run-record.json
+++ b/templates/factory-automation-run-record.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-automation-run-record.schema.json",
+  "record_type": "factory_automation_run_record",
+  "automation_id": "automation-public-readiness-audit",
+  "run_id": "run-public-readiness-audit-template",
+  "started_at": "2026-06-16T00:00:00+00:00",
+  "completed_at": "2026-06-16T00:10:00+00:00",
+  "trigger_observed": {
+    "trigger_type": "heartbeat",
+    "trigger_ref_public_safe": "external:public-recurring-audit-trigger",
+    "observed_at": "2026-06-16T00:00:00+00:00"
+  },
+  "target_resolved": {
+    "target_kind": "repo",
+    "target_ref": "external:public-overkill-factory-repo",
+    "scope_summary": "Public repository audit record with no private runtime evidence."
+  },
+  "authority_level": "read_only",
+  "status": "completed",
+  "allowed_actions_executed": true,
+  "actions_taken": [
+    "Inspected public-safe repository contracts.",
+    "Validated public JSON artifacts.",
+    "Recorded next safe action without claiming production runtime proof."
+  ],
+  "required_preflight_checks": [
+    "git_state_probe",
+    "public_safety_scan"
+  ],
+  "required_post_checks": [
+    "public_json_artifact_validation",
+    "public_safety_scan"
+  ],
+  "checks_run": [
+    {
+      "check_id": "git_state_probe",
+      "phase": "preflight",
+      "status": "PASS",
+      "evidence_ref": "external:public-git-state-summary"
+    },
+    {
+      "check_id": "public_json_artifact_validation",
+      "phase": "post",
+      "status": "PASS",
+      "evidence_ref": "scripts/validate_public_json_artifacts.py"
+    },
+    {
+      "check_id": "public_safety_scan",
+      "phase": "post",
+      "status": "PASS",
+      "evidence_ref": "scripts/public_safety_scan.py"
+    }
+  ],
+  "evidence_refs_public_safe": [
+    "schemas/factory-automation-run-record.schema.json",
+    "templates/factory-automation-run-record.json"
+  ],
+  "git_state": {
+    "branch": "main",
+    "head_sha": "template-only",
+    "dirty_state": "unknown",
+    "remote_state": "unknown",
+    "publication_state": "no_publication_attempted"
+  },
+  "issues_created_or_updated": [],
+  "prs_created_or_updated": [],
+  "next_safe_action": "Use this record shape only after the real automation run has produced current checks.",
+  "residual_risk": "Template proves only the public contract shape, not any live automation execution.",
+  "public_artifact_policy": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "no_raw_screenshots_or_logs": true
+  }
+}

--- a/templates/factory-automation-run-target.json
+++ b/templates/factory-automation-run-target.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-automation-run-target.schema.json",
+  "record_type": "factory_automation_run_target",
+  "automation_id": "automation-public-readiness-audit",
+  "created_at": "2026-06-16T00:00:00+00:00",
+  "trigger": {
+    "trigger_type": "heartbeat",
+    "trigger_ref_public_safe": "external:public-recurring-audit-trigger",
+    "trigger_contract": "Recurring audit trigger must name the bounded target before any work starts."
+  },
+  "target": {
+    "target_kind": "repo",
+    "target_ref": "external:public-overkill-factory-repo",
+    "scope_summary": "Audit public repository contracts and open issues without private runtime evidence."
+  },
+  "owner_worker": "factory-mechanic",
+  "runtime_target_ref": "external:public-hermes-runtime-or-equivalent",
+  "profile_binding_ref": "agents/hermes-profile-bindings.public.json",
+  "authority_level": "read_only",
+  "allowed_actions": [
+    "inspect_public_repo",
+    "validate_public_contracts",
+    "prepare_public_safe_recommendation"
+  ],
+  "forbidden_actions": [
+    "publish_private_evidence",
+    "claim_completion_without_checks",
+    "mutate_github_without_explicit_authority"
+  ],
+  "required_preflight_checks": [
+    "git_state_probe",
+    "public_safety_scan"
+  ],
+  "required_post_checks": [
+    "public_json_artifact_validation",
+    "public_safety_scan"
+  ],
+  "human_gate_triggers": [
+    "authority_escalates_to_github_pr",
+    "private_evidence_needed_for_claim"
+  ],
+  "public_artifact_policy": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "no_raw_screenshots_or_logs": true,
+    "allowed_ref_classes": [
+      "repo_relative",
+      "external_sanitized_ref",
+      "github_public_ref"
+    ]
+  },
+  "retry_policy": {
+    "max_attempts": 3,
+    "retry_when": [
+      "non_human_block",
+      "validator_failure_after_repair"
+    ],
+    "stop_condition": "Stop when the target is complete, superseded, or requires a real human gate."
+  },
+  "stop_condition": "Stop when the bounded audit has a validated run record and next safe action.",
+  "cleanup_policy": {
+    "temporary_artifacts_policy": "Keep raw run outputs outside the public repo.",
+    "branch_cleanup_required": false,
+    "private_evidence_cleanup_required": true
+  },
+  "next_safe_action": "Run factoryctl validate-automation-target before scheduling this automation."
+}

--- a/tests/test_factory_automation_run_contracts.py
+++ b/tests/test_factory_automation_run_contracts.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl", MODULE_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+def automation_target(**overrides: object) -> dict:
+    target = {
+        "$schema": "https://overkill-factory.dev/schemas/factory-automation-run-target.schema.json",
+        "record_type": "factory_automation_run_target",
+        "automation_id": "automation-fixture",
+        "created_at": "2026-06-16T00:00:00+00:00",
+        "trigger": {
+            "trigger_type": "heartbeat",
+            "trigger_ref_public_safe": "external:public-heartbeat-trigger",
+            "trigger_contract": "Heartbeat must name the target before execution."
+        },
+        "target": {
+            "target_kind": "repo",
+            "target_ref": "external:public-overkill-repo",
+            "scope_summary": "Read-only public repository audit fixture."
+        },
+        "owner_worker": "factory-mechanic",
+        "runtime_target_ref": "external:public-hermes-runtime",
+        "profile_binding_ref": "agents/hermes-profile-bindings.public.json",
+        "authority_level": "read_only",
+        "allowed_actions": ["inspect_public_repo", "validate_public_contracts"],
+        "forbidden_actions": ["publish_private_evidence", "mutate_github_without_explicit_authority"],
+        "required_preflight_checks": ["git_state_probe", "public_safety_scan"],
+        "required_post_checks": ["public_json_artifact_validation", "public_safety_scan"],
+        "human_gate_triggers": ["authority_escalates_to_github_pr"],
+        "public_artifact_policy": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "no_raw_screenshots_or_logs": True,
+            "allowed_ref_classes": ["repo_relative", "external_sanitized_ref", "github_public_ref"]
+        },
+        "retry_policy": {
+            "max_attempts": 3,
+            "retry_when": ["non_human_block"],
+            "stop_condition": "Stop after repeated non-human repair failure."
+        },
+        "stop_condition": "Stop when the bounded target has a validated run record.",
+        "cleanup_policy": {
+            "temporary_artifacts_policy": "Keep raw run outputs outside the public repo.",
+            "branch_cleanup_required": False,
+            "private_evidence_cleanup_required": True
+        },
+        "next_safe_action": "Validate target before scheduling."
+    }
+    target.update(overrides)
+    return target
+
+
+def automation_record(**overrides: object) -> dict:
+    record = {
+        "$schema": "https://overkill-factory.dev/schemas/factory-automation-run-record.schema.json",
+        "record_type": "factory_automation_run_record",
+        "automation_id": "automation-fixture",
+        "run_id": "run-fixture",
+        "started_at": "2026-06-16T00:00:00+00:00",
+        "completed_at": "2026-06-16T00:10:00+00:00",
+        "trigger_observed": {
+            "trigger_type": "heartbeat",
+            "trigger_ref_public_safe": "external:public-heartbeat-trigger",
+            "observed_at": "2026-06-16T00:00:00+00:00"
+        },
+        "target_resolved": {
+            "target_kind": "repo",
+            "target_ref": "external:public-overkill-repo",
+            "scope_summary": "Read-only public repository audit fixture."
+        },
+        "authority_level": "read_only",
+        "status": "completed",
+        "allowed_actions_executed": True,
+        "actions_taken": ["Inspected public contracts.", "Validated public-safe artifacts."],
+        "required_preflight_checks": ["git_state_probe", "public_safety_scan"],
+        "required_post_checks": ["public_json_artifact_validation", "public_safety_scan"],
+        "checks_run": [
+            {
+                "check_id": "git_state_probe",
+                "phase": "preflight",
+                "status": "PASS",
+                "evidence_ref": "external:public-git-state-summary"
+            },
+            {
+                "check_id": "public_json_artifact_validation",
+                "phase": "post",
+                "status": "PASS",
+                "evidence_ref": "scripts/validate_public_json_artifacts.py"
+            },
+            {
+                "check_id": "public_safety_scan",
+                "phase": "post",
+                "status": "PASS",
+                "evidence_ref": "scripts/public_safety_scan.py"
+            }
+        ],
+        "evidence_refs_public_safe": [
+            "schemas/factory-automation-run-record.schema.json",
+            "tests/test_factory_automation_run_contracts.py"
+        ],
+        "git_state": {
+            "branch": "main",
+            "head_sha": "abcdef1",
+            "dirty_state": "clean",
+            "remote_state": "pushed",
+            "publication_state": "no_publication_attempted"
+        },
+        "issues_created_or_updated": [],
+        "prs_created_or_updated": [],
+        "next_safe_action": "Continue with the next bounded audit cycle.",
+        "residual_risk": "Fixture proves contract behavior only.",
+        "public_artifact_policy": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "no_raw_screenshots_or_logs": True
+        }
+    }
+    record.update(overrides)
+    return record
+
+
+class FactoryAutomationRunContractsTest(unittest.TestCase):
+    def test_valid_read_only_target_and_record_validate(self) -> None:
+        self.assertEqual(factoryctl.validate_factory_automation_run_target(automation_target()), [])
+        self.assertEqual(factoryctl.validate_factory_automation_run_record(automation_record()), [])
+
+    def test_missing_trigger_is_rejected(self) -> None:
+        target = automation_target()
+        del target["trigger"]
+
+        errors = factoryctl.validate_factory_automation_run_target(target)
+
+        self.assertTrue(any("trigger" in error for error in errors), errors)
+
+    def test_missing_target_is_rejected(self) -> None:
+        record = automation_record()
+        del record["target_resolved"]
+
+        errors = factoryctl.validate_factory_automation_run_record(record)
+
+        self.assertTrue(any("target_resolved" in error for error in errors), errors)
+
+    def test_github_authority_requires_safety_gates_and_human_triggers(self) -> None:
+        target = automation_target(
+            authority_level="github_pr",
+            required_preflight_checks=["git_state_probe"],
+            required_post_checks=["public_json_artifact_validation"],
+            human_gate_triggers=[]
+        )
+
+        errors = factoryctl.validate_factory_automation_run_target(target)
+
+        self.assertTrue(any("preflight checks" in error and "secret_safety_scan" in error for error in errors), errors)
+        self.assertTrue(any("post checks" in error and "secret_safety_scan" in error for error in errors), errors)
+        self.assertTrue(any("human_gate_triggers" in error for error in errors), errors)
+
+    def test_completed_record_requires_passed_post_checks(self) -> None:
+        record = automation_record(checks_run=[])
+
+        errors = factoryctl.validate_factory_automation_run_record(record)
+
+        self.assertTrue(any("checks_run" in error for error in errors), errors)
+        self.assertTrue(any("passed post checks" in error for error in errors), errors)
+
+    def test_private_refs_are_rejected(self) -> None:
+        record = automation_record(evidence_refs_public_safe=[".tmp/factory-runs/private/raw-log.json"])
+
+        errors = factoryctl.validate_factory_automation_run_record(record)
+
+        self.assertTrue(any("evidence_refs_public_safe[0] must be public-safe" in error for error in errors), errors)
+
+    def test_repo_bound_record_requires_git_state_and_publication_state(self) -> None:
+        record = automation_record()
+        del record["git_state"]
+
+        errors = factoryctl.validate_factory_automation_run_record(record)
+
+        self.assertTrue(any("repo-bound run requires git_state" in error for error in errors), errors)
+
+    def test_github_record_requires_passed_public_and_secret_safety_checks(self) -> None:
+        record = automation_record(
+            authority_level="github_pr",
+            required_preflight_checks=["public_safety_scan", "secret_safety_scan"],
+            required_post_checks=["public_safety_scan", "secret_safety_scan"],
+            checks_run=[
+                {
+                    "check_id": "public_safety_scan",
+                    "phase": "post",
+                    "status": "PASS",
+                    "evidence_ref": "scripts/public_safety_scan.py"
+                }
+            ],
+            prs_created_or_updated=["external:public-pr-245"]
+        )
+
+        errors = factoryctl.validate_factory_automation_run_record(record)
+
+        self.assertTrue(any("secret_safety_scan" in error for error in errors), errors)
+
+    def test_external_research_record_allows_public_url_with_synthesis_only(self) -> None:
+        record = automation_record(
+            target_resolved={
+                "target_kind": "external_research_track",
+                "target_ref": "external:public-factory-ai-research-track",
+                "scope_summary": "Public research track for software factory comparison."
+            },
+            git_state=None,
+            external_research_sources=[
+                {
+                    "source_url": "https://factory.ai/news/software-factory",
+                    "source_type": "official_docs",
+                    "public_safe_synthesis": "Factory 2.0 emphasizes end-to-end software factory visibility.",
+                    "raw_capture_embedded": False
+                }
+            ]
+        )
+        del record["git_state"]
+
+        self.assertEqual(factoryctl.validate_factory_automation_run_record(record), [])
+
+    def test_external_research_rejects_raw_capture_fields(self) -> None:
+        record = automation_record(
+            target_resolved={
+                "target_kind": "external_research_track",
+                "target_ref": "external:public-factory-ai-research-track",
+                "scope_summary": "Public research track for software factory comparison."
+            },
+            external_research_sources=[
+                {
+                    "source_url": "https://factory.ai/news/software-factory",
+                    "source_type": "official_docs",
+                    "public_safe_synthesis": "Factory 2.0 emphasizes end-to-end software factory visibility.",
+                    "raw_capture_embedded": True
+                }
+            ]
+        )
+        record["raw_notes"] = "Do not publish raw notes."
+
+        errors = factoryctl.validate_factory_automation_run_record(record)
+
+        self.assertTrue(any("raw dump field raw_notes" in error for error in errors), errors)
+        self.assertTrue(any("raw_capture_embedded must be false" in error for error in errors), errors)
+
+    def test_public_templates_validate_with_schema_and_domain_rules(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        for filename in ("factory-automation-run-target.json", "factory-automation-run-record.json"):
+            artifact = json.loads((ROOT / "templates" / filename).read_text(encoding="utf-8"))
+            schema = schemas[Path(artifact["$schema"]).name]
+
+            errors = public_json_validator.validate_node(schema, artifact, "$", schemas=schemas, root_schema=schema)
+            errors.extend(public_json_validator.validate_domain_rules(artifact, "$"))
+
+            self.assertEqual(errors, [], filename)
+
+    def test_public_validator_rejects_private_automation_ref(self) -> None:
+        record = automation_record(evidence_refs_public_safe=[".tmp/factory-runs/private/raw-log.json"])
+
+        errors = public_json_validator.validate_domain_rules(record, "$")
+
+        self.assertTrue(any("$.evidence_refs_public_safe[0]" in error for error in errors), errors)
+
+    def test_factoryctl_cli_validates_target_and_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = Path(tmpdir) / "target.json"
+            record_path = Path(tmpdir) / "record.json"
+            target_path.write_text(json.dumps(automation_target()), encoding="utf-8")
+            record_path.write_text(json.dumps(automation_record()), encoding="utf-8")
+
+            target_result = factoryctl.main_with_args_for_test(["validate-automation-target", str(target_path)])
+            record_result = factoryctl.main_with_args_for_test(["validate-automation-record", str(record_path)])
+
+        self.assertEqual(target_result, 0)
+        self.assertEqual(record_result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds public schemas and templates for `factory_automation_run_target` and `factory_automation_run_record`.
- Adds `factoryctl` validators and CLI commands for automation targets/records.
- Extends public JSON artifact validation so automation contracts fail closed on private refs, unsafe GitHub authority, missing post-checks, missing repo state, and raw external research captures.
- Adds unit coverage for missing trigger, missing target, unsafe authority, missing post-checks, private leakage, repo-bound git/publication state, valid read-only runs, and external research synthesis.

Closes #245

## Boundaries
- Does not touch #84 or cockpit UI work.
- Does not couple the public repo to private Codex automation internals.
- Does not add raw automation logs, screenshots, local paths, private IDs, or private evidence.
- Does not add a Factory AI dependency; public source URLs are modeled as public-safe research inputs only.

## Validation
- `python -m unittest tests.test_factory_automation_run_contracts -q`
- `python -m py_compile scripts/factoryctl.py scripts/validate_public_json_artifacts.py`
- `python scripts/factoryctl.py validate-automation-target templates/factory-automation-run-target.json`
- `python scripts/factoryctl.py validate-automation-record templates/factory-automation-run-record.json`
- `python -m unittest tests.test_operational_evidence_bundle tests.test_factory_sdlc_lifecycle tests.test_public_json_artifact_validator -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -q`