### PR TITLE
Add factory readiness scorecard contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,8 @@ operator surface, maintainer internals or generated output.
 
 Use `maintenance/self-improvement-loop.md` for learnback issue candidates,
 missing-capability completion plans, owner issue intake, reasoning policy,
-SDLC feedback loops, reference quality packets and governance audit artifacts.
+factory readiness scorecards, SDLC feedback loops, reference quality packets
+and governance audit artifacts.
 
 Use `maintenance/factory-learning-skill-evolution-os.md` when repeated
 execution findings should become validated skills, rules, gates, tests, workers,

--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -18,6 +18,7 @@ intake and governance checks into structured artifacts.
 - `schemas/missing-capability-completion-plan.schema.json`
 - `schemas/execution-learnback-record.schema.json`
 - `schemas/factory-sdlc-feedback-loop.schema.json`
+- `schemas/factory-readiness-scorecard.schema.json`
 - `schemas/factory-learning-proposal.schema.json`
 - `schemas/factory-improvement-issue-candidate.schema.json`
 - `schemas/owner-issue-intake-config.schema.json`
@@ -82,6 +83,26 @@ python scripts/factoryctl.py validate-sdlc-feedback-loop \
 
 Use this before converting external research, incidents, review findings,
 runtime gaps or product quality findings into durable factory changes.
+
+## Factory Readiness Scorecard
+
+Use `factory_readiness_scorecard` before long autonomous execution to decide
+whether the factory can proceed, proceed with bounds, remediate, or block:
+
+```bash
+python scripts/factoryctl.py validate-readiness-scorecard \
+  templates/factory-readiness-scorecard.json
+```
+
+The scorecard checks the execution environment around the work: build/install,
+tests, static checks, docs/first run, task discovery, worker/profile readiness,
+public/private evidence hygiene, observability/incident/rollback, security,
+product success signals and autonomy risk.
+
+It is not product acceptance, customer readiness, release approval, security
+approval or a cockpit status. Non-passing dimensions require a remediation
+loop, and blocking dimensions must keep autonomous execution off until the
+scorecard is rerun with evidence.
 
 ## Learning Proposals
 

