### PR TITLE
Enforce Hermes async lane reconciliation

### DIFF
--- a/docs/automation/worker-automation-v0.md
+++ b/docs/automation/worker-automation-v0.md
@@ -214,9 +214,19 @@ At `done`, Hermes should:
 - run `scripts/evidence_reconciler.py` to produce the current evidence index,
   supersession ledger and `receipt_five_reconciliation_result`;
 - reconcile each result against its expected Receipt Five field;
+- reject Hermes background subagent output unless a worker result explicitly
+  marks it `reconciliation_state=reconciled`;
 - reject missing, failed, unsupported or preflight-only results;
 - reject Receipt Five without required evidence refs and transition metadata;
 - allow done only when worker results and Receipt Five agree.
+
+Hermes `delegate_task` is not the same thing as a worker result. Synchronous
+delegation can help a worker think. `delegate_task(background=true)` can run a
+bounded lane for candidate research, review or repair proposals. The durable
+factory state remains the Hermes Kanban card plus validated worker results. A
+background subagent summary cannot approve a human gate, mutate canonical Kanban
+state, publish public artifacts, or satisfy Receipt Five until a responsible
+worker accepts it through the async reconciliation contract.
 
 Hermes should reject a transition when:
 

--- a/docs/operations/parallel-execution-and-status.md
+++ b/docs/operations/parallel-execution-and-status.md
@@ -41,6 +41,31 @@ Editing lanes need a worktree or branch ref different from the base ref. Read-on
 lanes may use the base ref, but their output still requires synthesis before it
 changes canonical state.
 
+## Hermes Delegation Modes
+
+Hermes Kanban tasks are the durable factory lanes. Hermes `delegate_task`
+subagents are auxiliary execution lanes: useful for bounded research, review,
+candidate repair plans or parallel analysis, but not authoritative state.
+
+Use the modes this way:
+
+- `delegate_task` synchronous: bounded helper work inside the parent turn. The
+  parent still reconciles the answer before card, Receipt Five or release state
+  changes.
+- `delegate_task(background=true)`: a `background_subagent_lane`. It needs
+  `delegation_id`, parent card/worker ids, toolsets, public-safe context,
+  retry/supersession policy, candidate evidence refs and a named reconciliation
+  owner.
+- Hermes Kanban card/task: durable work that can block, retry, receive worker
+  packets, produce worker results and participate in Receipt Five.
+
+A background subagent lane is candidate-only until `delegation_status=reconciled`
+and `accepted_by_worker_result_ref` points to the worker result that accepted it.
+`completed` is not enough. `failed`, `cancelled`, `stale`, `superseded` and
+`rejected` cannot unblock anything. Background output cannot approve human gates,
+move canonical Kanban state, publish public artifacts, or directly satisfy
+Receipt Five.
+
 ## Cascade Operating Protocol
 
 Use a named-lane sweep:

--- a/schemas/parallel-lane-contract.schema.json
+++ b/schemas/parallel-lane-contract.schema.json
@@ -43,7 +43,17 @@
     },
     "record_type": { "const": "parallel_lane_contract" },
     "lane_id": { "type": "string", "minLength": 3 },
-    "lane_kind": { "enum": ["read_only", "write", "research", "planning", "execution", "review"] },
+    "lane_kind": {
+      "enum": [
+        "read_only",
+        "write",
+        "research",
+        "planning",
+        "execution",
+        "review",
+        "background_subagent_lane"
+      ]
+    },
     "objective": { "type": "string", "minLength": 3 },
     "read_scope": {
       "type": "array",
@@ -178,7 +188,92 @@
         "no_credentials_or_raw_logs": { "type": "boolean" }
       },
       "additionalProperties": { "type": "boolean" }
