### PR TITLE
Normalize Product Experience surface taxonomy

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -38,6 +38,38 @@ The repo runner in `scripts/product_face_proof.py` is a `web_visual_ui` runner.
 It should not be used to claim CLI/TUI, docs/onboarding or agentic-interface
 PASS without the matching profile evidence.
 
+## Surface Taxonomy
+
+Product Experience OS routes surface families before Product Face PASS. The
+taxonomy is separate from capability-pack activation: a pack may exist, but the
+Product Face evidence profile still has to be supported or explicitly blocked.
+
+Supported routes:
+
+- `web`, `web_app`, `website`, `frontend`, `ux`, `screen`, `component`,
+  `browser`, `mobile_web` and local web cockpit/app surfaces route to
+  `web_visual_ui`.
+- `cli`, `tui`, `terminal`, `console` and `command_line` route to `cli_tui`.
+- `docs`, `documentation`, `onboarding`, `quickstart` and `guide` route to
+  `docs_onboarding`.
+- `agentic_interface`, `ai_interface`, `chat_ui`, `assistant` and `copilot`
+  route to `agentic_interface`.
+- `wallet` and `wallet_ui` route to `web_visual_ui`, but still require the
+  separate wallet transaction/signing domain proof before product acceptance.
+
+Fail-closed routes:
+
+- `mobile` is ambiguous. Use `mobile_web` for browser UI, or activate a native
+  mobile evidence profile/pack first.
+- `native_mobile`, `ios`, `android`, `desktop`, `desktop_app`, `extension`,
+  `browser_extension`, `design_system`, `game`, `gameplay`, `2d` and `3d` are
+  template-only or blocked until their dedicated evidence profile and pack are
+  activated.
+
+Unsupported or template-only surfaces must not fall back to `web_visual_ui`.
+The validator reports the blocked reason instead of accepting generic Product
+Face proof.
+
 ## Output
 
 `product_face_result` with:

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -639,6 +639,63 @@ VISUAL_UI_SURFACE_TOKENS = PRODUCT_FACE_SURFACES | {
     "design-system",
     "design_system",
 }
