### PR TITLE
Add customer readiness gate contract

### DIFF
--- a/schemas/customer-readiness-gate.schema.json
+++ b/schemas/customer-readiness-gate.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/customer-readiness-gate.schema.json",
+  "title": "Overkill Factory Customer Readiness Gate",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "decision",
+    "target_user_or_customer",
+    "first_success_path",
+    "onboarding_handoff",
+    "support_path",
+    "terms_compliance_boundary",
+    "data_privacy_boundary",
+    "limits_of_use",
+    "acceptance_owner",
+    "evidence_refs"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/customer-readiness-gate.schema.json"
+    },
+    "record_type": { "const": "customer_readiness_gate" },
+    "decision": { "enum": ["PASS", "WAIVED", "BLOCKED"] },
+    "target_user_or_customer": { "type": "string", "minLength": 3 },
+    "first_success_path": { "type": "string", "minLength": 3 },
+    "onboarding_handoff": { "type": "string", "minLength": 3 },
+    "support_path": { "type": "string", "minLength": 3 },
+    "terms_compliance_boundary": { "type": "string", "minLength": 3 },
+    "data_privacy_boundary": { "type": "string", "minLength": 3 },
+    "limits_of_use": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "acceptance_owner": { "type": "string", "minLength": 3 },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "next_required_action": { "type": "string", "minLength": 3 },
+    "waiver": {
+      "type": "object",
+      "required": [
+        "owner",
+        "reason",
+        "expires_at",
+        "cannot_claim_customer_ready",
+        "next_required_action",
+        "evidence_refs"
+      ],
+      "properties": {
+        "owner": { "type": "string", "minLength": 3 },
+        "reason": { "type": "string", "minLength": 3 },
+        "expires_at": { "type": "string", "minLength": 10 },
+        "cannot_claim_customer_ready": { "const": true },
+        "next_required_action": { "type": "string", "minLength": 3 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "decision": { "const": "WAIVED" } },
+        "required": ["decision"]
+      },
+      "then": { "required": ["waiver"] }
+    },
+    {
+      "if": {
+        "properties": { "decision": { "const": "BLOCKED" } },
+        "required": ["decision"]
+      },
+      "then": { "required": ["next_required_action"] }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -158,6 +158,8 @@
     "product_context_packet_ref": { "type": "string" },
     "product_implementation_readiness": { "type": "object" },
     "product_implementation_readiness_ref": { "type": "string" },
+    "customer_readiness_gate": { "$ref": "customer-readiness-gate.schema.json" },
+    "customer_readiness_gate_ref": { "type": "string" },
     "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
     "autonomy_mode": {
       "enum": [

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -136,6 +136,19 @@
             "object",
             "null"
           ]
+        },
+        "customer_readiness_gate_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "customer_readiness_gate": {
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "additionalProperties": true

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -146,6 +146,7 @@ PRODUCTION_SURFACES = {
     "monitoring",
     "rollback",
 }
+CUSTOMER_READY_SURFACES = {"customers", "customer-ready", "user-facing", "client-facing"}
 COMPLETION_SOT_STATUSES = {"DONE", "BLOCKED", "DEFERRED_WITH_OWNER", "OUT_OF_SCOPE"}
 COMPLETION_METHOD_STATUSES = {"EXECUTED", "WAIVED", "BLOCKED"}
 USER_QUESTION_CLASSES = {"discoverable", "preference", "authority_required", "access_required", "risk_acceptance", "blocked"}
@@ -2151,6 +2152,90 @@ def _production_ladder_required(card: dict[str, Any]) -> bool:
     )
 
 
