### PR TITLE
Add scale SLO readiness gate contract

### DIFF
--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -160,6 +160,8 @@
     "product_implementation_readiness_ref": { "type": "string" },
     "customer_readiness_gate": { "$ref": "customer-readiness-gate.schema.json" },
     "customer_readiness_gate_ref": { "type": "string" },
+    "scale_slo_readiness_gate": { "$ref": "scale-slo-readiness-gate.schema.json" },
+    "scale_slo_readiness_gate_ref": { "type": "string" },
     "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
     "autonomy_mode": {
       "enum": [

--- a/schemas/scale-slo-readiness-gate.schema.json
+++ b/schemas/scale-slo-readiness-gate.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/scale-slo-readiness-gate.schema.json",
+  "title": "Overkill Factory Scale SLO Readiness Gate",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "decision",
+    "proof_result",
+    "target_load",
+    "concurrency_envelope",
+    "latency_slo",
+    "availability_slo",
+    "error_budget",
+    "saturation_behavior",
+    "degradation_policy",
+    "rate_limit_boundary",
+    "cost_capacity_boundary",
+    "monitoring_signals",
+    "acceptance_owner",
+    "evidence_refs"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/scale-slo-readiness-gate.schema.json"
+    },
+    "record_type": { "const": "scale_slo_readiness_gate" },
+    "decision": { "enum": ["PASS", "WAIVED", "BLOCKED"] },
+    "proof_result": { "enum": ["PASS", "FAIL", "DEGRADED", "NOT_RUN"] },
+    "target_load": {
+      "type": "object",
+      "required": ["basis", "steady_state", "peak", "unit"],
+      "properties": {
+        "basis": { "type": "string", "minLength": 3 },
+        "steady_state": { "type": "string", "minLength": 2 },
+        "peak": { "type": "string", "minLength": 2 },
+        "unit": { "type": "string", "minLength": 2 }
+      },
+      "additionalProperties": true
+    },
+    "concurrency_envelope": {
+      "type": "object",
+      "required": ["steady_concurrency", "peak_concurrency", "queue_policy"],
+      "properties": {
+        "steady_concurrency": { "type": "string", "minLength": 1 },
+        "peak_concurrency": { "type": "string", "minLength": 1 },
+        "queue_policy": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": true
+    },
+    "latency_slo": {
+      "type": "object",
+      "required": ["primary_path", "p95", "p99"],
+      "properties": {
+        "primary_path": { "type": "string", "minLength": 3 },
+        "p95": { "type": "string", "minLength": 2 },
+        "p99": { "type": "string", "minLength": 2 }
+      },
+      "additionalProperties": true
+    },
+    "availability_slo": { "type": "string", "minLength": 3 },
+    "error_budget": { "type": "string", "minLength": 3 },
+    "saturation_behavior": { "type": "string", "minLength": 3 },
+    "degradation_policy": { "type": "string", "minLength": 3 },
+    "rate_limit_boundary": { "type": "string", "minLength": 3 },
+    "cost_capacity_boundary": { "type": "string", "minLength": 3 },
+    "monitoring_signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "acceptance_owner": { "type": "string", "minLength": 3 },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "next_required_action": { "type": "string", "minLength": 3 },
+    "waiver": {
+      "type": "object",
+      "required": [
+        "owner",
+        "reason",
+        "expires_at",
+        "cannot_claim_scale_ready",
+        "next_required_action",
+        "evidence_refs"
+      ],
+      "properties": {
+        "owner": { "type": "string", "minLength": 3 },
+        "reason": { "type": "string", "minLength": 3 },
+        "expires_at": { "type": "string", "minLength": 10 },
+        "cannot_claim_scale_ready": { "const": true },
+        "next_required_action": { "type": "string", "minLength": 3 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "decision": { "const": "WAIVED" } },
+        "required": ["decision"]
+      },
+      "then": { "required": ["waiver"] }
+    },
+    {
+      "if": {
+        "properties": { "decision": { "const": "BLOCKED" } },
+        "required": ["decision"]
+      },
+      "then": { "required": ["next_required_action"] }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -149,6 +149,19 @@
             "object",
             "null"
           ]
+        },
+        "scale_slo_readiness_gate_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "scale_slo_readiness_gate": {
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "additionalProperties": true

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2236,6 +2236,95 @@ def validate_customer_readiness_contract(card: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _scale_slo_gate_required(card: dict[str, Any]) -> bool:
+    if card.get("factory_method_version") != "OVERKILL_VFINAL":
+        return False
+    return _customer_readiness_gate_required(card) or _production_ladder_required(card)
+
+
+def _scale_slo_ready_claimed(card: dict[str, Any]) -> bool:
+    if card.get("scale_slo_ready_claimed") is True:
+        return True
+    if card.get("production_ready_claimed") is True:
+        return True
+    if _customer_ready_claimed(card):
+        return True
+    lifecycle = card.get("factory_sdlc_lifecycle_state")
+    if not isinstance(lifecycle, dict):
+        return False
+    acceptance = lifecycle.get("lifecycle_acceptance") if isinstance(lifecycle.get("lifecycle_acceptance"), dict) else {}
+    scope_state = str(acceptance.get("scope_completion_state") or "").strip()
+    delivery_state = str(lifecycle.get("delivery_state") or "").strip()
+    return (
+        acceptance.get("production_ready_claimed") is True
+        or acceptance.get("scale_slo_ready_claimed") is True
+        or scope_state in {"production_complete", "released", "operational"}
+        or delivery_state in {"release_candidate", "deployed", "operational"}
+    )
+
+
+def validate_scale_slo_readiness_gate(gate: dict[str, Any], *, at: str = "scale_slo_readiness_gate") -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("scale-slo-readiness-gate.schema.json")
+    if not schema:
+        return ["scale_slo_readiness_gate schema is not bundled"]
+    errors.extend(validate_node(schema, gate, at, schemas=schemas, root_schema=schema))
+    _validate_lifecycle_refs(_list_items(gate.get("evidence_refs")), f"{at}.evidence_refs", errors)
+
+    decision = str(gate.get("decision") or "").strip().upper()
+    proof_result = str(gate.get("proof_result") or "").strip().upper()
+    waiver = gate.get("waiver") if isinstance(gate.get("waiver"), dict) else {}
+    if waiver:
+        _validate_lifecycle_refs(_list_items(waiver.get("evidence_refs")), f"{at}.waiver.evidence_refs", errors)
+        expires_at = str(waiver.get("expires_at") or "").strip()
+        if expires_at:
+            try:
+                parsed = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            except ValueError:
+                errors.append(f"{at}.waiver.expires_at must be ISO-8601")
+            else:
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                if parsed <= datetime.now(timezone.utc):
+                    errors.append(f"{at}.waiver.expires_at must be in the future")
+    if decision == "PASS" and waiver:
+        errors.append(f"{at} PASS must not carry a waiver")
+    if decision == "PASS" and proof_result != "PASS":
+        errors.append(f"{at} PASS requires proof_result PASS")
+    if proof_result in {"FAIL", "DEGRADED"} and decision == "PASS":
+        errors.append(f"{at} degraded or failed proof cannot pass scale/SLO readiness")
+    return errors
+
+
+def validate_scale_slo_readiness_contract(card: dict[str, Any]) -> list[str]:
+    if not _scale_slo_gate_required(card):
+        return []
+    errors: list[str] = []
+    has_gate = isinstance(card.get("scale_slo_readiness_gate"), dict)
+    gate_ref = str(card.get("scale_slo_readiness_gate_ref") or "").strip()
+    if not has_gate and not gate_ref:
+        errors.append("scale_slo_readiness_gate or scale_slo_readiness_gate_ref is required for customer-ready or production-scale products")
+        return errors
+    if gate_ref:
+        _validate_public_ref(gate_ref, "scale_slo_readiness_gate_ref", errors)
+
+    gate = card.get("scale_slo_readiness_gate") if has_gate else _load_repo_local_json_ref(gate_ref)
+    if isinstance(gate, dict) and gate:
+        errors.extend(validate_scale_slo_readiness_gate(gate))
+    elif _scale_slo_ready_claimed(card):
+        errors.append("scale/SLO ready claim requires resolvable scale_slo_readiness_gate")
+
+    if _scale_slo_ready_claimed(card):
+        decision = str(gate.get("decision") or "").strip().upper() if isinstance(gate, dict) else ""
+        proof_result = str(gate.get("proof_result") or "").strip().upper() if isinstance(gate, dict) else ""
+        if decision != "PASS":
+            errors.append("scale/SLO ready claim requires scale_slo_readiness_gate decision PASS")
+        if proof_result != "PASS":
+            errors.append("scale/SLO ready claim requires scale_slo_readiness_gate proof_result PASS")
+    return errors
+
+
 def _research_required(card: dict[str, Any]) -> bool:
     outcome = card.get("outcome_contract") if isinstance(card.get("outcome_contract"), dict) else {}
     if outcome.get("discovery_depth") == "research_required":
@@ -3881,6 +3970,7 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_specialist_research_contract(data))
     errors.extend(validate_product_creation_readiness_contract(data))
     errors.extend(validate_customer_readiness_contract(data))
+    errors.extend(validate_scale_slo_readiness_contract(data))
     errors.extend(validate_production_promotion_ladder_contract(data))
     errors.extend(validate_user_facing_autonomy_contract(data))
     errors.extend(validate_material_autonomy_routing_contract(data))
@@ -6330,6 +6420,9 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "customer_readiness_gate_ref": card.get("customer_readiness_gate_ref")
             or ("card.customer_readiness_gate" if isinstance(card.get("customer_readiness_gate"), dict) else None),
             "customer_readiness_gate": card.get("customer_readiness_gate"),
+            "scale_slo_readiness_gate_ref": card.get("scale_slo_readiness_gate_ref")
+            or ("card.scale_slo_readiness_gate" if isinstance(card.get("scale_slo_readiness_gate"), dict) else None),
+            "scale_slo_readiness_gate": card.get("scale_slo_readiness_gate"),
             "required_structured_proofs": _activated_capability_pack_structured_proof_ids(card),
             "required_completion_proofs": _required_domain_proof_ids(card, "before_completion"),
             "specialist_research_plan_ref": card.get("specialist_research_plan_ref")

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -686,6 +686,18 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: customer_readiness_gate WAIVED must set cannot_claim_customer_ready=true")
         if decision == "PASS" and waiver:
             errors.append(f"{at}: customer_readiness_gate PASS must not carry a waiver")
+    if data.get("record_type") == "scale_slo_readiness_gate":
+        add_public_ref_errors(data.get("evidence_refs"), f"{at}.evidence_refs", errors)
+        waiver = data.get("waiver") if isinstance(data.get("waiver"), dict) else {}
+        add_public_ref_errors(waiver.get("evidence_refs"), f"{at}.waiver.evidence_refs", errors)
+        decision = str(data.get("decision") or "").strip().upper()
+        proof_result = str(data.get("proof_result") or "").strip().upper()
+        if decision == "WAIVED" and waiver.get("cannot_claim_scale_ready") is not True:
+            errors.append(f"{at}: scale_slo_readiness_gate WAIVED must set cannot_claim_scale_ready=true")
+        if decision == "PASS" and waiver:
+            errors.append(f"{at}: scale_slo_readiness_gate PASS must not carry a waiver")
+        if decision == "PASS" and proof_result != "PASS":
+            errors.append(f"{at}: scale_slo_readiness_gate PASS requires proof_result PASS")
     if data.get("record_type") == "factory_sdlc_lifecycle_state":
         refs = data.get("evidence_refs") if isinstance(data.get("evidence_refs"), list) else []
         for index, ref in enumerate(refs):

--- a/templates/scale-slo-readiness-gate.json
+++ b/templates/scale-slo-readiness-gate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/scale-slo-readiness-gate.schema.json",
+  "record_type": "scale_slo_readiness_gate",
+  "decision": "WAIVED",
+  "proof_result": "NOT_RUN",
+  "target_load": {
+    "basis": "Template only; product-specific customer load has not been proven.",
+    "steady_state": "product-specific steady load required",
+    "peak": "product-specific peak load required",
+    "unit": "requests, jobs, users or transactions per declared time window"
+  },
+  "concurrency_envelope": {
+    "steady_concurrency": "product-specific steady concurrency required",
+    "peak_concurrency": "product-specific peak concurrency required",
+    "queue_policy": "Queueing, backpressure or rejection policy required before scale-ready claim."
+  },
+  "latency_slo": {
+    "primary_path": "primary customer-visible path",
+    "p95": "product-specific p95 required",
+    "p99": "product-specific p99 required"
+  },
+  "availability_slo": "Product-specific availability SLO required before scale-ready claim.",
+  "error_budget": "Product-specific error budget required before scale-ready claim.",
+  "saturation_behavior": "Saturation behavior must be known before scale-ready claim.",
+  "degradation_policy": "Graceful degradation or fail-closed policy required before scale-ready claim.",
+  "rate_limit_boundary": "Rate limit and quota boundaries required before scale-ready claim.",
+  "cost_capacity_boundary": "Cost and capacity budget required before scale-ready claim.",
+  "monitoring_signals": [
+    "latency",
+    "error_rate",
+    "saturation",
+    "cost_or_quota"
+  ],
+  "acceptance_owner": "scale-slo-readiness-owner",
+  "evidence_refs": [
+    "templates/scale-slo-readiness-gate.json"
+  ],
+  "waiver": {
+    "owner": "scale-slo-readiness-owner",
+    "reason": "Template only; product-specific scale/SLO proof has not been recorded.",
+    "expires_at": "2099-01-01T00:00:00+00:00",
+    "cannot_claim_scale_ready": true,
+    "next_required_action": "Replace this template with product-specific scale, capacity and SLO evidence before claiming customer-scale readiness.",
+    "evidence_refs": [
+      "templates/scale-slo-readiness-gate.json"
+    ]
+  }
+}

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -17,6 +17,7 @@
   "product_context_packet_ref": "templates/product-context-packet.json",
   "product_implementation_readiness_ref": "templates/product-implementation-readiness.json",
   "customer_readiness_gate_ref": "templates/customer-readiness-gate.json",
