### PR TITLE
Bind owner issue intake to SDLC feedback loops

### DIFF
--- a/docs/maintenance/self-improvement-loop.md
+++ b/docs/maintenance/self-improvement-loop.md
@@ -185,6 +185,11 @@ not an executed card. It is a bounded draft with source issue, risk, required
 gates, done definition and activation policy so the owner instance can hand it
 to the factory without losing auditability.
 
+Every non-ignored intake row also carries a `factory_sdlc_feedback_loop` and a
+matching `sdlc_feedback_loop_ref` on the card candidate. This keeps owner issue
+signals attached to the canonical SDLC thread before any Hermes dispatch,
+GitHub comment, implementation or human gate can happen.
+
 ## Reasoning Policy
 
 `reasoning_policy` makes the reasoning depth, profile class, review intensity

--- a/schemas/owner-issue-intake-report.schema.json
+++ b/schemas/owner-issue-intake-report.schema.json
@@ -21,6 +21,35 @@
           "reason": { "type": "string", "minLength": 3 },
           "card_status": { "enum": ["blocked", "planning", "not_created"] },
           "dedupe_key": { "type": "string", "minLength": 1 },
+          "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
+          "sdlc_feedback_loop": {
+            "type": "object",
+            "required": ["record_type", "loop_id", "execution_evidence", "sovereignty_boundary"],
+            "properties": {
+              "record_type": { "const": "factory_sdlc_feedback_loop" },
+              "loop_id": { "type": "string", "minLength": 3 },
+              "execution_evidence": {
+                "type": "object",
+                "required": ["status", "failed_outputs_consumable_as_success"],
+                "properties": {
+                  "status": { "enum": ["PENDING", "PASS", "BLOCKED", "REJECTED", "SUPERSEDED"] },
+                  "failed_outputs_consumable_as_success": { "const": false }
+                },
+                "additionalProperties": true
+              },
+              "sovereignty_boundary": {
+                "type": "object",
+                "required": ["public_safe_refs_only", "raw_private_evidence_embedded", "private_context_retained_outside_public_repo"],
+                "properties": {
+                  "public_safe_refs_only": { "const": true },
+                  "raw_private_evidence_embedded": { "const": false },
+                  "private_context_retained_outside_public_repo": { "const": true }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
           "factory_card_candidate": {
             "type": "object",
             "required": [
@@ -33,6 +62,7 @@
               "risk_effective",
               "required_gates",
               "done_definition",
+              "sdlc_feedback_loop_ref",
               "activation_policy"
             ],
             "properties": {
@@ -45,6 +75,7 @@
               "risk_effective": { "type": "string", "minLength": 2 },
               "required_gates": { "type": "array", "minItems": 1, "items": { "type": "string" } },
               "done_definition": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+              "sdlc_feedback_loop_ref": { "type": "string", "minLength": 3 },
               "activation_policy": {
                 "type": "object",
                 "required": ["auto_dispatch_allowed", "human_gate_required", "public_comment_allowed"],
@@ -59,7 +90,22 @@
             "additionalProperties": true
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "decision": {
+                  "enum": ["needs_human_triage", "documentation_only", "implementation_candidate", "critical_factory_change", "private_operator_only"]
+                }
+              },
+              "required": ["decision"]
+            },
+            "then": {
+              "required": ["sdlc_feedback_loop_ref", "sdlc_feedback_loop", "factory_card_candidate"]
+            }
+          }
+        ]
       }
     }
   },

--- a/scripts/factory_self_improvement.py
+++ b/scripts/factory_self_improvement.py
@@ -501,6 +501,7 @@ def build_factory_card_candidate(
     decision: str,
     labels: set[str],
     default_status: str,
+    sdlc_feedback_loop_ref: str,
 ) -> dict[str, Any]:
     critical = decision == "critical_factory_change"
     documentation = decision == "documentation_only"
@@ -534,11 +535,108 @@ def build_factory_card_candidate(
             "Receipt Five evidence records commands, artifacts and residual risk",
         ],
         "source_refs": [issue_ref],
+        "sdlc_feedback_loop_ref": sdlc_feedback_loop_ref,
         "activation_policy": {
             "auto_dispatch_allowed": False,
             "human_gate_required": critical,
             "public_comment_allowed": False,
         },