-    }
+    },
+    "runtime": {
+      "enum": ["hermes_delegate_task_background"]
+    },
+    "delegation_id": { "type": "string", "minLength": 3 },
+    "parent_card_id": { "type": "string", "minLength": 3 },
+    "parent_worker_id": { "type": "string", "minLength": 3 },
+    "goal": { "type": "string", "minLength": 3 },
+    "context_summary_public_safe": { "type": "string", "minLength": 3 },
+    "toolsets": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "model_profile": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "delegation_status": {
+      "enum": ["dispatched", "running", "completed", "failed", "cancelled", "stale", "superseded", "rejected", "reconciled"]
+    },
+    "max_async_children_observed": { "type": "integer", "minimum": 0 },
+    "expected_output_contract": { "type": "string", "minLength": 3 },
+    "candidate_evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "private_evidence_redaction_policy": { "type": "string", "minLength": 3 },
+    "reconciliation_owner": { "type": "string", "minLength": 3 },
+    "accepted_by_worker_result_ref": { "type": "string", "minLength": 3 },
+    "rejected_reason": { "type": "string" },
+    "retry_attempt": { "type": "integer", "minimum": 0 },
+    "retry_policy": {
+      "type": "object",
+      "required": ["max_attempts", "supersede_previous_attempt", "stop_classes"],
+      "properties": {
+        "max_attempts": { "type": "integer", "minimum": 1 },
+        "supersede_previous_attempt": { "type": "boolean" },
+        "stop_classes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "supersedes_lane_id": { "type": "string" },
+    "next_safe_action": { "type": "string", "minLength": 3 },
+    "direct_completion_authority": { "const": false },
+    "human_gate_authority": { "const": false },
+    "canonical_state_mutation_authority": { "const": false }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "lane_kind": { "const": "background_subagent_lane" } },
+        "required": ["lane_kind"]
+      },
+      "then": {
+        "required": [
+          "runtime",
+          "delegation_id",
+          "parent_card_id",
+          "parent_worker_id",
+          "goal",
+          "context_summary_public_safe",
+          "toolsets",
+          "delegation_status",
+          "expected_output_contract",
+          "candidate_evidence_refs",
+          "private_evidence_redaction_policy",
+          "reconciliation_owner",
+          "retry_attempt",
+          "retry_policy",
+          "next_safe_action",
+          "direct_completion_authority",
+          "human_gate_authority",
+          "canonical_state_mutation_authority"
+        ],
+        "properties": {
+          "runtime": { "const": "hermes_delegate_task_background" },
+          "direct_completion_authority": { "const": false },
+          "human_gate_authority": { "const": false },
+          "canonical_state_mutation_authority": { "const": false }
+        }
+      }
+    }
+  ],
   "additionalProperties": true
 }

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -177,6 +177,35 @@
     "reusable_for_product": {
       "type": "boolean"
     },
