### PR TITLE
Wire SDLC feedback refs into worker packets

### DIFF
--- a/docs/automation/worker-automation-v0.md
+++ b/docs/automation/worker-automation-v0.md
@@ -23,6 +23,12 @@ or "check frontend." The factory needs a narrower contract:
 This is better than generic assignment text because Hermes can inspect the
 packet before execution and refuse weak cards before agents start improvising.
 
+For material vFinal autonomous execution, the worker packet also carries
+`sdlc_feedback_loop_ref` inside `input_contract`. That ref is the thread that
+connects the worker's execution, evidence and learnback to the SDLC feedback
+loop. Hermes should preserve it on the worker subtask instead of letting the
+loop stay only on the source card.
+
 ## Worker Profiles
 
 Worker packets now include `profile_binding`.

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -103,6 +103,15 @@
         "authority_max",
         "forbidden_actions"
       ],
+      "properties": {
+        "sdlc_feedback_loop_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        }
+      },
       "additionalProperties": true
     },
     "output_contract": {

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -5757,6 +5757,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "reference_quality_packet": card.get("reference_quality_packet"),
             "professional_design_process": card.get("professional_design_process"),
             "learning_proposal_refs": card.get("learning_proposal_refs", []),
+            "sdlc_feedback_loop_ref": card.get("sdlc_feedback_loop_ref"),
             "canonical_product_sot_ref": card.get("canonical_product_sot_ref") or "card.product_sot",
             "product_creation_plan_ref": card.get("product_creation_plan_ref")
             or ("card.product_creation_plan" if isinstance(card.get("product_creation_plan"), dict) else None),

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -720,6 +720,25 @@ class FactoryCtlTest(unittest.TestCase):
             ],
         )
 
+    def test_worker_packet_carries_sdlc_feedback_loop_ref(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+
+        packet = factoryctl.build_worker_packet("implementation-worker", card, card_path)
+
+        self.assertEqual(
+            packet["input_contract"]["sdlc_feedback_loop_ref"],
+            card["sdlc_feedback_loop_ref"],
+        )
+
+    def test_worker_packet_schema_declares_sdlc_feedback_loop_ref(self) -> None:
+        schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
+
+        self.assertIn(
+            "sdlc_feedback_loop_ref",
+            schema["properties"]["input_contract"]["properties"],
+        )
+
     def test_worker_packet_schema_allows_every_registered_worker(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
         allowed = set(schema["properties"]["worker"]["properties"]["id"]["enum"])


### PR DESCRIPTION
## Summary
- carries sdlc_feedback_loop_ref from Factory cards into worker packet input_contract
- declares the field in worker-packet.schema.json
- documents that Hermes must preserve the ref on worker subtasks for material vFinal autonomous work
- adds tests so the SDLC feedback loop cannot remain only on the source card

## Validation
- python -m unittest tests.test_factoryctl.FactoryCtlTest.test_worker_packet_carries_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_worker_packet_schema_declares_sdlc_feedback_loop_ref -q
- python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json
- python -m py_compile scripts/factoryctl.py scripts/validate_public_json_artifacts.py
- git diff --check
- python scripts/validate_public_json_artifacts.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python -m unittest discover -s tests -q

Refs #252

Boundary: #84 untouched; no private evidence, raw research capture, or audit/history artifact added.