+  "scale_slo_readiness_gate_ref": "templates/scale-slo-readiness-gate.json",
   "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
   "autonomy_mode": "bounded_execution",
   "agent_readiness_basis": {

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -213,6 +213,57 @@ def human_gate_record(source_card: dict | None = None) -> dict:
     }
 
 
+def valid_customer_readiness_gate_fixture() -> dict:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/customer-readiness-gate.schema.json",
+        "record_type": "customer_readiness_gate",
+        "decision": "PASS",
+        "target_user_or_customer": "External operator using the product for real work.",
+        "first_success_path": "Operator completes the primary outcome without factory assistance.",
+        "onboarding_handoff": "docs/quickstart.md",
+        "support_path": "public support route with owner and response policy",
+        "terms_compliance_boundary": "public terms and authority boundary reviewed for this product",
+        "data_privacy_boundary": "no private customer data embedded in public evidence",
+        "limits_of_use": ["Customer readiness covers this declared product scope only."],
+        "acceptance_owner": "customer-readiness-owner",
+        "evidence_refs": ["templates/customer-readiness-gate.json"],
+    }
+
+
+def valid_scale_slo_gate_fixture(proof_result: str = "PASS") -> dict:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/scale-slo-readiness-gate.schema.json",
+        "record_type": "scale_slo_readiness_gate",
+        "decision": "PASS",
+        "proof_result": proof_result,
+        "target_load": {
+            "basis": "Product SOT expected customer load.",
+            "steady_state": "100 requests per minute",
+            "peak": "500 requests per minute",
+            "unit": "requests per minute",
+        },
+        "concurrency_envelope": {
+            "steady_concurrency": "25 concurrent users",
+            "peak_concurrency": "100 concurrent users",
+            "queue_policy": "Backpressure returns bounded retry guidance before saturation.",
+        },
+        "latency_slo": {
+            "primary_path": "primary customer success path",
+            "p95": "500ms",
+            "p99": "1200ms",
+        },
+        "availability_slo": "99.5 percent for the declared operating window.",
+        "error_budget": "0.5 percent failed primary-path requests per operating window.",
+        "saturation_behavior": "Reject excess work with bounded retry guidance before shared resources saturate.",
+        "degradation_policy": "Disable non-critical enrichment before the primary path fails.",
+        "rate_limit_boundary": "Public API and worker queues enforce declared per-tenant quotas.",
+        "cost_capacity_boundary": "Projected peak stays inside the product-specific cost budget.",
+        "monitoring_signals": ["latency", "error_rate", "saturation", "cost_or_quota"],
+        "acceptance_owner": "scale-slo-readiness-owner",
+        "evidence_refs": ["templates/scale-slo-readiness-gate.json"],
+    }
+
+
 def reference_quality_comparison_fixture() -> dict:
     compared_source_ids = [
         "21st-dev-components",
@@ -774,6 +825,17 @@ class FactoryCtlTest(unittest.TestCase):
             card["customer_readiness_gate_ref"],
         )
 
