### PR TITLE
Require fresh release gate evidence

### DIFF
--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -53,6 +53,10 @@ python scripts/validate_public_surface_sync.py --check-published
 These commands write local summaries under `.tmp` when an output path is
 provided. Generated summaries must not be committed as release proof.
 
+`release_integration_preflight.py` must run its materializers in the current
+process. Existing `.tmp` summaries are evidence inputs only after fresh
+materialization; stale files cannot support a release `PASS`.
+
 `validate_public_surface_sync.py --check-published` compares the validated local
 map to the published public object. Run it only after the public object has been
 published or refreshed; before publication it may correctly report the remote
@@ -107,5 +111,9 @@ A release claim needs:
 - independent review when required;
 - real human gate records for high-risk or release authority;
 - public-safety pass before public publication.
+
+Release authority cannot be satisfied by a string ref alone. A production or
+R4 release gate must dereference and validate the human gate record before it
+can claim `PASS`.
 
 No single chat answer, dashboard status or worker packet is a release proof.

--- a/schemas/release-integration-preflight.schema.json
+++ b/schemas/release-integration-preflight.schema.json
@@ -12,6 +12,7 @@
     "release_candidate_plan",
     "blocking_items",
     "attention_items",
+    "materialization",
     "evidence_refs",
     "next_required_actions",
     "limits"
@@ -80,6 +81,20 @@
     "attention_items": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