+def _customer_readiness_gate_required(card: dict[str, Any]) -> bool:
+    if card.get("factory_method_version") != "OVERKILL_VFINAL":
+        return False
+    if not _product_planning_required(card):
+        return False
+    if card.get("complete_product_required") is True or str(card.get("request_type") or "").strip() == "product_new":
+        return True
+    if normalized_surfaces(card) & CUSTOMER_READY_SURFACES:
+        return True
+    plan = card.get("product_creation_plan") if isinstance(card.get("product_creation_plan"), dict) else {}
+    scope_text = json.dumps(plan.get("production_readiness_scope", []), sort_keys=True).lower()
+    return any(token in scope_text for token in ("customer", "client", "real-user", "real user", "support", "onboarding"))
+
+
+def _customer_ready_claimed(card: dict[str, Any]) -> bool:
+    if card.get("customer_ready_claimed") is True:
+        return True
+    lifecycle = card.get("factory_sdlc_lifecycle_state")
+    if not isinstance(lifecycle, dict):
+        return False
+    acceptance = lifecycle.get("lifecycle_acceptance") if isinstance(lifecycle.get("lifecycle_acceptance"), dict) else {}
+    scope_state = str(acceptance.get("scope_completion_state") or "").strip()
+    delivery_state = str(lifecycle.get("delivery_state") or "").strip()
+    return (
+        acceptance.get("customer_ready_claimed") is True
+        or scope_state in {"customer_ready", "released", "operational"}
+        or delivery_state in {"released_to_customers", "customer_ready"}
+    )
+
+
+def validate_customer_readiness_gate(gate: dict[str, Any], *, at: str = "customer_readiness_gate") -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("customer-readiness-gate.schema.json")
+    if not schema:
+        return ["customer_readiness_gate schema is not bundled"]
+    errors.extend(validate_node(schema, gate, at, schemas=schemas, root_schema=schema))
+    _validate_lifecycle_refs(_list_items(gate.get("evidence_refs")), f"{at}.evidence_refs", errors)
+
+    decision = str(gate.get("decision") or "").strip().upper()
+    waiver = gate.get("waiver") if isinstance(gate.get("waiver"), dict) else {}
+    if waiver:
+        _validate_lifecycle_refs(_list_items(waiver.get("evidence_refs")), f"{at}.waiver.evidence_refs", errors)
+        expires_at = str(waiver.get("expires_at") or "").strip()
+        if expires_at:
+            try:
+                parsed = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            except ValueError:
+                errors.append(f"{at}.waiver.expires_at must be ISO-8601")
+            else:
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                if parsed <= datetime.now(timezone.utc):
+                    errors.append(f"{at}.waiver.expires_at must be in the future")
+    if decision == "PASS" and waiver:
+        errors.append(f"{at} PASS must not carry a waiver")
+    return errors
+
+
+def validate_customer_readiness_contract(card: dict[str, Any]) -> list[str]:
+    if not _customer_readiness_gate_required(card):
+        return []
+    errors: list[str] = []
+    has_gate = isinstance(card.get("customer_readiness_gate"), dict)
+    gate_ref = str(card.get("customer_readiness_gate_ref") or "").strip()
+    if not has_gate and not gate_ref:
+        errors.append("customer_readiness_gate or customer_readiness_gate_ref is required for complete product/customer-ready planning")
+        return errors
+    if gate_ref:
+        _validate_public_ref(gate_ref, "customer_readiness_gate_ref", errors)
+
+    gate = card.get("customer_readiness_gate") if has_gate else _load_repo_local_json_ref(gate_ref)
+    if isinstance(gate, dict) and gate:
+        errors.extend(validate_customer_readiness_gate(gate))
+    elif _customer_ready_claimed(card):
+        errors.append("customer_ready claim requires resolvable customer_readiness_gate")
+
+    if _customer_ready_claimed(card):
+        decision = str(gate.get("decision") or "").strip().upper() if isinstance(gate, dict) else ""
+        if decision != "PASS":
+            errors.append("customer_ready claim requires customer_readiness_gate decision PASS")
+    return errors
+
+
 def _research_required(card: dict[str, Any]) -> bool:
     outcome = card.get("outcome_contract") if isinstance(card.get("outcome_contract"), dict) else {}
     if outcome.get("discovery_depth") == "research_required":
@@ -3795,6 +3880,7 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_product_scope_planning_contract(data))
     errors.extend(validate_specialist_research_contract(data))
     errors.extend(validate_product_creation_readiness_contract(data))
+    errors.extend(validate_customer_readiness_contract(data))
     errors.extend(validate_production_promotion_ladder_contract(data))
     errors.extend(validate_user_facing_autonomy_contract(data))
     errors.extend(validate_material_autonomy_routing_contract(data))
@@ -6241,6 +6327,9 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
                 if isinstance(card.get("product_implementation_readiness"), dict)
                 else None
             ),
+            "customer_readiness_gate_ref": card.get("customer_readiness_gate_ref")
+            or ("card.customer_readiness_gate" if isinstance(card.get("customer_readiness_gate"), dict) else None),
+            "customer_readiness_gate": card.get("customer_readiness_gate"),
             "required_structured_proofs": _activated_capability_pack_structured_proof_ids(card),
             "required_completion_proofs": _required_domain_proof_ids(card, "before_completion"),
             "specialist_research_plan_ref": card.get("specialist_research_plan_ref")

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -677,6 +677,15 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                 errors.append(f"{at}: synthetic operational_evidence_bundle requires reusable_for_product=false")
             if not data.get("cannot_satisfy"):
                 errors.append(f"{at}: synthetic operational_evidence_bundle requires cannot_satisfy")