+    "async_subagent": {
+      "type": "object",
+      "required": [
+        "runtime",
+        "delegation_id",
+        "status",
+        "reconciliation_state",
+        "reconciliation_owner",
+        "accepted_by_worker_result_ref"
+      ],
+      "properties": {
+        "runtime": { "const": "hermes_delegate_task_background" },
+        "delegation_id": { "type": "string", "minLength": 3 },
+        "parent_card_id": { "type": "string", "minLength": 3 },
+        "parent_worker_id": { "type": "string", "minLength": 3 },
+        "status": {
+          "enum": ["dispatched", "running", "completed", "failed", "cancelled", "stale", "superseded", "rejected", "reconciled"]
+        },
+        "reconciliation_state": { "enum": ["pending", "rejected", "superseded", "reconciled"] },
+        "reconciliation_owner": { "type": "string", "minLength": 3 },
+        "accepted_by_worker_result_ref": { "type": "string", "minLength": 3 },
+        "rejected_reason": { "type": "string" },
+        "candidate_evidence_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
     "handoff_state": {
       "enum": [
         "consumable",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -233,6 +233,15 @@ TOOL_USING_SURFACES = {
 WIDE_FILESYSTEM_SCOPES = {"workspace_wide", "external_mount"}
 WIDE_NETWORK_SCOPES = {"unrestricted"}
 PARALLEL_EDIT_LANE_KINDS = {"write", "execution"}
+ASYNC_BACKGROUND_LANE_KIND = "background_subagent_lane"
+ASYNC_BACKGROUND_RUNTIME = "hermes_delegate_task_background"
+ASYNC_BACKGROUND_TERMINAL_BLOCKING_STATUSES = {"failed", "cancelled", "stale", "superseded", "rejected"}
+ASYNC_BACKGROUND_NON_RECONCILED_STATUSES = {
+    "dispatched",
+    "running",
+    "completed",
+    *ASYNC_BACKGROUND_TERMINAL_BLOCKING_STATUSES,
+}
 V2_APPROVAL_KEYS = [
     "qa",
     "independent_review",
@@ -2586,6 +2595,85 @@ def _lane_is_editing(lane: dict[str, Any]) -> bool:
     return lane_kind in PARALLEL_EDIT_LANE_KINDS or any(item not in {"none", "read-only", "readonly"} for item in write_scope)
 
 
+def _validate_background_subagent_lane(lane: dict[str, Any], *, at: str) -> list[str]:
+    errors: list[str] = []
+    required_fields = [
+        "runtime",
+        "delegation_id",
+        "parent_card_id",
+        "parent_worker_id",
+        "goal",
+        "context_summary_public_safe",
+        "toolsets",
+        "delegation_status",
+        "expected_output_contract",
+        "candidate_evidence_refs",
+        "private_evidence_redaction_policy",
+        "reconciliation_owner",
+        "retry_attempt",
+        "retry_policy",
+        "next_safe_action",
+    ]
+    for field in required_fields:
+        value = lane.get(field)
+        if isinstance(value, list):
+            if not _list_items(value):
+                errors.append(f"{at}.{field} must be a non-empty array")
+        elif isinstance(value, dict):
+            if not value:
+                errors.append(f"{at}.{field} must be a non-empty object")
+        elif field == "retry_attempt":
+            if not isinstance(value, int) or value < 0:
+                errors.append(f"{at}.retry_attempt must be a non-negative integer")
+        elif not _non_empty_text(value):
+            errors.append(f"{at}.{field} is required")
+
+    if lane.get("runtime") != ASYNC_BACKGROUND_RUNTIME:
+        errors.append(f"{at}.runtime must be {ASYNC_BACKGROUND_RUNTIME}")
+
+    delegation_status = str(lane.get("delegation_status") or "").strip()
+    allowed_statuses = ASYNC_BACKGROUND_NON_RECONCILED_STATUSES | {"reconciled"}
+    if delegation_status not in allowed_statuses:
+        errors.append(f"{at}.delegation_status must be one of {', '.join(sorted(allowed_statuses))}")
+
+    if lane.get("direct_completion_authority") is not False:
+        errors.append(f"{at}.direct_completion_authority must be false")
+    if lane.get("human_gate_authority") is not False:
+        errors.append(f"{at}.human_gate_authority must be false")
+    if lane.get("canonical_state_mutation_authority") is not False:
+        errors.append(f"{at}.canonical_state_mutation_authority must be false")
+
+    accepted_ref = str(lane.get("accepted_by_worker_result_ref") or "").strip()
+    if delegation_status == "reconciled":
+        if not accepted_ref:
+            errors.append(f"{at}.accepted_by_worker_result_ref is required when delegation_status=reconciled")
+        elif accepted_ref.startswith("external:"):
+            pass
+        else:
+            errors.extend(f"{at}.accepted_by_worker_result_ref: {error}" for error in _evidence_ref_errors([accepted_ref], ROOT))
+    elif accepted_ref:
+        errors.append(f"{at}.accepted_by_worker_result_ref must be empty until delegation_status=reconciled")
+
+    candidate_refs = string_list(lane.get("candidate_evidence_refs"))
+    if candidate_refs:
+        errors.extend(f"{at}.candidate_evidence_refs: {error}" for error in _evidence_ref_errors(candidate_refs, ROOT))
+
+    retry_policy = lane.get("retry_policy") if isinstance(lane.get("retry_policy"), dict) else {}
+    if retry_policy:
+        if not isinstance(retry_policy.get("max_attempts"), int) or retry_policy.get("max_attempts", 0) <= 0:
+            errors.append(f"{at}.retry_policy.max_attempts must be a positive integer")
+        if retry_policy.get("supersede_previous_attempt") is not True:
+            errors.append(f"{at}.retry_policy.supersede_previous_attempt must be true")
+        if not _list_items(retry_policy.get("stop_classes")):
+            errors.append(f"{at}.retry_policy.stop_classes must be a non-empty array")
+
+    if delegation_status in ASYNC_BACKGROUND_TERMINAL_BLOCKING_STATUSES and lane.get("validation_result") == "PASS":
+        errors.append(f"{at}.terminal async background lane cannot have validation_result=PASS")
+    if delegation_status != "reconciled" and str(lane.get("status") or "").strip() in {"ready_for_integration", "integrated"}:
+        errors.append(f"{at}.unreconciled async background lane cannot be ready_for_integration or integrated")
+    return errors
+
+
 def validate_parallel_lane_contract(lane: dict[str, Any], *, at: str = "parallel_lane_contract") -> list[str]:
     errors: list[str] = []
     required_fields = [
@@ -2639,6 +2727,9 @@ def validate_parallel_lane_contract(lane: dict[str, Any], *, at: str = "parallel
         errors.append(f"{at}.merge_reconciliation_policy.no_self_promotion must be true")
     if merge_policy and not _non_empty_text(merge_policy.get("synthesizer")):
         errors.append(f"{at}.merge_reconciliation_policy.synthesizer is required")
+
+    if str(lane.get("lane_kind") or "").strip().lower() == ASYNC_BACKGROUND_LANE_KIND:
+        errors.extend(_validate_background_subagent_lane(lane, at=at))
 
     return errors
 
@@ -6541,6 +6632,66 @@ def _evidence_ref_errors(refs: list[str], evidence_root: Path | None) -> list[st
     return errors
 
 
+def _async_background_signal(data: dict[str, Any]) -> bool:
+    text_fields = " ".join(
+        str(data.get(field) or "").strip().lower()
+        for field in ("tool_or_profile", "executed_by", "runtime", "delegation_id")
+    )
+    if ASYNC_BACKGROUND_RUNTIME in text_fields:
+        return True
+    if "background-subagent" in text_fields or "background_subagent" in text_fields:
+        return True
+    if isinstance(data.get("async_subagent"), dict):
+        return True
+    provenance = data.get("evidence_provenance")
+    if isinstance(provenance, dict):
+        return provenance.get("runtime") == ASYNC_BACKGROUND_RUNTIME or bool(provenance.get("delegation_id"))
+    if isinstance(provenance, list):
+        return any(
+            isinstance(item, dict) and (item.get("runtime") == ASYNC_BACKGROUND_RUNTIME or item.get("delegation_id"))
+            for item in provenance
+        )
+    return False
+
+
+def async_background_reconciliation_errors(data: dict[str, Any], *, record_type: str) -> list[str]:
+    if not _async_background_signal(data):
+        return []
+    if record_type == "human_gate_record":
+        return ["human_gate_record cannot be produced or satisfied by Hermes background subagent output"]
+
+    errors: list[str] = []
+    async_ref = data.get("async_subagent") if isinstance(data.get("async_subagent"), dict) else {}
+    if not async_ref:
+        errors.append("async_subagent object is required for Hermes background subagent output")
+        async_ref = {}
+
+    runtime = str(async_ref.get("runtime") or data.get("runtime") or data.get("tool_or_profile") or "").strip()
+    if runtime != ASYNC_BACKGROUND_RUNTIME:
+        errors.append(f"async_subagent.runtime must be {ASYNC_BACKGROUND_RUNTIME}")
+
+    delegation_id = str(async_ref.get("delegation_id") or data.get("delegation_id") or "").strip()
+    if not delegation_id:
+        errors.append("async_subagent.delegation_id is required")
+
+    status = str(async_ref.get("status") or async_ref.get("delegation_status") or data.get("delegation_status") or "").strip()
+    reconciliation_state = str(async_ref.get("reconciliation_state") or data.get("reconciliation_state") or "").strip()
+    accepted_ref = str(async_ref.get("accepted_by_worker_result_ref") or data.get("accepted_by_worker_result_ref") or "").strip()
+    owner = str(async_ref.get("reconciliation_owner") or data.get("reconciliation_owner") or "").strip()
+
+    if status in ASYNC_BACKGROUND_TERMINAL_BLOCKING_STATUSES:
+        errors.append("terminal Hermes background subagent output cannot satisfy Receipt Five")
+    if reconciliation_state != "reconciled":
+        errors.append("Hermes background subagent output must set reconciliation_state=reconciled before closure")
+    if not accepted_ref:
+        errors.append("Hermes background subagent output requires accepted_by_worker_result_ref before closure")
+    if not owner:
+        errors.append("Hermes background subagent output requires reconciliation_owner before closure")
+    if accepted_ref and not accepted_ref.startswith("external:"):
+        errors.extend(f"accepted_by_worker_result_ref: {error}" for error in _evidence_ref_errors([accepted_ref], ROOT))
+    return errors
+
+
 def _waiver_errors(data: dict[str, Any]) -> list[str]:
     if str(data.get("result") or "").strip() != "WAIVED":
         return []
@@ -6629,6 +6780,7 @@ def validate_worker_result_record(
         errors.append(f"record_type must be {expected_field}")
     if not record_type:
         errors.append("record_type is required")
+    errors.extend(async_background_reconciliation_errors(data, record_type=record_type))
 
     if record_type == "human_gate_record":
         if data.get("decision") != "approved":

--- a/templates/parallel-lane-contract.json
+++ b/templates/parallel-lane-contract.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/parallel-lane-contract.schema.json",
   "record_type": "parallel_lane_contract",
-  "lane_id": "example-readonly-audit",
-  "lane_kind": "read_only",
-  "objective": "Audit the public factory flow without writing to the repository.",
+  "lane_id": "example-hermes-background-research",
+  "lane_kind": "background_subagent_lane",
+  "objective": "Run a Hermes background subagent lane as candidate research only, then reconcile it through a worker result before it can affect Receipt Five.",
   "read_scope": [
     "docs/concepts/factory-flow.md",
     "scripts/factoryctl.py"
@@ -11,7 +11,7 @@
   "write_scope": [
     "none"
   ],
-  "owner_agent": "external:subagent",
+  "owner_agent": "external:hermes-background-subagent",
   "reviewer_or_synthesizer": "main-agent",
   "status": "ready_for_integration",
   "base_ref": "main",
@@ -29,9 +29,11 @@
   ],
   "changed_paths": [],
   "expected_outputs": [
-    "read-only audit summary"
+    "candidate research summary",
+    "public-safe evidence references",
+    "reconciliation recommendation"
   ],
-  "expected_artifact": "external:subagent-summary",
+  "expected_artifact": "external:hermes-background-subagent-summary",
   "timeout": {
     "limit": 45,
     "unit": "minutes"
@@ -45,13 +47,13 @@
   "conflict_risk": "low",
   "merge_reconciliation_policy": {
     "synthesizer": "main-agent",
-    "decision_rule": "Read-only findings must be reconciled against canonical card/source refs before they affect Receipt Five.",
+    "decision_rule": "Background subagent findings are candidate-only until an owning worker result explicitly accepts or rejects them.",
     "no_self_promotion": true
   },
   "cleanup_policy": {
     "owner": "main-agent",
     "when": "after synthesis",
-    "stale_or_failed_lane_action": "mark superseded or blocked and keep only public-safe summary refs"
+    "stale_or_failed_lane_action": "mark stale, failed, cancelled, rejected or superseded and keep only public-safe summary refs"
   },
   "validation_commands": [
     "python scripts/public_safety_scan.py",
@@ -59,7 +61,8 @@
   ],
   "validation_result": "PASS",
   "evidence_refs": [
-    "external:subagent-summary"
+    "external:hermes-background-subagent-summary",
+    "external:accepted-worker-result-after-reconciliation"
   ],
   "cleanup_status": "not_needed",
   "integration_owner": "main-agent",
@@ -72,6 +75,45 @@
     "local_state_authority": false,
     "materialized_hermes_task_refs": []
   },
+  "runtime": "hermes_delegate_task_background",
+  "delegation_id": "external:hermes-delegation-id",
+  "parent_card_id": "external:factory-card-id",
+  "parent_worker_id": "factory-orchestrator",
+  "goal": "Produce bounded candidate research for the parent factory card.",
+  "context_summary_public_safe": "Public-safe context summary only; no raw private prompt, local path, private customer data or credential material.",
+  "toolsets": [
+    "read_only",
+    "research"
+  ],
+  "model_profile": {
+    "selection_policy": "inherited_or_router_selected",
+    "cost_speed_quality_basis": "operator policy"
+  },
+  "delegation_status": "reconciled",
+  "max_async_children_observed": 1,
+  "expected_output_contract": "Candidate summary plus public-safe evidence refs; never direct completion, human gate approval or canonical Kanban mutation.",
+  "candidate_evidence_refs": [
+    "external:hermes-background-subagent-summary"
+  ],
+  "private_evidence_redaction_policy": "Only sanitized public-safe refs may enter the public repo; raw logs, local paths, prompts and private source extracts stay outside.",
+  "reconciliation_owner": "factory-orchestrator",
+  "accepted_by_worker_result_ref": "external:accepted-worker-result-after-reconciliation",
+  "rejected_reason": "",
+  "retry_attempt": 0,
+  "retry_policy": {
+    "max_attempts": 2,
+    "supersede_previous_attempt": true,
+    "stop_classes": [
+      "human_gate",
+      "security_gate",
+      "budget_exhausted"
+    ]
+  },
+  "supersedes_lane_id": "",
+  "next_safe_action": "Use the accepted worker result as the only consumable Receipt Five input.",
+  "direct_completion_authority": false,
+  "human_gate_authority": false,
+  "canonical_state_mutation_authority": false,
   "public_safety_boundary": {
     "no_private_product_names": true,
     "no_local_absolute_paths": true,

--- a/tests/test_evidence_reconciler.py
+++ b/tests/test_evidence_reconciler.py
@@ -82,6 +82,29 @@ def result_for(worker_id: str, card: dict, created_at: str) -> dict:
     return payload
 
 
+def mark_background_subagent(
+    payload: dict,
+    *,
+    status: str = "completed",
+    reconciliation_state: str = "pending",
+    accepted: bool = False,
+) -> dict:
+    payload["tool_or_profile"] = "hermes_delegate_task_background"
+    payload["executed_by"] = "background-subagent"
+    payload["async_subagent"] = {
+        "runtime": "hermes_delegate_task_background",
+        "delegation_id": "external:delegation-fixture",
+        "parent_card_id": "TEST-CLOSURE-R2",
+        "parent_worker_id": payload["worker"]["id"],
+        "status": status,
+        "reconciliation_state": reconciliation_state,
+        "reconciliation_owner": "factory-orchestrator",
+        "candidate_evidence_refs": ["external:background-subagent-summary"],
+        "accepted_by_worker_result_ref": "external:accepted-worker-result" if accepted else "",
+    }
+    return payload
+
+
 def write_results(card: dict, results_dir: Path, *, skip_worker: str | None = None) -> None:
     for index, worker_id in enumerate(required_before_done_workers(card), start=1):
         if worker_id == skip_worker:
@@ -107,6 +130,79 @@ class EvidenceReconcilerTest(unittest.TestCase):
         self.assertEqual(index["blocking_current_results"], [])
         self.assertIn("security_scan_result", index["effective_results"])
         self.assertIn("independent_review_result", index["effective_results"])
+
+    def test_unreconciled_background_subagent_result_does_not_satisfy_receipt_five(self) -> None:
+        card = closure_card()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            results_dir = Path(tmp)
+            write_results(card, results_dir)
+            async_security = mark_background_subagent(
+                result_for("codex-security", card, "2026-06-06T00:50:00+00:00"),
+                status="completed",
+                reconciliation_state="pending",
+                accepted=False,
+            )
+            results_dir.joinpath("codex-security.json").write_text(
+                factoryctl.json.dumps(async_security, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            index = evidence_reconciler.reconcile(card, results_dir)
+
+        self.assertFalse(index["receipt_five_ready"])
+        self.assertIn(
+            "security_scan_result",
+            {item["record_type"] for item in index["blocking_current_results"]},
+        )
+        security = index["effective_results"]["security_scan_result"]
+        self.assertFalse(security["valid_for_closure"])
+        self.assertIn(
+            "Hermes background subagent output must set reconciliation_state=reconciled before closure",
+            security["validation_errors"],
+        )
+
+    def test_reconciled_background_subagent_result_can_be_consumed(self) -> None:
+        card = closure_card()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            results_dir = Path(tmp)
+            write_results(card, results_dir)
+            async_security = mark_background_subagent(
+                result_for("codex-security", card, "2026-06-06T00:50:00+00:00"),
+                status="reconciled",
+                reconciliation_state="reconciled",
+                accepted=True,
+            )
+            results_dir.joinpath("codex-security.json").write_text(
+                factoryctl.json.dumps(async_security, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            index = evidence_reconciler.reconcile(card, results_dir)
+
+        self.assertTrue(index["receipt_five_ready"])
+        self.assertTrue(index["effective_results"]["security_scan_result"]["valid_for_closure"])
+
+    def test_stale_background_subagent_result_blocks_receipt_five_even_with_acceptance_ref(self) -> None:
+        card = closure_card()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            results_dir = Path(tmp)
+            write_results(card, results_dir)
+            async_security = mark_background_subagent(
+                result_for("codex-security", card, "2026-06-06T00:50:00+00:00"),
+                status="stale",
+                reconciliation_state="reconciled",
+                accepted=True,
+            )
+            results_dir.joinpath("codex-security.json").write_text(
+                factoryctl.json.dumps(async_security, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            index = evidence_reconciler.reconcile(card, results_dir)
+
+        self.assertFalse(index["receipt_five_ready"])
+        security = index["effective_results"]["security_scan_result"]
+        self.assertIn("terminal Hermes background subagent output cannot satisfy Receipt Five", security["validation_errors"])
 
     def test_newer_pass_supersedes_older_fail_for_same_receipt_field(self) -> None:
         card = closure_card()

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -827,6 +827,31 @@ class FactoryCtlTest(unittest.TestCase):
         schema = json.loads((ROOT / "schemas" / "worker-result.schema.json").read_text(encoding="utf-8"))
 
         self.assertIn("sdlc_feedback_loop_ref", schema["properties"])
+        self.assertIn("async_subagent", schema["properties"])
+
+    def test_async_background_subagent_cannot_satisfy_human_gate_record(self) -> None:
+        card = load_card("v35_valid_security_with_scan.md")
+        record = human_gate_record(source_card=card)
+        record["tool_or_profile"] = "hermes_delegate_task_background"
+        record["executed_by"] = "background-subagent"
+        record["async_subagent"] = {
+            "runtime": "hermes_delegate_task_background",
+            "delegation_id": "external:delegation-fixture",
+            "status": "reconciled",
+            "reconciliation_state": "reconciled",
+            "reconciliation_owner": "factory-orchestrator",
+            "accepted_by_worker_result_ref": "external:accepted-worker-result",
+        }
+
+        errors = factoryctl.validate_worker_result_record(
+            record,
+            expected_field="human_gate_record",
+            expected_worker_id="human-gate-clerk",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn("human_gate_record cannot be produced or satisfied by Hermes background subagent output", errors)
 
     def test_worker_packet_schema_allows_every_registered_worker(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))

--- a/tests/test_parallel_status_snapshot.py
+++ b/tests/test_parallel_status_snapshot.py
@@ -53,6 +53,40 @@ class ParallelStatusSnapshotTest(unittest.TestCase):
 
         self.assertIn("parallel_lane_contract.worktree_ref must differ from base_ref for editing lanes", errors)
 
+    def test_background_subagent_lane_template_is_reconciled_candidate_only(self) -> None:
+        lane = load_lane_template()
+
+        errors = factoryctl.validate_parallel_lane_contract(lane)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(lane["lane_kind"], "background_subagent_lane")
+        self.assertEqual(lane["runtime"], "hermes_delegate_task_background")
+        self.assertEqual(lane["delegation_status"], "reconciled")
+        self.assertFalse(lane["direct_completion_authority"])
+        self.assertFalse(lane["human_gate_authority"])
+        self.assertFalse(lane["canonical_state_mutation_authority"])
+        self.assertTrue(lane["accepted_by_worker_result_ref"])
+
+    def test_background_subagent_lane_requires_delegation_identity(self) -> None:
+        lane = load_lane_template()
+        lane["delegation_id"] = ""
+
+        errors = factoryctl.validate_parallel_lane_contract(lane)
+
+        self.assertIn("parallel_lane_contract.delegation_id is required", errors)
+
+    def test_unreconciled_background_subagent_lane_cannot_be_ready(self) -> None:
+        lane = load_lane_template()
+        lane["delegation_status"] = "completed"
+        lane["accepted_by_worker_result_ref"] = ""
+
+        errors = factoryctl.validate_parallel_lane_contract(lane)
+
+        self.assertIn(
+            "parallel_lane_contract.unreconciled async background lane cannot be ready_for_integration or integrated",
+            errors,
+        )
+
     def test_gate_report_warns_on_overlapping_parallel_write_scope(self) -> None:
         card = load_minimal_card()
         first = load_lane_template()


### PR DESCRIPTION
## Summary

Closes #244.

This PR models Hermes `delegate_task(background=true)` as a bounded background lane, not as direct factory truth. The core rule is now explicit: async subagent output can help with research/review/repair, but it cannot satisfy Receipt Five, mutate canonical Kanban state, approve human gates, or publish public artifacts until a responsible worker reconciles it.

## What changed

- Adds `background_subagent_lane` to the parallel lane contract schema.
- Extends the public lane template with a safe Hermes background subagent example.
- Adds `async_subagent` metadata to worker-result schema.
- Adds factoryctl validation that rejects:
  - unreconciled Hermes background output as closure evidence;
  - stale/failed/cancelled/superseded/rejected async output as unblocking evidence;
  - async output pretending to satisfy `human_gate_record`.
- Updates public docs to distinguish durable Hermes Kanban tasks from synchronous/background delegation.
- Adds regression tests for unreconciled, reconciled, stale, lane-contract and human-gate cases.

## Validation

- `python -m py_compile scripts\factoryctl.py scripts\evidence_reconciler.py`
- `python scripts\validate_public_json_artifacts.py`
- `python -m unittest tests.test_parallel_status_snapshot tests.test_evidence_reconciler -q`
- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_worker_result_schema_declares_sdlc_feedback_loop_ref tests.test_factoryctl.FactoryCtlTest.test_async_background_subagent_cannot_satisfy_human_gate_record -q`
- `python -m unittest discover -s tests -q` (643 tests)
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`

## Notes

No #84 files touched. No private audit/history artifacts added to the public repo.