--- a/schemas/factory-readiness-scorecard.schema.json
+++ b/schemas/factory-readiness-scorecard.schema.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-readiness-scorecard.schema.json",
+  "title": "Overkill Factory Readiness Scorecard",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "scorecard_id",
+    "created_at",
+    "factory_method_version",
+    "target",
+    "verdict",
+    "maturity_level",
+    "dimensions",
+    "remediation_loop",
+    "autonomy_boundary",
+    "public_private_boundary",
+    "next_safe_action"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-readiness-scorecard.schema.json"
+    },
+    "record_type": {
+      "const": "factory_readiness_scorecard"
+    },
+    "scorecard_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "target": {
+      "type": "object",
+      "required": [
+        "target_type",
+        "target_ref",
+        "scope",
+        "owner"
+      ],
+      "properties": {
+        "target_type": {
+          "enum": [
+            "repo",
+            "product",
+            "runtime",
+            "factory_issue",
+            "mixed"
+          ]
+        },
+        "target_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 3
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "verdict": {
+      "enum": [
+        "ready_for_autonomy",
+        "ready_with_bounds",
+        "remediation_required",
+        "blocked"
+      ]
+    },
+    "maturity_level": {
+      "type": "object",
+      "required": [
+        "level",
+        "basis"
+      ],
+      "properties": {
+        "level": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "basis": {
+          "type": "string",
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "dimensions": {
+      "type": "array",
+      "minItems": 11,
+      "items": {
+        "type": "object",
+        "required": [
+          "dimension_id",
+          "status",
+          "owner",
+          "severity",
+          "blocks_autonomous_execution",
+          "evidence_refs",
+          "smallest_safe_remediation",
+          "remediation_target_ref"
+        ],
+        "properties": {
+          "dimension_id": {
+            "enum": [
+              "build_install_health",
+              "test_coverage_determinism",
+              "lint_static_checks",
+              "docs_onboarding_first_run",
+              "task_discovery_issue_quality",
+              "worker_profile_capability_readiness",
+              "evidence_public_private_hygiene",
+              "observability_incident_rollback",
+              "security_secrets_supply_chain",
+              "product_analytics_success_signals",
+              "autonomy_risk_human_gates"
+            ]
+          },
+          "status": {
+            "enum": [
+              "PASS",
+              "BOUNDED",
+              "REMEDIATION_REQUIRED",
+              "BLOCKED"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 3
+          },
+          "severity": {
+            "enum": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
+          },
+          "blocks_autonomous_execution": {
+            "type": "boolean"
+          },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "smallest_safe_remediation": {
+            "type": "string",
+            "minLength": 3
+          },
+          "remediation_target_ref": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "remediation_loop": {
+      "type": "object",
+      "required": [
+        "required",
+        "loop_ref",
+        "rerun_required_before_unblock",
+        "unblock_requires_evidence",
+        "auto_approve_human_gates"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "loop_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "rerun_required_before_unblock": {
+          "const": true
+        },
+        "unblock_requires_evidence": {
+          "const": true
+        },
+        "auto_approve_human_gates": {
+          "const": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "autonomy_boundary": {
+      "type": "object",
+      "required": [
+        "autonomous_execution_allowed",
+        "allowed_scope",
+        "requires_human_gate_for",
+        "not_product_acceptance",
+        "not_release_approval"
+      ],
+      "properties": {
+        "autonomous_execution_allowed": {
+          "type": "boolean"
+        },
+        "allowed_scope": {
+          "enum": [
+            "none",
+            "read_only",
+            "bounded_remediation",
+            "material_execution"
+          ]
+        },
+        "requires_human_gate_for": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "not_product_acceptance": {
+          "const": true
+        },
+        "not_release_approval": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_runtime_evidence_stays_local"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "private_runtime_evidence_stays_local": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "linked_feedback_loop_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "next_safe_action": {
+      "type": "string",
+      "minLength": 6
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -227,6 +227,20 @@ V2_APPROVAL_KEYS = [
     "human_gate",
 ]
 
+FACTORY_READINESS_SCORECARD_DIMENSIONS = {
+    "build_install_health",
+    "test_coverage_determinism",
+    "lint_static_checks",
+    "docs_onboarding_first_run",
+    "task_discovery_issue_quality",
+    "worker_profile_capability_readiness",
+    "evidence_public_private_hygiene",
+    "observability_incident_rollback",
+    "security_secrets_supply_chain",
+    "product_analytics_success_signals",
+    "autonomy_risk_human_gates",
+}
+
 PRODUCT_FACE_SURFACES = {"ux", "frontend", "mobile", "wallet-ui", "product-face"}
 PRODUCT_EXPERIENCE_SURFACES = PRODUCT_FACE_SURFACES | {
     "web",
@@ -4417,6 +4431,168 @@ def validate_factory_sdlc_feedback_loop(loop: dict[str, Any]) -> list[str]:
         errors.append("factory_sdlc_feedback_loop must not embed raw private evidence")
     if sovereignty.get("private_context_retained_outside_public_repo") is not True:
         errors.append("factory_sdlc_feedback_loop private context must stay outside the public repo")
+
+    return errors
+
+
+def validate_factory_readiness_scorecard(scorecard: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-readiness-scorecard.schema.json")
+    if not schema:
+        return ["factory_readiness_scorecard schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            scorecard,
+            "factory_readiness_scorecard",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    target = scorecard.get("target") if isinstance(scorecard.get("target"), dict) else {}
+    target_ref = str(target.get("target_ref") or "").strip()
+    if target_ref:
+        _validate_public_ref(target_ref, "factory_readiness_scorecard.target.target_ref", errors)
+
+    linked_feedback_loop_ref = str(scorecard.get("linked_feedback_loop_ref") or "").strip()
+    if linked_feedback_loop_ref:
+        _validate_public_ref(
+            linked_feedback_loop_ref,
+            "factory_readiness_scorecard.linked_feedback_loop_ref",
+            errors,
+        )
+
+    remediation_loop = scorecard.get("remediation_loop") if isinstance(scorecard.get("remediation_loop"), dict) else {}
+    loop_ref = str(remediation_loop.get("loop_ref") or "").strip()
+    if loop_ref:
+        _validate_public_ref(loop_ref, "factory_readiness_scorecard.remediation_loop.loop_ref", errors)
+
+    dimensions = scorecard.get("dimensions") if isinstance(scorecard.get("dimensions"), list) else []
+    seen: set[str] = set()
+    duplicate_dimensions: set[str] = set()
+    non_pass_statuses: set[str] = set()
+    blocked_dimensions: set[str] = set()
+    remediation_dimensions: set[str] = set()
+    bounded_dimensions: set[str] = set()
+
+    for index, dimension in enumerate(dimensions):
+        if not isinstance(dimension, dict):
+            continue
+        dimension_id = str(dimension.get("dimension_id") or "").strip()
+        if dimension_id in seen:
+            duplicate_dimensions.add(dimension_id)
+        seen.add(dimension_id)
+
+        status = str(dimension.get("status") or "").strip().upper()
+        severity = str(dimension.get("severity") or "").strip()
+        blocks = dimension.get("blocks_autonomous_execution") is True
+        remediation_target_ref = str(dimension.get("remediation_target_ref") or "").strip()
+
+        _validate_lifecycle_refs(
+            _list_items(dimension.get("evidence_refs")),
+            f"factory_readiness_scorecard.dimensions[{index}].evidence_refs",
+            errors,
+        )
+        if remediation_target_ref:
+            _validate_public_ref(
+                remediation_target_ref,
+                f"factory_readiness_scorecard.dimensions[{index}].remediation_target_ref",
+                errors,
+            )
+
+        if status != "PASS":
+            non_pass_statuses.add(dimension_id)
+        if status == "REMEDIATION_REQUIRED":
+            remediation_dimensions.add(dimension_id)
+        if status == "BOUNDED":
+            bounded_dimensions.add(dimension_id)
+        if status == "BLOCKED" or blocks:
+            blocked_dimensions.add(dimension_id)
+
+        if status == "PASS":
+            if severity != "none":
+                errors.append(f"factory_readiness_scorecard.dimensions[{index}] PASS requires severity=none")
+            if blocks:
+                errors.append(f"factory_readiness_scorecard.dimensions[{index}] PASS cannot block autonomous execution")
+            if remediation_target_ref != "not_required":
+                errors.append(
+                    f"factory_readiness_scorecard.dimensions[{index}] PASS requires remediation_target_ref=not_required"
+                )
+        else:
+            if severity == "none":
+                errors.append(f"factory_readiness_scorecard.dimensions[{index}] non-PASS status requires non-none severity")
+            if remediation_target_ref == "not_required":
+                errors.append(
+                    f"factory_readiness_scorecard.dimensions[{index}] non-PASS status requires remediation target"
+                )
+        if status == "BLOCKED" and not blocks:
+            errors.append(f"factory_readiness_scorecard.dimensions[{index}] BLOCKED status must block autonomous execution")
+        if blocks and status != "BLOCKED":
+            errors.append(f"factory_readiness_scorecard.dimensions[{index}] blocking dimension must use BLOCKED status")
+
+    missing_dimensions = sorted(FACTORY_READINESS_SCORECARD_DIMENSIONS - seen)
+    unexpected_dimensions = sorted(seen - FACTORY_READINESS_SCORECARD_DIMENSIONS)
+    for dimension_id in missing_dimensions:
+        errors.append(f"factory_readiness_scorecard missing required dimension {dimension_id}")
+    for dimension_id in unexpected_dimensions:
+        errors.append(f"factory_readiness_scorecard unknown dimension {dimension_id}")
+    for dimension_id in sorted(duplicate_dimensions):
+        errors.append(f"factory_readiness_scorecard duplicate dimension {dimension_id}")
+
+    verdict = str(scorecard.get("verdict") or "").strip()
+    autonomy = scorecard.get("autonomy_boundary") if isinstance(scorecard.get("autonomy_boundary"), dict) else {}
+    allowed_scope = str(autonomy.get("allowed_scope") or "").strip()
+    autonomy_allowed = autonomy.get("autonomous_execution_allowed") is True
+    remediation_required = remediation_loop.get("required") is True
+
+    if non_pass_statuses and not remediation_required:
+        errors.append("factory_readiness_scorecard non-PASS dimensions require remediation_loop.required=true")
+    if blocked_dimensions:
+        if verdict != "blocked":
+            errors.append("factory_readiness_scorecard blocking dimensions require verdict=blocked")
+        if autonomy_allowed:
+            errors.append("factory_readiness_scorecard blocked verdict cannot allow autonomous execution")
+        if allowed_scope != "none":
+            errors.append("factory_readiness_scorecard blocked verdict requires allowed_scope=none")
+    if verdict == "blocked" and not blocked_dimensions:
+        errors.append("factory_readiness_scorecard verdict=blocked requires at least one blocking dimension")
+    if verdict == "ready_for_autonomy":
+        if non_pass_statuses:
+            errors.append("factory_readiness_scorecard ready_for_autonomy requires all dimensions PASS")
+        if not autonomy_allowed:
+            errors.append("factory_readiness_scorecard ready_for_autonomy requires autonomous_execution_allowed=true")
+        if allowed_scope != "material_execution":
+            errors.append("factory_readiness_scorecard ready_for_autonomy requires allowed_scope=material_execution")
+    if verdict == "ready_with_bounds":
+        if blocked_dimensions:
+            errors.append("factory_readiness_scorecard ready_with_bounds cannot include blocking dimensions")
+        if not autonomy_allowed:
+            errors.append("factory_readiness_scorecard ready_with_bounds requires autonomous_execution_allowed=true")
+        if allowed_scope == "none":
+            errors.append("factory_readiness_scorecard ready_with_bounds requires a non-none allowed_scope")
+    if verdict == "remediation_required":
+        if not remediation_required:
+            errors.append("factory_readiness_scorecard remediation_required requires remediation_loop.required=true")
+        if not (remediation_dimensions or bounded_dimensions):
+            errors.append("factory_readiness_scorecard remediation_required requires at least one non-PASS dimension")
+        if allowed_scope == "material_execution":
+            errors.append("factory_readiness_scorecard remediation_required cannot allow material_execution")
+
+    public_boundary = (
+        scorecard.get("public_private_boundary") if isinstance(scorecard.get("public_private_boundary"), dict) else {}
+    )
+    if public_boundary.get("public_safe_refs_only") is not True:
+        errors.append("factory_readiness_scorecard requires public_safe_refs_only=true")
+    if public_boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("factory_readiness_scorecard must not embed raw private evidence")
+    if public_boundary.get("private_runtime_evidence_stays_local") is not True:
+        errors.append("factory_readiness_scorecard private runtime evidence must stay local")
+    if autonomy.get("not_product_acceptance") is not True:
+        errors.append("factory_readiness_scorecard is not product acceptance")
+    if autonomy.get("not_release_approval") is not True:
+        errors.append("factory_readiness_scorecard is not release approval")
 
     return errors
 
@@ -8856,6 +9032,16 @@ def command_validate_sdlc_feedback_loop(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_readiness_scorecard(args: argparse.Namespace) -> int:
+    errors = validate_factory_readiness_scorecard(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_automation_target(args: argparse.Namespace) -> int:
     errors = validate_factory_automation_run_target(load_json_like(args.path))
     if errors:
@@ -9188,6 +9374,14 @@ def build_parser() -> argparse.ArgumentParser:
     validate_sdlc_feedback_parser = sub.add_parser("validate-sdlc-feedback-loop")
     validate_sdlc_feedback_parser.add_argument("path", type=Path)
     validate_sdlc_feedback_parser.set_defaults(func=command_validate_sdlc_feedback_loop)
+
+    validate_readiness_scorecard_parser = sub.add_parser("validate-readiness-scorecard")
+    validate_readiness_scorecard_parser.add_argument("path", type=Path)
+    validate_readiness_scorecard_parser.set_defaults(func=command_validate_readiness_scorecard)
+
+    validate_factory_readiness_scorecard_parser = sub.add_parser("validate-factory-readiness-scorecard")
+    validate_factory_readiness_scorecard_parser.add_argument("path", type=Path)
+    validate_factory_readiness_scorecard_parser.set_defaults(func=command_validate_readiness_scorecard)
 
     validate_automation_target_parser = sub.add_parser("validate-automation-target")
     validate_automation_target_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -108,6 +108,19 @@ AUTOMATION_GITHUB_AUTHORITIES = {"github_pr", "release_candidate", "production_o
 AUTOMATION_REPO_BOUND_AUTHORITIES = {"bounded_edit", "local_commit", "github_pr", "release_candidate", "production_operation"}
 AUTOMATION_REPO_BOUND_TARGETS = {"repo", "factory_issue", "release"}
 AUTOMATION_REQUIRED_SAFETY_CHECKS = {"public_safety_scan", "secret_safety_scan"}
+FACTORY_READINESS_SCORECARD_DIMENSIONS = {
+    "build_install_health",
+    "test_coverage_determinism",
+    "lint_static_checks",
+    "docs_onboarding_first_run",
+    "task_discovery_issue_quality",
+    "worker_profile_capability_readiness",
+    "evidence_public_private_hygiene",
+    "observability_incident_rollback",
+    "security_secrets_supply_chain",
+    "product_analytics_success_signals",
+    "autonomy_risk_human_gates",
+}
 
 
 def public_artifact_ref_error(ref: Any) -> str | None:
@@ -171,6 +184,140 @@ def add_public_ref_errors(refs: Any, at: str, errors: list[str]) -> None:
         reason = public_artifact_ref_error(ref)
         if reason:
             errors.append(f"{at}[{index}]: {reason}")
+
+
+def validate_factory_readiness_scorecard_domain(data: dict[str, Any], at: str) -> list[str]:
+    errors: list[str] = []
+    target = data.get("target") if isinstance(data.get("target"), dict) else {}
+    for field, ref in (
+        ("target.target_ref", target.get("target_ref")),
+        ("linked_feedback_loop_ref", data.get("linked_feedback_loop_ref")),
+    ):
+        if ref:
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.{field}: {reason}")
+
+    remediation_loop = data.get("remediation_loop") if isinstance(data.get("remediation_loop"), dict) else {}
+    if remediation_loop.get("loop_ref"):
+        reason = public_artifact_ref_error(remediation_loop.get("loop_ref"))
+        if reason:
+            errors.append(f"{at}.remediation_loop.loop_ref: {reason}")
+
+    dimensions = data.get("dimensions") if isinstance(data.get("dimensions"), list) else []
+    seen: set[str] = set()
+    duplicate_dimensions: set[str] = set()
+    non_pass_statuses: set[str] = set()
+    blocked_dimensions: set[str] = set()
+    remediation_dimensions: set[str] = set()
+    bounded_dimensions: set[str] = set()
+
+    for dimension_index, dimension in enumerate(dimensions):
+        if not isinstance(dimension, dict):
+            continue
+        dimension_id = str(dimension.get("dimension_id") or "").strip()
+        if dimension_id in seen:
+            duplicate_dimensions.add(dimension_id)
+        seen.add(dimension_id)
+
+        for ref_index, ref in enumerate(text_items(dimension.get("evidence_refs"))):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.dimensions[{dimension_index}].evidence_refs[{ref_index}]: {reason}")
+        remediation_target_ref = str(dimension.get("remediation_target_ref") or "").strip()
+        if remediation_target_ref:
+            reason = public_artifact_ref_error(remediation_target_ref)
+            if reason:
+                errors.append(f"{at}.dimensions[{dimension_index}].remediation_target_ref: {reason}")
+
+        status = str(dimension.get("status") or "").strip().upper()
+        severity = str(dimension.get("severity") or "").strip()
+        blocks = dimension.get("blocks_autonomous_execution") is True
+        if status != "PASS":
+            non_pass_statuses.add(dimension_id)
+        if status == "REMEDIATION_REQUIRED":
+            remediation_dimensions.add(dimension_id)
+        if status == "BOUNDED":
+            bounded_dimensions.add(dimension_id)
+        if status == "BLOCKED" or blocks:
+            blocked_dimensions.add(dimension_id)
+
+        if status == "PASS":
+            if severity != "none":
+                errors.append(f"{at}.dimensions[{dimension_index}]: PASS requires severity=none")
+            if blocks:
+                errors.append(f"{at}.dimensions[{dimension_index}]: PASS cannot block autonomous execution")
+            if remediation_target_ref != "not_required":
+                errors.append(f"{at}.dimensions[{dimension_index}]: PASS requires remediation_target_ref=not_required")
+        elif severity == "none":
+            errors.append(f"{at}.dimensions[{dimension_index}]: non-PASS status requires non-none severity")
+        elif remediation_target_ref == "not_required":
+            errors.append(f"{at}.dimensions[{dimension_index}]: non-PASS status requires remediation target")
+
+        if status == "BLOCKED" and not blocks:
+            errors.append(f"{at}.dimensions[{dimension_index}]: BLOCKED status must block autonomous execution")
+        if blocks and status != "BLOCKED":
+            errors.append(f"{at}.dimensions[{dimension_index}]: blocking dimension must use BLOCKED status")
+
+    for dimension_id in sorted(FACTORY_READINESS_SCORECARD_DIMENSIONS - seen):
+        errors.append(f"{at}: factory_readiness_scorecard missing required dimension {dimension_id}")
+    for dimension_id in sorted(seen - FACTORY_READINESS_SCORECARD_DIMENSIONS):
+        errors.append(f"{at}: factory_readiness_scorecard unknown dimension {dimension_id}")
+    for dimension_id in sorted(duplicate_dimensions):
+        errors.append(f"{at}: factory_readiness_scorecard duplicate dimension {dimension_id}")
+
+    verdict = str(data.get("verdict") or "").strip()
+    autonomy = data.get("autonomy_boundary") if isinstance(data.get("autonomy_boundary"), dict) else {}
+    allowed_scope = str(autonomy.get("allowed_scope") or "").strip()
+    autonomy_allowed = autonomy.get("autonomous_execution_allowed") is True
+    remediation_required = remediation_loop.get("required") is True
+
+    if non_pass_statuses and not remediation_required:
+        errors.append(f"{at}: factory_readiness_scorecard non-PASS dimensions require remediation_loop.required=true")
+    if blocked_dimensions:
+        if verdict != "blocked":
+            errors.append(f"{at}: factory_readiness_scorecard blocking dimensions require verdict=blocked")
+        if autonomy_allowed:
+            errors.append(f"{at}: factory_readiness_scorecard blocked verdict cannot allow autonomous execution")
+        if allowed_scope != "none":
+            errors.append(f"{at}: factory_readiness_scorecard blocked verdict requires allowed_scope=none")
+    if verdict == "blocked" and not blocked_dimensions:
+        errors.append(f"{at}: factory_readiness_scorecard verdict=blocked requires at least one blocking dimension")
+    if verdict == "ready_for_autonomy":
+        if non_pass_statuses:
+            errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires all dimensions PASS")
+        if not autonomy_allowed:
+            errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires autonomous_execution_allowed=true")
+        if allowed_scope != "material_execution":
+            errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires allowed_scope=material_execution")
+    if verdict == "ready_with_bounds":
+        if blocked_dimensions:
+            errors.append(f"{at}: factory_readiness_scorecard ready_with_bounds cannot include blocking dimensions")
+        if not autonomy_allowed:
+            errors.append(f"{at}: factory_readiness_scorecard ready_with_bounds requires autonomous_execution_allowed=true")
+        if allowed_scope == "none":
+            errors.append(f"{at}: factory_readiness_scorecard ready_with_bounds requires a non-none allowed_scope")
+    if verdict == "remediation_required":
+        if not remediation_required:
+            errors.append(f"{at}: factory_readiness_scorecard remediation_required requires remediation_loop.required=true")
+        if not (remediation_dimensions or bounded_dimensions):
+            errors.append(f"{at}: factory_readiness_scorecard remediation_required requires at least one non-PASS dimension")
+        if allowed_scope == "material_execution":
+            errors.append(f"{at}: factory_readiness_scorecard remediation_required cannot allow material_execution")
+
+    public_boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+    if public_boundary.get("public_safe_refs_only") is not True:
+        errors.append(f"{at}: factory_readiness_scorecard requires public_safe_refs_only=true")
+    if public_boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append(f"{at}: factory_readiness_scorecard must not embed raw private evidence")
+    if public_boundary.get("private_runtime_evidence_stays_local") is not True:
+        errors.append(f"{at}: factory_readiness_scorecard private runtime evidence must stay local")
+    if autonomy.get("not_product_acceptance") is not True:
+        errors.append(f"{at}: factory_readiness_scorecard is not product acceptance")
+    if autonomy.get("not_release_approval") is not True:
+        errors.append(f"{at}: factory_readiness_scorecard is not release approval")
+
+    return errors
 
 ANNOTATION_SCHEMA_KEYWORDS = {
     "$comment",
@@ -608,6 +755,8 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: factory_sdlc_feedback_loop must not embed raw private evidence")
         if sovereignty.get("private_context_retained_outside_public_repo") is not True:
             errors.append(f"{at}: factory_sdlc_feedback_loop private context must stay outside the public repo")
+    if data.get("record_type") == "factory_readiness_scorecard":
+        errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_automation_run_target":
         trigger = data.get("trigger") if isinstance(data.get("trigger"), dict) else {}
         target = data.get("target") if isinstance(data.get("target"), dict) else {}

--- a/templates/factory-readiness-scorecard.json
+++ b/templates/factory-readiness-scorecard.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-readiness-scorecard.schema.json",
+  "record_type": "factory_readiness_scorecard",
+  "scorecard_id": "factory-readiness-scorecard-public-template",
+  "created_at": "2026-06-16T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "target": {
+    "target_type": "repo",
+    "target_ref": "external:public-overkill-factory-repo",
+    "scope": "public-safe factory autonomy readiness template",
+    "owner": "factory-orchestrator"
+  },
+  "verdict": "ready_with_bounds",
+  "maturity_level": {
+    "level": 3,
+    "basis": "Template demonstrates standardized readiness with bounded remediation before material autonomy."
+  },
+  "dimensions": [
+    {
+      "dimension_id": "build_install_health",
+      "status": "PASS",
+      "owner": "platform-devex-worker",
+      "severity": "none",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["templates/platform-devex-plan.json"],
+      "smallest_safe_remediation": "Keep install and build commands explicit.",
+      "remediation_target_ref": "not_required"
+    },
+    {
+      "dimension_id": "test_coverage_determinism",
+      "status": "PASS",
+      "owner": "qa-verification-worker",
+      "severity": "none",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["tests/README.md"],
+      "smallest_safe_remediation": "Keep deterministic local test command documented.",
+      "remediation_target_ref": "not_required"
+    },
+    {
+      "dimension_id": "lint_static_checks",
+      "status": "PASS",
+      "owner": "test-automation-builder",
+      "severity": "none",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["scripts/validate_public_json_artifacts.py"],
+      "smallest_safe_remediation": "Keep schema and static checks in the preflight set.",
+      "remediation_target_ref": "not_required"
+    },
+    {
+      "dimension_id": "docs_onboarding_first_run",
+      "status": "PASS",
+      "owner": "docs-os-worker",
+      "severity": "none",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["docs/getting-started/quickstart-hermes.md"],
+      "smallest_safe_remediation": "Keep first-run instructions public-safe and current.",
+      "remediation_target_ref": "not_required"
+    },
+    {
+      "dimension_id": "task_discovery_issue_quality",
+      "status": "BOUNDED",
+      "owner": "factory-orchestrator",
+      "severity": "low",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["templates/owner-issue-intake-config.json"],
+      "smallest_safe_remediation": "Use issue intake before starting long autonomous work.",
+      "remediation_target_ref": "templates/owner-issue-intake-config.json"
+    },
+    {
+      "dimension_id": "worker_profile_capability_readiness",
+      "status": "BOUNDED",
+      "owner": "agent-runtime-builder",
+      "severity": "medium",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["agents/worker-profile-readiness.public.json"],
+      "smallest_safe_remediation": "Refresh profile smoke and eval evidence before treating profiles as current runtime readiness.",
+      "remediation_target_ref": "agents/worker-profile-readiness.public.json"
+    },
+    {
+      "dimension_id": "evidence_public_private_hygiene",
+      "status": "PASS",
+      "owner": "public-safety-gate",
+      "severity": "none",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["scripts/public_safety_scan.py"],
+      "smallest_safe_remediation": "Run public and secret safety scans before publishing artifacts.",
+      "remediation_target_ref": "not_required"
+    },
+    {
+      "dimension_id": "observability_incident_rollback",
+      "status": "REMEDIATION_REQUIRED",
+      "owner": "detection-monitoring-worker",
+      "severity": "medium",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["templates/incident-support-plan.json"],
+      "smallest_safe_remediation": "Attach concrete monitoring, incident and rollback evidence before production-like autonomy.",
+      "remediation_target_ref": "templates/incident-support-plan.json"
+    },
+    {
+      "dimension_id": "security_secrets_supply_chain",
+      "status": "PASS",
+      "owner": "supply-chain-gate",
+      "severity": "none",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["docs/security/oss-security.md"],
+      "smallest_safe_remediation": "Keep secret and supply-chain checks in the gate set.",
+      "remediation_target_ref": "not_required"
+    },
+    {
+      "dimension_id": "product_analytics_success_signals",
+      "status": "BOUNDED",
+      "owner": "data-metrics-worker",
+      "severity": "low",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["templates/data-metrics-plan.json"],
+      "smallest_safe_remediation": "Require success and risk signals when user/customer outcomes are claimed.",
+      "remediation_target_ref": "templates/data-metrics-plan.json"
+    },
+    {
+      "dimension_id": "autonomy_risk_human_gates",
+      "status": "BOUNDED",
+      "owner": "human-gate-clerk",
+      "severity": "medium",
+      "blocks_autonomous_execution": false,
+      "evidence_refs": ["templates/autonomy-readiness-packet.json"],
+      "smallest_safe_remediation": "Keep human, security and release gates explicit before material execution.",
+      "remediation_target_ref": "templates/autonomy-readiness-packet.json"
+    }
+  ],
+  "remediation_loop": {
+    "required": true,
+    "loop_ref": "templates/factory-sdlc-feedback-loop.json",
+    "rerun_required_before_unblock": true,
+    "unblock_requires_evidence": true,
+    "auto_approve_human_gates": false
+  },
+  "autonomy_boundary": {
+    "autonomous_execution_allowed": true,
+    "allowed_scope": "bounded_remediation",
+    "requires_human_gate_for": [
+      "security",
+      "customer_acceptance",
+      "release",
+      "deployment"
+    ],
+    "not_product_acceptance": true,
+    "not_release_approval": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_runtime_evidence_stays_local": true
+  },
+  "linked_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
+  "next_safe_action": "Use this scorecard before starting long autonomous execution, then remediate gaps and rerun."
+}

--- a/tests/test_factory_readiness_scorecard.py
+++ b/tests/test_factory_readiness_scorecard.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl", MODULE_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+def scorecard() -> dict:
+    return json.loads((ROOT / "templates" / "factory-readiness-scorecard.json").read_text(encoding="utf-8"))
+
+
+def make_all_pass(card: dict) -> dict:
+    card = copy.deepcopy(card)
+    card["verdict"] = "ready_for_autonomy"
+    card["maturity_level"]["level"] = 5
+    card["remediation_loop"]["required"] = False
+    card["autonomy_boundary"]["autonomous_execution_allowed"] = True
+    card["autonomy_boundary"]["allowed_scope"] = "material_execution"
+    for dimension in card["dimensions"]:
+        dimension["status"] = "PASS"
+        dimension["severity"] = "none"
+        dimension["blocks_autonomous_execution"] = False
+        dimension["remediation_target_ref"] = "not_required"
+    return card
+
+
+def make_blocked(card: dict) -> dict:
+    card = copy.deepcopy(card)
+    card["verdict"] = "blocked"
+    card["remediation_loop"]["required"] = True
+    card["autonomy_boundary"]["autonomous_execution_allowed"] = False
+    card["autonomy_boundary"]["allowed_scope"] = "none"
+    dimension = card["dimensions"][0]
+    dimension["status"] = "BLOCKED"
+    dimension["severity"] = "high"
+    dimension["blocks_autonomous_execution"] = True
+    dimension["remediation_target_ref"] = "templates/platform-devex-plan.json"
+    return card
+
+
+class FactoryReadinessScorecardTest(unittest.TestCase):
+    def test_public_template_validates_as_bounded(self) -> None:
+        errors = factoryctl.validate_factory_readiness_scorecard(scorecard())
+
+        self.assertEqual(errors, [])
+
+    def test_green_scorecard_validates(self) -> None:
+        errors = factoryctl.validate_factory_readiness_scorecard(make_all_pass(scorecard()))
+
+        self.assertEqual(errors, [])
+
+    def test_remediation_required_scorecard_validates(self) -> None:
+        card = scorecard()
+        card["verdict"] = "remediation_required"
+        card["autonomy_boundary"]["allowed_scope"] = "bounded_remediation"
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertEqual(errors, [])
+
+    def test_blocked_scorecard_validates(self) -> None:
+        errors = factoryctl.validate_factory_readiness_scorecard(make_blocked(scorecard()))
+
+        self.assertEqual(errors, [])
+
+    def test_missing_required_dimension_is_rejected(self) -> None:
+        card = scorecard()
+        card["dimensions"] = [dimension for dimension in card["dimensions"] if dimension["dimension_id"] != "build_install_health"]
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("missing required dimension build_install_health" in error for error in errors), errors)
+
+    def test_duplicate_dimension_is_rejected(self) -> None:
+        card = scorecard()
+        card["dimensions"].append(copy.deepcopy(card["dimensions"][0]))
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("duplicate dimension build_install_health" in error for error in errors), errors)
+
+    def test_private_evidence_ref_is_rejected(self) -> None:
+        card = scorecard()
+        card["dimensions"][0]["evidence_refs"] = ["C:/Users/felip/private/proof.json"]
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("dimensions[0].evidence_refs" in error for error in errors), errors)
+
+    def test_ready_for_autonomy_requires_all_dimensions_pass(self) -> None:
+        card = scorecard()
+        card["verdict"] = "ready_for_autonomy"
+        card["autonomy_boundary"]["allowed_scope"] = "material_execution"
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("ready_for_autonomy requires all dimensions PASS" in error for error in errors), errors)
+
+    def test_blocking_dimension_requires_blocked_verdict(self) -> None:
+        card = scorecard()
+        card["dimensions"][0]["status"] = "BLOCKED"
+        card["dimensions"][0]["severity"] = "high"
+        card["dimensions"][0]["blocks_autonomous_execution"] = True
+        card["dimensions"][0]["remediation_target_ref"] = "templates/platform-devex-plan.json"
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("blocking dimensions require verdict=blocked" in error for error in errors), errors)
+
+    def test_blocked_verdict_requires_blocking_dimension(self) -> None:
+        card = scorecard()
+        card["verdict"] = "blocked"
+        card["autonomy_boundary"]["autonomous_execution_allowed"] = False
+        card["autonomy_boundary"]["allowed_scope"] = "none"
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("verdict=blocked requires at least one blocking dimension" in error for error in errors), errors)
+
+    def test_non_pass_requires_remediation_loop(self) -> None:
+        card = scorecard()
+        card["remediation_loop"]["required"] = False
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertTrue(any("non-PASS dimensions require remediation_loop.required=true" in error for error in errors), errors)
+
+    def test_public_validator_applies_scorecard_domain_rules(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        schema = schemas["factory-readiness-scorecard.schema.json"]
+        card = scorecard()
+        bad = copy.deepcopy(card)
+        bad["verdict"] = "ready_for_autonomy"
+        bad["autonomy_boundary"]["allowed_scope"] = "material_execution"
+
+        schema_errors = public_json_validator.validate_node(schema, card, "$", schemas=schemas, root_schema=schema)
+        domain_errors = public_json_validator.validate_domain_rules(card, "$")
+        bad_domain_errors = public_json_validator.validate_domain_rules(bad, "$")
+
+        self.assertEqual(schema_errors + domain_errors, [])
+        self.assertTrue(any("ready_for_autonomy requires all dimensions PASS" in error for error in bad_domain_errors), bad_domain_errors)
+
+    def test_factoryctl_cli_validates_scorecard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "scorecard.json"
+            path.write_text(json.dumps(scorecard()), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(["validate-readiness-scorecard", str(path)])
+
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #254.

Adds a canonical `factory_readiness_scorecard` contract so the factory can answer, before long autonomous execution, whether a repo/product/runtime is ready, ready with bounds, needs remediation, or must block.

This is informed by the Factory 2.0 / software-factory signal: autonomy is not only a stronger coding agent; it requires the surrounding engineering system to be instrumented across planning, build, tests, security, monitoring and learnback.

## What changed

- Added `schemas/factory-readiness-scorecard.schema.json` and a public-safe template.
- Added `factoryctl validate-readiness-scorecard` and `validate-factory-readiness-scorecard`.
- Added fail-closed domain checks for:
  - all 11 required readiness dimensions;
  - duplicate/missing dimensions;
  - public-safe evidence/remediation refs;
  - PASS/non-PASS severity coherence;
  - blocked dimensions requiring blocked verdict and no autonomous execution;
  - ready-for-autonomy requiring all dimensions PASS and material execution scope;
  - remediation loops before unblocking.
- Added public JSON validator coverage so bad public artifacts fail outside the CLI too.
- Documented that this scorecard is not product acceptance, customer readiness, security approval, release approval or cockpit status.

## Validation

- `python -m unittest tests.test_factory_readiness_scorecard -q`
- `python scripts/factoryctl.py validate-readiness-scorecard templates/factory-readiness-scorecard.json`
- `python scripts/validate_public_json_artifacts.py`
- `python -m py_compile scripts/factoryctl.py scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -q`

## Boundaries

- Does not touch #84.
- Does not add cockpit UI.
- Does not publish private evidence, raw study notes or historical artifacts.
- Does not auto-approve human, security, customer, release or deployment gates.