+    def test_worker_packet_carries_scale_slo_readiness_gate_ref(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+
+        packet = factoryctl.build_worker_packet("implementation-worker", card, card_path)
+
+        self.assertEqual(
+            packet["input_contract"]["scale_slo_readiness_gate_ref"],
+            card["scale_slo_readiness_gate_ref"],
+        )
+
     def test_worker_packet_schema_declares_sdlc_feedback_loop_ref(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-packet.schema.json").read_text(encoding="utf-8"))
 
@@ -792,6 +854,8 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("model_routing_decision", input_properties)
         self.assertIn("customer_readiness_gate_ref", input_properties)
         self.assertIn("customer_readiness_gate", input_properties)
+        self.assertIn("scale_slo_readiness_gate_ref", input_properties)
+        self.assertIn("scale_slo_readiness_gate", input_properties)
 
     def test_worker_result_carries_sdlc_feedback_loop_ref(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
@@ -1030,6 +1094,72 @@ class FactoryCtlTest(unittest.TestCase):
             "customer_readiness_gate or customer_readiness_gate_ref is required for complete product/customer-ready planning",
             errors,
         )
+
+    def test_vfinal_complete_product_requires_scale_slo_readiness_gate(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("scale_slo_readiness_gate_ref", None)
+        card.pop("scale_slo_readiness_gate", None)
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn(
+            "scale_slo_readiness_gate or scale_slo_readiness_gate_ref is required for customer-ready or production-scale products",
+            errors,
+        )
+
+    def test_vfinal_scale_slo_gate_blocks_prose_only_capacity(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("scale_slo_readiness_gate_ref", None)
+        card["scale_slo_readiness_gate"] = {
+            "$schema": "https://overkill-factory.dev/schemas/scale-slo-readiness-gate.schema.json",
+            "record_type": "scale_slo_readiness_gate",
+            "decision": "PASS",
+            "proof_result": "PASS",
+            "evidence_refs": ["templates/scale-slo-readiness-gate.json"],
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertTrue(any("target_load" in error for error in errors), errors)
+        self.assertTrue(any("concurrency_envelope" in error for error in errors), errors)
+        self.assertTrue(any("latency_slo" in error for error in errors), errors)
+
+    def test_vfinal_degraded_scale_slo_proof_cannot_claim_customer_ready(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("scale_slo_readiness_gate_ref", None)
+        card["scale_slo_readiness_gate"] = valid_scale_slo_gate_fixture(proof_result="DEGRADED")
+        card["factory_sdlc_lifecycle_state"] = {
+            "lifecycle_acceptance": {
+                "customer_ready_claimed": True,
+                "scope_completion_state": "customer_ready",
+                "proof_level": "customer_validated",
+            }
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("scale_slo_readiness_gate PASS requires proof_result PASS", errors)
+        self.assertIn("scale_slo_readiness_gate degraded or failed proof cannot pass scale/SLO readiness", errors)
+        self.assertIn("scale/SLO ready claim requires scale_slo_readiness_gate proof_result PASS", errors)
+
+    def test_vfinal_pass_scale_slo_gate_allows_customer_ready_claim(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("customer_readiness_gate_ref", None)
+        card.pop("scale_slo_readiness_gate_ref", None)
+        card["customer_readiness_gate"] = valid_customer_readiness_gate_fixture()
+        card["scale_slo_readiness_gate"] = valid_scale_slo_gate_fixture()
+        card["factory_sdlc_lifecycle_state"] = {
+            "lifecycle_acceptance": {
+                "customer_ready_claimed": True,
+                "scope_completion_state": "customer_ready",
+                "proof_level": "customer_validated",
+            }
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertNotIn("scale/SLO ready claim requires scale_slo_readiness_gate decision PASS", errors)
+        self.assertNotIn("scale/SLO ready claim requires scale_slo_readiness_gate proof_result PASS", errors)
 
     def test_vfinal_customer_readiness_gate_blocks_prose_only_acceptance(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -305,6 +305,31 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
         self.assertTrue(any("$.evidence_refs[0]" in error and "private" in error for error in errors), errors)
         self.assertTrue(any("cannot_claim_customer_ready=true" in error for error in errors), errors)
 
+    def test_scale_slo_readiness_gate_schema_and_public_domain_rules(self) -> None:
+        validator = load_validator()
+        schemas = validator.load_schemas()
+        schema = schemas["scale-slo-readiness-gate.schema.json"]
+        gate = json.loads((ROOT / "templates" / "scale-slo-readiness-gate.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(validator.validate_node(schema, gate, "$", schemas=schemas, root_schema=schema), [])
+        self.assertEqual(validator.validate_domain_rules(gate, "$"), [])
+
+        unsafe = json.loads(json.dumps(gate))
+        unsafe["evidence_refs"] = ["C:/Users/felip/private/scale-proof.json"]
+        unsafe["waiver"]["cannot_claim_scale_ready"] = False
+        errors = validator.validate_domain_rules(unsafe, "$")
+
+        self.assertTrue(any("$.evidence_refs[0]" in error and "private" in error for error in errors), errors)
+        self.assertTrue(any("cannot_claim_scale_ready=true" in error for error in errors), errors)
+
+        incoherent = json.loads(json.dumps(gate))
+        incoherent["decision"] = "PASS"
+        incoherent["proof_result"] = "DEGRADED"
+        incoherent.pop("waiver", None)
+        errors = validator.validate_domain_rules(incoherent, "$")
+
+        self.assertTrue(any("PASS requires proof_result PASS" in error for error in errors), errors)
+
     def test_professional_design_process_schema_accepts_controlled_blocked_gate(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary

Closes #231.

This adds a first-class Scale / Capacity / SLO readiness gate for customer-ready or production-scale vFinal products. A product may carry a bounded template waiver during planning, but it can no longer claim customer-ready or production-scale status unless the scale/SLO gate resolves to `PASS` with `proof_result=PASS`.

## What changed

- Adds `schemas/scale-slo-readiness-gate.schema.json` and a public-safe template.
- Declares `scale_slo_readiness_gate` / `scale_slo_readiness_gate_ref` on factory cards.
- Requires the scale/SLO gate for complete-product, customer-ready, or production-scale vFinal cards.
- Resolves repo-local gate refs and validates the referenced JSON, not just the presence of a string.
- Blocks customer/production-scale claims when the gate is missing, unresolved, invalid, waived, blocked, failed, degraded, or not run.
- Carries scale/SLO gate refs into worker packets so implementation workers see load, concurrency, SLO, error budget, degradation, rate-limit, cost and monitoring boundaries.
- Adds public JSON domain rules for proof refs, waiver semantics and incoherent PASS/degraded combinations.

## Validation

- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest tests.test_public_json_artifact_validator -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python -m unittest discover -s tests -q`
- `git diff --check`