### PR TITLE
Require material autonomy routing contracts

### DIFF
--- a/docs/automation/worker-automation-v0.md
+++ b/docs/automation/worker-automation-v0.md
@@ -29,6 +29,12 @@ connects the worker's execution, evidence and learnback to the SDLC feedback
 loop. Hermes should preserve it on the worker subtask instead of letting the
 loop stay only on the source card.
 
+The same packet carries `autonomy_mode`, `agent_readiness_basis` and the
+model/profile routing decision ref or inline decision. This prevents material
+work from reaching Hermes as a vague "use an agent" request. The worker receives
+the declared autonomy scope, sensitivity/readiness basis and fallback route that
+must govern execution and repair.
+
 Worker results for those material cards must carry the same
 `sdlc_feedback_loop_ref`. The evidence reconciler preserves it in the Receipt
 Five reconciliation index and draft receipt so execution evidence can feed the

--- a/docs/concepts/overkill-factory-method.md
+++ b/docs/concepts/overkill-factory-method.md
@@ -95,6 +95,8 @@ flow, `factoryctl help-next` and the workflow catalog compress them into:
 | Surface Pack | Rules for a visible or operational surface such as web, mobile, CLI, docs or onboarding. |
 | Method Router | The decision step that chooses the process weight and required gates. |
 | Method Contract | The recorded router decision: canonical SOT scope, factory route, engineering methods, evidence and blockers. |
+| SDLC Feedback Loop | The signal thread that connects source signal, triage, model/profile route, execution evidence and learnback. Material autonomous work must not lose this thread. |
+| Material Autonomy Routing | The executable autonomy decision on a material card: autonomy mode, agent readiness basis, model/profile routing decision and fallback route. |
 | Product Creation Plan | The complete product decomposition from Product SOT into work units, slices, proof, stop rules and reconciliation. |
 | Product Context Packet | The compact product-specific rules that implementation and review workers load instead of relying on chat memory. |
 | Product Implementation Readiness | The alignment gate across SOT, method, research, architecture, experience, work units, packs, access and proof. |
@@ -157,22 +159,23 @@ record why a step is omitted.
 19. Loop Plan
 20. Product Context Packet
 21. Product Implementation Readiness
