### PR TITLE
Harden Product Face residual acceptance

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -121,6 +121,11 @@ Useful options:
   product approval alignment.
 - `--visual-quality-status`, `--visual-quality-reviewer` and
   `--visual-quality-basis` to record the professional visual quality verdict.
+- `--visual-quality-residual` only when the verdict is
+  `PASS_WITH_RESIDUALS`. The value must be
+  `ID|SEVERITY|OWNER|EXPIRES_AT|ACCEPTED_SCOPE|PROOF_REF[,PROOF_REF]|DESCRIPTION`.
+  Only bounded `low` or `medium` residuals that do not block full acceptance
+  are valid for a Product Face PASS.
 - `--reference-quality-ref`, `--reference-quality-comparison-basis`,
   `--compared-reference-id`, `--reference-comparison-dimension` and
   `--reference-comparison-artifact` to record the material reference/design
@@ -155,6 +160,11 @@ packet comparison, source-promise coverage, design-fit review and
 visually unacceptable UI. Reference/design comparison cannot be prose-only:
 `reference_quality_comparison` must bind the compared source ids to material
 comparison artifacts or to a bounded sanitized comparison manifest.
+`PASS_WITH_RESIDUALS` is not an informal approval note. Each residual must have
+an id, severity, owner, expiry, accepted scope and proof refs. Any warning in
+`usage_evidence_matrix` must point to one of those residual ids through
+`accepted_residual_ref`, otherwise the result cannot be consumed as a Product
+Face PASS.
 
 `templates/professional-design-process.json` is a starter contract. Its gates
 are intentionally `PENDING`; copying that template into a card is not

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -465,7 +465,7 @@
         },
         "residuals": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "$ref": "#/$defs/visual_quality_residual" }
         }
       },
       "additionalProperties": true
@@ -525,6 +525,7 @@
           },
           "a11y_status": { "enum": ["pass", "warn", "fail"] },
           "performance_status": { "enum": ["pass", "warn", "fail"] },
+          "accepted_residual_ref": { "type": "string", "minLength": 3 },
           "reviewer": { "type": "string", "minLength": 3 },
           "basis": { "type": "string", "minLength": 3 }
         },
@@ -578,6 +579,34 @@
           "type": "array",
           "items": { "type": "string", "minLength": 3 }
         }
+      },
+      "additionalProperties": true
+    },
+    "visual_quality_residual": {
+      "type": "object",
+      "required": [
+        "id",
+        "description",
+        "severity",
+        "owner",
+        "expires_at",
+        "accepted_scope",
+        "proof_refs",
+        "blocks_full_acceptance"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 3 },
+        "description": { "type": "string", "minLength": 3 },
+        "severity": { "enum": ["low", "medium", "high", "critical"] },
+        "owner": { "type": "string", "minLength": 3 },
+        "expires_at": { "type": "string", "minLength": 10 },
+        "accepted_scope": { "type": "string", "minLength": 10 },
+        "proof_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "blocks_full_acceptance": { "type": "boolean" }
       },
       "additionalProperties": true
     },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -548,6 +548,8 @@ USAGE_EVIDENCE_MATRIX_REQUIRED_FIELDS = (
 )
 USAGE_EVIDENCE_ALLOWED_STATUSES = {"pass", "warn", "fail"}
 VISUAL_QUALITY_ALLOWED_RESULTS = {"PASS", "PASS_WITH_RESIDUALS", "BLOCK"}
