### PR TITLE
Add SDLC feedback loop contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ operator surface, maintainer internals or generated output.
 
 Use `maintenance/self-improvement-loop.md` for learnback issue candidates,
 missing-capability completion plans, owner issue intake, reasoning policy,
-reference quality packets and governance audit artifacts.
+SDLC feedback loops, reference quality packets and governance audit artifacts.
 
 Use `maintenance/factory-learning-skill-evolution-os.md` when repeated
 execution findings should become validated skills, rules, gates, tests, workers,

--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -17,6 +17,7 @@ intake and governance checks into structured artifacts.
 
 - `schemas/missing-capability-completion-plan.schema.json`
 - `schemas/execution-learnback-record.schema.json`
+- `schemas/factory-sdlc-feedback-loop.schema.json`
 - `schemas/factory-learning-proposal.schema.json`
 - `schemas/factory-improvement-issue-candidate.schema.json`
 - `schemas/owner-issue-intake-config.schema.json`
@@ -58,6 +59,29 @@ python scripts/factory_self_improvement.py learnback-issues \
 Public issue candidates must be generalized and redacted. Raw private logs,
 local paths, private board ids, Discord ids and screenshots do not belong in
 public issue bodies.
+
+## SDLC Feedback Loop
+
+Use `factory_sdlc_feedback_loop` when a signal needs to stay connected across
+the full factory loop:
+
+```text
+signal -> triage -> model/profile route -> evidence -> learnback
+```
+
+The loop record does not replace lifecycle state, worker results, evidence
+bundles or learning proposals. It binds them so a signal cannot disappear into
+chat-only state, a model/profile choice cannot become implicit, and learnback
+cannot claim improvement without a target, validation path and promotion
+boundary.
+
+```bash
+python scripts/factoryctl.py validate-sdlc-feedback-loop \
+  templates/factory-sdlc-feedback-loop.json
+```
+
+Use this before converting external research, incidents, review findings,
+runtime gaps or product quality findings into durable factory changes.
 
 ## Learning Proposals
 