-22. Autonomy Readiness Packet
-23. Ready Gate
-24. Operator Projection
-25. Runtime execution
-26. Worker Results
-27. Verification
-28. Independent Review
-29. Human Gate when required
-30. Closure Summary
-31. Receipt Five
-32. Completion Audit
-33. Production Promotion Ladder and Operations
-34. Release or Block
-35. Monitoring, Incident and Support when needed
-36. Learnback
-37. Factory Maturity Audit
+22. SDLC Feedback Loop for material autonomous work
+23. Autonomy Readiness Packet and material autonomy routing
+24. Ready Gate
+25. Operator Projection
+26. Runtime execution
+27. Worker Results
+28. Verification
+29. Independent Review
+30. Human Gate when required
+31. Closure Summary
+32. Receipt Five
+33. Completion Audit
+34. Production Promotion Ladder and Operations
+35. Release or Block
+36. Monitoring, Incident and Support when needed
+37. Learnback
+38. Factory Maturity Audit
 ```
 
 ## Work Units

--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -104,6 +104,14 @@ execution, add `sdlc_feedback_loop_ref`. Planning-only and read-only work can
 stay lighter, but material work must not run without a feedback loop that keeps
 signal, routing, evidence and learnback connected.
 
+Those material cards must also declare `autonomy_mode`,
+`agent_readiness_basis` and either `model_routing_decision_ref` or an inline
+`model_routing_decision`. The feedback loop records the broader signal and
+learning context, while the card records the executable autonomy choice that the
+worker packet must preserve: how much human guidance is required, how sensitive
+the information is, which autonomy scope is allowed, why the model/profile route
+is acceptable, and where the work returns when validation fails.
+
 ## Factory Readiness Scorecard
 
 Use `factory_readiness_scorecard` before long autonomous execution to decide

--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -159,6 +159,52 @@
     "product_implementation_readiness": { "type": "object" },
     "product_implementation_readiness_ref": { "type": "string" },
     "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
+    "autonomy_mode": {
+      "enum": [
+        "bounded_execution",
+        "material_execution",
+        "production_operation",
+        "human_only",
+        "deferred"
+      ]
+    },
+    "agent_readiness_basis": {
+      "type": "object",
+      "required": [
+        "human_guidance_required",
+        "information_sensitivity",
+        "agent_readiness_level",
+        "allowed_autonomy_scope",
+        "fallback_route",
+        "evidence_refs"
+      ],
+      "properties": {
+        "human_guidance_required": { "type": "string", "minLength": 3 },
+        "information_sensitivity": { "type": "string", "minLength": 3 },
+        "agent_readiness_level": { "type": "string", "minLength": 3 },
+        "allowed_autonomy_scope": { "type": "string", "minLength": 3 },
+        "fallback_route": { "type": "string", "minLength": 3 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "model_routing_decision_ref": { "type": "string", "minLength": 3 },
+    "model_routing_decision": {
+      "type": "object",
+      "required": [
+        "router_ref",
+        "selected_profile",
+        "selected_model_class",
+        "selection_basis",
+        "model_independence_preserved",
+        "single_provider_assumption"
+      ],
+      "additionalProperties": true
+    },
     "user_facing_autonomy_contract": { "type": "object" },
     "user_facing_autonomy_contract_ref": { "type": "string" },
     "product_experience_plan": { "type": "object" },

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -110,6 +110,32 @@
             "null"
           ],
           "minLength": 3
+        },
+        "autonomy_mode": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "agent_readiness_basis": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "model_routing_decision_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "model_routing_decision": {
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "additionalProperties": true

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -202,6 +202,21 @@ SECRET_POLICY_FORBIDDEN_KEYS = {
     "local_secret_path",
 }
 HARDENING_REQUIRED_EXECUTION_MODES = {"bounded_execution", "material_execution", "production_operation"}
+MATERIAL_AUTONOMY_MODES = {
+    "bounded_execution",
+    "material_execution",
+    "production_operation",
+    "human_only",
+    "deferred",
+}
+MODEL_ROUTING_MODEL_CLASSES = {
+    "small_fast",
+    "balanced",
+    "frontier_reasoning",
+    "specialist_tooling",
+    "human_only",
+    "deferred",
+}
 TOOL_USING_SURFACES = {
     "shell",
     "browser",
@@ -2308,6 +2323,82 @@ def _execution_mode(card: dict[str, Any]) -> str:
     return ""
 
 
+def _model_routing_decision_errors(decision: Any, *, at: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(decision, dict):
+        return [f"{at} must be an object"]
+    for field in ("router_ref", "selected_profile", "selected_model_class", "selection_basis"):
+        if field == "selection_basis":
+            if not isinstance(decision.get(field), dict):
+                errors.append(f"{at}.{field} must be a non-empty object")
+        elif not _non_empty_text(decision.get(field)):
+            errors.append(f"{at}.{field} is required")
+    selected_model_class = str(decision.get("selected_model_class") or "").strip()
+    if selected_model_class and selected_model_class not in MODEL_ROUTING_MODEL_CLASSES:
+        errors.append(f"{at}.selected_model_class must be one of " + ", ".join(sorted(MODEL_ROUTING_MODEL_CLASSES)))
+    basis = decision.get("selection_basis") if isinstance(decision.get("selection_basis"), dict) else {}
+    for field in (
+        "cost",
+        "speed",
+        "quality",
+        "context_need",
+        "data_sensitivity",
+        "tool_requirements",
+        "expected_horizon",
+        "fallback_route",
+    ):
+        if not _non_empty_text(basis.get(field)):
+            errors.append(f"{at}.selection_basis.{field} is required")
+    if decision.get("model_independence_preserved") is not True:
+        errors.append(f"{at}.model_independence_preserved must be true")
+    if decision.get("single_provider_assumption") is not False:
+        errors.append(f"{at}.single_provider_assumption must be false")
+    return errors
+
+
+def validate_material_autonomy_routing_contract(card: dict[str, Any]) -> list[str]:
+    if not material_sdlc_feedback_loop_required(card):
+        return []
+    errors: list[str] = []
+    autonomy_mode = str(card.get("autonomy_mode") or "").strip()
+    execution_mode = _execution_mode(card)
+    if not autonomy_mode:
+        errors.append("autonomy_mode required for material vFinal autonomous execution")
+    elif autonomy_mode not in MATERIAL_AUTONOMY_MODES:
+        errors.append("autonomy_mode must be one of " + ", ".join(sorted(MATERIAL_AUTONOMY_MODES)))
+    elif execution_mode and autonomy_mode != execution_mode:
+        errors.append("autonomy_mode must match autonomy readiness execution_mode")
+
+    basis = card.get("agent_readiness_basis")
+    if not isinstance(basis, dict) or not basis:
+        errors.append("agent_readiness_basis required for material vFinal autonomous execution")
+    else:
+        for field in (
+            "human_guidance_required",
+            "information_sensitivity",
+            "agent_readiness_level",
+            "allowed_autonomy_scope",
+            "fallback_route",
+        ):
+            if not _non_empty_text(basis.get(field)):
+                errors.append(f"agent_readiness_basis.{field} is required")
+        evidence_refs = _list_items(basis.get("evidence_refs"))
+        if not evidence_refs:
+            errors.append("agent_readiness_basis.evidence_refs must be a non-empty array")
+        else:
+            errors.extend(_evidence_ref_errors(evidence_refs, ROOT))
+
+    routing_ref = str(card.get("model_routing_decision_ref") or "").strip()
+    routing_decision = card.get("model_routing_decision")
+    if routing_ref:
+        _validate_public_ref(routing_ref, "model_routing_decision_ref", errors)
+    if routing_decision is not None:
+        errors.extend(_model_routing_decision_errors(routing_decision, at="model_routing_decision"))
+    if not routing_ref and routing_decision is None:
+        errors.append("model_routing_decision_ref or model_routing_decision required for material vFinal autonomous execution")
+    return errors
+
+
 def _tool_surfaces_from(card: dict[str, Any]) -> set[str]:
     surfaces: set[str] = set()
     for source_name in ("agent_runtime_hardening_profile", "runtime_contract"):
@@ -3467,6 +3558,7 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_product_creation_readiness_contract(data))
     errors.extend(validate_production_promotion_ladder_contract(data))
     errors.extend(validate_user_facing_autonomy_contract(data))
+    errors.extend(validate_material_autonomy_routing_contract(data))
     errors.extend(
         _validate_vfinal_schema_backed_plan_gate(
             data,
@@ -5780,6 +5872,10 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "professional_design_process": card.get("professional_design_process"),
             "learning_proposal_refs": card.get("learning_proposal_refs", []),
             "sdlc_feedback_loop_ref": card.get("sdlc_feedback_loop_ref"),
+            "autonomy_mode": card.get("autonomy_mode"),
+            "agent_readiness_basis": card.get("agent_readiness_basis"),
+            "model_routing_decision_ref": card.get("model_routing_decision_ref"),
+            "model_routing_decision": card.get("model_routing_decision"),
             "canonical_product_sot_ref": card.get("canonical_product_sot_ref") or "card.product_sot",
             "product_creation_plan_ref": card.get("product_creation_plan_ref")
             or ("card.product_creation_plan" if isinstance(card.get("product_creation_plan"), dict) else None),

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -17,6 +17,20 @@
   "product_context_packet_ref": "templates/product-context-packet.json",
   "product_implementation_readiness_ref": "templates/product-implementation-readiness.json",
   "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
+  "autonomy_mode": "bounded_execution",
+  "agent_readiness_basis": {
+    "human_guidance_required": "bounded approvals for material scope, access, risk and release decisions",
+    "information_sensitivity": "public-safe template; product instances must classify private/customer/secret data separately",
+    "agent_readiness_level": "ready_with_bounds",
+    "allowed_autonomy_scope": "bounded material execution after ready gate and before human-gated promotion",
+    "fallback_route": "return to blocked or repair loop when a non-human gate fails; request human decision only for authority gates",
+    "evidence_refs": [
+      "templates/autonomy-readiness-packet.json",
+      "templates/agent-runtime-hardening-profile.json",
+      "templates/factory-sdlc-feedback-loop.json"
+    ]
+  },
+  "model_routing_decision_ref": "templates/factory-sdlc-feedback-loop.json#routing_decision",
   "user_facing_autonomy_contract_ref": "templates/user-facing-autonomy-contract.json",
   "source_refs": ["source-ledger.md"],
   "source_state": "promoted",

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -737,6 +737,17 @@ class FactoryCtlTest(unittest.TestCase):
             card["sdlc_feedback_loop_ref"],
         )
 
+    def test_worker_packet_carries_material_autonomy_routing_contract(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+
+        packet = factoryctl.build_worker_packet("implementation-worker", card, card_path)
+        input_contract = packet["input_contract"]
+
+        self.assertEqual(input_contract["autonomy_mode"], card["autonomy_mode"])
+        self.assertEqual(input_contract["agent_readiness_basis"], card["agent_readiness_basis"])
+        self.assertEqual(input_contract["model_routing_decision_ref"], card["model_routing_decision_ref"])
+
     def test_worker_packet_schema_declares_sdlc_feedback_loop_ref(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
 
@@ -744,6 +755,15 @@ class FactoryCtlTest(unittest.TestCase):
             "sdlc_feedback_loop_ref",
             schema["properties"]["input_contract"]["properties"],
         )
+
+    def test_worker_packet_schema_declares_material_autonomy_routing_contract(self) -> None:
+        schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
+        input_properties = schema["properties"]["input_contract"]["properties"]
+
+        self.assertIn("autonomy_mode", input_properties)
+        self.assertIn("agent_readiness_basis", input_properties)
+        self.assertIn("model_routing_decision_ref", input_properties)
+        self.assertIn("model_routing_decision", input_properties)
 
     def test_worker_result_carries_sdlc_feedback_loop_ref(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
@@ -968,6 +988,45 @@ class FactoryCtlTest(unittest.TestCase):
         errors = factoryctl.validate_card(card)
 
         self.assertIn("sdlc_feedback_loop_ref must be public-safe", errors)
+
+    def test_vfinal_material_execution_requires_autonomy_and_model_routing_decision(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("autonomy_mode", None)
+        card.pop("agent_readiness_basis", None)
+        card.pop("model_routing_decision_ref", None)
+        card.pop("model_routing_decision", None)
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("autonomy_mode required for material vFinal autonomous execution", errors)
+        self.assertIn("agent_readiness_basis required for material vFinal autonomous execution", errors)
+        self.assertIn(
+            "model_routing_decision_ref or model_routing_decision required for material vFinal autonomous execution",
+            errors,
+        )
+
+    def test_vfinal_material_execution_accepts_inline_model_routing_decision(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("model_routing_decision_ref", None)
+        card["model_routing_decision"] = {
+            "router_ref": "templates/method-contract.json",
+            "selected_profile": "implementation-worker",
+            "selected_model_class": "balanced",
+            "selection_basis": {
+                "cost": "bounded local execution",
+                "speed": "single worker cycle",
+                "quality": "requires tests and independent review",
+                "context_need": "factory card and source refs",
+                "data_sensitivity": "public-safe fixtures",
+                "tool_requirements": "repo filesystem and unit tests",
+                "expected_horizon": "bounded implementation task",
+                "fallback_route": "return to repair loop if validation fails",
+            },
+            "model_independence_preserved": True,
+            "single_provider_assumption": False,
+        }
+
+        self.assertEqual(factoryctl.validate_card(card), [])
 
     def test_vfinal_method_contract_requires_named_plan_fields(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")


### PR DESCRIPTION
## Summary

- require material vFinal autonomous execution cards to declare `autonomy_mode`, `agent_readiness_basis`, and a model/profile routing decision ref or inline decision
- propagate the material autonomy routing contract into generated worker packets
- expose the SDLC feedback loop and material autonomy routing in the public method/automation docs

## Why

This closes the next #252 gear gap: after the SDLC feedback loop ref is attached to material work, the actual card still needed an executable autonomy/model-routing decision so workers do not receive a vague "use an agent" request.

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_vfinal_card_requires_core_canonical_contracts tests.test_factoryctl.FactoryCtlTest.test_vfinal_material_execution_requires_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_vfinal_planning_only_does_not_require_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_vfinal_feedback_loop_ref_must_be_public_safe tests.test_factoryctl.FactoryCtlTest.test_vfinal_material_execution_requires_autonomy_and_model_routing_decision tests.test_factoryctl.FactoryCtlTest.test_vfinal_material_execution_accepts_inline_model_routing_decision tests.test_factoryctl.FactoryCtlTest.test_worker_packet_carries_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_worker_packet_carries_material_autonomy_routing_contract tests.test_factoryctl.FactoryCtlTest.test_worker_packet_schema_declares_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_worker_packet_schema_declares_material_autonomy_routing_contract -q`
- `python scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `python -m py_compile scripts\factoryctl.py`
- `git diff --check`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python -m unittest discover -s tests -q` (635 tests)

Refs #252