+VISUAL_QUALITY_RESIDUAL_SEVERITIES = {"low", "medium", "high", "critical"}
+VISUAL_QUALITY_RESIDUAL_BLOCKING_SEVERITIES = {"high", "critical"}
 DOMAIN_PROOF_ALLOWED_STATUSES = {"PASS", "WARN", "FAIL", "WAIVED"}
 REFERENCE_RESEARCH_SOURCE_TYPES = {
     "component_registry",
@@ -4214,6 +4216,91 @@ def validate_usage_evidence_matrix(result: dict[str, Any], *, is_pass: bool) -> 
                 errors.append(f"product_face_result.usage_evidence_matrix[{index}].{field} must be pass, warn or fail")
             if is_pass and status == "fail":
                 errors.append(f"product_face_result PASS cannot include usage_evidence_matrix[{index}].{field}=fail")
+            if is_pass and status == "warn" and not _non_empty_text(entry.get("accepted_residual_ref")):
+                errors.append(
+                    f"product_face_result PASS usage_evidence_matrix[{index}].{field}=warn "
+                    "requires accepted_residual_ref"
+                )
+    return errors
+
+
+def _visual_quality_residual_records(visual_quality: dict[str, Any]) -> list[dict[str, Any]]:
+    residuals = visual_quality.get("residuals")
+    if not isinstance(residuals, list):
+        return []
+    return [residual for residual in residuals if isinstance(residual, dict)]
+
+
+def validate_visual_quality_residuals(
+    result: dict[str, Any],
+    visual_quality: dict[str, Any],
+    *,
+    visual_status: str,
+    is_pass: bool,
+) -> list[str]:
+    errors: list[str] = []
+    residuals_value = visual_quality.get("residuals")
+    if residuals_value is None:
+        residuals_value = []
+    if residuals_value is not None and not isinstance(residuals_value, list):
+        errors.append("product_face_result.visual_quality_result.residuals must be an array")
+        return errors
+
+    residuals = _visual_quality_residual_records(visual_quality)
+    if residuals_value and len(residuals) != len(residuals_value):
+        errors.append("product_face_result.visual_quality_result.residuals entries must be objects")
+
+    residual_ids: set[str] = set()
+    for index, residual in enumerate(residuals):
+        at = f"product_face_result.visual_quality_result.residuals[{index}]"
+        for field in ("id", "description", "severity", "owner", "expires_at", "accepted_scope", "proof_refs"):
+            if field == "proof_refs":
+                if not _non_empty_string_list(residual.get(field)):
+                    errors.append(f"{at}.proof_refs must be a non-empty string array")
+            elif not _non_empty_text(residual.get(field)):
+                errors.append(f"{at}.{field} is required")
+        residual_id = str(residual.get("id") or "").strip()
+        if residual_id:
+            if residual_id in residual_ids:
+                errors.append(f"{at}.id must be unique")
+            residual_ids.add(residual_id)
+        severity = str(residual.get("severity") or "").strip().lower()
+        if severity and severity not in VISUAL_QUALITY_RESIDUAL_SEVERITIES:
+            errors.append(f"{at}.severity must be low, medium, high or critical")
+        expires_at = _parse_artifact_timestamp(residual.get("expires_at"))
+        if residual.get("expires_at") and expires_at is None:
+            errors.append(f"{at}.expires_at must be an ISO timestamp")
+        elif expires_at is not None and expires_at <= datetime.now(timezone.utc):
+            errors.append(f"{at} is stale; expires_at is in the past")
+        if is_pass and residual.get("blocks_full_acceptance") is not False:
+            errors.append(f"{at}.blocks_full_acceptance=false is required for Product Face PASS")
+        if is_pass and severity in VISUAL_QUALITY_RESIDUAL_BLOCKING_SEVERITIES:
+            errors.append(f"{at}.severity cannot be high or critical for Product Face PASS")
+        if residual.get("proof_refs"):
+            errors.extend(f"{at}: {error}" for error in _evidence_ref_errors(_list_items(residual.get("proof_refs")), ROOT))
+
+    if is_pass and visual_status == "PASS_WITH_RESIDUALS" and not residuals:
+        errors.append("product_face_result PASS_WITH_RESIDUALS requires structured residuals")
+
+    matrix = result.get("usage_evidence_matrix")
+    if is_pass and isinstance(matrix, list):
+        for index, entry in enumerate(matrix):
+            if not isinstance(entry, dict):
+                continue
+            has_warning = any(_normalized_usage_value(entry.get(field)) == "warn" for field in ("a11y_status", "performance_status"))
+            if not has_warning:
+                continue
+            residual_ref = str(entry.get("accepted_residual_ref") or "").strip()
+            if residual_ref and residual_ref not in residual_ids:
+                errors.append(
+                    f"product_face_result.usage_evidence_matrix[{index}].accepted_residual_ref "
+                    "must match visual_quality_result.residuals[].id"
+                )
+            if visual_status != "PASS_WITH_RESIDUALS":
+                errors.append(
+                    f"product_face_result PASS usage_evidence_matrix[{index}] warnings require "
+                    "visual_quality_result.status PASS_WITH_RESIDUALS"
+                )
     return errors
 
 
@@ -4477,6 +4564,14 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
             errors.append("product_face_result PASS requires visual_quality_result.status PASS or PASS_WITH_RESIDUALS")
         if is_pass and visual_status == "PASS_WITH_RESIDUALS" and not _list_items(visual_quality.get("residuals")):
             errors.append("product_face_result PASS_WITH_RESIDUALS requires residuals")
+        errors.extend(
+            validate_visual_quality_residuals(
+                result,
+                visual_quality,
+                visual_status=visual_status,
+                is_pass=is_pass,
+            )
+        )
     professional_comparison = result.get("professional_design_process_comparison")
     if is_pass:
         if not _non_empty_text(result.get("professional_design_process_ref")):

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -30,6 +30,7 @@ PRODUCT_ALIGNMENT_FIELDS = (
     "reference_quality_comparison",
 )
 VISUAL_QUALITY_PASS_RESULTS = {"PASS", "PASS_WITH_RESIDUALS"}
+VISUAL_QUALITY_RESIDUAL_SEVERITIES = {"low", "medium"}
 REFERENCE_COMPARISON_DIMENSIONS = (
     "layout_hierarchy",
     "interaction_model",
@@ -691,9 +692,70 @@ def visual_quality_passes(result: dict[str, Any]) -> bool:
         return False
     if not str(visual_quality.get("basis") or "").strip():
         return False
-    if visual_quality.get("status") == "PASS_WITH_RESIDUALS" and not visual_quality.get("residuals"):
+    if visual_quality.get("status") == "PASS_WITH_RESIDUALS":
+        residuals = visual_quality.get("residuals")
+        if not isinstance(residuals, list) or not residuals:
+            return False
+        for residual in residuals:
+            if not visual_quality_residual_is_bounded(residual):
+                return False
+    return True
+
+
+def parse_iso_timestamp(value: str) -> datetime | None:
+    text = str(value or "").strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def visual_quality_residual_is_bounded(residual: Any) -> bool:
+    if not isinstance(residual, dict):
+        return False
+    for field in ("id", "description", "severity", "owner", "expires_at", "accepted_scope"):
+        if not str(residual.get(field) or "").strip():
+            return False
+    if str(residual.get("severity") or "").strip().lower() not in VISUAL_QUALITY_RESIDUAL_SEVERITIES:
+        return False
+    expires_at = parse_iso_timestamp(str(residual.get("expires_at") or ""))
+    if expires_at is None or expires_at <= datetime.now(timezone.utc):
+        return False
+    if residual.get("blocks_full_acceptance") is not False:
+        return False
+    proof_refs = residual.get("proof_refs")
+    if not isinstance(proof_refs, list) or not any(str(item).strip() for item in proof_refs):
         return False
     return True
+
+
+def parse_visual_quality_residual(raw: str) -> dict[str, Any]:
+    parts = [part.strip() for part in str(raw or "").split("|", 6)]
+    if len(parts) != 7:
+        raise ValueError(
+            "--visual-quality-residual must use "
+            "ID|SEVERITY|OWNER|EXPIRES_AT|ACCEPTED_SCOPE|PROOF_REF[,PROOF_REF]|DESCRIPTION"
+        )
+    residual_id, severity, owner, expires_at, accepted_scope, proof_refs_raw, description = parts
+    proof_refs = [item.strip() for item in proof_refs_raw.split(",") if item.strip()]
+    residual = {
+        "id": residual_id,
+        "description": description,
+        "severity": severity.lower(),
+        "owner": owner,
+        "expires_at": expires_at,
+        "accepted_scope": accepted_scope,
+        "proof_refs": proof_refs,
+        "blocks_full_acceptance": False,
+    }
+    if not visual_quality_residual_is_bounded(residual):
+        raise ValueError("--visual-quality-residual must describe a bounded low/medium non-blocking residual with proof refs")
+    return residual
 
 
 def reference_quality_passes(result: dict[str, Any]) -> bool:
@@ -840,7 +902,7 @@ def apply_visual_quality_review(
     status: str | None,
     reviewer: str | None,
     basis: str | None,
-    residuals: list[str] | None = None,
+    residuals: list[dict[str, Any]] | None = None,
 ) -> None:
     supplied = any(str(value or "").strip() for value in (status, reviewer, basis)) or bool(residuals)
     if not supplied:
@@ -855,6 +917,8 @@ def apply_visual_quality_review(
         missing.append("visual-quality-basis")
     if normalized_status == "PASS_WITH_RESIDUALS" and not residuals:
         missing.append("visual-quality-residual")
+    if residuals and any(not visual_quality_residual_is_bounded(residual) for residual in residuals):
+        missing.append("bounded-visual-quality-residual")
     if missing:
         raise ValueError("Visual quality review is incomplete: missing " + ", ".join(missing))
     result["visual_quality_result"] = {
@@ -1224,7 +1288,7 @@ def build_product_face_proof(
     visual_quality_status: str | None = None,
     visual_quality_reviewer: str | None = None,
     visual_quality_basis: str | None = None,
-    visual_quality_residuals: list[str] | None = None,
+    visual_quality_residuals: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     output_dir = out if out.suffix == "" else out.parent
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1363,7 +1427,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--visual-quality-status", choices=["PASS", "BLOCK", "PASS_WITH_RESIDUALS"], help="Professional visual quality verdict.")
     parser.add_argument("--visual-quality-reviewer", help="Reviewer empowered to block visually unacceptable UI.")
     parser.add_argument("--visual-quality-basis", help="Why the surface meets or fails the product-specific quality bar.")
-    parser.add_argument("--visual-quality-residual", action="append", help="Residual visual quality issue when status is PASS_WITH_RESIDUALS.")
+    parser.add_argument(
+        "--visual-quality-residual",
+        action="append",
+        help=(
+            "Bounded residual when status is PASS_WITH_RESIDUALS, as "
+            "ID|SEVERITY|OWNER|EXPIRES_AT|ACCEPTED_SCOPE|PROOF_REF[,PROOF_REF]|DESCRIPTION."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -1381,6 +1452,10 @@ def main(argv: list[str] | None = None) -> int:
         reference_artifacts = [
             parse_reference_comparison_artifact(raw, compared_ids)
             for raw in args.reference_comparison_artifact or []
+        ]
+        visual_quality_residuals = [
+            parse_visual_quality_residual(raw)
+            for raw in args.visual_quality_residual or []
         ]
         result = build_product_face_proof(
             target=args.target,
@@ -1410,7 +1485,7 @@ def main(argv: list[str] | None = None) -> int:
             visual_quality_status=args.visual_quality_status,
             visual_quality_reviewer=args.visual_quality_reviewer,
             visual_quality_basis=args.visual_quality_basis,
-            visual_quality_residuals=args.visual_quality_residual,
+            visual_quality_residuals=visual_quality_residuals,
         )
     except Exception as exc:
         print(f"product_face_proof failed: {exc}", file=sys.stderr)

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -551,6 +551,21 @@ def product_face_result_fixture(**overrides: object) -> dict:
     return result
 
 
+def visual_quality_residual_fixture(**overrides: object) -> dict:
+    residual = {
+        "id": "residual-minor-spacing",
+        "description": "Minor spacing variance remains in a bounded non-critical state.",
+        "severity": "low",
+        "owner": "product-face-reviewer",
+        "expires_at": "2099-01-01T00:00:00+00:00",
+        "accepted_scope": "Accepted only for this bounded Product Face validation result.",
+        "proof_refs": ["external:product-face-residual-review"],
+        "blocks_full_acceptance": False,
+    }
+    residual.update(overrides)
+    return residual
+
+
 def surface_profile(profile_id: str, surface: str) -> dict:
     return {
         "profile_id": profile_id,
@@ -2300,6 +2315,123 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("product_face_result PASS requires a11y.status=pass", errors)
         self.assertIn("product_face_result PASS requires overlap_check.status=pass", errors)
         self.assertIn("product_face_result.visual_quality_result is required", errors)
+
+    def test_product_face_pass_with_residuals_requires_structured_acceptance(self) -> None:
+        result = product_face_result_fixture(
+            visual_quality_result={
+                "status": "PASS_WITH_RESIDUALS",
+                "reviewer": "product-face-reviewer",
+                "basis": "Residual was accepted as bounded.",
+                "reference_quality_bar_checked": True,
+                "ai_generic_symptoms": [],
+                "residuals": ["minor spacing issue"],
+            }
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn("product_face_result.visual_quality_result.residuals entries must be objects", errors)
+        self.assertIn("product_face_result PASS_WITH_RESIDUALS requires structured residuals", errors)
+
+    def test_product_face_pass_rejects_unbounded_or_blocking_residual(self) -> None:
+        result = product_face_result_fixture(
+            visual_quality_result={
+                "status": "PASS_WITH_RESIDUALS",
+                "reviewer": "product-face-reviewer",
+                "basis": "Residual was accepted as bounded.",
+                "reference_quality_bar_checked": True,
+                "ai_generic_symptoms": [],
+                "residuals": [
+                    visual_quality_residual_fixture(
+                        severity="high",
+                        blocks_full_acceptance=True,
+                        expires_at="2020-01-01T00:00:00+00:00",
+                        proof_refs=[],
+                    )
+                ],
+            }
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.visual_quality_result.residuals[0].proof_refs must be a non-empty string array",
+            errors,
+        )
+        self.assertIn(
+            "product_face_result.visual_quality_result.residuals[0] is stale; expires_at is in the past",
+            errors,
+        )
+        self.assertIn(
+            "product_face_result.visual_quality_result.residuals[0].blocks_full_acceptance=false is required for Product Face PASS",
+            errors,
+        )
+        self.assertIn(
+            "product_face_result.visual_quality_result.residuals[0].severity cannot be high or critical for Product Face PASS",
+            errors,
+        )
+
+    def test_product_face_pass_warn_requires_matching_accepted_residual(self) -> None:
+        usage_matrix = usage_evidence_matrix_fixture(
+            journeys=["pilot status review"],
+            states=["success"],
+            viewports=["desktop 1440x900"],
+        )
+        usage_matrix[0]["a11y_status"] = "warn"
+        result = product_face_result_fixture(
+            user_journeys_checked=["pilot status review"],
+            checked_states=["success"],
+            viewports=["desktop 1440x900"],
+            screenshots=["external:product-face-fixture-desktop.png"],
+            usage_evidence_matrix=usage_matrix,
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result PASS usage_evidence_matrix[0].a11y_status=warn requires accepted_residual_ref",
+            errors,
+        )
+
+        usage_matrix[0]["accepted_residual_ref"] = "residual-minor-spacing"
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn(
+            "product_face_result.usage_evidence_matrix[0].accepted_residual_ref must match visual_quality_result.residuals[].id",
+            errors,
+        )
+        self.assertIn(
+            "product_face_result PASS usage_evidence_matrix[0] warnings require visual_quality_result.status PASS_WITH_RESIDUALS",
+            errors,
+        )
+
+    def test_product_face_pass_accepts_bounded_warning_residual_contract(self) -> None:
+        usage_matrix = usage_evidence_matrix_fixture(
+            journeys=["pilot status review"],
+            states=["success"],
+            viewports=["desktop 1440x900"],
+        )
+        usage_matrix[0]["performance_status"] = "warn"
+        usage_matrix[0]["accepted_residual_ref"] = "residual-minor-spacing"
+        result = product_face_result_fixture(
+            user_journeys_checked=["pilot status review"],
+            checked_states=["success"],
+            viewports=["desktop 1440x900"],
+            screenshots=["external:product-face-fixture-desktop.png"],
+            usage_evidence_matrix=usage_matrix,
+            visual_quality_result={
+                "status": "PASS_WITH_RESIDUALS",
+                "reviewer": "product-face-reviewer",
+                "basis": "Residual is bounded, owned and does not block the accepted scope.",
+                "reference_quality_bar_checked": True,
+                "ai_generic_symptoms": [],
+                "residuals": [visual_quality_residual_fixture()],
+            },
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertEqual([], errors)
 
     def test_product_face_waived_allows_pending_reference_quality(self) -> None:
         result = {

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -344,6 +344,61 @@ class ProductFaceProofTest(unittest.TestCase):
                 reference_quality_dimensions=reference_dimension_basis(),
             )
 
+    def test_visual_quality_residual_parser_requires_bounded_structured_input(self) -> None:
+        residual = product_face_proof.parse_visual_quality_residual(
+            "residual-minor-spacing|low|product-face-reviewer|2099-01-01T00:00:00+00:00|"
+            "Accepted only for this bounded Product Face validation|external:residual-proof|"
+            "Minor spacing variance remains after review."
+        )
+
+        self.assertEqual(residual["id"], "residual-minor-spacing")
+        self.assertEqual(residual["severity"], "low")
+        self.assertFalse(residual["blocks_full_acceptance"])
+        self.assertEqual(residual["proof_refs"], ["external:residual-proof"])
+
+    def test_visual_quality_review_rejects_unstructured_residuals(self) -> None:
+        result = product_face_proof.base_result(
+            target_ref="examples/minimal-hermes-project",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=["initial-render"],
+            journeys=["open target"],
+            tool_or_profile="unit-test",
+        )
+
+        with self.assertRaisesRegex(ValueError, "bounded-visual-quality-residual"):
+            product_face_proof.apply_visual_quality_review(
+                result=result,
+                status="PASS_WITH_RESIDUALS",
+                reviewer="product-face-reviewer",
+                basis="Residual is accepted.",
+                residuals=["minor issue"],  # type: ignore[list-item]
+            )
+
+    def test_visual_quality_review_accepts_bounded_structured_residuals(self) -> None:
+        result = product_face_proof.base_result(
+            target_ref="examples/minimal-hermes-project",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=["initial-render"],
+            journeys=["open target"],
+            tool_or_profile="unit-test",
+        )
+        residual = product_face_proof.parse_visual_quality_residual(
+            "residual-minor-spacing|medium|product-face-reviewer|2099-01-01T00:00:00+00:00|"
+            "Accepted only for this bounded Product Face validation|external:residual-proof|"
+            "Minor non-blocking performance variance remains after review."
+        )
+
+        product_face_proof.apply_visual_quality_review(
+            result=result,
+            status="PASS_WITH_RESIDUALS",
+            reviewer="product-face-reviewer",
+            basis="Residual is bounded, owned and expires.",
+            residuals=[residual],
+        )
+
+        self.assertTrue(product_face_proof.visual_quality_passes(result))
+        self.assertEqual(result["visual_quality_result"]["residuals"], [residual])
+
     def test_reusable_for_product_requires_packet_alignment(self) -> None:
         result = product_face_proof.base_result(
             target_ref="examples/minimal-hermes-project",


### PR DESCRIPTION
## Summary

- hardens Product Face `PASS_WITH_RESIDUALS` so residuals must be structured with id, severity, owner, expiry, accepted scope, proof refs and full-acceptance boundary
- requires `usage_evidence_matrix` warnings in Product Face PASS to bind to an accepted residual id and require `PASS_WITH_RESIDUALS`
- aligns `product_face_proof.py`/CLI and docs with the same bounded residual contract
- adds focused tests for unstructured residuals, stale/blocking residuals, warning/ref mismatch and valid bounded residual acceptance

Closes #266

## Validation

- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest tests.test_product_face_proof -q`
- `python -m py_compile scripts\factoryctl.py scripts\product_face_proof.py`
- `python -m unittest discover -s tests -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `git diff --check`

## Scope Guard

- Does not touch issue #84 or cockpit implementation.
- Does not add historical audit/private evidence artifacts.
- Does not create a new orchestration engine; this is schema/validator/runner hardening.