--- a/schemas/factory-sdlc-feedback-loop.schema.json
+++ b/schemas/factory-sdlc-feedback-loop.schema.json
@@ -1,0 +1,390 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-sdlc-feedback-loop.schema.json",
+  "title": "Overkill Factory SDLC Feedback Loop",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "loop_id",
+    "created_at",
+    "factory_method_version",
+    "source_signal",
+    "triage_decision",
+    "routing_decision",
+    "execution_evidence",
+    "learnback_decision",
+    "sovereignty_boundary",
+    "next_safe_action"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-sdlc-feedback-loop.schema.json"
+    },
+    "record_type": {
+      "const": "factory_sdlc_feedback_loop"
+    },
+    "loop_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "linked_lifecycle_state_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "source_signal": {
+      "type": "object",
+      "required": [
+        "signal_type",
+        "source_class",
+        "sensitivity_class",
+        "freshness",
+        "owner",
+        "target_surface",
+        "signal_ref_public_safe",
+        "raw_private_embedded"
+      ],
+      "properties": {
+        "signal_type": {
+          "enum": [
+            "bug_report",
+            "customer_feedback",
+            "internal_request",
+            "business_requirement",
+            "monitoring_alert",
+            "incident",
+            "security_finding",
+            "code_review_finding",
+            "docs_gap",
+            "product_quality_gap",
+            "dependency_or_runtime_change",
+            "external_research_signal"
+          ]
+        },
+        "source_class": {
+          "enum": [
+            "internal_structured",
+            "external_untrusted",
+            "operator_supplied",
+            "runtime_observed",
+            "mixed"
+          ]
+        },
+        "sensitivity_class": {
+          "enum": [
+            "public_safe",
+            "redacted_private",
+            "private_runtime",
+            "customer_sensitive",
+            "secret"
+          ]
+        },
+        "freshness": {
+          "enum": [
+            "fresh",
+            "bounded",
+            "stale",
+            "unknown"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 3
+        },
+        "target_surface": {
+          "type": "string",
+          "minLength": 3
+        },
+        "signal_ref_public_safe": {
+          "type": "string",
+          "minLength": 3
+        },
+        "raw_private_embedded": {
+          "const": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "triage_decision": {
+      "type": "object",
+      "required": [
+        "decision",
+        "route_ref",
+        "rationale",
+        "human_gate_required",
+        "rejects_chat_only_state"
+      ],
+      "properties": {
+        "decision": {
+          "enum": [
+            "product_sot_delta",
+            "work_unit",
+            "blocker",
+            "risk_gate",
+            "docs_task",
+            "incident_response",
+            "learnback_only",
+            "reject_with_rationale"
+          ]
+        },
+        "route_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 6
+        },
+        "human_gate_required": {
+          "type": "boolean"
+        },
+        "rejects_chat_only_state": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "routing_decision": {
+      "type": "object",
+      "required": [
+        "router_ref",
+        "selected_profile",
+        "selected_model_class",
+        "selection_basis",
+        "model_independence_preserved",
+        "single_provider_assumption"
+      ],
+      "properties": {
+        "router_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "selected_profile": {
+          "type": "string",
+          "minLength": 3
+        },
+        "selected_model_class": {
+          "enum": [
+            "small_fast",
+            "balanced",
+            "frontier_reasoning",
+            "specialist_tooling",
+            "human_only",
+            "deferred"
+          ]
+        },
+        "selection_basis": {
+          "type": "object",
+          "required": [
+            "cost",
+            "speed",
+            "quality",
+            "context_need",
+            "data_sensitivity",
+            "tool_requirements",
+            "expected_horizon",
+            "fallback_route"
+          ],
+          "properties": {
+            "cost": {
+              "type": "string",
+              "minLength": 3
+            },
+            "speed": {
+              "type": "string",
+              "minLength": 3
+            },
+            "quality": {
+              "type": "string",
+              "minLength": 3
+            },
+            "context_need": {
+              "type": "string",
+              "minLength": 3
+            },
+            "data_sensitivity": {
+              "type": "string",
+              "minLength": 3
+            },
+            "tool_requirements": {
+              "type": "string",
+              "minLength": 3
+            },
+            "expected_horizon": {
+              "type": "string",
+              "minLength": 3
+            },
+            "fallback_route": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "additionalProperties": false
+        },
+        "model_independence_preserved": {
+          "const": true
+        },
+        "single_provider_assumption": {
+          "const": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "execution_evidence": {
+      "type": "object",
+      "required": [
+        "status",
+        "evidence_refs",
+        "failed_outputs_consumable_as_success",
+        "validation_refs"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "PENDING",
+            "PASS",
+            "BLOCKED",
+            "REJECTED",
+            "SUPERSEDED"
+          ]
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "failed_outputs_consumable_as_success": {
+          "const": false
+        },
+        "validation_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "learnback_decision": {
+      "type": "object",
+      "required": [
+        "classification",
+        "target_artifact_type",
+        "source_evidence_refs",
+        "validation_refs",
+        "promotion_boundary",
+        "rejection_rationale"
+      ],
+      "properties": {
+        "classification": {
+          "enum": [
+            "gate_update",
+            "template_update",
+            "schema_update",
+            "worker_packet_update",
+            "routing_rule_update",
+            "checklist_update",
+            "docs_update",
+            "test_or_eval_update",
+            "public_issue",
+            "reject"
+          ]
+        },
+        "target_artifact_type": {
+          "enum": [
+            "gate",
+            "template",
+            "schema",
+            "worker_packet",
+            "routing_rule",
+            "checklist",
+            "doc",
+            "test_or_eval",
+            "issue",
+            "none"
+          ]
+        },
+        "source_evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "validation_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "promotion_boundary": {
+          "enum": [
+            "inactive_candidate",
+            "public_issue_only",
+            "requires_independent_review",
+            "requires_human_gate",
+            "rejected"
+          ]
+        },
+        "rejection_rationale": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "sovereignty_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo",
+        "reusable_across_products",
+        "memory_owner"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "private_context_retained_outside_public_repo": {
+          "const": true
+        },
+        "reusable_across_products": {
+          "enum": [
+            "yes",
+            "no",
+            "bounded"
+          ]
+        },
+        "memory_owner": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "next_safe_action": {
+      "type": "string",
+      "minLength": 6
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4214,6 +4214,12 @@ def _validate_lifecycle_refs(refs: list[str], at: str, errors: list[str]) -> Non
             errors.append(f"{at}[{index}] must be public-safe")
 
 
+def _validate_public_ref(ref: str, at: str, errors: list[str]) -> None:
+    _, redaction = sanitize_public_ref(ref)
+    if redaction is not None:
+        errors.append(f"{at} must be public-safe")
+
+
 def validate_factory_sdlc_lifecycle_state(state: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -4320,6 +4326,97 @@ def validate_factory_sdlc_lifecycle_state(state: dict[str, Any]) -> list[str]:
         errors.append("factory_sdlc_lifecycle_state cockpit must not be source of truth")
     if projection.get("dashboard_visibility_is_evidence") is not False:
         errors.append("factory_sdlc_lifecycle_state dashboard visibility must not be evidence")
+
+    return errors
+
+
+def validate_factory_sdlc_feedback_loop(loop: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-sdlc-feedback-loop.schema.json")
+    if not schema:
+        return ["factory_sdlc_feedback_loop schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            loop,
+            "factory_sdlc_feedback_loop",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    linked_lifecycle = str(loop.get("linked_lifecycle_state_ref") or "").strip()
+    if linked_lifecycle:
+        _validate_public_ref(linked_lifecycle, "factory_sdlc_feedback_loop.linked_lifecycle_state_ref", errors)
+
+    source = loop.get("source_signal") if isinstance(loop.get("source_signal"), dict) else {}
+    source_ref = str(source.get("signal_ref_public_safe") or "").strip()
+    if source_ref:
+        _validate_public_ref(source_ref, "factory_sdlc_feedback_loop.source_signal.signal_ref_public_safe", errors)
+    if source.get("sensitivity_class") == "secret":
+        errors.append("factory_sdlc_feedback_loop cannot publish secret-class signals")
+    if source.get("raw_private_embedded") is not False:
+        errors.append("factory_sdlc_feedback_loop source signal must not embed raw private evidence")
+
+    triage = loop.get("triage_decision") if isinstance(loop.get("triage_decision"), dict) else {}
+    route_ref = str(triage.get("route_ref") or "").strip()
+    if route_ref:
+        _validate_public_ref(route_ref, "factory_sdlc_feedback_loop.triage_decision.route_ref", errors)
+    if triage.get("rejects_chat_only_state") is not True:
+        errors.append("factory_sdlc_feedback_loop triage must reject chat-only state")
+
+    routing = loop.get("routing_decision") if isinstance(loop.get("routing_decision"), dict) else {}
+    router_ref = str(routing.get("router_ref") or "").strip()
+    if router_ref:
+        _validate_public_ref(router_ref, "factory_sdlc_feedback_loop.routing_decision.router_ref", errors)
+    if routing.get("model_independence_preserved") is not True:
+        errors.append("factory_sdlc_feedback_loop routing must preserve model independence")
+    if routing.get("single_provider_assumption") is not False:
+        errors.append("factory_sdlc_feedback_loop routing must not assume a single provider")
+
+    evidence = loop.get("execution_evidence") if isinstance(loop.get("execution_evidence"), dict) else {}
+    _validate_lifecycle_refs(
+        _list_items(evidence.get("evidence_refs")),
+        "factory_sdlc_feedback_loop.execution_evidence.evidence_refs",
+        errors,
+    )
+    _validate_lifecycle_refs(
+        _list_items(evidence.get("validation_refs")),
+        "factory_sdlc_feedback_loop.execution_evidence.validation_refs",
+        errors,
+    )
+    if evidence.get("failed_outputs_consumable_as_success") is not False:
+        errors.append("factory_sdlc_feedback_loop failed outputs cannot be consumed as success")
+
+    learnback = loop.get("learnback_decision") if isinstance(loop.get("learnback_decision"), dict) else {}
+    _validate_lifecycle_refs(
+        _list_items(learnback.get("source_evidence_refs")),
+        "factory_sdlc_feedback_loop.learnback_decision.source_evidence_refs",
+        errors,
+    )
+    _validate_lifecycle_refs(
+        _list_items(learnback.get("validation_refs")),
+        "factory_sdlc_feedback_loop.learnback_decision.validation_refs",
+        errors,
+    )
+    classification = str(learnback.get("classification") or "").strip()
+    target_artifact = str(learnback.get("target_artifact_type") or "").strip()
+    promotion_boundary = str(learnback.get("promotion_boundary") or "").strip()
+    if classification != "reject" and target_artifact == "none":
+        errors.append("factory_sdlc_feedback_loop learnback requires an actionable target artifact")
+    if classification == "reject" and target_artifact != "none":
+        errors.append("factory_sdlc_feedback_loop rejected learnback must use target_artifact_type=none")
+    if classification != "reject" and promotion_boundary == "rejected":
+        errors.append("factory_sdlc_feedback_loop non-rejected learnback cannot use rejected promotion boundary")
+
+    sovereignty = loop.get("sovereignty_boundary") if isinstance(loop.get("sovereignty_boundary"), dict) else {}
+    if sovereignty.get("public_safe_refs_only") is not True:
+        errors.append("factory_sdlc_feedback_loop requires public_safe_refs_only=true")
+    if sovereignty.get("raw_private_evidence_embedded") is not False:
+        errors.append("factory_sdlc_feedback_loop must not embed raw private evidence")
+    if sovereignty.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("factory_sdlc_feedback_loop private context must stay outside the public repo")
 
     return errors
 
@@ -8749,6 +8846,16 @@ def command_validate_sdlc_lifecycle(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_sdlc_feedback_loop(args: argparse.Namespace) -> int:
+    errors = validate_factory_sdlc_feedback_loop(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_automation_target(args: argparse.Namespace) -> int:
     errors = validate_factory_automation_run_target(load_json_like(args.path))
     if errors:
@@ -9077,6 +9184,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_lifecycle_parser = sub.add_parser("validate-lifecycle")
     validate_lifecycle_parser.add_argument("path", type=Path)
     validate_lifecycle_parser.set_defaults(func=command_validate_sdlc_lifecycle)
+
+    validate_sdlc_feedback_parser = sub.add_parser("validate-sdlc-feedback-loop")
+    validate_sdlc_feedback_parser.add_argument("path", type=Path)
+    validate_sdlc_feedback_parser.set_defaults(func=command_validate_sdlc_feedback_loop)
 
     validate_automation_target_parser = sub.add_parser("validate-automation-target")
     validate_automation_target_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -549,6 +549,65 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: production readiness requires production_strict or customer_validated proof")
         if acceptance.get("customer_ready_claimed") is True and proof_level != "customer_validated":
             errors.append(f"{at}: customer readiness requires customer_validated proof")
+    if data.get("record_type") == "factory_sdlc_feedback_loop":
+        linked_lifecycle = str(data.get("linked_lifecycle_state_ref") or "").strip()
+        if linked_lifecycle:
+            reason = public_artifact_ref_error(linked_lifecycle)
+            if reason:
+                errors.append(f"{at}.linked_lifecycle_state_ref: {reason}")
+        source = data.get("source_signal") if isinstance(data.get("source_signal"), dict) else {}
+        source_ref = str(source.get("signal_ref_public_safe") or "").strip()
+        reason = public_artifact_ref_error(source_ref)
+        if reason:
+            errors.append(f"{at}.source_signal.signal_ref_public_safe: {reason}")
+        if source.get("sensitivity_class") == "secret":
+            errors.append(f"{at}: factory_sdlc_feedback_loop cannot publish secret-class signals")
+        triage = data.get("triage_decision") if isinstance(data.get("triage_decision"), dict) else {}
+        route_ref = str(triage.get("route_ref") or "").strip()
+        reason = public_artifact_ref_error(route_ref)
+        if reason:
+            errors.append(f"{at}.triage_decision.route_ref: {reason}")
+        routing = data.get("routing_decision") if isinstance(data.get("routing_decision"), dict) else {}
+        router_ref = str(routing.get("router_ref") or "").strip()
+        reason = public_artifact_ref_error(router_ref)
+        if reason:
+            errors.append(f"{at}.routing_decision.router_ref: {reason}")
+        if routing.get("model_independence_preserved") is not True:
+            errors.append(f"{at}: factory_sdlc_feedback_loop routing must preserve model independence")
+        if routing.get("single_provider_assumption") is not False:
+            errors.append(f"{at}: factory_sdlc_feedback_loop routing must not assume a single provider")
+        evidence = data.get("execution_evidence") if isinstance(data.get("execution_evidence"), dict) else {}
+        for field in ("evidence_refs", "validation_refs"):
+            refs = evidence.get(field) if isinstance(evidence.get(field), list) else []
+            for index, ref in enumerate(refs):
+                reason = public_artifact_ref_error(ref)
+                if reason:
+                    errors.append(f"{at}.execution_evidence.{field}[{index}]: {reason}")
+        if evidence.get("failed_outputs_consumable_as_success") is not False:
+            errors.append(f"{at}: factory_sdlc_feedback_loop failed outputs cannot be consumed as success")
+        learnback = data.get("learnback_decision") if isinstance(data.get("learnback_decision"), dict) else {}
+        for field in ("source_evidence_refs", "validation_refs"):
+            refs = learnback.get(field) if isinstance(learnback.get(field), list) else []
+            for index, ref in enumerate(refs):
+                reason = public_artifact_ref_error(ref)
+                if reason:
+                    errors.append(f"{at}.learnback_decision.{field}[{index}]: {reason}")
+        classification = str(learnback.get("classification") or "").strip()
+        target_artifact = str(learnback.get("target_artifact_type") or "").strip()
+        promotion_boundary = str(learnback.get("promotion_boundary") or "").strip()
+        if classification != "reject" and target_artifact == "none":
+            errors.append(f"{at}: factory_sdlc_feedback_loop learnback requires an actionable target artifact")
+        if classification == "reject" and target_artifact != "none":
+            errors.append(f"{at}: factory_sdlc_feedback_loop rejected learnback must use target_artifact_type=none")
+        if classification != "reject" and promotion_boundary == "rejected":
+            errors.append(f"{at}: factory_sdlc_feedback_loop non-rejected learnback cannot use rejected promotion boundary")
+        sovereignty = data.get("sovereignty_boundary") if isinstance(data.get("sovereignty_boundary"), dict) else {}
+        if sovereignty.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: factory_sdlc_feedback_loop requires public_safe_refs_only=true")
+        if sovereignty.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: factory_sdlc_feedback_loop must not embed raw private evidence")
+        if sovereignty.get("private_context_retained_outside_public_repo") is not True:
+            errors.append(f"{at}: factory_sdlc_feedback_loop private context must stay outside the public repo")
     if data.get("record_type") == "factory_automation_run_target":
         trigger = data.get("trigger") if isinstance(data.get("trigger"), dict) else {}
         target = data.get("target") if isinstance(data.get("target"), dict) else {}

--- a/templates/factory-sdlc-feedback-loop.json
+++ b/templates/factory-sdlc-feedback-loop.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-sdlc-feedback-loop.schema.json",
+  "record_type": "factory_sdlc_feedback_loop",
+  "loop_id": "sdlc-feedback-loop-public-template",
+  "created_at": "2026-06-16T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "linked_lifecycle_state_ref": "templates/factory-sdlc-lifecycle-state.json",
+  "source_signal": {
+    "signal_type": "external_research_signal",
+    "source_class": "external_untrusted",
+    "sensitivity_class": "public_safe",
+    "freshness": "bounded",
+    "owner": "factory-improvement-radar",
+    "target_surface": "factory-method",
+    "signal_ref_public_safe": "external:public-factory-ai-software-factory-article",
+    "raw_private_embedded": false
+  },
+  "triage_decision": {
+    "decision": "learnback_only",
+    "route_ref": "schemas/factory-learning-proposal.schema.json",
+    "rationale": "Public research signal becomes a bounded learning candidate before changing factory behavior.",
+    "human_gate_required": false,
+    "rejects_chat_only_state": true
+  },
+  "routing_decision": {
+    "router_ref": "templates/method-contract.json",
+    "selected_profile": "skill-eval-distiller",
+    "selected_model_class": "balanced",
+    "selection_basis": {
+      "cost": "bounded schema and template work",
+      "speed": "small public-safe contract update",
+      "quality": "requires validation and independent review before activation",
+      "context_need": "needs factory method and self-improvement context",
+      "data_sensitivity": "public-safe source only",
+      "tool_requirements": "schema, unit test and public artifact validation",
+      "expected_horizon": "single bounded maintenance cycle",
+      "fallback_route": "open public-safe improvement issue if implementation is unsafe"
+    },
+    "model_independence_preserved": true,
+    "single_provider_assumption": false
+  },
+  "execution_evidence": {
+    "status": "PENDING",
+    "evidence_refs": [
+      "schemas/factory-sdlc-feedback-loop.schema.json",
+      "templates/factory-sdlc-feedback-loop.json"
+    ],
+    "failed_outputs_consumable_as_success": false,
+    "validation_refs": [
+      "tests/test_factory_sdlc_feedback_loop.py",
+      "scripts/validate_public_json_artifacts.py"
+    ]
+  },
+  "learnback_decision": {
+    "classification": "schema_update",
+    "target_artifact_type": "schema",
+    "source_evidence_refs": [
+      "external:public-factory-ai-software-factory-article"
+    ],
+    "validation_refs": [
+      "tests/test_factory_sdlc_feedback_loop.py",
+      "scripts/validate_public_json_artifacts.py"
+    ],
+    "promotion_boundary": "requires_independent_review",
+    "rejection_rationale": "not_rejected"
+  },
+  "sovereignty_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true,
+    "reusable_across_products": "bounded",
+    "memory_owner": "operator-owned-factory-instance"
+  },
+  "next_safe_action": "Validate this loop before using it as learnback input."
+}

--- a/tests/test_factory_sdlc_feedback_loop.py
+++ b/tests/test_factory_sdlc_feedback_loop.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl", MODULE_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+def feedback_loop() -> dict:
+    return json.loads((ROOT / "templates" / "factory-sdlc-feedback-loop.json").read_text(encoding="utf-8"))
+
+
+class FactorySdlcFeedbackLoopTest(unittest.TestCase):
+    def test_public_template_validates(self) -> None:
+        loop = feedback_loop()
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertEqual(errors, [])
+
+    def test_missing_route_is_rejected_by_schema(self) -> None:
+        loop = feedback_loop()
+        del loop["triage_decision"]["route_ref"]
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("route_ref" in error for error in errors), errors)
+
+    def test_private_signal_ref_is_rejected(self) -> None:
+        loop = feedback_loop()
+        loop["source_signal"]["signal_ref_public_safe"] = "C:/Users/felip/private/signal.json"
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("source_signal.signal_ref_public_safe" in error for error in errors), errors)
+
+    def test_secret_class_signal_is_rejected(self) -> None:
+        loop = feedback_loop()
+        loop["source_signal"]["sensitivity_class"] = "secret"
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("secret-class" in error for error in errors), errors)
+
+    def test_single_provider_routing_is_rejected(self) -> None:
+        loop = feedback_loop()
+        loop["routing_decision"]["model_independence_preserved"] = False
+        loop["routing_decision"]["single_provider_assumption"] = True
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("preserve model independence" in error for error in errors), errors)
+        self.assertTrue(any("single provider" in error for error in errors), errors)
+
+    def test_failed_outputs_cannot_be_consumable_as_success(self) -> None:
+        loop = feedback_loop()
+        loop["execution_evidence"]["failed_outputs_consumable_as_success"] = True
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("failed outputs cannot be consumed" in error for error in errors), errors)
+
+    def test_non_rejected_learnback_requires_actionable_target(self) -> None:
+        loop = feedback_loop()
+        loop["learnback_decision"]["target_artifact_type"] = "none"
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("learnback requires an actionable target" in error for error in errors), errors)
+
+    def test_rejected_learnback_must_not_target_artifact(self) -> None:
+        loop = feedback_loop()
+        loop["learnback_decision"]["classification"] = "reject"
+        loop["learnback_decision"]["promotion_boundary"] = "rejected"
+        loop["learnback_decision"]["target_artifact_type"] = "schema"
+
+        errors = factoryctl.validate_factory_sdlc_feedback_loop(loop)
+
+        self.assertTrue(any("rejected learnback must use target_artifact_type=none" in error for error in errors), errors)
+
+    def test_public_validator_applies_feedback_loop_domain_rules(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        schema = schemas["factory-sdlc-feedback-loop.schema.json"]
+        loop = feedback_loop()
+        bad = copy.deepcopy(loop)
+        bad["learnback_decision"]["target_artifact_type"] = "none"
+
+        schema_errors = public_json_validator.validate_node(schema, loop, "$", schemas=schemas, root_schema=schema)
+        domain_errors = public_json_validator.validate_domain_rules(loop, "$")
+        bad_domain_errors = public_json_validator.validate_domain_rules(bad, "$")
+
+        self.assertEqual(schema_errors + domain_errors, [])
+        self.assertTrue(any("learnback requires an actionable target" in error for error in bad_domain_errors), bad_domain_errors)
+
+    def test_factoryctl_cli_validates_feedback_loop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "feedback-loop.json"
+            path.write_text(json.dumps(feedback_loop()), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(["validate-sdlc-feedback-loop", str(path)])
+
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #252

## Summary
- Add a public-safe actory_sdlc_feedback_loop schema and template to bind signal -> triage -> model/profile route -> evidence -> learnback.
- Add actoryctl validate-sdlc-feedback-loop plus public JSON domain validation for route refs, model independence, evidence boundaries, failed-output consumption, and actionable learnback targets.
- Document the contract as an integration layer over lifecycle state, worker results, evidence bundles and learning proposals.

## Boundaries
- Does not touch #84 or cockpit files.
- Does not add private evidence, historical artifacts, raw social captures, local paths, screenshots or private runtime data.
- This is the contract foundation for #252; it does not yet make every material worker result require a feedback-loop ref.

## Validation
- python -m unittest tests.test_factory_sdlc_feedback_loop tests.test_factory_sdlc_lifecycle -q
- python scripts/factoryctl.py validate-sdlc-feedback-loop templates/factory-sdlc-feedback-loop.json
- python scripts/validate_public_json_artifacts.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- git diff --check
- python -m unittest discover -s tests -q