### PR TITLE
Require typed Product SOT and work-unit proof graphs

### DIFF
--- a/docs/concepts/overkill-factory-method.md
+++ b/docs/concepts/overkill-factory-method.md
@@ -200,6 +200,14 @@ The method uses different units for different parts of the line:
 | Worker Result | Specialist output with evidence. |
 | Receipt Five | Closure record for done. |
 
+Product SOT requirements and Product Creation work units are typed gears, not
+planning prose. A Product SOT requirement needs a stable requirement id, source
+refs, decision state, owner and next action. A Product Creation work unit needs
+SOT requirement refs, required proof ids, owner worker, reviewer role,
+capability/profile refs, ready rules, blocked rules and done rules. If a work
+unit is blocked, it must name the blocker, owner and next action before the
+factory can route repair.
+
 ## Risk Tiers
 
 | Tier | Typical use | Required rigor |

--- a/schemas/product-creation-plan.schema.json
+++ b/schemas/product-creation-plan.schema.json
@@ -53,6 +53,13 @@
           "scope_out",
           "verification",
           "expected_result",
+          "proof_ids_required",
+          "owner_worker",
+          "reviewer_role",
+          "capability_profile_refs",
+          "ready_rules",
+          "blocked_when",
+          "done_rules",
           "stop_conditions",
           "status"
         ],
@@ -64,12 +71,51 @@
           "scope_out": { "type": "array", "minItems": 1, "items": { "type": "string" } },
           "verification": { "type": "array", "minItems": 1, "items": { "type": "string" } },
           "expected_result": { "type": "string", "minLength": 3 },
+          "proof_ids_required": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "owner_worker": { "type": "string", "minLength": 3 },
+          "reviewer_role": { "type": "string", "minLength": 3 },
+          "capability_profile_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "ready_rules": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "blocked_when": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "done_rules": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "blocker_id": { "type": "string", "minLength": 3 },
+          "blocker_owner": { "type": "string", "minLength": 3 },
+          "next_action": { "type": "string", "minLength": 3 },
           "stop_conditions": { "type": "array", "minItems": 1, "items": { "type": "string" } },
           "status": {
             "enum": ["todo", "ready", "blocked", "in_progress", "done", "rejected", "superseded", "needs_refresh"]
           },
           "product_context_packet_ref": { "type": "string" }
         },
+        "allOf": [
+          {
+            "if": {
+              "properties": { "status": { "const": "blocked" } },
+              "required": ["status"]
+            },
+            "then": { "required": ["blocker_id", "blocker_owner", "next_action"] }
+          }
+        ],
         "additionalProperties": true
       }
     },

--- a/schemas/product-sot.schema.json
+++ b/schemas/product-sot.schema.json
@@ -19,6 +19,7 @@
     "cost_relevance",
     "operations_expected",
     "success_criteria",
+    "requirement_graph",
     "full_product_sot_scope_coverage_ref",
     "evidence_refs"
   ],
@@ -39,6 +40,42 @@
     "cost_relevance": { "type": "string", "minLength": 3 },
     "operations_expected": { "type": "array", "items": { "type": "string" } },
     "success_criteria": { "type": "array", "items": { "type": "string" } },
+    "requirement_graph": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["requirement_id", "source_refs", "decision_state", "owner", "next_action"],
+        "properties": {
+          "requirement_id": { "type": "string", "minLength": 3 },
+          "source_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "decision_state": {
+            "enum": ["approved", "blocked", "open_decision", "rejected", "superseded"]
+          },
+          "owner": { "type": "string", "minLength": 3 },
+          "blocker_id": { "type": "string", "minLength": 3 },
+          "next_action": { "type": "string", "minLength": 3 },
+          "evidence_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": { "decision_state": { "enum": ["blocked", "open_decision"] } },
+              "required": ["decision_state"]
+            },
+            "then": { "required": ["blocker_id"] }
+          }
+        ],
+        "additionalProperties": true
+      }
+    },
     "full_product_sot_scope_coverage_ref": { "type": "string", "minLength": 3 },
     "research_decision_refs": { "type": "array", "items": { "type": "string" } },
     "research_confirmations": { "type": "array", "items": { "type": "string" } },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2360,6 +2360,95 @@ def _selected_engineering_methods(method_contract: dict[str, Any]) -> set[str]:
     return methods
 
 
