### PR TITLE
Bound readiness remediation autonomy

### DIFF
--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -132,6 +132,11 @@ approval or a cockpit status. Non-passing dimensions require a remediation
 loop, and blocking dimensions must keep autonomous execution off until the
 scorecard is rerun with evidence.
 
+`ready_with_bounds` is not the same as material autonomy. When any dimension is
+`REMEDIATION_REQUIRED`, the autonomy boundary may allow only bounded remediation
+and rerun work. It must keep `material_autonomous_execution_allowed=false` until
+the remediation evidence exists and the scorecard is rerun.
+
 ## Learning Proposals
 
 Use `factory_learning_proposal` when a finding should become a durable rule,

--- a/schemas/factory-readiness-scorecard.schema.json
+++ b/schemas/factory-readiness-scorecard.schema.json
@@ -205,6 +205,8 @@
       "required": [
         "autonomous_execution_allowed",
         "allowed_scope",
+        "bounded_remediation_allowed",
+        "material_autonomous_execution_allowed",
         "requires_human_gate_for",
         "not_product_acceptance",
         "not_release_approval"
@@ -220,6 +222,12 @@
             "bounded_remediation",
             "material_execution"
           ]
+        },
+        "bounded_remediation_allowed": {
+          "type": "boolean"
+        },
+        "material_autonomous_execution_allowed": {
+          "type": "boolean"
         },
         "requires_human_gate_for": {
           "type": "array",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4672,6 +4672,8 @@ def validate_factory_readiness_scorecard(scorecard: dict[str, Any]) -> list[str]
     autonomy = scorecard.get("autonomy_boundary") if isinstance(scorecard.get("autonomy_boundary"), dict) else {}
     allowed_scope = str(autonomy.get("allowed_scope") or "").strip()
     autonomy_allowed = autonomy.get("autonomous_execution_allowed") is True
+    bounded_remediation_allowed = autonomy.get("bounded_remediation_allowed") is True
+    material_autonomy_allowed = autonomy.get("material_autonomous_execution_allowed") is True
     remediation_required = remediation_loop.get("required") is True
 
     if non_pass_statuses and not remediation_required:
@@ -4690,6 +4692,8 @@ def validate_factory_readiness_scorecard(scorecard: dict[str, Any]) -> list[str]
             errors.append("factory_readiness_scorecard ready_for_autonomy requires all dimensions PASS")
         if not autonomy_allowed:
             errors.append("factory_readiness_scorecard ready_for_autonomy requires autonomous_execution_allowed=true")
+        if not material_autonomy_allowed:
+            errors.append("factory_readiness_scorecard ready_for_autonomy requires material_autonomous_execution_allowed=true")
         if allowed_scope != "material_execution":
             errors.append("factory_readiness_scorecard ready_for_autonomy requires allowed_scope=material_execution")
     if verdict == "ready_with_bounds":
@@ -4699,6 +4703,19 @@ def validate_factory_readiness_scorecard(scorecard: dict[str, Any]) -> list[str]
             errors.append("factory_readiness_scorecard ready_with_bounds requires autonomous_execution_allowed=true")
         if allowed_scope == "none":
             errors.append("factory_readiness_scorecard ready_with_bounds requires a non-none allowed_scope")
+        if remediation_dimensions:
+            if material_autonomy_allowed:
+                errors.append(
+                    "factory_readiness_scorecard ready_with_bounds with remediation cannot allow material autonomous execution"
+                )
+            if allowed_scope == "material_execution":
+                errors.append(
+                    "factory_readiness_scorecard ready_with_bounds with remediation cannot use allowed_scope=material_execution"
+                )
+            if not bounded_remediation_allowed:
+                errors.append(
+                    "factory_readiness_scorecard ready_with_bounds with remediation requires bounded_remediation_allowed=true"
+                )
     if verdict == "remediation_required":
         if not remediation_required:
             errors.append("factory_readiness_scorecard remediation_required requires remediation_loop.required=true")
@@ -4706,6 +4723,8 @@ def validate_factory_readiness_scorecard(scorecard: dict[str, Any]) -> list[str]
             errors.append("factory_readiness_scorecard remediation_required requires at least one non-PASS dimension")
         if allowed_scope == "material_execution":
             errors.append("factory_readiness_scorecard remediation_required cannot allow material_execution")
+        if material_autonomy_allowed:
+            errors.append("factory_readiness_scorecard remediation_required cannot allow material autonomous execution")
 
     public_boundary = (
         scorecard.get("public_private_boundary") if isinstance(scorecard.get("public_private_boundary"), dict) else {}

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -270,6 +270,8 @@ def validate_factory_readiness_scorecard_domain(data: dict[str, Any], at: str) -
     autonomy = data.get("autonomy_boundary") if isinstance(data.get("autonomy_boundary"), dict) else {}
     allowed_scope = str(autonomy.get("allowed_scope") or "").strip()
     autonomy_allowed = autonomy.get("autonomous_execution_allowed") is True
+    bounded_remediation_allowed = autonomy.get("bounded_remediation_allowed") is True
+    material_autonomy_allowed = autonomy.get("material_autonomous_execution_allowed") is True
     remediation_required = remediation_loop.get("required") is True
 
     if non_pass_statuses and not remediation_required:
@@ -288,6 +290,8 @@ def validate_factory_readiness_scorecard_domain(data: dict[str, Any], at: str) -
             errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires all dimensions PASS")
         if not autonomy_allowed:
             errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires autonomous_execution_allowed=true")
+        if not material_autonomy_allowed:
+            errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires material_autonomous_execution_allowed=true")
         if allowed_scope != "material_execution":
             errors.append(f"{at}: factory_readiness_scorecard ready_for_autonomy requires allowed_scope=material_execution")
     if verdict == "ready_with_bounds":
@@ -297,6 +301,19 @@ def validate_factory_readiness_scorecard_domain(data: dict[str, Any], at: str) -
             errors.append(f"{at}: factory_readiness_scorecard ready_with_bounds requires autonomous_execution_allowed=true")
         if allowed_scope == "none":
             errors.append(f"{at}: factory_readiness_scorecard ready_with_bounds requires a non-none allowed_scope")
+        if remediation_dimensions:
+            if material_autonomy_allowed:
+                errors.append(
+                    f"{at}: factory_readiness_scorecard ready_with_bounds with remediation cannot allow material autonomous execution"
+                )
+            if allowed_scope == "material_execution":
+                errors.append(
+                    f"{at}: factory_readiness_scorecard ready_with_bounds with remediation cannot use allowed_scope=material_execution"
+                )
+            if not bounded_remediation_allowed:
+                errors.append(
+                    f"{at}: factory_readiness_scorecard ready_with_bounds with remediation requires bounded_remediation_allowed=true"
+                )
     if verdict == "remediation_required":
         if not remediation_required:
             errors.append(f"{at}: factory_readiness_scorecard remediation_required requires remediation_loop.required=true")
@@ -304,6 +321,8 @@ def validate_factory_readiness_scorecard_domain(data: dict[str, Any], at: str) -
             errors.append(f"{at}: factory_readiness_scorecard remediation_required requires at least one non-PASS dimension")
         if allowed_scope == "material_execution":
             errors.append(f"{at}: factory_readiness_scorecard remediation_required cannot allow material_execution")
+        if material_autonomy_allowed:
+            errors.append(f"{at}: factory_readiness_scorecard remediation_required cannot allow material autonomous execution")
 
     public_boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
     if public_boundary.get("public_safe_refs_only") is not True:

--- a/templates/factory-readiness-scorecard.json
+++ b/templates/factory-readiness-scorecard.json
@@ -137,6 +137,8 @@
   "autonomy_boundary": {
     "autonomous_execution_allowed": true,
     "allowed_scope": "bounded_remediation",
+    "bounded_remediation_allowed": true,
+    "material_autonomous_execution_allowed": false,
     "requires_human_gate_for": [
       "security",
       "customer_acceptance",

--- a/tests/test_factory_readiness_scorecard.py
+++ b/tests/test_factory_readiness_scorecard.py
@@ -38,6 +38,8 @@ def make_all_pass(card: dict) -> dict:
     card["remediation_loop"]["required"] = False
     card["autonomy_boundary"]["autonomous_execution_allowed"] = True
     card["autonomy_boundary"]["allowed_scope"] = "material_execution"
+    card["autonomy_boundary"]["bounded_remediation_allowed"] = False
+    card["autonomy_boundary"]["material_autonomous_execution_allowed"] = True
     for dimension in card["dimensions"]:
         dimension["status"] = "PASS"
         dimension["severity"] = "none"
@@ -52,6 +54,8 @@ def make_blocked(card: dict) -> dict:
     card["remediation_loop"]["required"] = True
     card["autonomy_boundary"]["autonomous_execution_allowed"] = False
     card["autonomy_boundary"]["allowed_scope"] = "none"
+    card["autonomy_boundary"]["bounded_remediation_allowed"] = False
+    card["autonomy_boundary"]["material_autonomous_execution_allowed"] = False
     dimension = card["dimensions"][0]
     dimension["status"] = "BLOCKED"
     dimension["severity"] = "high"
@@ -75,6 +79,7 @@ class FactoryReadinessScorecardTest(unittest.TestCase):
         card = scorecard()
         card["verdict"] = "remediation_required"
         card["autonomy_boundary"]["allowed_scope"] = "bounded_remediation"
+        card["autonomy_boundary"]["material_autonomous_execution_allowed"] = False
 
         errors = factoryctl.validate_factory_readiness_scorecard(card)
 
@@ -113,6 +118,7 @@ class FactoryReadinessScorecardTest(unittest.TestCase):
         card = scorecard()
         card["verdict"] = "ready_for_autonomy"
         card["autonomy_boundary"]["allowed_scope"] = "material_execution"
+        card["autonomy_boundary"]["material_autonomous_execution_allowed"] = True
 
         errors = factoryctl.validate_factory_readiness_scorecard(card)
 
@@ -134,6 +140,8 @@ class FactoryReadinessScorecardTest(unittest.TestCase):
         card["verdict"] = "blocked"
         card["autonomy_boundary"]["autonomous_execution_allowed"] = False
         card["autonomy_boundary"]["allowed_scope"] = "none"
+        card["autonomy_boundary"]["bounded_remediation_allowed"] = False
+        card["autonomy_boundary"]["material_autonomous_execution_allowed"] = False
 
         errors = factoryctl.validate_factory_readiness_scorecard(card)
 
@@ -154,6 +162,7 @@ class FactoryReadinessScorecardTest(unittest.TestCase):
         bad = copy.deepcopy(card)
         bad["verdict"] = "ready_for_autonomy"
         bad["autonomy_boundary"]["allowed_scope"] = "material_execution"
+        bad["autonomy_boundary"]["material_autonomous_execution_allowed"] = True
 
         schema_errors = public_json_validator.validate_node(schema, card, "$", schemas=schemas, root_schema=schema)
         domain_errors = public_json_validator.validate_domain_rules(card, "$")
@@ -161,6 +170,27 @@ class FactoryReadinessScorecardTest(unittest.TestCase):
 
         self.assertEqual(schema_errors + domain_errors, [])
         self.assertTrue(any("ready_for_autonomy requires all dimensions PASS" in error for error in bad_domain_errors), bad_domain_errors)
+
+    def test_ready_with_bounds_with_remediation_cannot_allow_material_autonomy(self) -> None:
+        card = scorecard()
+        card["autonomy_boundary"]["allowed_scope"] = "material_execution"
+        card["autonomy_boundary"]["bounded_remediation_allowed"] = False
+        card["autonomy_boundary"]["material_autonomous_execution_allowed"] = True
+
+        errors = factoryctl.validate_factory_readiness_scorecard(card)
+
+        self.assertIn(
+            "factory_readiness_scorecard ready_with_bounds with remediation cannot allow material autonomous execution",
+            errors,
+        )
+        self.assertIn(
+            "factory_readiness_scorecard ready_with_bounds with remediation cannot use allowed_scope=material_execution",
+            errors,
+        )
+        self.assertIn(
+            "factory_readiness_scorecard ready_with_bounds with remediation requires bounded_remediation_allowed=true",
+            errors,
+        )
 
     def test_factoryctl_cli_validates_scorecard(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- split readiness autonomy into bounded remediation versus material autonomous execution
- require scorecards to declare `bounded_remediation_allowed` and `material_autonomous_execution_allowed`
- fail closed when `ready_with_bounds` has `REMEDIATION_REQUIRED` dimensions but still claims material autonomy
- document that remediation-bound readiness is not product/material autonomy

## Why

The factory needs Swiss-watch semantics around readiness. A scorecard can allow bounded autonomous remediation and rerun work, but that must not be mistaken for permission to start material product execution while remediation evidence is still missing.

This is a follow-up slice for #252 after material autonomy routing was made explicit on vFinal cards.

## Validation

- `python -m unittest tests.test_factory_readiness_scorecard -q`
- `python scripts\factoryctl.py validate-readiness-scorecard templates\factory-readiness-scorecard.json`
- `python scripts\validate_public_json_artifacts.py`
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py`
- `git diff --check`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python -m unittest discover -s tests -q` (636 tests)

Refs #252
