### PR TITLE
Wire SDLC feedback refs into learnback

### DIFF
--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -48,8 +48,17 @@ mainnet, legal/regulatory, privacy or hardware must not auto-activate.
 
 ## Execution Learnback
 
-After material execution, write an `execution_learnback_record` and generate
-issue candidates:
+After material execution, generate an `execution_learnback_record` from Receipt
+Five and, when available, the Evidence Graph:
+
+```bash
+python scripts/factory_self_improvement.py learnback-record \
+  --receipt .tmp/receipt-five.json \
+  --evidence-graph .tmp/evidence-graph.json \
+  --out .tmp/execution-learnback-record.json
+```
+
+Then generate issue candidates:
 
 ```bash
 python scripts/factory_self_improvement.py learnback-issues \
@@ -60,6 +69,12 @@ python scripts/factory_self_improvement.py learnback-issues \
 Public issue candidates must be generalized and redacted. Raw private logs,
 local paths, private board ids, Discord ids and screenshots do not belong in
 public issue bodies.
+
+For material vFinal execution, the learnback record must carry the same
+`sdlc_feedback_loop_ref` used by the card, worker packet, worker results and
+Receipt Five reconciliation. Issue candidates generated from learnback preserve
+that ref so a public-safe issue can still point to the SDLC loop without
+publishing private evidence.
 
 ## SDLC Feedback Loop
 
@@ -125,6 +140,11 @@ Learning proposals land as inactive candidates. They need validation,
 independent review and explicit activation policy before they can change factory
 behavior. Sensitive artifacts such as workers, gates, hooks, MCPs and install
 profiles must not auto-activate.
+
+Non-rejected learning proposals must also preserve `sdlc_feedback_loop_refs`.
+This keeps durable rules, gates, schemas, tests or docs tied to the execution
+evidence that justified them, instead of letting learnback become chat-only
+memory or an unowned mutation.
 
 See `maintenance/factory-learning-skill-evolution-os.md` for the operating
 rules.

--- a/schemas/execution-learnback-record.schema.json
+++ b/schemas/execution-learnback-record.schema.json
@@ -8,6 +8,11 @@
     "record_type": { "const": "execution_learnback_record" },
     "project_ref": { "type": "string", "minLength": 3 },
     "method_version": { "type": "string", "minLength": 3 },
+    "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
+    "sdlc_feedback_loop_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
     "attempted_transitions": { "type": "array", "items": { "type": "string" } },
     "workers_required": { "type": "array", "items": { "type": "string" } },
     "workers_executed": { "type": "array", "items": { "type": "string" } },

--- a/schemas/factory-improvement-issue-candidate.schema.json
+++ b/schemas/factory-improvement-issue-candidate.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://overkill-factory.dev/schemas/factory-improvement-issue-candidate.schema.json",
   "title": "Overkill Factory Improvement Issue Candidate",
   "type": "object",
-  "required": ["record_type", "title", "body", "route", "severity", "area", "public_safe"],
+  "required": ["record_type", "title", "body", "route", "severity", "area", "sdlc_feedback_loop_refs", "public_safe"],
   "properties": {
     "record_type": { "const": "factory_improvement_issue_candidate" },
     "title": { "type": "string", "minLength": 3 },
@@ -11,6 +11,10 @@
     "route": { "enum": ["public_issue", "private_followup", "critical_change_proposal", "docs_update", "eval_or_test"] },
     "severity": { "enum": ["low", "medium", "high", "critical"] },
     "area": { "type": "string", "minLength": 2 },
+    "sdlc_feedback_loop_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
     "public_safe": { "type": "boolean" },
     "requires_human_gate": { "type": "boolean" },
     "dedupe_key": { "type": "string" }

--- a/schemas/factory-learning-proposal.schema.json
+++ b/schemas/factory-learning-proposal.schema.json
@@ -30,6 +30,10 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 3 }
     },
+    "sdlc_feedback_loop_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
     "source_trust": {
       "enum": ["internal_structured", "external_untrusted", "mixed"]
     },

--- a/scripts/factory_self_improvement.py
+++ b/scripts/factory_self_improvement.py
@@ -107,6 +107,44 @@ def contains_any(text: str, terms: set[str]) -> bool:
     return any(term in normalized for term in terms)
 
 
+def unique_public_refs(values: list[Any]) -> list[str]:
+    refs: list[str] = []
+    for value in values:
+        ref = clean_public_text(value)
+        if ref and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def learnback_sdlc_feedback_loop_refs(learnback: dict[str, Any]) -> list[str]:
+    raw_refs: list[Any] = []
+    if learnback.get("sdlc_feedback_loop_ref"):
+        raw_refs.append(learnback.get("sdlc_feedback_loop_ref"))
+    if isinstance(learnback.get("sdlc_feedback_loop_refs"), list):
+        raw_refs.extend(learnback.get("sdlc_feedback_loop_refs", []))
+    return unique_public_refs(raw_refs)
+
+
+def collect_sdlc_feedback_loop_refs(value: Any) -> list[str]:
+    raw_refs: list[Any] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, child in node.items():
+                if key == "sdlc_feedback_loop_ref":
+                    raw_refs.append(child)
+                elif key in {"sdlc_feedback_loop_refs", "factory_sdlc_lifecycle_refs"} and isinstance(child, list):
+                    raw_refs.extend(child)
+                else:
+                    walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                walk(child)
+
+    walk(value)
+    return unique_public_refs(raw_refs)
+
+
 def default_reference_source_registry() -> dict[str, Any]:
     return load_json(ROOT / "templates" / "reference-source-registry.json")
 
@@ -186,7 +224,7 @@ def build_missing_capability_plan(gate_report: dict[str, Any]) -> dict[str, Any]
     }
 
 
-def build_issue_candidate(finding: dict[str, Any]) -> dict[str, Any] | None:
+def build_issue_candidate(finding: dict[str, Any], sdlc_feedback_loop_refs: list[str] | None = None) -> dict[str, Any] | None:
     route = str(finding.get("recommended_route") or "").strip()
     if route in {"no_issue", ""}:
         return None
@@ -218,6 +256,7 @@ def build_issue_candidate(finding: dict[str, Any]) -> dict[str, Any] | None:
         "route": route if route != "public_issue" else "public_issue",
         "severity": severity,
         "area": area,
+        "sdlc_feedback_loop_refs": sdlc_feedback_loop_refs or [],
         "public_safe": public_safe,
         "requires_human_gate": requires_human_gate,
         "dedupe_key": slug(f"{area}-{summary}"),
@@ -226,9 +265,10 @@ def build_issue_candidate(finding: dict[str, Any]) -> dict[str, Any] | None:
 
 def build_issue_candidates(learnback: dict[str, Any]) -> dict[str, Any]:
     candidates = []
+    feedback_refs = learnback_sdlc_feedback_loop_refs(learnback)
     for finding in learnback.get("findings", []):
         if isinstance(finding, dict):
-            candidate = build_issue_candidate(finding)
+            candidate = build_issue_candidate(finding, feedback_refs)
             if candidate:
                 candidates.append(candidate)
     return {
@@ -236,8 +276,101 @@ def build_issue_candidates(learnback: dict[str, Any]) -> dict[str, Any]:
         "record_type": "factory_improvement_issue_candidate_list",
         "created_at": utc_now(),
         "source_project_ref": clean_public_text(learnback.get("project_ref")),
+        "sdlc_feedback_loop_refs": feedback_refs,
         "candidates": candidates,
         "issue_count": len(candidates),
+    }
+
+
+def normalize_severity(value: Any) -> str:
+    severity = str(value or "medium").lower()
+    return severity if severity in {"low", "medium", "high", "critical"} else "medium"
+
+
+def build_execution_learnback_record(
+    receipt: dict[str, Any],
+    evidence_graph: dict[str, Any] | None = None,
+    project_ref: str | None = None,
+) -> dict[str, Any]:
+    refs = collect_sdlc_feedback_loop_refs([receipt, evidence_graph or {}])
+    if not refs:
+        raise ValueError("execution learnback requires sdlc_feedback_loop_refs from Receipt Five or Evidence Graph")
+
+    receipt_five = receipt.get("receipt_five") if isinstance(receipt.get("receipt_five"), dict) else {}
+    transition = receipt.get("kanban_transition_event") if isinstance(receipt.get("kanban_transition_event"), dict) else {}
+    reconciliation = receipt.get("receipt_five_reconciliation_result") if isinstance(receipt.get("receipt_five_reconciliation_result"), dict) else {}
+    graph = evidence_graph if isinstance(evidence_graph, dict) else {}
+
+    attempted_transitions = [
+        clean_public_text(transition.get(field))
+        for field in ("from_status", "to_status")
+        if str(transition.get(field) or "").strip()
+    ]
+    workers_required = unique_public_refs(list(reconciliation.get("required_workers") or []))
+    missing_workers = unique_public_refs(list(reconciliation.get("missing_blocking_workers") or []))
+    graph_findings = graph.get("findings") if isinstance(graph.get("findings"), list) else []
+    blockers = [
+        clean_public_text(finding.get("message"))
+        for finding in graph_findings
+        if isinstance(finding, dict) and str(finding.get("message") or "").strip()
+    ]
+    if str(receipt_five.get("verification_result") or "").strip().upper() == "BLOCKED":
+        blockers.append(clean_public_text(receipt_five.get("next_action") or "Receipt Five is blocked."))
+
+    findings: list[dict[str, Any]] = []
+    for finding in graph_findings:
+        if not isinstance(finding, dict):
+            continue
+        message = clean_public_text(finding.get("message"))
+        if not message:
+            continue
+        node_id = clean_public_text(finding.get("node_id") or "evidence-graph")
+        findings.append(
+            {
+                "summary": message,
+                "severity": normalize_severity(finding.get("severity")),
+                "area": node_id,
+                "recommended_route": "eval_or_test",
+                "reproduction_condition": "Evidence Graph reported this finding before learnback.",
+                "acceptance_hint": "Add or update a contract/static/unit check so the same blocker returns to the execution rail.",
+            }
+        )
+    if not findings:
+        result = str(receipt_five.get("verification_result") or graph.get("result") or "PASS").strip().upper()
+        findings.append(
+            {
+                "summary": "Receipt Five evidence completed without a self-improvement finding."
+                if result == "PASS"
+                else clean_public_text(receipt_five.get("next_action") or "Receipt Five evidence is blocked."),
+                "severity": "low" if result == "PASS" else "medium",
+                "area": "receipt-five",
+                "recommended_route": "no_issue" if result == "PASS" else "eval_or_test",
+                "reproduction_condition": "Generated from Receipt Five and Evidence Graph.",
+                "acceptance_hint": "Keep the learnback record attached to the SDLC feedback loop.",
+            }
+        )
+
+    graph_target = graph.get("target") if isinstance(graph.get("target"), dict) else {}
+    resolved_project_ref = project_ref or graph_target.get("card_ref")
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/execution-learnback-record.schema.json",
+        "record_type": "execution_learnback_record",
+        "project_ref": clean_public_text(resolved_project_ref or "external:receipt-five"),
+        "method_version": "OVERKILL_VFINAL",
+        "sdlc_feedback_loop_ref": refs[0],
+        "sdlc_feedback_loop_refs": refs,
+        "source_evidence_refs": ["receipt_five", "evidence_graph"] if evidence_graph else ["receipt_five"],
+        "attempted_transitions": attempted_transitions,
+        "workers_required": workers_required,
+        "workers_executed": [],
+        "blockers": blockers + [f"missing worker: {worker}" for worker in missing_workers],
+        "operator_friction": [],
+        "test_scan_results": [clean_public_text(command) for command in receipt_five.get("verification_commands", [])],
+        "findings": findings,
+        "public_safety_boundary": {
+            "raw_private_evidence_forbidden": True,
+            "public_issue_requires_redaction": True,
+        },
     }
 
 
@@ -257,7 +390,11 @@ def learning_classification_for(finding: dict[str, Any]) -> str:
     return "reject" if route in {"no_issue", "private_followup"} else "issue"
 
 
-def build_learning_proposal(finding: dict[str, Any], source_ref: str) -> dict[str, Any]:
+def build_learning_proposal(
+    finding: dict[str, Any],
+    source_ref: str,
+    sdlc_feedback_loop_refs: list[str] | None = None,
+) -> dict[str, Any]:
     summary = clean_public_text(finding.get("summary"))
     area = clean_public_text(finding.get("area") or "factory")
     classification = learning_classification_for(finding)
@@ -270,6 +407,7 @@ def build_learning_proposal(finding: dict[str, Any], source_ref: str) -> dict[st
         "$schema": "https://overkill-factory.dev/schemas/factory-learning-proposal.schema.json",
         "record_type": "factory_learning_proposal",
         "source_evidence_refs": [evidence_ref],
+        "sdlc_feedback_loop_refs": sdlc_feedback_loop_refs or [],
         "source_trust": "internal_structured",
         "classification": classification,
         "proposed_artifact_type": classification,
@@ -325,8 +463,9 @@ def build_learning_proposal(finding: dict[str, Any], source_ref: str) -> dict[st
 
 def build_learning_proposals(learnback: dict[str, Any]) -> dict[str, Any]:
     source_ref = clean_public_text(learnback.get("project_ref") or "external:learnback-record")
+    feedback_refs = learnback_sdlc_feedback_loop_refs(learnback)
     proposals = [
-        build_learning_proposal(finding, source_ref)
+        build_learning_proposal(finding, source_ref, feedback_refs)
         for finding in learnback.get("findings", [])
         if isinstance(finding, dict)
     ]
@@ -335,6 +474,7 @@ def build_learning_proposals(learnback: dict[str, Any]) -> dict[str, Any]:
         "record_type": "factory_learning_proposal_list",
         "created_at": utc_now(),
         "source_project_ref": source_ref,
+        "sdlc_feedback_loop_refs": feedback_refs,
         "proposals": proposals,
         "proposal_count": len(proposals),
     }
@@ -532,6 +672,16 @@ def command_learnback_issues(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_learnback_record(args: argparse.Namespace) -> int:
+    evidence_graph = load_json(args.evidence_graph) if args.evidence_graph else None
+    try:
+        record = build_execution_learnback_record(load_json(args.receipt), evidence_graph, args.project_ref)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    write_json(args.out, record)
+    return 0
+
+
 def command_learning_proposals(args: argparse.Namespace) -> int:
     write_json(args.out, build_learning_proposals(load_json(args.record)))
     return 0
@@ -567,6 +717,13 @@ def build_parser() -> argparse.ArgumentParser:
     learnback.add_argument("--record", type=Path, required=True)
     learnback.add_argument("--out", type=Path)
     learnback.set_defaults(func=command_learnback_issues)
+
+    learnback_record = sub.add_parser("learnback-record", help="Build a learnback record from Receipt Five and optional Evidence Graph")
+    learnback_record.add_argument("--receipt", type=Path, required=True)
+    learnback_record.add_argument("--evidence-graph", type=Path)
+    learnback_record.add_argument("--project-ref")
+    learnback_record.add_argument("--out", type=Path)
+    learnback_record.set_defaults(func=command_learnback_record)
 
     learning = sub.add_parser("learning-proposals", help="Turn a learnback record into typed learning proposals")
     learning.add_argument("--record", type=Path, required=True)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -973,6 +973,12 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
         serialized_refs = "\n".join(str(ref) for ref in data.get("source_evidence_refs", []))
         if PRIVATE_MARKERS.search(serialized_refs):
             errors.append(f"{at}: factory_learning_proposal source_evidence_refs must be public-safe")
+        feedback_refs = data.get("sdlc_feedback_loop_refs") if isinstance(data.get("sdlc_feedback_loop_refs"), list) else []
+        serialized_feedback_refs = "\n".join(str(ref) for ref in feedback_refs)
+        if data.get("classification") != "reject" and not feedback_refs:
+            errors.append(f"{at}: factory_learning_proposal requires sdlc_feedback_loop_refs for non-rejected learnback")
+        if PRIVATE_MARKERS.search(serialized_feedback_refs):
+            errors.append(f"{at}: factory_learning_proposal sdlc_feedback_loop_refs must be public-safe")
         validation = data.get("validation_plan") if isinstance(data.get("validation_plan"), dict) else {}
         if data.get("classification") != "reject" and validation.get("independent_review_required") is not True:
             errors.append(f"{at}: factory_learning_proposal requires independent review before activation")
@@ -996,6 +1002,25 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: active tool surfaces require reviewed trust status")
         if required_tools and not str(tools.get("supply_chain_review") or "").strip():
             errors.append(f"{at}: required tools require supply_chain_review")
+    if data.get("record_type") == "execution_learnback_record":
+        feedback_refs = []
+        feedback_ref = str(data.get("sdlc_feedback_loop_ref") or "").strip()
+        if feedback_ref:
+            feedback_refs.append(feedback_ref)
+        if isinstance(data.get("sdlc_feedback_loop_refs"), list):
+            feedback_refs.extend(str(ref) for ref in data.get("sdlc_feedback_loop_refs", []))
+        serialized_feedback_refs = "\n".join(feedback_refs)
+        if data.get("method_version") == "OVERKILL_VFINAL" and not feedback_refs:
+            errors.append(f"{at}: execution_learnback_record requires sdlc_feedback_loop_ref(s) for OVERKILL_VFINAL learnback")
+        if PRIVATE_MARKERS.search(serialized_feedback_refs):
+            errors.append(f"{at}: execution_learnback_record sdlc_feedback_loop_ref(s) must be public-safe")
+    if data.get("record_type") == "factory_improvement_issue_candidate":
+        feedback_refs = data.get("sdlc_feedback_loop_refs") if isinstance(data.get("sdlc_feedback_loop_refs"), list) else []
+        serialized_feedback_refs = "\n".join(str(ref) for ref in feedback_refs)
+        if data.get("route") in {"public_issue", "docs_update", "eval_or_test"} and not feedback_refs:
+            errors.append(f"{at}: factory_improvement_issue_candidate requires sdlc_feedback_loop_refs for public/actionable routes")
+        if PRIVATE_MARKERS.search(serialized_feedback_refs):
+            errors.append(f"{at}: factory_improvement_issue_candidate sdlc_feedback_loop_refs must be public-safe")
     if data.get("record_type") == "discord_control_tower_ux_audit":
         serialized = json.dumps(data, sort_keys=True)
         if "todo" in serialized.lower():

--- a/templates/execution-learnback-record.json
+++ b/templates/execution-learnback-record.json
@@ -3,6 +3,8 @@
   "record_type": "execution_learnback_record",
   "project_ref": "external:current-product",
   "method_version": "OVERKILL_VFINAL",
+  "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
+  "sdlc_feedback_loop_refs": ["templates/factory-sdlc-feedback-loop.json"],
   "attempted_transitions": ["ready", "done"],
   "workers_required": ["factory-orchestrator", "qa-verification-worker"],
   "workers_executed": ["factory-orchestrator"],

--- a/templates/factory-learning-proposal.json
+++ b/templates/factory-learning-proposal.json
@@ -4,6 +4,9 @@
   "source_evidence_refs": [
     "external:execution-learnback-record"
   ],
+  "sdlc_feedback_loop_refs": [
+    "templates/factory-sdlc-feedback-loop.json"
+  ],
   "source_trust": "internal_structured",
   "classification": "skill",
   "proposed_artifact_type": "skill",

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -292,6 +292,7 @@ class FactorySelfImprovementTest(unittest.TestCase):
             "record_type": "execution_learnback_record",
             "project_ref": "external:factory-run",
             "method_version": "OVERKILL_VFINAL",
+            "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
             "findings": [
                 {
                     "summary": "Repeated review correction should become a reusable skill.",
@@ -318,6 +319,106 @@ class FactorySelfImprovementTest(unittest.TestCase):
         self.assertFalse(proposal["activation_policy"]["auto_activation_allowed"])
         self.assertTrue(proposal["validation_plan"]["independent_review_required"])
         self.assertIn("max_agents", proposal["activation_policy"]["budget"])
+        self.assertEqual(proposal["sdlc_feedback_loop_refs"], ["templates/factory-sdlc-feedback-loop.json"])
+        self.assertEqual(result["sdlc_feedback_loop_refs"], ["templates/factory-sdlc-feedback-loop.json"])
+
+    def test_learnback_issue_candidates_preserve_sdlc_feedback_loop_ref(self) -> None:
+        learnback = {
+            "record_type": "execution_learnback_record",
+            "project_ref": "external:factory-run",
+            "method_version": "OVERKILL_VFINAL",
+            "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
+            "findings": [
+                {
+                    "summary": "Repeated missing worker result should become a public issue.",
+                    "severity": "medium",
+                    "area": "runtime",
+                    "recommended_route": "public_issue",
+                    "reproduction_condition": "Receipt Five reconciliation blocked on missing result.",
+                    "acceptance_hint": "Add fail-closed guidance and tests.",
+                }
+            ],
+            "public_safety_boundary": {
+                "raw_private_evidence_forbidden": True,
+                "public_issue_requires_redaction": True,
+            },
+        }
+
+        result = self_improvement.build_issue_candidates(learnback)
+
+        self.assertEqual(result["sdlc_feedback_loop_refs"], ["templates/factory-sdlc-feedback-loop.json"])
+        self.assertEqual(
+            result["candidates"][0]["sdlc_feedback_loop_refs"],
+            ["templates/factory-sdlc-feedback-loop.json"],
+        )
+
+    def test_execution_learnback_record_from_receipt_preserves_sdlc_refs(self) -> None:
+        receipt = {
+            "receipt_five": {
+                "changed": "runtime gate tightened",
+                "artifact_paths": ["scripts/factoryctl.py"],
+                "verification_commands": ["python -m unittest tests.test_factory_self_improvement -q"],
+                "verification_result": "BLOCKED",
+                "reviewer_required": True,
+                "sdlc_feedback_loop_refs": ["templates/factory-sdlc-feedback-loop.json"],
+                "next_action": "rerun missing worker result",
+            },
+            "kanban_transition_event": {
+                "from_status": "review",
+                "to_status": "blocked",
+                "actor": "factory",
+                "worker": "evidence-reconciler",
+                "receipt_refs": ["receipt_five"],
+                "artifact_refs": ["scripts/factoryctl.py"],
+            },
+            "receipt_five_reconciliation_result": {
+                "required_workers": ["qa-verification-worker"],
+                "missing_blocking_workers": ["qa-verification-worker"],
+                "sdlc_feedback_loop_refs": ["templates/factory-sdlc-feedback-loop.json"],
+            },
+        }
+        evidence_graph = {
+            "record_type": "evidence_graph",
+            "result": "BLOCKED",
+            "target": {"card_ref": "examples/cards/card.md"},
+            "findings": [
+                {
+                    "severity": "high",
+                    "node_id": "worker-result:qa_verification_result",
+                    "message": "qa-verification-worker result is missing",
+                }
+            ],
+        }
+
+        record = self_improvement.build_execution_learnback_record(receipt, evidence_graph)
+
+        self.assertEqual(record["project_ref"], "examples/cards/card.md")
+        self.assertEqual(record["sdlc_feedback_loop_refs"], ["templates/factory-sdlc-feedback-loop.json"])
+        self.assertEqual(record["findings"][0]["recommended_route"], "eval_or_test")
+        self.assertIn("missing worker: qa-verification-worker", record["blockers"])
+
+    def test_execution_learnback_record_requires_receipt_or_graph_sdlc_refs(self) -> None:
+        receipt = {
+            "receipt_five": {
+                "changed": "runtime gate tightened",
+                "artifact_paths": ["scripts/factoryctl.py"],
+                "verification_commands": ["python -m unittest tests.test_factory_self_improvement -q"],
+                "verification_result": "PASS",
+                "reviewer_required": False,
+                "next_action": "continue",
+            },
+            "kanban_transition_event": {
+                "from_status": "review",
+                "to_status": "done",
+                "actor": "factory",
+                "worker": "evidence-reconciler",
+                "receipt_refs": ["receipt_five"],
+                "artifact_refs": ["scripts/factoryctl.py"],
+            },
+        }
+
+        with self.assertRaisesRegex(ValueError, "requires sdlc_feedback_loop_refs"):
+            self_improvement.build_execution_learnback_record(receipt)
 
     def test_learning_proposal_domain_rules_fail_closed(self) -> None:
         validator_spec = importlib.util.spec_from_file_location(
@@ -340,14 +441,81 @@ class FactorySelfImprovementTest(unittest.TestCase):
         proposal["tool_governance"]["third_party_trust_status"] = "unknown"
         proposal["source_trust"] = "external_untrusted"
         proposal["untrusted_input_handling"]["reader_actor_split"] = False
+        proposal["sdlc_feedback_loop_refs"] = []
 
         errors = validator.validate_domain_rules(proposal, "$")
 
         self.assertIn("$: factory_learning_proposal source_evidence_refs must be public-safe", errors)
+        self.assertIn("$: factory_learning_proposal requires sdlc_feedback_loop_refs for non-rejected learnback", errors)
         self.assertIn("$: sensitive factory learning artifacts must not auto-activate", errors)
         self.assertIn("$: factory_learning_proposal must land inactive before activation", errors)
         self.assertIn("$: untrusted learning input requires reader_actor_split", errors)
         self.assertIn("$: active tool surfaces require reviewed trust status", errors)
+
+    def test_execution_learnback_domain_rules_require_public_sdlc_ref(self) -> None:
+        validator_spec = importlib.util.spec_from_file_location(
+            "validate_public_json_artifacts",
+            ROOT / "scripts" / "validate_public_json_artifacts.py",
+        )
+        assert validator_spec is not None
+        validator = importlib.util.module_from_spec(validator_spec)
+        assert validator_spec.loader is not None
+        sys.modules["validate_public_json_artifacts"] = validator
+        validator_spec.loader.exec_module(validator)
+
+        learnback = json.loads((ROOT / "templates" / "execution-learnback-record.json").read_text(encoding="utf-8"))
+        learnback.pop("sdlc_feedback_loop_ref")
+        learnback.pop("sdlc_feedback_loop_refs")
+
+        errors = validator.validate_domain_rules(learnback, "$")
+
+        self.assertIn(
+            "$: execution_learnback_record requires sdlc_feedback_loop_ref(s) for OVERKILL_VFINAL learnback",
+            errors,
+        )
+
+        private_windows_path = "C:" + "\\" + "Users" + "\\owner\\private-run.json"
+        learnback["sdlc_feedback_loop_ref"] = private_windows_path
+
+        errors = validator.validate_domain_rules(learnback, "$")
+
+        self.assertIn("$: execution_learnback_record sdlc_feedback_loop_ref(s) must be public-safe", errors)
+
+    def test_issue_candidate_domain_rules_require_public_sdlc_ref(self) -> None:
+        validator_spec = importlib.util.spec_from_file_location(
+            "validate_public_json_artifacts",
+            ROOT / "scripts" / "validate_public_json_artifacts.py",
+        )
+        assert validator_spec is not None
+        validator = importlib.util.module_from_spec(validator_spec)
+        assert validator_spec.loader is not None
+        sys.modules["validate_public_json_artifacts"] = validator
+        validator_spec.loader.exec_module(validator)
+
+        candidate = self_improvement.build_issue_candidate(
+            {
+                "summary": "Repeated missing worker result should become a public issue.",
+                "severity": "medium",
+                "area": "runtime",
+                "recommended_route": "public_issue",
+            },
+            [],
+        )
+        assert candidate is not None
+
+        errors = validator.validate_domain_rules(candidate, "$")
+
+        self.assertIn(
+            "$: factory_improvement_issue_candidate requires sdlc_feedback_loop_refs for public/actionable routes",
+            errors,
+        )
+
+        private_windows_path = "C:" + "\\" + "Users" + "\\owner\\private-run.json"
+        candidate["sdlc_feedback_loop_refs"] = [private_windows_path]
+
+        errors = validator.validate_domain_rules(candidate, "$")
+
+        self.assertIn("$: factory_improvement_issue_candidate sdlc_feedback_loop_refs must be public-safe", errors)
 
     def test_owner_issue_intake_routes_critical_factory_change_to_human_gate_path(self) -> None:
         config = json.loads((ROOT / "templates" / "owner-issue-intake-config.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add a deterministic `learnback-record` command that builds execution learnback from Receipt Five and optional Evidence Graph while preserving SDLC feedback loop refs
- carry `sdlc_feedback_loop_refs` into public issue candidates and learning proposals
- fail closed when material vFinal learnback, actionable public issue candidates, or non-rejected learning proposals lack public-safe SDLC feedback refs

## Why
This completes the next link for #252: after worker packets, worker results, Receipt Five, and Evidence Graph carry the SDLC feedback loop, learnback must not become chat-only memory or an unowned public issue/proposal.

## Validation
- `python -m unittest tests.test_factory_self_improvement.FactorySelfImprovementTest.test_execution_learnback_record_from_receipt_preserves_sdlc_refs tests.test_factory_self_improvement.FactorySelfImprovementTest.test_execution_learnback_record_requires_receipt_or_graph_sdlc_refs tests.test_factory_self_improvement.FactorySelfImprovementTest.test_issue_candidate_domain_rules_require_public_sdlc_ref tests.test_factory_self_improvement.FactorySelfImprovementTest.test_execution_learnback_domain_rules_require_public_sdlc_ref tests.test_factory_self_improvement.FactorySelfImprovementTest.test_learning_proposal_domain_rules_fail_closed -q`
- `python -m py_compile scripts\\factory_self_improvement.py scripts\\validate_public_json_artifacts.py`
- `git diff --check`
- `python scripts\\validate_public_json_artifacts.py`
- `python scripts\\public_safety_scan.py`
- `python scripts\\secret_safety_scan.py`
- `python -m unittest discover -s tests -q`

Refs #252