+    if data.get("record_type") == "customer_readiness_gate":
+        add_public_ref_errors(data.get("evidence_refs"), f"{at}.evidence_refs", errors)
+        waiver = data.get("waiver") if isinstance(data.get("waiver"), dict) else {}
+        add_public_ref_errors(waiver.get("evidence_refs"), f"{at}.waiver.evidence_refs", errors)
+        decision = str(data.get("decision") or "").strip().upper()
+        if decision == "WAIVED" and waiver.get("cannot_claim_customer_ready") is not True:
+            errors.append(f"{at}: customer_readiness_gate WAIVED must set cannot_claim_customer_ready=true")
+        if decision == "PASS" and waiver:
+            errors.append(f"{at}: customer_readiness_gate PASS must not carry a waiver")
     if data.get("record_type") == "factory_sdlc_lifecycle_state":
         refs = data.get("evidence_refs") if isinstance(data.get("evidence_refs"), list) else []
         for index, ref in enumerate(refs):

--- a/templates/customer-readiness-gate.json
+++ b/templates/customer-readiness-gate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/customer-readiness-gate.schema.json",
+  "record_type": "customer_readiness_gate",
+  "decision": "WAIVED",
+  "target_user_or_customer": "Primary customer or real target user named by the Product SOT.",
+  "first_success_path": "The first user-visible success path is named, but this template is not customer acceptance proof.",
+  "onboarding_handoff": "Public-safe onboarding handoff path for a real user or customer.",
+  "support_path": "Support owner, channel and response route required before customer-ready claim.",
+  "terms_compliance_boundary": "Terms, compliance and authority boundary for the delivered product.",
+  "data_privacy_boundary": "Data, privacy and retention boundary for the delivered product.",
+  "limits_of_use": [
+    "This template cannot claim customer readiness by itself."
+  ],
+  "acceptance_owner": "customer-readiness-owner",
+  "evidence_refs": [
+    "templates/customer-readiness-gate.json"
+  ],
+  "waiver": {
+    "owner": "customer-readiness-owner",
+    "reason": "Template only; a product-specific real-user acceptance proof has not been recorded.",
+    "expires_at": "2099-01-01T00:00:00+00:00",
+    "cannot_claim_customer_ready": true,
+    "next_required_action": "Replace this template with product-specific customer acceptance evidence before claiming customer readiness.",
+    "evidence_refs": [
+      "templates/customer-readiness-gate.json"
+    ]
+  }
+}

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -16,6 +16,7 @@
   "product_delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
   "product_context_packet_ref": "templates/product-context-packet.json",
   "product_implementation_readiness_ref": "templates/product-implementation-readiness.json",