+def _load_required_repo_local_contract(data: dict[str, Any], field: str, errors: list[str]) -> dict[str, Any]:
+    value = data.get(field)
+    if isinstance(value, dict) and value:
+        return value
+    ref_field = f"{field}_ref"
+    ref = data.get(ref_field)
+    if not _non_empty_text(ref):
+        return {}
+    _validate_public_ref(str(ref), f"card.{ref_field}", errors)
+    path = _repo_local_json_ref_path(ref)
+    if path is None or not path.is_file():
+        errors.append(f"card.{ref_field} does not resolve to a repo-local file: {ref}")
+        return {}
+    loaded = _load_repo_local_json_ref(ref)
+    if not loaded:
+        errors.append(f"card.{ref_field} could not be loaded as JSON: {ref}")
+        return {}
+    return loaded
+
+
+def validate_product_sot_requirement_graph(product_sot: dict[str, Any], at: str = "product_sot") -> list[str]:
+    errors: list[str] = []
+    graph = product_sot.get("requirement_graph")
+    if not isinstance(graph, list) or not graph:
+        return [f"{at}.requirement_graph must be non-empty with stable requirement ids"]
+    seen_ids: set[str] = set()
+    for index, requirement in enumerate(graph):
+        requirement = requirement if isinstance(requirement, dict) else {}
+        prefix = f"{at}.requirement_graph[{index}]"
+        requirement_id = str(requirement.get("requirement_id") or "").strip()
+        if not requirement_id:
+            errors.append(f"{prefix}.requirement_id is required")
+        elif requirement_id in seen_ids:
+            errors.append(f"{prefix}.requirement_id must be unique: {requirement_id}")
+        else:
+            seen_ids.add(requirement_id)
+        if not _non_empty_string_list(requirement.get("source_refs")):
+            errors.append(f"{prefix}.source_refs must be non-empty")
+        decision_state = str(requirement.get("decision_state") or "").strip()
+        if decision_state not in {"approved", "blocked", "open_decision", "rejected", "superseded"}:
+            errors.append(f"{prefix}.decision_state must be approved, blocked, open_decision, rejected or superseded")
+        if not _non_empty_text(requirement.get("owner")):
+            errors.append(f"{prefix}.owner is required")
+        if not _non_empty_text(requirement.get("next_action")):
+            errors.append(f"{prefix}.next_action is required")
+        if decision_state in {"blocked", "open_decision"} and not _non_empty_text(requirement.get("blocker_id")):
+            errors.append(f"{prefix}.blocker_id is required when decision_state is {decision_state}")
+    return errors
+
+
+def validate_product_creation_plan_work_unit_graph(plan: dict[str, Any], at: str = "product_creation_plan") -> list[str]:
+    errors: list[str] = []
+    work_units = plan.get("work_units")
+    if not isinstance(work_units, list) or not work_units:
+        return [f"{at}.work_units must be non-empty"]
+    unit_ids: set[str] = set()
+    for index, unit in enumerate(work_units):
+        unit = unit if isinstance(unit, dict) else {}
+        prefix = f"{at}.work_units[{index}]"
+        unit_id = str(unit.get("unit_id") or "").strip()
+        if not unit_id:
+            errors.append(f"{prefix}.unit_id is required")
+        elif unit_id in unit_ids:
+            errors.append(f"{prefix}.unit_id must be unique: {unit_id}")
+        else:
+            unit_ids.add(unit_id)
+        for field in ("product_sot_requirement_refs", "scope_in", "scope_out", "verification", "stop_conditions"):
+            if not _non_empty_string_list(unit.get(field)):
+                errors.append(f"{prefix}.{field} must be non-empty")
+        for field in ("proof_ids_required", "capability_profile_refs", "ready_rules", "blocked_when", "done_rules"):
+            if not _non_empty_string_list(unit.get(field)):
+                errors.append(f"{prefix}.{field} must be non-empty")
+        for field in ("owner_worker", "reviewer_role", "expected_result"):
+            if not _non_empty_text(unit.get(field)):
+                errors.append(f"{prefix}.{field} is required")
+        status = str(unit.get("status") or "").strip()
+        if status == "blocked":
+            for field in ("blocker_id", "blocker_owner", "next_action"):
+                if not _non_empty_text(unit.get(field)):
+                    errors.append(f"{prefix}.{field} is required when status is blocked")
+        if status in {"ready", "done"} and not _non_empty_string_list(unit.get("proof_ids_required")):
+            errors.append(f"{prefix}.proof_ids_required is required before {status} can be claimed")
+    execution_order = _list_items(plan.get("execution_order"))
+    missing_order_refs = [unit_id for unit_id in execution_order if unit_id not in unit_ids]
+    if missing_order_refs:
+        errors.append(f"{at}.execution_order references unknown work_units: " + ", ".join(missing_order_refs))
+    return errors
+
+
 def validate_product_scope_planning_contract(card: dict[str, Any]) -> list[str]:
     if card.get("factory_method_version") != "OVERKILL_VFINAL":
         return []