+SURFACE_EVIDENCE_PROFILE_ROUTES = {
+    "frontend": ("web_visual_ui", "supported", "Browser/front-end UI is proven through rendered visual evidence."),
+    "product_face": ("web_visual_ui", "supported", "Product Face surfaces are proven through rendered visual evidence."),
+    "product-face": ("web_visual_ui", "supported", "Product Face surfaces are proven through rendered visual evidence."),
+    "ux": ("web_visual_ui", "supported", "UX/browser UI is proven through rendered visual evidence."),
+    "web": ("web_visual_ui", "supported", "Web UI is proven through rendered visual evidence."),
+    "web_app": ("web_visual_ui", "supported", "Web app UI is proven through rendered visual evidence."),
+    "web-app": ("web_visual_ui", "supported", "Web app UI is proven through rendered visual evidence."),
+    "website": ("web_visual_ui", "supported", "Website UI is proven through rendered visual evidence."),
+    "site": ("web_visual_ui", "supported", "Website UI is proven through rendered visual evidence."),
+    "screen": ("web_visual_ui", "supported", "Screen UI is proven through rendered visual evidence."),
+    "component": ("web_visual_ui", "supported", "Component UI is proven through rendered visual evidence."),
+    "browser": ("web_visual_ui", "supported", "Browser UI is proven through rendered visual evidence."),
+    "mobile_web": ("web_visual_ui", "supported", "Mobile web is proven through the web visual profile with mobile viewport evidence."),
+    "mobile-web": ("web_visual_ui", "supported", "Mobile web is proven through the web visual profile with mobile viewport evidence."),
+    "local_web_app": ("web_visual_ui", "supported", "Local web app UI is proven through rendered visual evidence."),
+    "local_web_cockpit": ("web_visual_ui", "supported", "Local web cockpit UI is proven through rendered visual evidence."),
+    "cli": ("cli_tui", "supported", "CLI surfaces are proven through command transcript evidence."),
+    "tui": ("cli_tui", "supported", "TUI surfaces are proven through command transcript evidence."),
+    "terminal": ("cli_tui", "supported", "Terminal surfaces are proven through command transcript evidence."),
+    "console": ("cli_tui", "supported", "Console surfaces are proven through command transcript evidence."),
+    "command_line": ("cli_tui", "supported", "Command-line surfaces are proven through command transcript evidence."),
+    "command-line": ("cli_tui", "supported", "Command-line surfaces are proven through command transcript evidence."),
+    "docs": ("docs_onboarding", "supported", "Docs surfaces are proven through reader/onboarding success evidence."),
+    "documentation": ("docs_onboarding", "supported", "Documentation surfaces are proven through reader/onboarding success evidence."),
+    "onboarding": ("docs_onboarding", "supported", "Onboarding surfaces are proven through reader success evidence."),
+    "quickstart": ("docs_onboarding", "supported", "Quickstart surfaces are proven through reader success evidence."),
+    "guide": ("docs_onboarding", "supported", "Guide surfaces are proven through reader success evidence."),
+    "agentic_interface": ("agentic_interface", "supported", "Agentic interfaces are proven through task, control and recovery evidence."),
+    "agentic-interface": ("agentic_interface", "supported", "Agentic interfaces are proven through task, control and recovery evidence."),
+    "ai_interface": ("agentic_interface", "supported", "AI interfaces are proven through task, control and recovery evidence."),
+    "ai-interface": ("agentic_interface", "supported", "AI interfaces are proven through task, control and recovery evidence."),
+    "chat_ui": ("agentic_interface", "supported", "Chat UI is proven through task, control and recovery evidence."),
+    "chat-ui": ("agentic_interface", "supported", "Chat UI is proven through task, control and recovery evidence."),
+    "assistant": ("agentic_interface", "supported", "Assistant surfaces are proven through task, control and recovery evidence."),
+    "copilot": ("agentic_interface", "supported", "Copilot surfaces are proven through task, control and recovery evidence."),
+    "mobile": ("", "blocked", "Ambiguous mobile surface: use mobile_web for browser UI, or activate a native mobile evidence profile/pack first."),
+    "native_mobile": ("", "template_only", "Native mobile Product Face evidence is not activated in the public core taxonomy yet."),
+    "native-mobile": ("", "template_only", "Native mobile Product Face evidence is not activated in the public core taxonomy yet."),
+    "ios": ("", "template_only", "iOS Product Face evidence is not activated in the public core taxonomy yet."),
+    "android": ("", "template_only", "Android Product Face evidence is not activated in the public core taxonomy yet."),
+    "desktop": ("", "template_only", "Native desktop Product Face evidence is not activated in the public core taxonomy yet."),
+    "desktop_app": ("", "template_only", "Native desktop Product Face evidence is not activated in the public core taxonomy yet."),
+    "desktop-app": ("", "template_only", "Native desktop Product Face evidence is not activated in the public core taxonomy yet."),
+    "extension": ("", "template_only", "Browser extension Product Face evidence is not activated in the public core taxonomy yet."),
+    "browser_extension": ("", "template_only", "Browser extension Product Face evidence is not activated in the public core taxonomy yet."),
+    "browser-extension": ("", "template_only", "Browser extension Product Face evidence is not activated in the public core taxonomy yet."),
+    "design_system": ("", "template_only", "Design-system Product Face evidence needs a dedicated component/variant proof profile before PASS."),
+    "design-system": ("", "template_only", "Design-system Product Face evidence needs a dedicated component/variant proof profile before PASS."),
+    "wallet": ("web_visual_ui", "supported", "Wallet UI uses visual evidence plus separate wallet transaction/signing proof."),
+    "wallet_ui": ("web_visual_ui", "supported", "Wallet UI uses visual evidence plus separate wallet transaction/signing proof."),
+    "wallet-ui": ("web_visual_ui", "supported", "Wallet UI uses visual evidence plus separate wallet transaction/signing proof."),
+    "game": ("", "template_only", "Game Product Face evidence needs an activated game product pack and playable proof profile before PASS."),
+    "gameplay": ("", "template_only", "Game Product Face evidence needs an activated game product pack and playable proof profile before PASS."),
+    "2d": ("", "template_only", "Game Product Face evidence needs an activated game product pack and playable proof profile before PASS."),
+    "3d": ("", "template_only", "Game Product Face evidence needs an activated game product pack and playable proof profile before PASS."),
+}
 
 
 @dataclass(frozen=True)
@@ -1934,6 +1991,74 @@ def _declared_surface_evidence_profiles(data: dict[str, Any]) -> list[str]:
     return sorted({profile_id for profile_id in profile_ids if profile_id})
 
 
