### PR TITLE
Separate completion accounting from production acceptance

### DIFF
--- a/schemas/completion-audit.schema.json
+++ b/schemas/completion-audit.schema.json
@@ -10,6 +10,7 @@
     "reviewed",
     "residual_risk",
     "decision",
+    "acceptance_decision",
     "sot_claim_results",
     "method_execution_results"
   ],
@@ -20,6 +21,29 @@
     "reviewed": { "type": "array", "items": { "type": "string" } },
     "residual_risk": { "type": "array", "items": { "type": "string" } },
     "decision": { "enum": ["done", "block", "done_with_owner"] },
+    "acceptance_decision": {
+      "enum": ["scope_accounted", "done_with_owner", "production_complete", "customer_ready"]
+    },
+    "scope_rebaseline": {
+      "type": "object",
+      "required": ["required", "human_gate_ref", "rebaselined_scope_refs", "evidence_refs"],
+      "properties": {
+        "required": { "const": true },
+        "human_gate_ref": { "type": "string", "minLength": 3 },
+        "rationale": { "type": "string" },
+        "rebaselined_scope_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": true
+    },
     "sot_claim_results": {
       "type": "array",
       "items": {

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -149,6 +149,8 @@ PRODUCTION_SURFACES = {
 CUSTOMER_READY_SURFACES = {"customers", "customer-ready", "user-facing", "client-facing"}
 COMPLETION_SOT_STATUSES = {"DONE", "BLOCKED", "DEFERRED_WITH_OWNER", "OUT_OF_SCOPE"}
 COMPLETION_METHOD_STATUSES = {"EXECUTED", "WAIVED", "BLOCKED"}
+COMPLETION_ACCEPTANCE_DECISIONS = {"scope_accounted", "done_with_owner", "production_complete", "customer_ready"}
+PRODUCTION_ACCEPTANCE_DECISIONS = {"production_complete", "customer_ready"}
 USER_QUESTION_CLASSES = {"discoverable", "preference", "authority_required", "access_required", "risk_acceptance", "blocked"}
 ALLOWED_USER_QUESTION_CLASSES = USER_QUESTION_CLASSES - {"discoverable"}
 INTERNAL_COORDINATION_TERMS = {
@@ -5926,11 +5928,39 @@ def validate_receipt(data: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _completion_scope_rebaseline_errors(audit: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    rebaseline = audit.get("scope_rebaseline")
+    if not isinstance(rebaseline, dict):
+        return ["completion_audit.scope_rebaseline is required for production/customer acceptance with deferred or out-of-scope SOT claims"]
+    if rebaseline.get("required") is not True:
+        errors.append("completion_audit.scope_rebaseline.required must be true")
+    human_gate_ref = str(rebaseline.get("human_gate_ref") or "").strip()
+    if not human_gate_ref:
+        errors.append("completion_audit.scope_rebaseline.human_gate_ref is required")
+    else:
+        _validate_public_ref(human_gate_ref, "completion_audit.scope_rebaseline.human_gate_ref", errors)
+    scope_refs = rebaseline.get("rebaselined_scope_refs")
+    if not _non_empty_string_list(scope_refs):
+        errors.append("completion_audit.scope_rebaseline.rebaselined_scope_refs is required")
+    evidence_refs = _list_items(rebaseline.get("evidence_refs"))
+    if not evidence_refs:
+        errors.append("completion_audit.scope_rebaseline.evidence_refs is required")
+    else:
+        _validate_lifecycle_refs(evidence_refs, "completion_audit.scope_rebaseline.evidence_refs", errors)
+    return errors
+
+
 def validate_completion_audit_contract(card: dict[str, Any], audit: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     decision = str(audit.get("decision") or "").strip().lower()
     if decision not in {"done", "block", "done_with_owner"}:
         errors.append("completion_audit.decision must be done, block or done_with_owner")
+    acceptance_decision = str(audit.get("acceptance_decision") or "").strip().lower()
+    if acceptance_decision not in COMPLETION_ACCEPTANCE_DECISIONS:
+        errors.append(
+            "completion_audit.acceptance_decision must be scope_accounted, done_with_owner, production_complete or customer_ready"
+        )
     claim_results = audit.get("sot_claim_results")
     sot_statuses: list[str] = []
     if not isinstance(claim_results, list) or not claim_results:
@@ -5948,12 +5978,36 @@ def validate_completion_audit_contract(card: dict[str, Any], audit: dict[str, An
                 )
             if status in {"BLOCKED", "DEFERRED_WITH_OWNER", "OUT_OF_SCOPE"} and not _non_empty_text(item.get("owner")):
                 errors.append(f"completion_audit.sot_claim_results[{index}].owner is required for non-DONE status")
+        production_acceptance = acceptance_decision in PRODUCTION_ACCEPTANCE_DECISIONS
+        needs_rebaseline = production_acceptance and any(
+            status in {"DEFERRED_WITH_OWNER", "OUT_OF_SCOPE"} for status in sot_statuses
+        )
+        rebaseline_errors = _completion_scope_rebaseline_errors(audit) if needs_rebaseline else []
+        rebaseline_valid = needs_rebaseline and not rebaseline_errors
+        errors.extend(rebaseline_errors)
+        if acceptance_decision == "scope_accounted":
+            if audit.get("production_ready_claimed") is True:
+                errors.append("completion_audit scope_accounted cannot claim production_ready")
+            if audit.get("customer_ready_claimed") is True:
+                errors.append("completion_audit scope_accounted cannot claim customer_ready")
+        if production_acceptance:
+            if "OUT_OF_SCOPE" in sot_statuses and not rebaseline_valid:
+                errors.append("completion_audit production/customer acceptance cannot include OUT_OF_SCOPE without scope_rebaseline")
+            if "DEFERRED_WITH_OWNER" in sot_statuses and not rebaseline_valid:
+                errors.append("completion_audit production/customer acceptance cannot include DEFERRED_WITH_OWNER without scope_rebaseline")
+            if decision == "done_with_owner" and not rebaseline_valid:
+                errors.append("completion_audit production/customer acceptance cannot use done_with_owner without scope_rebaseline")
+        if acceptance_decision == "done_with_owner" and decision != "done_with_owner":
+            errors.append("completion_audit.acceptance_decision=done_with_owner requires decision=done_with_owner")
         if "BLOCKED" in sot_statuses and decision != "block":
             errors.append("completion_audit.decision must be block when any SOT claim is BLOCKED")
-        elif "DEFERRED_WITH_OWNER" in sot_statuses and decision != "done_with_owner":
+        elif "DEFERRED_WITH_OWNER" in sot_statuses and decision != "done_with_owner" and not rebaseline_valid:
             errors.append("completion_audit.decision must be done_with_owner when any SOT claim is DEFERRED_WITH_OWNER")
         elif decision == "done":
-            incomplete = sorted(set(sot_statuses) - {"DONE", "OUT_OF_SCOPE"})
+            allowed_done_statuses = {"DONE", "OUT_OF_SCOPE"}
+            if rebaseline_valid:
+                allowed_done_statuses.add("DEFERRED_WITH_OWNER")
+            incomplete = sorted(set(sot_statuses) - allowed_done_statuses)
             if incomplete:
                 errors.append("completion_audit.decision=done requires SOT claims to be DONE or OUT_OF_SCOPE, found " + ", ".join(incomplete))
 

--- a/templates/completion-audit.json
+++ b/templates/completion-audit.json
@@ -6,6 +6,7 @@
   "reviewed": ["review evidence"],
   "residual_risk": ["known remaining risk with owner"],
   "decision": "done_with_owner",
+  "acceptance_decision": "done_with_owner",
   "sot_claim_results": [
     {
       "claim_ref": "product-sot#scope-in-001",

--- a/templates/full-product-sot-scope-coverage.json
+++ b/templates/full-product-sot-scope-coverage.json
@@ -25,6 +25,6 @@
     "slices_are_order_only": true,
     "waiver_required_for_defer": true
   },
-  "completion_rule": "The Product SOT cannot be claimed complete until every meaningful SOT requirement is done, blocked, deferred with owner, or explicitly out of scope.",
+  "completion_rule": "Scope-accounted completion may track done, blocked, deferred-with-owner and out-of-scope requirements, but production-complete or customer-ready acceptance requires every active Product SOT requirement to be DONE unless a human-gated SOT rebaseline explicitly supersedes that scope.",
   "evidence_refs": ["source-ledger.md"]
 }

--- a/templates/product-creation-plan.json
+++ b/templates/product-creation-plan.json
@@ -44,7 +44,10 @@
   "risk_map": ["scope shrinkage is blocked by the full Product SOT coverage map"],
   "access_and_secret_requirements": ["no secrets required by default"],
   "release_promotion_ladder_refs": ["templates/production-promotion-ladder.json"],
-  "complete_product_done_criteria": ["all SOT requirements are done, blocked, deferred with owner, or out of scope"],
+  "complete_product_done_criteria": [
+    "scope-accounted completion may record done, blocked, deferred-with-owner or out-of-scope requirements for traceability",
+    "production-complete or customer-ready acceptance requires every active SOT requirement to be DONE unless a human-gated SOT rebaseline explicitly supersedes that scope"
+  ],
   "slice_done_criteria": ["slice verification passes and evidence refs are attached"],
   "drift_check": "Refresh this plan when Product SOT, method, architecture, capability packs or landed slices change.",
   "stop_conditions": ["missing Product SOT coverage", "missing promotion ladder for production intent", "stale product context"],

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -1138,6 +1138,7 @@
     "reviewed": ["independent review required before done"],
     "residual_risk": ["worker execution still required"],
     "decision": "block",
+    "acceptance_decision": "scope_accounted",
     "sot_claim_results": [
       {
         "claim_ref": "product-sot#scope-in-001",

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -2355,6 +2355,7 @@ class FactoryCtlTest(unittest.TestCase):
         card = load_card("v35_valid_onchain_auditor_scan.md")
         audit = {
             "decision": "done",
+            "acceptance_decision": "scope_accounted",
             "sot_claim_results": [
                 {"claim_ref": "product-sot#scope", "status": "BLOCKED", "owner": "product-owner"}
             ],
@@ -2371,6 +2372,7 @@ class FactoryCtlTest(unittest.TestCase):
         card = load_card("v35_valid_onchain_auditor_scan.md")
         audit = {
             "decision": "done",
+            "acceptance_decision": "scope_accounted",
             "sot_claim_results": [
                 {"claim_ref": "product-sot#scope", "status": "DEFERRED_WITH_OWNER", "owner": "product-owner"}
             ],
@@ -2385,6 +2387,79 @@ class FactoryCtlTest(unittest.TestCase):
             "completion_audit.decision must be done_with_owner when any SOT claim is DEFERRED_WITH_OWNER",
             errors,
         )
+
+    def test_completion_audit_scope_accounted_allows_out_of_scope_without_production_acceptance(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        audit = {
+            "decision": "done",
+            "acceptance_decision": "scope_accounted",
+            "sot_claim_results": [
+                {"claim_ref": "product-sot#core", "status": "DONE", "owner": "product-owner"},
+                {"claim_ref": "product-sot#later", "status": "OUT_OF_SCOPE", "owner": "product-owner"},
+            ],
+            "method_execution_results": [
+                {"method": "security-review", "status": "EXECUTED", "evidence_refs": ["README.md"]}
+            ],
+        }
+
+        self.assertEqual(factoryctl.validate_completion_audit_contract(card, audit), [])
+
+    def test_completion_audit_production_complete_rejects_out_of_scope_without_rebaseline(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        audit = {
+            "decision": "done",
+            "acceptance_decision": "production_complete",
+            "sot_claim_results": [
+                {"claim_ref": "product-sot#later", "status": "OUT_OF_SCOPE", "owner": "product-owner"}
+            ],
+            "method_execution_results": [
+                {"method": "security-review", "status": "EXECUTED", "evidence_refs": ["README.md"]}
+            ],
+        }
+
+        errors = factoryctl.validate_completion_audit_contract(card, audit)
+
+        self.assertIn(
+            "completion_audit production/customer acceptance cannot include OUT_OF_SCOPE without scope_rebaseline",
+            errors,
+        )
+
+    def test_completion_audit_done_with_owner_keeps_deferred_out_of_production_acceptance(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        audit = {
+            "decision": "done_with_owner",
+            "acceptance_decision": "done_with_owner",
+            "sot_claim_results": [
+                {"claim_ref": "product-sot#later", "status": "DEFERRED_WITH_OWNER", "owner": "product-owner"}
+            ],
+            "method_execution_results": [
+                {"method": "security-review", "status": "EXECUTED", "evidence_refs": ["README.md"]}
+            ],
+        }
+
+        self.assertEqual(factoryctl.validate_completion_audit_contract(card, audit), [])
+
+    def test_completion_audit_production_complete_accepts_human_rebaselined_scope(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        audit = {
+            "decision": "done",
+            "acceptance_decision": "production_complete",
+            "scope_rebaseline": {
+                "required": True,
+                "human_gate_ref": "templates/human-gate-record.json",
+                "rebaselined_scope_refs": ["product-sot#later"],
+                "evidence_refs": ["templates/full-product-sot-scope-coverage.json"],
+            },
+            "sot_claim_results": [
+                {"claim_ref": "product-sot#core", "status": "DONE", "owner": "product-owner"},
+                {"claim_ref": "product-sot#later", "status": "OUT_OF_SCOPE", "owner": "product-owner"},
+            ],
+            "method_execution_results": [
+                {"method": "security-review", "status": "EXECUTED", "evidence_refs": ["README.md"]}
+            ],
+        }
+
+        self.assertEqual(factoryctl.validate_completion_audit_contract(card, audit), [])
 
     def test_product_face_completion_rejects_screenshot_without_plan_alignment(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -409,6 +409,8 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
         )
 
         metadata["completion_audit"] = {
+            "decision": "done",
+            "acceptance_decision": "production_complete",
             "sot_claim_results": [
                 {"claim_ref": "product-sot#scope-in-001", "status": "DONE", "owner": "product-owner"}
             ],


### PR DESCRIPTION
## Summary
- adds explicit `acceptance_decision` semantics to completion audits: `scope_accounted`, `done_with_owner`, `production_complete`, `customer_ready`
- blocks production/customer acceptance when SOT claims are deferred or out-of-scope unless a public-safe human-gated `scope_rebaseline` is present
- updates public templates so scope accounting is not described as full product completion
- adds regression coverage for scope-accounted OUT_OF_SCOPE, production-complete rejection, done-with-owner deferred scope, and valid rebaseline flow

## Why
Issue #232 identified a dangerous ambiguity: accounting for scope is useful for traceability, but it must not look like production-complete acceptance. This keeps the factory gear-like: each completion claim has a precise operational meaning and cannot silently skip unresolved Product SOT scope.

The Factory 2.0 material also reinforces this direction: a software factory needs an instrumented end-to-end loop, not isolated coding acceleration. That only works if the loop distinguishes traceability, blocked/deferred ownership, production acceptance, and customer readiness.

## Validation
- `python -m unittest tests.test_factoryctl tests.test_product_method_sot_planning -q`
- `python -m unittest discover -s tests -q`
- `python -m py_compile scripts/factoryctl.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/public_safety_scan.py`
- `python scripts/public_safety_scan.py --git-ref HEAD`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/supply_chain_proof.py`

## Notes
- `python scripts/release_integration_preflight.py` is still `BLOCKED` while this branch is not integrated into the release ref; its blocking item is `release_ref_has_no_unintegrated_worktree_entries`, not a new contract failure.

Closes #232