### PR TITLE
Enforce delivery quality proofs before promotion

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2878,6 +2878,13 @@ def _required_domain_proof_ids(card: dict[str, Any], phase: str) -> list[str]:
     return sorted({proof_id for proof_id in proof_ids if proof_id})
 
 
+def _required_delivery_profile_proof_ids(card: dict[str, Any], phase: str) -> list[str]:
+    profile = _product_delivery_quality_profile(card)
+    if not profile:
+        return []
+    return _delivery_profile_required_proof_ids(profile, phase)
+
+
 def _validate_delivery_profile_proof_coverage(
     coverage: Any,
     required_proof_ids: list[str],
@@ -5362,7 +5369,7 @@ def validate_completion(
     to_status: str | None = None,
 ) -> list[str]:
     errors = validate_receipt(metadata)
-    errors.extend(done_promotion_errors(metadata, from_status=from_status, to_status=to_status))
+    errors.extend(done_promotion_errors(metadata, card=card, from_status=from_status, to_status=to_status))
     receipt = metadata.get("receipt_five") if isinstance(metadata.get("receipt_five"), dict) else {}
     if receipt.get("reviewer_required") is True and str(receipt.get("reviewer_result") or "").strip().upper() != "PASS":
         errors.append("reviewer_result must be PASS when reviewer_required=true")
@@ -7357,10 +7364,31 @@ def receipt_reconciliation_errors(metadata: dict[str, Any] | None) -> list[str]:
 def done_promotion_errors(
     metadata: dict[str, Any] | None,
     *,
+    card: dict[str, Any] | None = None,
     from_status: str | None = None,
     to_status: str | None = None,
 ) -> list[str]:
     errors = receipt_reconciliation_errors(metadata)
+    if isinstance(card, dict) and isinstance(metadata, dict):
+        required_promotion_proofs = _required_delivery_profile_proof_ids(card, "before_promotion")
+        if required_promotion_proofs:
+            profile = _product_delivery_quality_profile(card) or {
+                "waiver_policy": {
+                    "allowed": True,
+                    "requires_owner": True,
+                    "requires_reason": True,
+                    "cannot_claim_full_acceptance": True,
+                }
+            }
+            errors.extend(
+                _validate_delivery_profile_proof_coverage(
+                    metadata.get("product_delivery_promotion_proof_coverage"),
+                    required_promotion_proofs,
+                    at="product_delivery_promotion_proof_coverage",
+                    profile=profile,
+                    full_acceptance=True,
+                )
+            )
     if from_status is not None and to_status is not None and isinstance(metadata, dict):
         errors.extend(
             validate_transition_event_matches(

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -206,6 +206,81 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             factoryctl.validate_card(card),
         )
 
+    def test_product_delivery_before_promotion_proofs_block_done_promotion_when_missing(self) -> None:
+        card = self.vfinal_card()
+        profile = factoryctl.load_json_like(ROOT / "templates" / "product-delivery-quality-profile.json")
+        profile["required_proofs"].append(
+            {
+                "proof_id": "generic.release-readiness",
+                "name": "Release readiness proof",
+                "required_at": ["before_promotion"],
+                "owner_worker": "release-ops-worker",
+                "reviewer_role": "independent-reviewer",
+                "evidence_kind": "review",
+                "human_gate_required": False,
+            }
+        )
+        card["product_delivery_quality_profile"] = profile
+        metadata = {
+            "kanban_transition_event": {
+                "allowed": True,
+                "from_status": "review",
+                "to_status": "done",
+            },
+            "receipt_five_reconciliation_result": {
+                "result": "PASS",
+                "valid": True,
+                "promotion_authority": {"result": "PASS"},
+            },
+        }
+
+        errors = factoryctl.done_promotion_errors(metadata, card=card)
+
+        self.assertIn(
+            "product_delivery_promotion_proof_coverage missing product delivery proof coverage for required proof ids: generic.release-readiness",
+            errors,
+        )
+
+    def test_product_delivery_before_promotion_proofs_accept_valid_coverage(self) -> None:
+        card = self.vfinal_card()
+        profile = factoryctl.load_json_like(ROOT / "templates" / "product-delivery-quality-profile.json")
+        profile["required_proofs"].append(
+            {
+                "proof_id": "generic.release-readiness",
+                "name": "Release readiness proof",
+                "required_at": ["before_promotion"],
+                "owner_worker": "release-ops-worker",
+                "reviewer_role": "independent-reviewer",
+                "evidence_kind": "review",
+                "human_gate_required": False,
+            }
+        )
+        card["product_delivery_quality_profile"] = profile
+        metadata = {
+            "kanban_transition_event": {
+                "allowed": True,
+                "from_status": "review",
+                "to_status": "done",
+            },
+            "receipt_five_reconciliation_result": {
+                "result": "PASS",
+                "valid": True,
+                "promotion_authority": {"result": "PASS"},
+            },
+            "product_delivery_promotion_proof_coverage": [
+                {
+                    "proof_id": "generic.release-readiness",
+                    "status": "PASS",
+                    "evidence_refs": ["external:release-readiness-review"],
+                    "basis": "Independent release readiness review passed.",
+                    "reviewer_role": "independent-reviewer",
+                    "evidence_kind": "review",
+                }
+            ],
+        }
+
+        self.assertEqual(factoryctl.done_promotion_errors(metadata, card=card), [])
+
     def test_missing_repo_local_product_delivery_quality_profile_ref_fails_closed(self) -> None:
         card = self.vfinal_card()
         card["product_delivery_quality_profile_ref"] = "templates/missing-product-delivery-quality-profile.json"


### PR DESCRIPTION
## Summary
- enforce Product Delivery Quality Profile proofs declared as `before_promotion` during done/promotion validation
- add `product_delivery_promotion_proof_coverage` as the structured metadata field for promotion-time quality proof coverage
- keep implementation/completion proof timing distinct from promotion proof timing

## Why
Closes the concrete gap in #238: a profile could declare `required_at=["before_promotion"]`, but promotion would still pass with only Receipt Five reconciliation. That made promotion-specific quality proofs declarative instead of mechanical.

## Validation
- `python -m unittest tests.test_product_method_sot_planning.ProductMethodSotPlanningTest.test_product_delivery_before_promotion_proofs_block_done_promotion_when_missing tests.test_product_method_sot_planning.ProductMethodSotPlanningTest.test_product_delivery_before_promotion_proofs_accept_valid_coverage tests.test_product_method_sot_planning.ProductMethodSotPlanningTest.test_product_delivery_quality_profile_requires_readiness_proof_coverage tests.test_product_method_sot_planning.ProductMethodSotPlanningTest.test_product_delivery_quality_profile_ref_requires_readiness_proof_coverage -q`
- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_validate_completion_requires_done_promotion_gate tests.test_factoryctl.FactoryCtlTest.test_transition_plan_done_blocks_missing_required_worker_results tests.test_factoryctl.FactoryCtlTest.test_transition_plan_done_allows_when_blocking_worker_results_exist -q`
- `python -m py_compile scripts\\factoryctl.py`
- `git diff --check`
- `python scripts\\validate_public_json_artifacts.py`
- `python scripts\\public_safety_scan.py`
- `python scripts\\secret_safety_scan.py`
- `python scripts\\supply_chain_proof.py --check --no-write`
- `python -m unittest discover -s tests -q`

Refs #238
