### PR TITLE
Expose recovery routes in factory help

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,16 +42,19 @@ factoryctl validate-card examples/minimal-hermes-project/card.md
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
 factoryctl recovery-plan --card examples/minimal-hermes-project/card.md --receipt .tmp/receipt.json --worker-results-dir .tmp/worker-results
-factoryctl help-next --card examples/minimal-hermes-project/card.md --out .tmp/factory-help.json
+factoryctl help-next --card examples/minimal-hermes-project/card.md --worker-results-dir .tmp/worker-results --out .tmp/factory-help.json
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
 factoryctl status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
 ```
 
 `help-next` reads the card, workflow catalog and gate report, then separates the
-factory's next action from bounded user decisions. It does not dispatch
-workers, approve gates, or make the operator coordinate schemas, worker packets
-or internal evidence machinery.
+factory's next action from bounded user decisions. With `--receipt` or
+`--worker-results-dir`, it also exposes active recovery routes so a recoverable
+non-human block points back into the factory-owned repair path instead of asking
+the operator to infer the next worker from prose. It does not dispatch workers,
+approve gates, or make the operator coordinate schemas, worker packets or
+internal evidence machinery.
 
 `status-snapshot` projects card, gate, lane and evidence state for operators. It
 does not replace Hermes, card contracts, gate reports or Receipt Five as the

--- a/schemas/factory-help.schema.json
+++ b/schemas/factory-help.schema.json
@@ -13,6 +13,7 @@
     "gate_status",
     "truth_scope",
     "factory_next_action",
+    "active_recovery_routes",
     "user_decision_required",
     "blocked_because",
     "blocked_actions",
@@ -51,6 +52,49 @@
         "command_refs": { "type": "array", "items": { "type": "string" } }
       },
       "additionalProperties": false
+    },
+    "active_recovery_routes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "recovery_route_id",
+          "route_digest",
+          "blocker_type",
+          "factory_owned_repair_allowed",
+          "human_gate_required",
+          "repair_owner_worker",
+          "unblock_authority_ref",
+          "downstream_freeze_scope",
+          "retry_state",
+          "operator_visible_next_action"
+        ],
+        "properties": {
+          "recovery_route_id": { "type": "string", "minLength": 1 },
+          "route_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "blocker_type": { "type": "string", "minLength": 1 },
+          "factory_owned_repair_allowed": { "type": "boolean" },
+          "human_gate_required": { "type": "boolean" },
+          "repair_owner_worker": { "type": "string", "minLength": 1 },
+          "unblock_authority_ref": { "type": "string", "minLength": 1 },
+          "downstream_freeze_scope": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "retry_state": {
+            "type": "object",
+            "required": ["attempt_number", "max_attempts", "escalation_reason"],
+            "properties": {
+              "attempt_number": { "type": "integer", "minimum": 1 },
+              "max_attempts": { "type": "integer", "minimum": 1 },
+              "escalation_reason": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "operator_visible_next_action": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
     },
     "user_decision_required": {
       "type": "array",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -9096,6 +9096,52 @@ def help_action_from_gate(card: dict[str, Any], gate_report: dict[str, Any], pha
     }
 
 
+def summarize_recovery_route_for_help(route: dict[str, Any]) -> dict[str, Any]:
+    route_id = str(route.get("recovery_route_id") or "").strip()
+    repair_owner = str(route.get("repair_owner_worker") or "").strip()
+    human_gate_required = route.get("human_gate_required") is True
+    factory_owned = route.get("factory_owned_repair_allowed") is True and not human_gate_required
+    retry_policy = route.get("retry_policy") if isinstance(route.get("retry_policy"), dict) else {}
+    summary = {
+        "recovery_route_id": route_id,
+        "route_digest": recovery_route_digest(route) if route_id else "",
+        "blocker_type": str(route.get("blocker_type") or "unknown"),
+        "factory_owned_repair_allowed": factory_owned,
+        "human_gate_required": human_gate_required,
+        "repair_owner_worker": repair_owner,
+        "unblock_authority_ref": str(route.get("unblock_authority_ref") or ""),
+        "downstream_freeze_scope": _list_items(route.get("downstream_freeze_scope")),
+        "retry_state": {
+            "attempt_number": int(retry_policy.get("attempt_number") or 1),
+            "max_attempts": int(retry_policy.get("max_attempts") or 1),
+            "escalation_reason": str(retry_policy.get("escalation_reason") or ""),
+        },
+        "operator_visible_next_action": (
+            "wait for the real human gate record; the factory must not simulate this approval"
+            if human_gate_required
+            else f"route the bounded repair through {repair_owner or 'the assigned factory worker'} and keep downstream frozen until fresh review passes"
+        ),
+    }
+    return summary
+
+
+def recovery_decisions_for_help(routes: list[dict[str, Any]]) -> list[dict[str, str]]:
+    decisions: list[dict[str, str]] = []
+    for route in routes:
+        if route.get("human_gate_required") is not True:
+            continue
+        route_id = str(route.get("recovery_route_id") or "human-gate-recovery")
+        decisions.append(
+            {
+                "decision_type": "authority_required",
+                "reason": f"Recovery route {route_id} requires a real human gate before the factory can continue.",
+                "user_action": "approve, reject or request changes on the bounded human gate packet",
+                "factory_prepares": "human gate packet with recovery route, frozen scope, evidence and forbidden actions",
+            }
+        )
+    return decisions
+
+
 def user_decisions_for_card(card: dict[str, Any], gate_report: dict[str, Any]) -> list[dict[str, str]]:
     decisions: list[dict[str, str]] = []
     contract = card.get("user_facing_autonomy_contract") if isinstance(card.get("user_facing_autonomy_contract"), dict) else {}
@@ -9138,13 +9184,39 @@ def user_decisions_for_card(card: dict[str, Any], gate_report: dict[str, Any]) -
     return decisions
 
 
-def build_factory_help(card: dict[str, Any], card_path: Path, *, catalog_path: Path | None = None) -> dict[str, Any]:
+def build_factory_help(
+    card: dict[str, Any],
+    card_path: Path,
+    *,
+    catalog_path: Path | None = None,
+    worker_results_dir: Path | None = None,
+    receipt: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     catalog = load_workflow_catalog(catalog_path)
     phase_row = workflow_phase_for_card(card, catalog)
     gate_report = build_gate_report(card)
+    recovery_plan = build_factory_recovery_plan(card, worker_results_dir=worker_results_dir, receipt=receipt)
+    active_recovery_routes = [
+        summarize_recovery_route_for_help(route)
+        for route in recovery_plan.get("recovery_routes", [])
+        if isinstance(route, dict)
+    ]
     if product_experience_planning_gap(card, _list_items(gate_report.get("card_validation_errors"))):
         phase_row = workflow_phase_by_id(catalog, "F8A") or phase_row
     factory_action = help_action_from_gate(card, gate_report, phase_row)
+    factory_owned_routes = [
+        route
+        for route in active_recovery_routes
+        if route.get("factory_owned_repair_allowed") is True and (worker_results_dir is not None or receipt is not None)
+    ]
+    if factory_owned_routes:
+        route = factory_owned_routes[0]
+        factory_action = {
+            "owner": "factory",
+            "action": f"execute recovery route {route['recovery_route_id']} through {route['repair_owner_worker']}",
+            "why": "A recoverable non-human BLOCK has a known repair route; the operator should not infer the next worker from prose.",
+            "command_refs": ["factoryctl recovery-plan", "factoryctl transition-plan", "factoryctl help-next"],
+        }
     blocked_workers = _list_items(gate_report.get("blocked_workers"))
     validation_errors = _list_items(gate_report.get("card_validation_errors"))
     next_actions: list[str] = []
@@ -9167,7 +9239,8 @@ def build_factory_help(card: dict[str, Any], card_path: Path, *, catalog_path: P
         "gate_status": str(gate_report.get("gate_status") or "not_run"),
         "truth_scope": truth_scope_for_card(card),
         "factory_next_action": factory_action,
-        "user_decision_required": user_decisions_for_card(card, gate_report),
+        "active_recovery_routes": active_recovery_routes,
+        "user_decision_required": user_decisions_for_card(card, gate_report) + recovery_decisions_for_help(active_recovery_routes),
         "blocked_because": validation_errors + [f"{worker_id} is blocked by missing inputs" for worker_id in blocked_workers],
         "blocked_actions": sorted(set(_list_items(phase_row.get("blocked_actions")) + _list_items(card.get("forbidden_actions")))),
         "evidence_needed": next_actions or _list_items(phase_row.get("required_artifacts")) + _list_items(phase_row.get("required_gates")),
@@ -9939,7 +10012,14 @@ def command_recovery_plan(args: argparse.Namespace) -> int:
 
 def command_help_next(args: argparse.Namespace) -> int:
     card = load_json_like(args.card)
-    payload = build_factory_help(card, args.card, catalog_path=args.catalog)
+    receipt = load_json_like(args.receipt) if args.receipt else None
+    payload = build_factory_help(
+        card,
+        args.card,
+        catalog_path=args.catalog,
+        worker_results_dir=args.worker_results_dir,
+        receipt=receipt,
+    )
     write_json(args.out, payload)
     return 0
 
@@ -10264,6 +10344,8 @@ def build_parser() -> argparse.ArgumentParser:
     help_next_parser = sub.add_parser("help-next", help="Show the next safe action without making the user operate internal factory machinery.")
     help_next_parser.add_argument("--card", type=Path, required=True)
     help_next_parser.add_argument("--catalog", type=Path)
+    help_next_parser.add_argument("--receipt", type=Path)
+    help_next_parser.add_argument("--worker-results-dir", type=Path)
     help_next_parser.add_argument("--out", type=Path)
     help_next_parser.set_defaults(func=command_help_next)
 

--- a/tests/test_operator_experience.py
+++ b/tests/test_operator_experience.py
@@ -54,6 +54,71 @@ def write_product_card_missing_experience(tmp: Path) -> Path:
     return path
 
 
+def write_blocked_worker_result(tmp: Path, *, human_gate: bool = False) -> Path:
+    worker_id = "human-gate-clerk" if human_gate else "handoff-packer"
+    record_type = "human_gate_record" if human_gate else "handoff_packet_result"
+    blocker_type = "human_gate" if human_gate else "orchestration"
+    route_id = "recovery:test-card:human-gate" if human_gate else "recovery:test-card:handoff-repair"
+    recovery = {
+        "blocker_type": blocker_type,
+        "factory_owned_repair_allowed": not human_gate,
+        "human_gate_required": human_gate,
+        "recovery_route_id": route_id,
+        "repair_owner_worker": worker_id,
+        "repair_task_ref": f"hermes:intent:{route_id}",
+        "invalidates_refs": ["worker-result:stale-output"],
+        "supersedes_refs": ["worker-result:fresh-output"],
+        "fresh_review_required": not human_gate,
+        "fresh_review_result_ref": "worker-result:independent-reviewer:fresh-pass",
+        "unblock_authority_ref": "human_gate_record" if human_gate else "graph-requirement:fresh-review-pass",
+        "retry_policy": {
+            "max_attempts": 3,
+            "attempt_number": 1,
+            "attempt_number_role": "planner_seed_not_runtime_counter",
+            "runtime_attempt_source": "hermes_task_history",
+            "runtime_attempt_marker": "factory_recovery_attempt",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "stop_classes": ["human_gate_required", "repeated_failure"],
+            "escalation_reason": "only after bounded recovery fails",
+        },
+        "hermes_runtime_boundary": {
+            "runtime_authority": "hermes_kanban",
+            "uses_native_kanban_primitives": True,
+            "local_state_authority": False,
+        },
+        "downstream_freeze_scope": ["next worker", "done promotion"],
+    }
+    if human_gate:
+        recovery["fresh_review_result_ref"] = "human_gate_record"
+    result = {
+        "$schema": "https://overkill-factory.dev/schemas/worker-result.schema.json",
+        "record_type": record_type,
+        "created_at": "2026-06-16T00:00:00+00:00",
+        "worker": {"id": worker_id, "name": "Fixture Worker", "factory_phase": "F13"},
+        "card_ref": {
+            "card_id": "VAL-SOLANA-QUASAR-R3",
+            "slice_id": "VAL_FACTORY_HEAVY_03",
+            "phase": "F13",
+            "risk_effective": "R3",
+            "surfaces": ["solana-quasar"],
+        },
+        "result": "BLOCKED",
+        "blocking_findings": True,
+        "findings_summary": "Synthetic blocked fixture.",
+        "tool_or_profile": "fixture-tool",
+        "executed_by": "fixture-runner",
+        "evidence_refs": ["README.md"],
+        "evidence_kind": "synthetic",
+        "reusable_for_product": False,
+        "next_action": "follow the recovery route",
+        "recovery_recommendation": recovery,
+    }
+    path = tmp / ("human-gate-block.json" if human_gate else "recoverable-block.json")
+    path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
 class OperatorExperienceTest(unittest.TestCase):
     def test_factoryctl_exposes_single_operator_entrypoint(self) -> None:
         help_text = run_factoryctl("--help").stdout
@@ -122,6 +187,52 @@ class OperatorExperienceTest(unittest.TestCase):
         self.assertIn(
             "populate card.product_experience_plan with public-safe contract data or attach the required worker evidence",
             payload["evidence_needed"],
+        )
+
+    def test_help_next_exposes_recoverable_block_as_factory_recovery_route(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            write_blocked_worker_result(tmp)
+            result = run_factoryctl(
+                "help-next",
+                "--card",
+                "examples/cards/v35_valid_onchain_auditor_scan.md",
+                "--worker-results-dir",
+                str(tmp),
+            )
+            payload = json.loads(result.stdout)
+
+        self.assertEqual(len(payload["active_recovery_routes"]), 1)
+        route = payload["active_recovery_routes"][0]
+        self.assertEqual(route["recovery_route_id"], "recovery:test-card:handoff-repair")
+        self.assertTrue(route["factory_owned_repair_allowed"])
+        self.assertFalse(route["human_gate_required"])
+        self.assertEqual(route["repair_owner_worker"], "handoff-packer")
+        self.assertIn("next worker", route["downstream_freeze_scope"])
+        self.assertIn("factoryctl recovery-plan", payload["factory_next_action"]["command_refs"])
+        self.assertIn("recovery route recovery:test-card:handoff-repair", payload["factory_next_action"]["action"])
+
+    def test_help_next_keeps_human_gate_recovery_as_user_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            write_blocked_worker_result(tmp, human_gate=True)
+            result = run_factoryctl(
+                "help-next",
+                "--card",
+                "examples/cards/v35_valid_onchain_auditor_scan.md",
+                "--worker-results-dir",
+                str(tmp),
+            )
+            payload = json.loads(result.stdout)
+
+        self.assertEqual(len(payload["active_recovery_routes"]), 1)
+        route = payload["active_recovery_routes"][0]
+        self.assertEqual(route["recovery_route_id"], "recovery:test-card:human-gate")
+        self.assertFalse(route["factory_owned_repair_allowed"])
+        self.assertTrue(route["human_gate_required"])
+        self.assertIn("human gate record", route["operator_visible_next_action"])
+        self.assertTrue(
+            any(decision["decision_type"] == "authority_required" for decision in payload["user_decision_required"])
         )
 
     def test_doctor_reports_public_install_health_without_real_hermes_e2e(self) -> None:


### PR DESCRIPTION
## Summary
- Adds structured `active_recovery_routes` to `factoryctl help-next` and the public factory-help schema.
- Lets `help-next` ingest `--receipt` and `--worker-results-dir` so an operator sees the real recovery route for an active blocked state.
- Makes recoverable non-human `BLOCKED` results point back into a factory-owned repair route, while true human gates remain explicit user authority decisions.
- Updates CLI docs and regression coverage for recoverable block vs human-gate behavior.

## Why
This advances #134: non-human blocked states should not end in vague prose or hidden manual paths. The factory help surface now exposes route id, route digest, retry state, repair owner, unblock authority, downstream freeze scope and operator-visible next action.

## Validation
- `python -m unittest tests.test_operator_experience tests.test_user_facing_autonomy_help_router tests.test_factoryctl -q`
- `python -m unittest discover -s tests -q`
- `python scripts\public_safety_scan.py --git-ref HEAD`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\release_integration_preflight.py`

## Boundaries
- Did not touch #84 or the cockpit work.
- Did not add historical/audit/private evidence artifacts to the public repo.
- This advances #134, but does not close it alone; #134 still has broader runtime/adapter acceptance beyond this operator-facing recovery surface.