### PR TITLE
Resolve model routing decision refs

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2120,6 +2120,16 @@ def _load_repo_local_json_ref(ref: Any) -> dict[str, Any]:
         return {}
 
 
+def _load_repo_local_json_ref_node(ref: Any) -> Any:
+    data = _load_repo_local_json_ref(ref)
+    if not data:
+        return None
+    fragment = str(ref).split("#", 1)[1] if "#" in str(ref) else ""
+    if not fragment:
+        return data
+    return _fragment_node(data, fragment)
+
+
 def _product_planning_required(card: dict[str, Any]) -> bool:
     request_type = str(card.get("request_type") or "").strip()
     scope_intent = str(card.get("scope_intent") or "").strip()
@@ -2705,6 +2715,11 @@ def validate_material_autonomy_routing_contract(card: dict[str, Any]) -> list[st
     routing_decision = card.get("model_routing_decision")
     if routing_ref:
         _validate_public_ref(routing_ref, "model_routing_decision_ref", errors)
+        resolved_routing_decision = _load_repo_local_json_ref_node(routing_ref)
+        if not isinstance(resolved_routing_decision, dict):
+            errors.append("model_routing_decision_ref must resolve to a repo-local routing decision object")
+        else:
+            errors.extend(_model_routing_decision_errors(resolved_routing_decision, at="model_routing_decision_ref"))
     if routing_decision is not None:
         errors.extend(_model_routing_decision_errors(routing_decision, at="model_routing_decision"))
     if not routing_ref and routing_decision is None:

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1282,6 +1282,32 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertEqual(factoryctl.validate_card(card), [])
 
+    def test_vfinal_material_execution_resolves_model_routing_decision_ref(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card.pop("model_routing_decision", None)
+
+        self.assertEqual(factoryctl.validate_card(card), [])
+
+    def test_vfinal_material_execution_rejects_unresolved_model_routing_decision_ref(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["model_routing_decision_ref"] = "templates/missing-routing-decision.json#routing_decision"
+        card.pop("model_routing_decision", None)
+
+        self.assertIn(
+            "model_routing_decision_ref must resolve to a repo-local routing decision object",
+            factoryctl.validate_card(card),
+        )
+
+    def test_vfinal_material_execution_rejects_invalid_resolved_model_routing_decision_ref(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["model_routing_decision_ref"] = "templates/factory-sdlc-feedback-loop.json#triage_decision"
+        card.pop("model_routing_decision", None)
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("model_routing_decision_ref.router_ref is required", errors)
+        self.assertIn("model_routing_decision_ref.selected_profile is required", errors)
+
     def test_vfinal_method_contract_requires_named_plan_fields(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
         card["method_contract"] = dict(card["method_contract"])


### PR DESCRIPTION
## Summary
- resolve repo-local `model_routing_decision_ref` values, including fragments, during material vFinal autonomy routing validation
- validate the resolved object with the same model-routing rules used by inline `model_routing_decision`
- add focused tests for valid resolved refs, unresolved refs, and invalid resolved routing decisions

## Why
A routing reference cannot be decorative in the factory gear model. If material autonomous execution points to a model-routing decision, the validator must prove the referenced decision exists and is structurally valid before the card can pass.

Closes #271.
Supports #252 without taking over the broader SDLC feedback-loop work.

## Validation
- `python -m unittest tests.test_factoryctl tests.test_factory_sdlc_feedback_loop -q`
- `python scripts\public_safety_scan.py --git-ref HEAD`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_public_json_artifacts.py`