+    }
+
+
+def triage_decision_for_issue_intake(decision: str) -> str:
+    if decision == "documentation_only":
+        return "docs_task"
+    if decision == "critical_factory_change":
+        return "risk_gate"
+    if decision == "needs_human_triage":
+        return "blocker"
+    if decision == "private_operator_only":
+        return "reject_with_rationale"
+    return "work_unit"
+
+
+def build_issue_intake_sdlc_feedback_loop(
+    issue_ref: str,
+    title: str,
+    decision: str,
+    reason: str,
+    dedupe_key: str,
+) -> dict[str, Any]:
+    critical = decision == "critical_factory_change"
+    feedback_ref = f"external:operator-sdlc-feedback-loop-{dedupe_key}"
+    source_ref = f"external:operator-owner-issue-{dedupe_key}"
+    selected_profile = "human-gate-clerk" if critical else "factory-mechanic-loop"
+    selected_model_class = "human_only" if decision in {"critical_factory_change", "needs_human_triage"} else "balanced"
+    promotion_boundary = "requires_human_gate" if critical else "public_issue_only"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-sdlc-feedback-loop.schema.json",
+        "record_type": "factory_sdlc_feedback_loop",
+        "loop_id": feedback_ref,
+        "created_at": utc_now(),
+        "factory_method_version": "OVERKILL_VFINAL",
+        "source_signal": {
+            "signal_type": "internal_request",
+            "source_class": "operator_supplied",
+            "sensitivity_class": "public_safe",
+            "freshness": "bounded",
+            "owner": "operator-owned-factory-instance",
+            "target_surface": "factory-method",
+            "signal_ref_public_safe": source_ref,
+            "raw_private_embedded": False,
+        },
+        "triage_decision": {
+            "decision": triage_decision_for_issue_intake(decision),
+            "route_ref": "schemas/owner-issue-intake-report.schema.json",
+            "rationale": clean_public_text(reason or title),
+            "human_gate_required": critical or decision == "needs_human_triage",
+            "rejects_chat_only_state": True,
+        },
+        "routing_decision": {
+            "router_ref": "templates/owner-issue-intake-config.json",
+            "selected_profile": selected_profile,
+            "selected_model_class": selected_model_class,
+            "selection_basis": {
+                "cost": "bounded public issue intake",
+                "speed": "dry-run candidate creation only",
+                "quality": "requires schema validation and independent review before activation",
+                "context_need": "issue title, body, labels and owner intake config",
+                "data_sensitivity": "public-safe issue fields only",
+                "tool_requirements": "factory_self_improvement issue-intake and public validators",
+                "expected_horizon": "single bounded intake cycle",
+                "fallback_route": "keep blocked for human triage without dispatching workers",
+            },
+            "model_independence_preserved": True,
+            "single_provider_assumption": False,
+        },
+        "execution_evidence": {
+            "status": "PENDING",
+            "evidence_refs": [source_ref, "templates/owner-issue-intake-config.json"],
+            "failed_outputs_consumable_as_success": False,
+            "validation_refs": [
+                "schemas/owner-issue-intake-report.schema.json",
+                "schemas/factory-sdlc-feedback-loop.schema.json",
+            ],
+        },
+        "learnback_decision": {
+            "classification": "public_issue",
+            "target_artifact_type": "issue",
+            "source_evidence_refs": [source_ref],
+            "validation_refs": [
+                "tests/test_factory_self_improvement.py",
+                "scripts/validate_public_json_artifacts.py",
+            ],
+            "promotion_boundary": promotion_boundary,
+            "rejection_rationale": "not_rejected",
+        },
+        "sovereignty_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+            "reusable_across_products": "bounded",
+            "memory_owner": "operator-owned-factory-instance",
+        },
+        "next_safe_action": "Validate this issue-intake loop before creating or dispatching a factory card.",
     }
 
 
