### PR TITLE
Bind professional design reference IDs

### DIFF
--- a/examples/cards/v35_valid_product_face.md
+++ b/examples/cards/v35_valid_product_face.md
@@ -464,9 +464,19 @@
           "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
         },
         {
+          "source_id": "oversized-hero-block",
+          "source_url_or_ref": "external:oversized-hero-block",
+          "rejection_reason": "Rejected because hero-style presentation blocks are not suitable for dense product-operation surfaces."
+        },
+        {
           "source_id": "marketing-dashboard-gallery",
           "source_url_or_ref": "external:marketing-dashboard-gallery",
           "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "single-screenshot-flow",
+          "source_url_or_ref": "external:single-screenshot-flow",
+          "rejection_reason": "Rejected because a single static screenshot cannot prove state transitions, recovery paths or interaction quality."
         },
         {
           "source_id": "happy-path-only-flow",

--- a/examples/local-web-cockpit-factory-slice/card.md
+++ b/examples/local-web-cockpit-factory-slice/card.md
@@ -811,9 +811,19 @@
           "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
         },
         {
+          "source_id": "oversized-hero-block",
+          "source_url_or_ref": "external:oversized-hero-block",
+          "rejection_reason": "Rejected because hero-style presentation blocks are not suitable for dense product-operation surfaces."
+        },
+        {
           "source_id": "marketing-dashboard-gallery",
           "source_url_or_ref": "external:marketing-dashboard-gallery",
           "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "single-screenshot-flow",
+          "source_url_or_ref": "external:single-screenshot-flow",
+          "rejection_reason": "Rejected because a single static screenshot cannot prove state transitions, recovery paths or interaction quality."
         },
         {
           "source_id": "happy-path-only-flow",

--- a/examples/minimal-hermes-project/card.md
+++ b/examples/minimal-hermes-project/card.md
@@ -560,9 +560,19 @@
           "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
         },
         {
+          "source_id": "oversized-hero-block",
+          "source_url_or_ref": "external:oversized-hero-block",
+          "rejection_reason": "Rejected because hero-style presentation blocks are not suitable for dense product-operation surfaces."
+        },
+        {
           "source_id": "marketing-dashboard-gallery",
           "source_url_or_ref": "external:marketing-dashboard-gallery",
           "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "single-screenshot-flow",
+          "source_url_or_ref": "external:single-screenshot-flow",
+          "rejection_reason": "Rejected because a single static screenshot cannot prove state transitions, recovery paths or interaction quality."
         },
         {
           "source_id": "happy-path-only-flow",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -3418,6 +3418,16 @@ def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
     rejected_references = (
         research.get("rejected_references") if isinstance(research.get("rejected_references"), list) else []
     )
+    source_ids = {
+        str(source.get("source_id")).strip()
+        for source in sources
+        if isinstance(source, dict) and _non_empty_text(source.get("source_id"))
+    }
+    rejected_reference_ids = {
+        str(rejected.get("source_id")).strip()
+        for rejected in rejected_references
+        if isinstance(rejected, dict) and _non_empty_text(rejected.get("source_id"))
+    }
     if len(sources) < 3:
         errors.append("professional_design_process.reference_research.sources requires at least 3 sources")
     if len(_list_items(research.get("registry_refs"))) < 2:
@@ -3450,6 +3460,21 @@ def validate_professional_design_process(process: dict[str, Any]) -> list[str]:
             errors.append(
                 f"professional_design_process.reference_research.library_searches[{index}].rejected_candidate_ids is required"
             )
+        for field, declared_ids, target_name in (
+            ("selected_source_ids", source_ids, "reference_research.sources"),
+            ("rejected_candidate_ids", rejected_reference_ids, "reference_research.rejected_references"),
+        ):
+            seen: set[str] = set()
+            for item_index, item_id in enumerate(_list_items(search.get(field))):
+                if item_id in seen:
+                    errors.append(
+                        f"professional_design_process.reference_research.library_searches[{index}].{field} contains duplicate id: {item_id}"
+                    )
+                seen.add(item_id)
+                if item_id not in declared_ids:
+                    errors.append(
+                        f"professional_design_process.reference_research.library_searches[{index}].{field}[{item_index}] does not resolve to {target_name}: {item_id}"
+                    )
 
     source_types: set[str] = set()
     for index, source in enumerate(sources):

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -906,6 +906,16 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
         rejected_references = research.get("rejected_references") if isinstance(research.get("rejected_references"), list) else []
         pattern_synthesis = research.get("pattern_synthesis") if isinstance(research.get("pattern_synthesis"), dict) else {}
         evidence_policy = research.get("reference_evidence_policy") if isinstance(research.get("reference_evidence_policy"), dict) else {}
+        source_ids = {
+            str(source.get("source_id")).strip()
+            for source in sources
+            if isinstance(source, dict) and str(source.get("source_id") or "").strip()
+        }
+        rejected_reference_ids = {
+            str(rejected.get("source_id")).strip()
+            for rejected in rejected_references
+            if isinstance(rejected, dict) and str(rejected.get("source_id") or "").strip()
+        }
         source_types: set[str] = set()
         if len(sources) < 3:
             errors.append(f"{at}: professional_design_process requires at least 3 reference sources")
@@ -926,6 +936,21 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                 errors.append(f"{at}.reference_research.library_searches[{index}]: selected_source_ids is required")
             if not search.get("rejected_candidate_ids"):
                 errors.append(f"{at}.reference_research.library_searches[{index}]: rejected_candidate_ids is required")
+            for field, declared_ids, target_name in (
+                ("selected_source_ids", source_ids, "reference_research.sources"),
+                ("rejected_candidate_ids", rejected_reference_ids, "reference_research.rejected_references"),
+            ):
+                seen: set[str] = set()
+                for item_index, item_id in enumerate(str(item).strip() for item in search.get(field, []) if str(item).strip()):
+                    if item_id in seen:
+                        errors.append(
+                            f"{at}.reference_research.library_searches[{index}].{field}: duplicate id {item_id}"
+                        )
+                    seen.add(item_id)
+                    if item_id not in declared_ids:
+                        errors.append(
+                            f"{at}.reference_research.library_searches[{index}].{field}[{item_index}]: does not resolve to {target_name}: {item_id}"
+                        )
         for index, source in enumerate(sources):
             if not isinstance(source, dict):
                 errors.append(f"{at}.reference_research.sources[{index}]: expected object")

--- a/templates/professional-design-process.json
+++ b/templates/professional-design-process.json
@@ -279,9 +279,19 @@
         "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
       },
       {
+        "source_id": "oversized-hero-block",
+        "source_url_or_ref": "external:oversized-hero-block",
+        "rejection_reason": "Rejected because hero-style presentation blocks are not suitable for dense product-operation surfaces."
+      },
+      {
         "source_id": "marketing-dashboard-gallery",
         "source_url_or_ref": "external:marketing-dashboard-gallery",
         "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+      },
+      {
+        "source_id": "single-screenshot-flow",
+        "source_url_or_ref": "external:single-screenshot-flow",
+        "rejection_reason": "Rejected because a single static screenshot cannot prove state transitions, recovery paths or interaction quality."
       },
       {
         "source_id": "happy-path-only-flow",

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -657,9 +657,19 @@
           "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
         },
         {
+          "source_id": "oversized-hero-block",
+          "source_url_or_ref": "external:oversized-hero-block",
+          "rejection_reason": "Rejected because hero-style presentation blocks are not suitable for dense product-operation surfaces."
+        },
+        {
           "source_id": "marketing-dashboard-gallery",
           "source_url_or_ref": "external:marketing-dashboard-gallery",
           "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+        },
+        {
+          "source_id": "single-screenshot-flow",
+          "source_url_or_ref": "external:single-screenshot-flow",
+          "rejection_reason": "Rejected because a single static screenshot cannot prove state transitions, recovery paths or interaction quality."
         },
         {
           "source_id": "happy-path-only-flow",

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -153,6 +153,53 @@ class FactorySelfImprovementTest(unittest.TestCase):
             errors,
         )
 
+    def test_professional_design_process_binds_selected_source_ids(self) -> None:
+        process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
+        process["reference_research"]["library_searches"][0]["selected_source_ids"] = [
+            "21st-dev-components",
+            "invented-reference",
+        ]
+
+        errors = factoryctl.validate_professional_design_process(process)
+
+        self.assertIn(
+            "professional_design_process.reference_research.library_searches[0].selected_source_ids[1] does not resolve to reference_research.sources: invented-reference",
+            errors,
+        )
+
+    def test_professional_design_process_binds_rejected_candidate_ids(self) -> None:
+        process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
+        process["reference_research"]["library_searches"][0]["rejected_candidate_ids"] = [
+            "decorative-dashboard-template",
+            "missing-rejected-candidate",
+        ]
+
+        errors = factoryctl.validate_professional_design_process(process)
+
+        self.assertIn(
+            "professional_design_process.reference_research.library_searches[0].rejected_candidate_ids[1] does not resolve to reference_research.rejected_references: missing-rejected-candidate",
+            errors,
+        )
+
+    def test_professional_design_process_rejects_duplicate_reference_ids(self) -> None:
+        process = json.loads(json.dumps(vfinal_card()["professional_design_process"]))
+        process["reference_research"]["library_searches"][0]["selected_source_ids"] = [
+            "21st-dev-components",
+            "21st-dev-components",
+        ]
+
+        errors = factoryctl.validate_professional_design_process(process)
+
+        self.assertIn(
+            "professional_design_process.reference_research.library_searches[0].selected_source_ids contains duplicate id: 21st-dev-components",
+            errors,
+        )
+
+    def test_professional_design_process_template_reference_ids_resolve(self) -> None:
+        process = json.loads((ROOT / "templates" / "professional-design-process.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(factoryctl.validate_professional_design_process(process), [])
+
     def test_reference_quality_rejects_copy_without_license_ref(self) -> None:
         packet = dict(vfinal_card()["reference_quality_packet"])
         packet["references"] = [

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -308,6 +308,27 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         self.assertTrue(any("$.wireframe_gate" in error and "next_action" in error for error in errors), errors)
         self.assertTrue(any("$.wireframe_gate" in error and "proof_refs" in error for error in errors), errors)
 
+    def test_professional_design_process_public_validator_binds_reference_ids(self) -> None:
+        validator = load_validator()
+        process = json.loads((ROOT / "templates" / "professional-design-process.json").read_text(encoding="utf-8"))
+        broken_selected = json.loads(json.dumps(process))
+        broken_selected["reference_research"]["library_searches"][0]["selected_source_ids"].append("invented-reference")
+        broken_rejected = json.loads(json.dumps(process))
+        broken_rejected["reference_research"]["library_searches"][0]["rejected_candidate_ids"].append("missing-rejected")
+        duplicated = json.loads(json.dumps(process))
+        duplicated["reference_research"]["library_searches"][0]["selected_source_ids"].append("21st-dev-components")
+
+        self.assertEqual(validator.validate_domain_rules(process, "$"), [])
+        self.assertTrue(
+            any("selected_source_ids[2]" in error and "invented-reference" in error for error in validator.validate_domain_rules(broken_selected, "$"))
+        )
+        self.assertTrue(
+            any("rejected_candidate_ids[2]" in error and "missing-rejected" in error for error in validator.validate_domain_rules(broken_rejected, "$"))
+        )
+        self.assertTrue(
+            any("selected_source_ids" in error and "duplicate id 21st-dev-components" in error for error in validator.validate_domain_rules(duplicated, "$"))
+        )
+
     def test_resolves_internal_defs_refs(self) -> None:
         validator = load_validator()
         schema = {

--- a/ui/issue-84-local-cockpit/professional-design-process.json
+++ b/ui/issue-84-local-cockpit/professional-design-process.json
@@ -279,9 +279,19 @@
         "rejection_reason": "Rejected because decorative metrics and large cards do not prove gate, evidence or next-action clarity."
       },
       {
+        "source_id": "oversized-hero-block",
+        "source_url_or_ref": "external:oversized-hero-block",
+        "rejection_reason": "Rejected because hero-style presentation blocks are not suitable for dense product-operation surfaces."
+      },
+      {
         "source_id": "marketing-dashboard-gallery",
         "source_url_or_ref": "external:marketing-dashboard-gallery",
         "rejection_reason": "Rejected because the surface optimizes for presentation, not repeated operator decisions and recovery states."
+      },
+      {
+        "source_id": "single-screenshot-flow",
+        "source_url_or_ref": "external:single-screenshot-flow",
+        "rejection_reason": "Rejected because a single static screenshot cannot prove state transitions, recovery paths or interaction quality."
       },
       {
         "source_id": "happy-path-only-flow",


### PR DESCRIPTION
## Summary
- Bind `professional_design_process.reference_research.library_searches[*].selected_source_ids` to declared `reference_research.sources`.
- Bind `rejected_candidate_ids` to declared `reference_research.rejected_references`.
- Reject duplicate, stale, misspelled, or invented selected/rejected IDs in both `factoryctl` and public JSON artifact validation.
- Align public templates/examples, including the local cockpit design-process JSON fixture, so every cited rejected ID is declared.

## Why
Issue #240 found that the Professional Design Process could look rigorous while selected/rejected IDs were disconnected from the actual studied references. That breaks the factory's gear-like invariant: every design decision ID must resolve to a declared source or rejection record.

## Scope guard
- Closes #240.
- Does not touch issue #84 implementation, cockpit HTML, runtime behavior, JS, CSS, or executor flow.
- The only #84-adjacent change is the public-safe `ui/issue-84-local-cockpit/professional-design-process.json` fixture, updated so the global design-process validator remains green.
- No historical/audit/private evidence artifacts added.

## Validation
- `python -m unittest tests.test_factory_self_improvement tests.test_public_json_artifact_validator -q`
- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest tests.test_issue84_local_cockpit_ui.Issue84LocalCockpitUITest.test_local_cockpit_professional_design_process_is_valid -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py`
- `python -m unittest discover -s tests -q` (648 tests)
- `git diff --check`

Closes #240