### PR TITLE
Require SDLC feedback loop for material vFinal cards

### DIFF
--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -84,6 +84,11 @@ python scripts/factoryctl.py validate-sdlc-feedback-loop \
 Use this before converting external research, incidents, review findings,
 runtime gaps or product quality findings into durable factory changes.
 
+For `OVERKILL_VFINAL` cards with bounded, material or production autonomous
+execution, add `sdlc_feedback_loop_ref`. Planning-only and read-only work can
+stay lighter, but material work must not run without a feedback loop that keeps
+signal, routing, evidence and learnback connected.
+
 ## Factory Readiness Scorecard
 
 Use `factory_readiness_scorecard` before long autonomous execution to decide

--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -158,6 +158,7 @@
     "product_context_packet_ref": { "type": "string" },
     "product_implementation_readiness": { "type": "object" },
     "product_implementation_readiness_ref": { "type": "string" },
+    "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
     "user_facing_autonomy_contract": { "type": "object" },
     "user_facing_autonomy_contract_ref": { "type": "string" },
     "product_experience_plan": { "type": "object" },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3438,6 +3438,19 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
         if field in data and not _non_empty_dict(data.get(field)):
             errors.append(f"OVERKILL_VFINAL {field} must be a non-empty object")
 
+    execution_mode = _execution_mode(data)
+    authority = str(data.get("authority_max") or "").strip()
+    material_feedback_required = (
+        data.get("material_execution") is True
+        or execution_mode in HARDENING_REQUIRED_EXECUTION_MODES
+        or authority in HARDENING_REQUIRED_EXECUTION_MODES
+    )
+    feedback_ref = str(data.get("sdlc_feedback_loop_ref") or "").strip()
+    if material_feedback_required and not feedback_ref:
+        errors.append("sdlc_feedback_loop_ref required for material vFinal autonomous execution")
+    if feedback_ref:
+        _validate_public_ref(feedback_ref, "sdlc_feedback_loop_ref", errors)
+
     method_contract = data.get("method_contract") if isinstance(data.get("method_contract"), dict) else {}
     required_plans = method_contract.get("required_plans") if isinstance(method_contract, dict) else []
     if isinstance(required_plans, list):

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -16,6 +16,7 @@
   "product_delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
   "product_context_packet_ref": "templates/product-context-packet.json",
   "product_implementation_readiness_ref": "templates/product-implementation-readiness.json",
+  "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
   "user_facing_autonomy_contract_ref": "templates/user-facing-autonomy-contract.json",
   "source_refs": ["source-ledger.md"],
   "source_state": "promoted",

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -850,6 +850,37 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertIn("OVERKILL_VFINAL card missing core contracts: product_sot, spec_graph", errors)
 
+    def test_vfinal_material_execution_requires_sdlc_feedback_loop_ref(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("sdlc_feedback_loop_ref", None)
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("sdlc_feedback_loop_ref required for material vFinal autonomous execution", errors)
+
+    def test_vfinal_planning_only_does_not_require_sdlc_feedback_loop_ref(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("sdlc_feedback_loop_ref", None)
+        card["authority_max"] = "validate_gate_only"
+        card["runtime_contract"] = dict(card["runtime_contract"], mode="planning_only")
+        card["autonomy_readiness_packet"] = dict(card["autonomy_readiness_packet"], execution_mode="planning_only")
+        card["agent_runtime_hardening_profile"] = dict(
+            card["agent_runtime_hardening_profile"],
+            execution_mode="planning_only",
+        )
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertNotIn("sdlc_feedback_loop_ref required for material vFinal autonomous execution", errors)
+
+    def test_vfinal_feedback_loop_ref_must_be_public_safe(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["sdlc_feedback_loop_ref"] = "C:/Users/felip/private/feedback-loop.json"
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("sdlc_feedback_loop_ref must be public-safe", errors)
+
     def test_vfinal_method_contract_requires_named_plan_fields(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
         card["method_contract"] = dict(card["method_contract"])


### PR DESCRIPTION
## Summary

Refs #252.

Turns the SDLC feedback-loop contract from optional template into a required gear for material `OVERKILL_VFINAL` card execution.

## What changed

- Adds `sdlc_feedback_loop_ref` to `factory-card.schema.json`.
- Adds the ref to `templates/vfinal-factory-card.json`.
- Makes `factoryctl validate-card` fail closed when a vFinal card has bounded, material, or production autonomous execution but no `sdlc_feedback_loop_ref`.
- Keeps planning-only/read-only cards lighter so the loop does not become ceremony for tiny non-material work.
- Validates that the feedback-loop ref is public-safe.
- Documents the rule in `docs/maintenance/self-improvement-loop.md`.

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_vfinal_card_requires_core_canonical_contracts tests.test_factoryctl.FactoryCtlTest.test_vfinal_material_execution_requires_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_vfinal_planning_only_does_not_require_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_vfinal_feedback_loop_ref_must_be_public_safe -q`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/validate_public_json_artifacts.py`
- `python -m py_compile scripts/factoryctl.py scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -q`

## Boundaries

- Does not touch #84.
- Does not replace Hermes or create a parallel orchestrator.
- Does not publish private evidence, raw research, screenshots, or historical artifacts.
- Does not auto-approve human/security/release/product gates.
- Does not close #252 yet; remaining adoption work still includes deeper wiring of worker/evidence/lifecycle outputs to feedback-loop records.