@@ -2375,6 +2464,8 @@ def validate_product_scope_planning_contract(card: dict[str, Any]) -> list[str]:
         errors.append("full_product_sot_scope_coverage or full_product_sot_scope_coverage_ref is required for complete Product SOT planning")
     if not _non_empty_text(product_sot.get("full_product_sot_scope_coverage_ref")):
         errors.append("product_sot.full_product_sot_scope_coverage_ref is required")
+    if product_sot:
+        errors.extend(validate_product_sot_requirement_graph(product_sot))
     if str(method.get("canonical_scope_source") or "").strip().lower() not in {"approved product sot", "product_sot", "product sot"}:
         errors.append("method_contract.canonical_scope_source must be approved Product SOT")
     if str(method.get("scope_intent") or "").strip() not in PRODUCT_SCOPE_INTENTS:
@@ -2482,7 +2573,7 @@ def validate_product_creation_readiness_contract(card: dict[str, Any]) -> list[s
     if not _has_ref_or_object(card, "product_implementation_readiness"):
         errors.append("product_implementation_readiness or product_implementation_readiness_ref is required before material product implementation")
 
-    plan = card.get("product_creation_plan") if isinstance(card.get("product_creation_plan"), dict) else {}
+    plan = _load_required_repo_local_contract(card, "product_creation_plan", errors)
     if plan:
         if plan.get("complete_product_required") is not True:
             errors.append("product_creation_plan.complete_product_required must be true for complete-product planning")
@@ -2494,17 +2585,7 @@ def validate_product_creation_readiness_contract(card: dict[str, Any]) -> list[s
             errors.append("product_creation_plan.complete_product_scope is required")
         if not _non_empty_string_list(plan.get("release_promotion_ladder_refs")):
             errors.append("product_creation_plan.release_promotion_ladder_refs is required")
-        work_units = plan.get("work_units")
-        if not isinstance(work_units, list) or not work_units:
-            errors.append("product_creation_plan.work_units must be non-empty")
-        else:
-            for index, unit in enumerate(work_units):
-                unit = unit if isinstance(unit, dict) else {}
-                for field in ("product_sot_requirement_refs", "scope_in", "scope_out", "verification", "stop_conditions"):
-                    if not _non_empty_string_list(unit.get(field)):
-                        errors.append(f"product_creation_plan.work_units[{index}].{field} must be non-empty")
-                if not _non_empty_text(unit.get("expected_result")):
-                    errors.append(f"product_creation_plan.work_units[{index}].expected_result is required")
+        errors.extend(validate_product_creation_plan_work_unit_graph(plan))
     errors.extend(_product_delivery_quality_profile_ref_errors(card))
     profile = _product_delivery_quality_profile(card)
     if profile:

--- a/templates/product-creation-plan.json
+++ b/templates/product-creation-plan.json
@@ -28,6 +28,22 @@
       "scope_out": ["unrelated Product SOT requirements"],
       "verification": ["run the checks named by the work unit"],
       "expected_result": "PASS or explicit BLOCK with owner",
+      "proof_ids_required": ["generic.scope-fit"],
+      "owner_worker": "implementation-worker",
+      "reviewer_role": "independent-reviewer",
+      "capability_profile_refs": ["agents/hermes-profile-bindings.public.json#implementation-worker"],
+      "ready_rules": [
+        "Product SOT requirement refs resolve to the approved Product SOT",
+        "required proof ids are mapped before execution starts"
+      ],
+      "blocked_when": [
+        "required proof cannot be produced",
+        "owner worker or reviewer role is unavailable"
+      ],
+      "done_rules": [
+        "all proof_ids_required have PASS or valid waiver evidence",
+        "reviewer_role has reviewed the work-unit evidence"
+      ],
       "stop_conditions": ["Product SOT drifted", "required context packet is stale"],
       "status": "ready",
       "product_context_packet_ref": "templates/product-context-packet.json"

--- a/templates/product-sot.json
+++ b/templates/product-sot.json
@@ -15,6 +15,16 @@
   "cost_relevance": "No material spend, or named budget/cost boundary.",
   "operations_expected": ["how the product is expected to run or be supported"],
   "success_criteria": ["observable criterion for success"],
+  "requirement_graph": [
+    {
+      "requirement_id": "product-sot#scope-in-001",
+      "source_refs": ["source-ledger.md"],
+      "decision_state": "approved",
+      "owner": "product-owner",
+      "next_action": "decompose this requirement into typed work units with proof coverage",
+      "evidence_refs": ["templates/full-product-sot-scope-coverage.json"]
+    }
+  ],
   "full_product_sot_scope_coverage_ref": "templates/full-product-sot-scope-coverage.json",
   "research_decision_refs": ["templates/specialist-decision-packet.json"],
   "research_confirmations": ["research decisions that confirm or change Product SOT requirements"],

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -198,6 +198,16 @@
     "cost_relevance": "No material spend, or named budget/cost boundary.",
     "operations_expected": ["how the product is expected to run or be supported"],
     "success_criteria": ["observable criterion for success"],
+    "requirement_graph": [
+      {
+        "requirement_id": "product-sot#scope-in-001",
+        "source_refs": ["source-ledger.md"],
+        "decision_state": "approved",
+        "owner": "product-owner",
+        "next_action": "decompose this requirement into typed work units with proof coverage",
+        "evidence_refs": ["templates/full-product-sot-scope-coverage.json"]
+      }
+    ],
     "full_product_sot_scope_coverage_ref": "templates/full-product-sot-scope-coverage.json",
     "research_decision_refs": ["templates/specialist-decision-packet.json"],
     "research_confirmations": ["research decisions that confirm or change Product SOT requirements"],

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -107,6 +107,43 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             errors,
         )
 
+    def test_product_sot_requires_typed_requirement_graph(self) -> None:
+        card = self.vfinal_card()
+        card["product_sot"].pop("requirement_graph")
+
+        self.assertIn(
+            "product_sot.requirement_graph must be non-empty with stable requirement ids",
+            factoryctl.validate_card(card),
+        )
+
+    def test_product_creation_plan_ref_is_loaded_and_validated(self) -> None:
+        card = self.vfinal_card()
+        card["product_creation_plan_ref"] = "templates/work-unit-contract.json"
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("product_creation_plan.complete_product_required must be true for complete-product planning", errors)
+        self.assertIn("product_creation_plan.work_units must be non-empty", errors)
+
+    def test_product_creation_work_units_require_typed_proof_graph(self) -> None:
+        card = self.vfinal_card()
+        card.pop("product_creation_plan_ref")
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        unit = card["product_creation_plan"]["work_units"][0]
+        unit.pop("proof_ids_required")
+        unit.pop("owner_worker")
+        unit.pop("reviewer_role")
+        unit["status"] = "blocked"
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn("product_creation_plan.work_units[0].proof_ids_required must be non-empty", errors)
+        self.assertIn("product_creation_plan.work_units[0].owner_worker is required", errors)
+        self.assertIn("product_creation_plan.work_units[0].reviewer_role is required", errors)
+        self.assertIn("product_creation_plan.work_units[0].blocker_id is required when status is blocked", errors)
+        self.assertIn("product_creation_plan.work_units[0].blocker_owner is required when status is blocked", errors)
+        self.assertIn("product_creation_plan.work_units[0].next_action is required when status is blocked", errors)
+
     def test_slice_plan_cannot_replace_full_product_plan(self) -> None:
         card = self.vfinal_card()
         card["software_development_plan"].pop("full_product_plan")


### PR DESCRIPTION
## Summary
- Requires Product SOT records to expose a typed `requirement_graph` with stable requirement ids, source refs, decision state, owner and next action.
- Requires Product Creation Plan work units to declare proof ids, owner worker, reviewer role, capability/profile refs, ready/blocked/done rules and blocked-state blocker ownership.
- Makes `factoryctl validate-card` load and validate `product_creation_plan_ref`, so a referenced plan cannot bypass the stricter work-unit graph checks.
- Updates public templates, method docs and regression tests.

## Why
Advances #197. Complete-product planning should decompose into verifiable gears, not prose. A ready/done work unit now needs explicit proof coverage and a blocked work unit must have a routeable blocker, owner and next action.

## Validation
- `python -m unittest tests.test_product_method_sot_planning tests.test_agent_reference_study_execution tests.test_factoryctl -q`
- `python -m unittest discover -s tests -q`
- `python scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py --git-ref HEAD`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\release_integration_preflight.py`

## Boundaries
- Did not touch #84/cockpit work.
- Did not add historical/audit/private evidence artifacts.
- This closes the contract/proof-graph slice of #197. After merge, #197 should be rechecked for any remaining non-template adoption gaps before closure.