+    },
+    "materialization": {
+      "type": "object",
+      "required": ["record_type", "all_materializers_passed", "failed_materializers", "runs"],
+      "properties": {
+        "record_type": { "const": "release_preflight_materialization" },
+        "all_materializers_passed": { "type": ["boolean", "null"] },
+        "failed_materializers": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "runs": { "type": "array" }
+      },
+      "additionalProperties": true
     },
     "evidence_refs": {
       "type": "array",

--- a/scripts/production_release_gate.py
+++ b/scripts/production_release_gate.py
@@ -173,11 +173,20 @@ def load_human_gate_record(path: Path) -> dict[str, Any]:
     return record
 
 
-def build_release_ops(*, created_at: str, validation: list[dict[str, Any]], human_gate_ref: str = ".tmp/factory-runs/production/release/human-gate-record.json") -> dict[str, Any]:
+def build_release_ops(
+    *,
+    created_at: str,
+    validation: list[dict[str, Any]],
+    human_gate_ref: str = ".tmp/factory-runs/production/release/human-gate-record.json",
+    human_gate_record: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     head = git_value("rev-parse", "HEAD")
     branch = git_value("branch", "--show-current")
     remote_ref = git_value("ls-remote", "origin", branch)
-    validation_passed = all(item["exit_code"] == 0 for item in validation)
+    human_gate_validation_errors = (
+        human_gate_errors(human_gate_record) if isinstance(human_gate_record, dict) else ["production release ops requires dereferenced human_gate_record"]
+    )
+    validation_passed = all(item["exit_code"] == 0 for item in validation) and not human_gate_validation_errors
     evidence_refs = [
         ".tmp/factory-runs/production/release/release-ops-result.md",
         human_gate_ref,
@@ -208,7 +217,7 @@ def build_release_ops(*, created_at: str, validation: list[dict[str, Any]], huma
         "findings_summary": (
             "Release-control validation passed for the public validation product and current public branch state."
             if validation_passed
-            else "Release-control validation failed; see command evidence."
+            else "Release-control validation failed; see command evidence and human gate validation."
         ),
         "tool_or_profile": "Hermes release-ops-worker",
         "executed_by": "release-ops-worker",
@@ -258,6 +267,11 @@ def build_release_ops(*, created_at: str, validation: list[dict[str, Any]], huma
             producer="release-ops-worker",
             artifact_refs=evidence_refs,
         ),
+        "human_gate_validation": {
+            "dereferenced": isinstance(human_gate_record, dict),
+            "valid": not human_gate_validation_errors,
+            "errors": human_gate_validation_errors,
+        },
         "next_action": "Repeat this gate whenever the release target, product source, branch or authority boundary changes.",
     }
 
@@ -308,6 +322,7 @@ def main(argv: list[str] | None = None) -> int:
         created_at=created_at,
         validation=validation,
         human_gate_ref=repo_ref(args.human_gate_record.resolve()),
+        human_gate_record=human_gate,
     )
 
     if not args.no_write:

--- a/scripts/release_integration_preflight.py
+++ b/scripts/release_integration_preflight.py
@@ -241,11 +241,18 @@ def build_preflight(
     unintegrated_release_entries = max(entries - generated_from_status, 0)
     materializers_passed = True
     failed_materializers: list[str] = []
+    fresh_materialization_provided = materialization is not None
     if materialization is not None:
         materializers_passed = materialization.get("all_materializers_passed") is True
         failed_materializers = [str(item) for item in materialization.get("failed_materializers") or []]
+        fresh_materialization_provided = (
+            materialization.get("record_type") == "release_preflight_materialization"
+            and isinstance(materialization.get("runs"), list)
+            and bool(materialization.get("runs"))
+        )
 
     checks = {
+        "fresh_preflight_materialization_provided": fresh_materialization_provided,
         "preflight_materializers_passed": materializers_passed,
         "worktree_public_safety_passed": public_worktree.get("result") == "PASS",
         "head_public_safety_passed": public_head.get("result") == "PASS",
@@ -283,6 +290,8 @@ def build_preflight(
         next_required_actions.append("integrate the public-safe worktree into the target release ref")
     if not checks["preflight_evidence_refs_exist"]:
         next_required_actions.append("materialize missing preflight evidence summaries before release review")
+    if not checks["fresh_preflight_materialization_provided"]:
+        next_required_actions.append("rerun release preflight materializers in the current process before release review")
     if not checks["preflight_materializers_passed"]:
         next_required_actions.append("rerun failing preflight materializers before release review")
     if not checks["head_public_safety_passed"] or not checks["origin_main_public_safety_passed"]:

--- a/tests/test_production_release_gate.py
+++ b/tests/test_production_release_gate.py
@@ -66,7 +66,11 @@ class ProductionReleaseGateTest(unittest.TestCase):
             {"command": "bad", "exit_code": 1},
         ]
         with mock.patch.object(module, "git_value", return_value="git-value"):
-            result = module.build_release_ops(created_at="2026-06-06T00:00:00+00:00", validation=validation)
+            result = module.build_release_ops(
+                created_at="2026-06-06T00:00:00+00:00",
+                validation=validation,
+                human_gate_record=self.valid_human_gate(),
+            )
 
         self.assertEqual(result["result"], "FAIL")
         self.assertFalse(result["reusable_for_product"])
@@ -74,7 +78,11 @@ class ProductionReleaseGateTest(unittest.TestCase):
     def test_release_ops_passes_with_validation_and_rollback_plan(self) -> None:
         validation = [{"command": "ok", "exit_code": 0}]
         with mock.patch.object(module, "git_value", return_value="git-value"):
-            result = module.build_release_ops(created_at="2026-06-06T00:00:00+00:00", validation=validation)
+            result = module.build_release_ops(
+                created_at="2026-06-06T00:00:00+00:00",
+                validation=validation,
+                human_gate_record=self.valid_human_gate(),
+            )
 
         self.assertEqual(result["result"], "PASS")
         self.assertTrue(result["reusable_for_product"])
@@ -83,6 +91,22 @@ class ProductionReleaseGateTest(unittest.TestCase):
         self.assertIn("product_source_sha256", result["evidence_provenance"]["integrity"])
         self.assertIn(".tmp/factory-runs/production/release/upstream-worker-graph.json", result["evidence_refs"])
         self.assertNotIn(".tmp/factory-runs/production/full-product-worker-graph.json", result["evidence_refs"])
+        self.assertTrue(result["human_gate_validation"]["dereferenced"])
+        self.assertTrue(result["human_gate_validation"]["valid"])
+
+    def test_release_ops_cannot_pass_with_ref_only_human_gate(self) -> None:
+        validation = [{"command": "ok", "exit_code": 0}]
+        with mock.patch.object(module, "git_value", return_value="git-value"):
+            result = module.build_release_ops(
+                created_at="2026-06-06T00:00:00+00:00",
+                validation=validation,
+                human_gate_ref="external:real-approval-but-not-dereferenced",
+            )
+
+        self.assertEqual(result["result"], "FAIL")
+        self.assertFalse(result["reusable_for_product"])
+        self.assertFalse(result["human_gate_validation"]["dereferenced"])
+        self.assertIn("production release ops requires dereferenced human_gate_record", result["human_gate_validation"]["errors"])
 
     def test_release_gate_uses_production_strict_worker_graph(self) -> None:
         commands = [" ".join(command) for command in module.VALIDATION_COMMANDS]

--- a/tests/test_release_integration_preflight.py
+++ b/tests/test_release_integration_preflight.py
@@ -20,6 +20,21 @@ SPEC.loader.exec_module(preflight)
 
 
 class ReleaseIntegrationPreflightTest(unittest.TestCase):
+    def materialization(self) -> dict:
+        return {
+            "record_type": "release_preflight_materialization",
+            "all_materializers_passed": True,
+            "failed_materializers": [],
+            "missing_evidence_refs": [],
+            "runs": [
+                {
+                    "name": "fresh-fixture",
+                    "result": "PASS",
+                    "output_exists": True,
+                }
+            ],
+        }
+
     def test_dirty_main_blocks_release_integration(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             paths = self._fixtures(Path(tmp), worktree="PASS", head="FAIL", origin="FAIL")
@@ -32,6 +47,7 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
                 branch_name="main",
                 status_entries=10,
                 created_at="2026-06-10T00:00:00Z",
+                materialization=self.materialization(),
             )
 
         self.assertEqual(receipt["result"], "BLOCKED")
@@ -55,6 +71,7 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
                 branch_name="codex/release",
                 status_entries=0,
                 created_at="2026-06-10T00:00:00Z",
+                materialization=self.materialization(),
             )
 
         self.assertEqual(receipt["result"], "PASS")
@@ -73,6 +90,7 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
                 branch_name="main",
                 status_entries=10,
                 created_at="2026-06-10T00:00:00Z",
+                materialization=self.materialization(),
             )
 
         self.assertEqual(receipt["result"], "BLOCKED")
@@ -98,6 +116,7 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
                 status_entries=4,
                 generated_status_entries=4,
                 created_at="2026-06-10T00:00:00Z",
+                materialization=self.materialization(),
             )
 
         self.assertEqual(receipt["result"], "PASS")
@@ -125,6 +144,7 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
                 status_entries=0,
                 generated_status_entries=0,
                 created_at="2026-06-10T00:00:00Z",
+                materialization=self.materialization(),
             )
 
         self.assertEqual(receipt["evidence_refs"], [])