+  "customer_readiness_gate_ref": "templates/customer-readiness-gate.json",
   "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
   "autonomy_mode": "bounded_execution",
   "agent_readiness_basis": {

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -763,6 +763,17 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(input_contract["agent_readiness_basis"], card["agent_readiness_basis"])
         self.assertEqual(input_contract["model_routing_decision_ref"], card["model_routing_decision_ref"])
 
+    def test_worker_packet_carries_customer_readiness_gate_ref(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+
+        packet = factoryctl.build_worker_packet("implementation-worker", card, card_path)
+
+        self.assertEqual(
+            packet["input_contract"]["customer_readiness_gate_ref"],
+            card["customer_readiness_gate_ref"],
+        )
+
     def test_worker_packet_schema_declares_sdlc_feedback_loop_ref(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
 
@@ -779,6 +790,8 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("agent_readiness_basis", input_properties)
         self.assertIn("model_routing_decision_ref", input_properties)
         self.assertIn("model_routing_decision", input_properties)
+        self.assertIn("customer_readiness_gate_ref", input_properties)
+        self.assertIn("customer_readiness_gate", input_properties)
 
     def test_worker_result_carries_sdlc_feedback_loop_ref(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
@@ -1005,6 +1018,77 @@ class FactoryCtlTest(unittest.TestCase):
         errors = factoryctl.validate_card(card)
 
         self.assertIn("sdlc_feedback_loop_ref required for material vFinal autonomous execution", errors)
+
+    def test_vfinal_complete_product_requires_customer_readiness_gate(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("customer_readiness_gate_ref", None)
+        card.pop("customer_readiness_gate", None)
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn(
+            "customer_readiness_gate or customer_readiness_gate_ref is required for complete product/customer-ready planning",
+            errors,
+        )
+
+    def test_vfinal_customer_readiness_gate_blocks_prose_only_acceptance(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("customer_readiness_gate_ref", None)
+        card["customer_readiness_gate"] = {
+            "$schema": "https://overkill-factory.dev/schemas/customer-readiness-gate.schema.json",
+            "record_type": "customer_readiness_gate",
+            "decision": "PASS",
+            "evidence_refs": ["templates/customer-readiness-gate.json"],
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertTrue(any("target_user_or_customer" in error for error in errors), errors)
+        self.assertTrue(any("first_success_path" in error for error in errors), errors)
+        self.assertTrue(any("support_path" in error for error in errors), errors)
+
+    def test_vfinal_waived_customer_readiness_gate_cannot_claim_customer_ready(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["factory_sdlc_lifecycle_state"] = {
+            "lifecycle_acceptance": {
+                "customer_ready_claimed": True,
+                "scope_completion_state": "customer_ready",
+                "proof_level": "customer_validated",
+            }
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("customer_ready claim requires customer_readiness_gate decision PASS", errors)
+
+    def test_vfinal_pass_customer_readiness_gate_allows_customer_ready_claim(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("customer_readiness_gate_ref", None)
+        card["customer_readiness_gate"] = {
+            "$schema": "https://overkill-factory.dev/schemas/customer-readiness-gate.schema.json",
+            "record_type": "customer_readiness_gate",
+            "decision": "PASS",
+            "target_user_or_customer": "External operator using the product for real work.",
+            "first_success_path": "Operator completes the primary outcome without factory assistance.",
+            "onboarding_handoff": "docs/quickstart.md",
+            "support_path": "public support route with owner and response policy",
+            "terms_compliance_boundary": "public terms and authority boundary reviewed for this product",
+            "data_privacy_boundary": "no private customer data embedded in public evidence",
+            "limits_of_use": ["Customer readiness covers this declared product scope only."],
+            "acceptance_owner": "customer-readiness-owner",
+            "evidence_refs": ["templates/customer-readiness-gate.json"],
+        }
+        card["factory_sdlc_lifecycle_state"] = {
+            "lifecycle_acceptance": {
+                "customer_ready_claimed": True,
+                "scope_completion_state": "customer_ready",
+                "proof_level": "customer_validated",
+            }
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertNotIn("customer_ready claim requires customer_readiness_gate decision PASS", errors)
 
     def test_vfinal_planning_only_does_not_require_sdlc_feedback_loop_ref(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -288,6 +288,23 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
 
         self.assertTrue(any("concern_items" in error for error in errors), errors)
 
+    def test_customer_readiness_gate_schema_and_public_domain_rules(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["customer-readiness-gate.schema.json"]
+        gate = json.loads((ROOT / "templates" / "customer-readiness-gate.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, gate, "$", schemas=schemas, root_schema=schema), [])
+        self.assertEqual(validator.validate_domain_rules(gate, "$"), [])
+
+        unsafe = json.loads(json.dumps(gate))
+        unsafe["evidence_refs"] = ["C:/Users/felip/private/customer-proof.json"]
+        unsafe["waiver"]["cannot_claim_customer_ready"] = False
+        errors = validator.validate_domain_rules(unsafe, "$")
+
+        self.assertTrue(any("$.evidence_refs[0]" in error and "private" in error for error in errors), errors)
+        self.assertTrue(any("cannot_claim_customer_ready=true" in error for error in errors), errors)
+
     def test_professional_design_process_schema_accepts_controlled_blocked_gate(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary

Closes #230.

This adds a first-class Customer Readiness / Real-User Acceptance gate for complete-product and customer-ready vFinal planning. The factory can still carry a bounded waiver during planning, but it can no longer claim customer-ready status unless the gate resolves to `PASS`.

## What changed

- Adds `schemas/customer-readiness-gate.schema.json` and a public-safe template.
- Declares `customer_readiness_gate` / `customer_readiness_gate_ref` on factory cards.
- Validates required customer readiness for complete product planning in `factoryctl.py`.
- Resolves repo-local gate refs and validates them, instead of only checking that a string exists.
- Blocks customer-ready claims when the gate is missing, unresolved, invalid, `WAIVED`, or `BLOCKED`.
- Carries customer readiness gate refs into worker packets so execution sees the acceptance boundary.
- Adds public JSON domain hygiene for gate evidence refs and waiver semantics.

## Validation

- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest tests.test_public_json_artifact_validator -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python -m unittest discover -s tests -q`
- `git diff --check`