@@ -572,6 +670,16 @@ def build_issue_intake_report(config: dict[str, Any], issues: list[dict[str, Any
             "dedupe_key": slug(f"{issue_ref}-{title}"),
         }
         if decision != "ignore":
+            feedback_loop = build_issue_intake_sdlc_feedback_loop(
+                issue_ref,
+                title,
+                decision,
+                reason,
+                row["dedupe_key"],
+            )
+            feedback_ref = feedback_loop["loop_id"]
+            row["sdlc_feedback_loop_ref"] = feedback_ref
+            row["sdlc_feedback_loop"] = feedback_loop
             row["factory_card_candidate"] = build_factory_card_candidate(
                 issue_ref,
                 title,
@@ -579,6 +687,7 @@ def build_issue_intake_report(config: dict[str, Any], issues: list[dict[str, Any
                 decision,
                 labels,
                 card_status,
+                feedback_ref,
             )
         decisions.append(row)
     return {

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1086,6 +1086,34 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             errors.append(f"{at}: factory_improvement_issue_candidate requires sdlc_feedback_loop_refs for public/actionable routes")
         if PRIVATE_MARKERS.search(serialized_feedback_refs):
             errors.append(f"{at}: factory_improvement_issue_candidate sdlc_feedback_loop_refs must be public-safe")
+    if data.get("record_type") == "owner_issue_intake_report":
+        decisions = data.get("decisions") if isinstance(data.get("decisions"), list) else []
+        actionable = {"needs_human_triage", "documentation_only", "implementation_candidate", "critical_factory_change", "private_operator_only"}
+        for index, row in enumerate(decisions):
+            if not isinstance(row, dict):
+                continue
+            decision = str(row.get("decision") or "").strip()
+            if decision not in actionable:
+                continue
+            feedback_ref = str(row.get("sdlc_feedback_loop_ref") or "").strip()
+            if not feedback_ref:
+                errors.append(f"{at}.decisions[{index}]: actionable owner issue intake requires sdlc_feedback_loop_ref")
+            else:
+                reason = public_artifact_ref_error(feedback_ref)
+                if reason:
+                    errors.append(f"{at}.decisions[{index}].sdlc_feedback_loop_ref: {reason}")
+            loop = row.get("sdlc_feedback_loop") if isinstance(row.get("sdlc_feedback_loop"), dict) else {}
+            candidate = row.get("factory_card_candidate") if isinstance(row.get("factory_card_candidate"), dict) else {}
+            if not loop:
+                errors.append(f"{at}.decisions[{index}]: actionable owner issue intake requires sdlc_feedback_loop")
+            else:
+                if loop.get("loop_id") != feedback_ref:
+                    errors.append(f"{at}.decisions[{index}]: sdlc_feedback_loop.loop_id must match sdlc_feedback_loop_ref")
+                errors.extend(validate_domain_rules(loop, f"{at}.decisions[{index}].sdlc_feedback_loop"))
+            if not candidate:
+                errors.append(f"{at}.decisions[{index}]: actionable owner issue intake requires factory_card_candidate")
+            elif candidate.get("sdlc_feedback_loop_ref") != feedback_ref:
+                errors.append(f"{at}.decisions[{index}]: factory_card_candidate.sdlc_feedback_loop_ref must match row sdlc_feedback_loop_ref")
     if data.get("record_type") == "discord_control_tower_ux_audit":
         serialized = json.dumps(data, sort_keys=True)
         if "todo" in serialized.lower():

--- a/tests/test_factory_self_improvement.py
+++ b/tests/test_factory_self_improvement.py
@@ -28,6 +28,19 @@ def vfinal_card() -> dict:
     return json.loads((ROOT / "templates" / "vfinal-factory-card.json").read_text(encoding="utf-8"))
 
 
+def public_validator_module():
+    validator_spec = importlib.util.spec_from_file_location(
+        "validate_public_json_artifacts",
+        ROOT / "scripts" / "validate_public_json_artifacts.py",
+    )
+    assert validator_spec is not None
+    validator = importlib.util.module_from_spec(validator_spec)
+    assert validator_spec.loader is not None
+    sys.modules["validate_public_json_artifacts"] = validator
+    validator_spec.loader.exec_module(validator)
+    return validator
+
+
 class FactorySelfImprovementTest(unittest.TestCase):
     def test_vfinal_card_requires_reasoning_policy(self) -> None:
         card = vfinal_card()
@@ -583,6 +596,70 @@ class FactorySelfImprovementTest(unittest.TestCase):
         self.assertEqual(candidate["record_type"], "owner_issue_factory_card_candidate")
         self.assertFalse(candidate["activation_policy"]["auto_dispatch_allowed"])
         self.assertTrue(candidate["activation_policy"]["human_gate_required"])
+        self.assertEqual(candidate["sdlc_feedback_loop_ref"], report["decisions"][0]["sdlc_feedback_loop_ref"])
+        self.assertEqual(
+            report["decisions"][0]["sdlc_feedback_loop"]["triage_decision"]["decision"],
+            "risk_gate",
+        )
+        self.assertEqual(
+            report["decisions"][0]["sdlc_feedback_loop"]["routing_decision"]["selected_model_class"],
+            "human_only",
+        )
+        self.assertEqual(factoryctl.validate_factory_sdlc_feedback_loop(report["decisions"][0]["sdlc_feedback_loop"]), [])
+
+    def test_owner_issue_intake_attaches_valid_sdlc_feedback_loop_to_actionable_candidate(self) -> None:
+        config = json.loads((ROOT / "templates" / "owner-issue-intake-config.json").read_text(encoding="utf-8"))
+        issues = [
+            {
+                "number": 102,
+                "title": "Add product proof test",
+                "body": "Create a bounded test for a product proof gap.",
+                "labels": ["factory-improvement"],
+            }
+        ]
+
+        report = self_improvement.build_issue_intake_report(config, issues)
+        decision = report["decisions"][0]
+        loop = decision["sdlc_feedback_loop"]
+        candidate = decision["factory_card_candidate"]
+
+        self.assertEqual(decision["decision"], "implementation_candidate")
+        self.assertEqual(loop["record_type"], "factory_sdlc_feedback_loop")
+        self.assertEqual(loop["loop_id"], decision["sdlc_feedback_loop_ref"])
+        self.assertEqual(candidate["sdlc_feedback_loop_ref"], decision["sdlc_feedback_loop_ref"])
+        self.assertEqual(loop["execution_evidence"]["status"], "PENDING")
+        self.assertFalse(loop["execution_evidence"]["failed_outputs_consumable_as_success"])
+        self.assertEqual(factoryctl.validate_factory_sdlc_feedback_loop(loop), [])
+
+        validator = public_validator_module()
+        schemas = validator.load_schemas()
+        schema = schemas["owner-issue-intake-report.schema.json"]
+
+        schema_errors = validator.validate_node(schema, report, "$", schemas=schemas, root_schema=schema)
+        domain_errors = validator.validate_domain_rules(report, "$")
+
+        self.assertEqual(schema_errors + domain_errors, [])
+
+    def test_owner_issue_intake_domain_rejects_actionable_candidate_without_feedback_loop(self) -> None:
+        config = json.loads((ROOT / "templates" / "owner-issue-intake-config.json").read_text(encoding="utf-8"))
+        issues = [
+            {
+                "number": 103,
+                "title": "Add docs for proof",
+                "body": "Documentation update.",
+                "labels": ["factory-improvement"],
+            }
+        ]
+        report = self_improvement.build_issue_intake_report(config, issues)
+        decision = report["decisions"][0]
+        decision.pop("sdlc_feedback_loop_ref")
+        decision.pop("sdlc_feedback_loop")
+
+        validator = public_validator_module()
+        errors = validator.validate_domain_rules(report, "$")
+
+        self.assertIn("$.decisions[0]: actionable owner issue intake requires sdlc_feedback_loop_ref", errors)
+        self.assertIn("$.decisions[0]: actionable owner issue intake requires sdlc_feedback_loop", errors)
 
     def test_governance_report_declares_mandatory_public_checks(self) -> None:
         report = self_improvement.governance_report()


### PR DESCRIPTION
## Summary
- Bind owner issue intake decisions to a public-safe `factory_sdlc_feedback_loop` before they can become factory card candidates.
- Require matching `sdlc_feedback_loop_ref` on actionable intake rows and generated card candidates.
- Add public artifact domain validation so the row ref, loop id, and candidate ref cannot drift apart.
- Document the owner issue intake SDLC boundary.

## Validation
- `python -m unittest tests.test_factory_self_improvement tests.test_factory_sdlc_feedback_loop -q`
- `python -m unittest tests.test_factory_self_improvement tests.test_factory_sdlc_feedback_loop tests.test_factoryctl tests.test_evidence_reconciler tests.test_evidence_graph_truth -q`
- `python -m unittest discover -s tests -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py --git-ref HEAD`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\release_integration_preflight.py`

## Scope
- Advances/closes #252 by making owner issue intake part of the canonical SDLC feedback gear.
- Does not replace Hermes, dispatch workers, approve gates, or touch #84/cockpit.
- Adds no historical, private, screenshot, raw research, or audit artifacts to the public repo.