+def _surface_family_tokens_from_data(data: dict[str, Any]) -> list[tuple[str, str, str]]:
+    tokens: list[tuple[str, str, str]] = []
+    for field in ("surface", "surface_type"):
+        if _non_empty_text(data.get(field)):
+            raw = str(data.get(field)).strip()
+            surface_key = _normalized_contract_token(raw)
+            if surface_key in SURFACE_EVIDENCE_PROFILE_ROUTES:
+                tokens.append((field, raw, surface_key))
+    return tokens
+
+
+def _surface_family_tokens_from_card(card: dict[str, Any]) -> list[tuple[str, str, str]]:
+    tokens: list[tuple[str, str, str]] = []
+    for surface in normalized_surfaces(card):
+        surface_key = _normalized_contract_token(surface)
+        if surface_key in SURFACE_EVIDENCE_PROFILE_ROUTES:
+            tokens.append(("surfaces", surface, surface_key))
+    packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
+    plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
+    tokens.extend(_surface_family_tokens_from_data(packet))
+    tokens.extend(_surface_family_tokens_from_data(plan))
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[tuple[str, str, str]] = []
+    for entry in tokens:
+        if entry not in seen:
+            unique.append(entry)
+            seen.add(entry)
+    return unique
+
+
+def _surface_evidence_profile_route_errors(data: dict[str, Any], *, at: str) -> list[str]:
+    errors: list[str] = []
+    declared_profiles = set(_declared_surface_evidence_profiles(data))
+    for field, raw, token in _surface_family_tokens_from_data(data):
+        profile_id, route_state, reason = SURFACE_EVIDENCE_PROFILE_ROUTES[token]
+        if route_state != "supported":
+            errors.append(
+                f"{at}.{field} '{raw}' is {route_state} in Product Experience OS taxonomy: {reason}"
+            )
+            continue
+        if declared_profiles and profile_id not in declared_profiles:
+            errors.append(
+                f"{at}.{field} '{raw}' requires surface_evidence_profile {profile_id}"
+            )
+    return errors
+
+
+def _surface_evidence_profile_route_errors_for_card(card: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    declared_profiles: set[str] = set()
+    packet = card.get("product_face_packet") if isinstance(card.get("product_face_packet"), dict) else {}
+    plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
+    for source in (packet, plan):
+        declared_profiles.update(_declared_surface_evidence_profiles(source))
+    for field, raw, token in _surface_family_tokens_from_card(card):
+        profile_id, route_state, reason = SURFACE_EVIDENCE_PROFILE_ROUTES[token]
+        if route_state != "supported":
+            errors.append(
+                f"product_experience_surface.{field} '{raw}' is {route_state} in Product Experience OS taxonomy: {reason}"
+            )
+            continue
+        if declared_profiles and profile_id not in declared_profiles:
+            errors.append(
+                f"product_experience_surface.{field} '{raw}' requires surface_evidence_profile {profile_id}"
+            )
+    return sorted(set(errors))
+
+
 def _validate_surface_evidence_profile_declarations(data: dict[str, Any], *, at: str) -> list[str]:
     errors: list[str] = []
     if "surface_evidence_profile" in data and not _surface_evidence_profile_id(data.get("surface_evidence_profile")):
@@ -1946,6 +2071,7 @@ def _validate_surface_evidence_profile_declarations(data: dict[str, Any], *, at:
     for profile_id in _declared_surface_evidence_profiles(data):
         if profile_id not in SURFACE_EVIDENCE_PROFILES:
             errors.append(f"{at}.surface_evidence_profile must be one of " + ", ".join(sorted(SURFACE_EVIDENCE_PROFILES)))
+    errors.extend(_surface_evidence_profile_route_errors(data, at=at))
     return errors
 
 
@@ -2786,15 +2912,10 @@ def _expected_surface_evidence_profiles(card: dict[str, Any]) -> list[str]:
     if profiles:
         return sorted(profile for profile in profiles if profile in SURFACE_EVIDENCE_PROFILES)
 
-    tokens = _surface_profile_tokens(card)
-    if tokens & {_normalized_contract_token(token) for token in CLI_TUI_SURFACE_TOKENS}:
-        profiles.add("cli_tui")
-    if tokens & {_normalized_contract_token(token) for token in DOCS_ONBOARDING_SURFACE_TOKENS}:
-        profiles.add("docs_onboarding")
-    if tokens & {_normalized_contract_token(token) for token in AGENTIC_INTERFACE_SURFACE_TOKENS}:
-        profiles.add("agentic_interface")
-    if tokens & {_normalized_contract_token(token) for token in VISUAL_UI_SURFACE_TOKENS}:
-        profiles.add("web_visual_ui")
+    for _, _, token in _surface_family_tokens_from_card(card):
+        profile_id, route_state, _reason = SURFACE_EVIDENCE_PROFILE_ROUTES[token]
+        if route_state == "supported" and profile_id:
+            profiles.add(profile_id)
     if not profiles and product_experience_surface_required(card):
         profiles.add("web_visual_ui")
     return sorted(profiles)
@@ -3750,6 +3871,8 @@ def validate_card(data: dict[str, Any]) -> list[str]:
         errors.append("product_face_packet required for product-facing surfaces")
     elif product_facing:
         errors.extend(validate_product_face_packet(data["product_face_packet"], strict=strict_experience))
+    if product_facing:
+        errors.extend(_surface_evidence_profile_route_errors_for_card(data))
     if strict_experience:
         if not isinstance(data.get("product_experience_plan"), dict):
             errors.append("product_experience_plan required for vFinal product-facing surfaces")
@@ -5168,6 +5291,7 @@ def validate_usage_evidence_matrix_against_card(result: dict[str, Any], card: di
 
 def validate_product_face_result_against_card(result: dict[str, Any], card: dict[str, Any]) -> list[str]:
     errors = validate_product_face_result(result)
+    errors.extend(_surface_evidence_profile_route_errors_for_card(card))
     errors.extend(_product_delivery_quality_profile_ref_errors(card))
     result_status = str(result.get("result") or "").upper()
     if result_status == "WAIVED":

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -2396,6 +2396,57 @@ class FactoryCtlTest(unittest.TestCase):
             errors,
         )
 
+    def test_docs_surface_maps_to_docs_onboarding_profile(self) -> None:
+        card = product_surface_card_fixture("docs", "docs_onboarding")
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("docs_onboarding", "docs"),
+            surface_evidence_profiles=[surface_profile("docs_onboarding", "docs")],
+            docs_onboarding_evidence={
+                "first_success_replay_refs": ["reports/docs/first-success.md"],
+                "tasks_covered": ["install and run the first value path"],
+                "stale_link_check_refs": ["reports/docs/link-check.txt"],
+                "public_safety_check_refs": ["reports/docs/public-safety.txt"],
+                "reader_success_criteria": ["reader reaches first useful factory output"],
+            },
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
+
+    def test_mobile_surface_cannot_fallback_to_web_visual_profile(self) -> None:
+        card = product_surface_card_fixture("mobile", "web_visual_ui")
+        result = product_face_result_fixture()
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertTrue(
+            any(
+                "product_experience_surface.surfaces 'mobile' is blocked in Product Experience OS taxonomy"
+                in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_surface_taxonomy_blocks_mismatched_or_template_only_profiles(self) -> None:
+        plan = factoryctl.load_json_like(ROOT / "templates" / "product-experience-plan.json")
+        plan["surface_type"] = "docs"
+        plan["surface_evidence_profile"] = "web_visual_ui"
+        self.assertIn(
+            "product_experience_plan.surface_type 'docs' requires surface_evidence_profile docs_onboarding",
+            factoryctl.validate_product_experience_plan(plan),
+        )
+
+        packet = factoryctl.load_json_like(ROOT / "templates" / "product-face-packet.json")
+        packet["surface"] = "mobile"
+        packet["surface_evidence_profile"] = "web_visual_ui"
+        self.assertTrue(
+            any(
+                "product_face_packet.surface 'mobile' is blocked in Product Experience OS taxonomy"
+                in error
+                for error in factoryctl.validate_product_face_packet(packet, strict=True)
+            )
+        )
+
     def test_agentic_surface_requires_task_state_control_and_recovery_evidence(self) -> None:
         card = product_surface_card_fixture("agentic_interface", "agentic_interface")
         result = product_face_result_fixture(


### PR DESCRIPTION
## Summary
- Add a Product Experience OS surface-to-evidence-profile taxonomy in `factoryctl`.
- Route supported surface families to `web_visual_ui`, `cli_tui`, `docs_onboarding`, or `agentic_interface` instead of relying on generic fallback.
- Fail closed for ambiguous/template-only surfaces such as `mobile`, native mobile, desktop app, extension, design system and game surfaces until a dedicated profile/pack exists.
- Preserve wallet UI as `web_visual_ui` plus separate wallet transaction/signing proof, matching existing domain-proof gates.
- Document the taxonomy in the Product Face proof runner.

## Why
The factory advertised broad Product Experience OS coverage, but unsupported surfaces could still fall back toward generic `web_visual_ui` proof. That violates the gear-like invariant: every surface must have an explicit proof route or a clear blocked/template-only reason.

## Validation
- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest discover -s tests -q` (651 tests)
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python -m py_compile scripts\factoryctl.py`
- `git diff --check`

## Scope guard
- Closes #241.
- Does not touch #84, cockpit implementation, runtime HTML, local executor flow, or private evidence.
- No historical/audit artifacts added.

Closes #241