@@ -132,6 +152,28 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
         self.assertIn("preflight_evidence_refs_exist", receipt["blocking_items"])
         self.assertIn(
             "materialize missing preflight evidence summaries before release review",
+            receipt["next_required_actions"],
+        )
+
+    def test_build_preflight_without_fresh_materialization_cannot_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._fixtures(Path(tmp), worktree="PASS", head="PASS", origin="PASS", release_candidate_entries=0)
+
+            receipt = preflight.build_preflight(
+                inventory_path=paths["inventory"],
+                public_worktree_path=paths["worktree"],
+                public_head_path=paths["head"],
+                public_origin_path=paths["origin"],
+                branch_name="codex/release",
+                status_entries=0,
+                generated_status_entries=0,
+                created_at="2026-06-10T00:00:00Z",
+            )
+
+        self.assertEqual(receipt["result"], "BLOCKED")
+        self.assertIn("fresh_preflight_materialization_provided", receipt["blocking_items"])
+        self.assertIn(
+            "rerun release preflight materializers in the current process before release review",
             receipt["next_required_actions"],
         )
 


### PR DESCRIPTION
## Summary
- Require `release_integration_preflight.build_preflight()` to receive fresh materialization from the current run before it can pass.
- Require production release ops to dereference and validate the human gate record; a string ref alone cannot authorize PASS.
- Update schemas, release docs, and regression tests for stale-materialization and ref-only human-gate bypasses.

## Validation
- `python -m unittest tests.test_release_integration_preflight tests.test_production_release_gate tests.test_factoryctl tests.test_production_full_product_worker_graph -q`
- `python -m unittest discover -s tests -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py --git-ref HEAD`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\release_integration_preflight.py`

## Scope
- Closes #200 after CI confirms.
- Does not touch #84 / cockpit work.
- Adds no historical, private, screenshot, or raw audit artifacts to the public repo.