### PR TITLE
Structure production and incident readiness gates

### DIFF
--- a/docs/concepts/overkill-factory-method.md
+++ b/docs/concepts/overkill-factory-method.md
@@ -247,6 +247,13 @@ The important gates are:
 | Completion Audit | Required method, gate or evidence is skipped. |
 | Release Gate | Release lacks owner, rollback, monitoring, channel or approval. |
 
+Production and incident readiness are structured gates. A release-ready card
+needs named owners, executable health checks, monitoring signal refs, rollback
+procedure and validation refs, approval authority, support handoff, incident
+triggers, severity model, escalation path, public/private communication boundary,
+recovery actions and evidence refs. Narrative monitoring or rollback text is not
+enough for `OVERKILL_VFINAL` material work.
+
 ## Definition Of Done
 
 Work is done only when the factory can answer:

--- a/schemas/incident-support-plan.schema.json
+++ b/schemas/incident-support-plan.schema.json
@@ -3,13 +3,110 @@
   "$id": "https://overkill-factory.dev/schemas/incident-support-plan.schema.json",
   "title": "Overkill Factory Incident Support Plan",
   "type": "object",
-  "required": ["severity", "owner", "communication_path", "resolution_or_next_action"],
+  "required": [
+    "$schema",
+    "gate_enforcement",
+    "incident_triggers",
+    "severity_model",
+    "owner",
+    "escalation_path",
+    "communication_boundary",
+    "recovery_actions",
+    "evidence_refs",
+    "learnback_target"
+  ],
   "properties": {
-    "severity": { "type": "string", "minLength": 1 },
-    "owner": { "type": "string", "minLength": 3 },
-    "communication_path": { "type": "string", "minLength": 3 },
-    "resolution_or_next_action": { "type": "string", "minLength": 3 },
-    "evidence_refs": { "type": "array", "items": { "type": "string" } }
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/incident-support-plan.schema.json"
+    },
+    "gate_enforcement": {
+      "enum": ["strict", "production"]
+    },
+    "incident_triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["trigger_id", "signal_ref", "condition", "owner"],
+        "properties": {
+          "trigger_id": { "type": "string", "minLength": 3 },
+          "signal_ref": { "type": "string", "minLength": 3 },
+          "condition": { "type": "string", "minLength": 3 },
+          "owner": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "severity_model": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["severity", "impact", "response_slo", "escalation_owner"],
+        "properties": {
+          "severity": { "type": "string", "minLength": 3 },
+          "impact": { "type": "string", "minLength": 3 },
+          "response_slo": { "type": "string", "minLength": 3 },
+          "escalation_owner": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 3
+    },
+    "escalation_path": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["step", "owner", "condition", "handoff_ref"],
+        "properties": {
+          "step": { "type": "string", "minLength": 3 },
+          "owner": { "type": "string", "minLength": 3 },
+          "condition": { "type": "string", "minLength": 3 },
+          "handoff_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "communication_boundary": {
+      "type": "object",
+      "required": ["public_status_allowed", "private_details_forbidden", "communication_channel_ref", "update_cadence"],
+      "properties": {
+        "public_status_allowed": { "type": "boolean" },
+        "private_details_forbidden": { "const": true },
+        "communication_channel_ref": { "type": "string", "minLength": 3 },
+        "update_cadence": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "recovery_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["action_id", "action_type", "owner", "procedure_ref", "validation_ref"],
+        "properties": {
+          "action_id": { "type": "string", "minLength": 3 },
+          "action_type": { "enum": ["rollback", "disable_feature", "repair_forward", "keep_blocked", "escalate_human_gate"] },
+          "owner": { "type": "string", "minLength": 3 },
+          "procedure_ref": { "type": "string", "minLength": 3 },
+          "validation_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "learnback_target": {
+      "type": "string",
+      "minLength": 3
+    }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/schemas/production-readiness-plan.schema.json
+++ b/schemas/production-readiness-plan.schema.json
@@ -4,21 +4,121 @@
   "title": "Overkill Factory Production Readiness Plan",
   "type": "object",
   "required": [
+    "$schema",
+    "gate_enforcement",
+    "release_owner",
     "release_path",
     "rollback_path",
-    "monitoring",
+    "health_checks",
+    "monitoring_signals",
+    "release_approval_rule",
+    "support_handoff",
     "incident_owner",
-    "support_path",
-    "production_promotion_ladder_ref"
+    "production_promotion_ladder_ref",
+    "evidence_refs"
   ],
   "properties": {
-    "release_path": { "type": "string", "minLength": 3 },
-    "rollback_path": { "type": "string", "minLength": 3 },
-    "monitoring": { "type": "array", "items": { "type": "string" } },
-    "incident_owner": { "type": "string", "minLength": 3 },
-    "support_path": { "type": "string", "minLength": 3 },
-    "production_promotion_ladder_ref": { "type": "string", "minLength": 3 },
-    "evidence_refs": { "type": "array", "items": { "type": "string" } }
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/production-readiness-plan.schema.json"
+    },
+    "gate_enforcement": {
+      "enum": ["strict", "production"]
+    },
+    "release_owner": {
+      "type": "string",
+      "minLength": 3
+    },
+    "release_path": {
+      "type": "object",
+      "required": ["release_channel", "release_artifact_ref", "pre_release_smoke_ref", "approval_rule_ref"],
+      "properties": {
+        "release_channel": { "type": "string", "minLength": 3 },
+        "release_artifact_ref": { "type": "string", "minLength": 3 },
+        "pre_release_smoke_ref": { "type": "string", "minLength": 3 },
+        "approval_rule_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "rollback_path": {
+      "type": "object",
+      "required": ["rollback_owner", "rollback_trigger", "rollback_procedure_ref", "rollback_validation_ref", "max_time_to_restore"],
+      "properties": {
+        "rollback_owner": { "type": "string", "minLength": 3 },
+        "rollback_trigger": { "type": "string", "minLength": 3 },
+        "rollback_procedure_ref": { "type": "string", "minLength": 3 },
+        "rollback_validation_ref": { "type": "string", "minLength": 3 },
+        "max_time_to_restore": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "health_checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["check_id", "signal_ref", "pass_condition", "owner", "cadence"],
+        "properties": {
+          "check_id": { "type": "string", "minLength": 3 },
+          "signal_ref": { "type": "string", "minLength": 3 },
+          "pass_condition": { "type": "string", "minLength": 3 },
+          "owner": { "type": "string", "minLength": 3 },
+          "cadence": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "monitoring_signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["signal_id", "source_ref", "alert_condition", "owner", "evidence_ref"],
+        "properties": {
+          "signal_id": { "type": "string", "minLength": 3 },
+          "source_ref": { "type": "string", "minLength": 3 },
+          "alert_condition": { "type": "string", "minLength": 3 },
+          "owner": { "type": "string", "minLength": 3 },
+          "evidence_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "release_approval_rule": {
+      "type": "object",
+      "required": ["authority", "required_before", "human_gate_required", "evidence_ref"],
+      "properties": {
+        "authority": { "type": "string", "minLength": 3 },
+        "required_before": { "enum": ["release_candidate", "production_release", "mainnet_release"] },
+        "human_gate_required": { "type": "boolean" },
+        "evidence_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "support_handoff": {
+      "type": "object",
+      "required": ["support_owner", "support_channel_ref", "escalation_policy_ref", "response_slo", "handoff_evidence_ref"],
+      "properties": {
+        "support_owner": { "type": "string", "minLength": 3 },
+        "support_channel_ref": { "type": "string", "minLength": 3 },
+        "escalation_policy_ref": { "type": "string", "minLength": 3 },
+        "response_slo": { "type": "string", "minLength": 3 },
+        "handoff_evidence_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "incident_owner": {
+      "type": "string",
+      "minLength": 3
+    },
+    "production_promotion_ladder_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2663,6 +2663,138 @@ def validate_production_promotion_ladder_contract(card: dict[str, Any]) -> list[
     return errors
 
 
+def _validate_named_ref(value: Any, at: str, errors: list[str]) -> None:
+    ref = str(value or "").strip()
+    if not ref:
+        errors.append(f"{at} is required")
+        return
+    _validate_public_ref(ref, at, errors)
+
+
+def validate_production_readiness_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("production-readiness-plan.schema.json")
+    if not schema:
+        return ["production_readiness_plan schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            plan,
+            "production_readiness_plan",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    release_path = plan.get("release_path") if isinstance(plan.get("release_path"), dict) else {}
+    rollback_path = plan.get("rollback_path") if isinstance(plan.get("rollback_path"), dict) else {}
+    approval = plan.get("release_approval_rule") if isinstance(plan.get("release_approval_rule"), dict) else {}
+    support = plan.get("support_handoff") if isinstance(plan.get("support_handoff"), dict) else {}
+
+    if not isinstance(plan.get("release_path"), dict):
+        errors.append("production_readiness_plan.release_path must be structured, not prose")
+    if not isinstance(plan.get("rollback_path"), dict):
+        errors.append("production_readiness_plan.rollback_path must be structured, not prose")
+    if not isinstance(plan.get("support_handoff"), dict):
+        errors.append("production_readiness_plan.support_handoff must be structured, not prose")
+    if not isinstance(plan.get("release_approval_rule"), dict):
+        errors.append("production_readiness_plan.release_approval_rule must be structured, not prose")
+
+    for field in ("release_artifact_ref", "pre_release_smoke_ref", "approval_rule_ref"):
+        _validate_named_ref(release_path.get(field), f"production_readiness_plan.release_path.{field}", errors)
+    for field in ("rollback_procedure_ref", "rollback_validation_ref"):
+        _validate_named_ref(rollback_path.get(field), f"production_readiness_plan.rollback_path.{field}", errors)
+    _validate_named_ref(approval.get("evidence_ref"), "production_readiness_plan.release_approval_rule.evidence_ref", errors)
+    for field in ("support_channel_ref", "escalation_policy_ref", "handoff_evidence_ref"):
+        _validate_named_ref(support.get(field), f"production_readiness_plan.support_handoff.{field}", errors)
+    _validate_named_ref(
+        plan.get("production_promotion_ladder_ref"),
+        "production_readiness_plan.production_promotion_ladder_ref",
+        errors,
+    )
+    _validate_lifecycle_refs(_list_items(plan.get("evidence_refs")), "production_readiness_plan.evidence_refs", errors)
+
+    health_checks = plan.get("health_checks") if isinstance(plan.get("health_checks"), list) else []
+    monitoring_signals = plan.get("monitoring_signals") if isinstance(plan.get("monitoring_signals"), list) else []
+    if not health_checks:
+        errors.append("production_readiness_plan.health_checks must be non-empty")
+    if not monitoring_signals:
+        errors.append("production_readiness_plan.monitoring_signals must be non-empty")
+    for index, check in enumerate(health_checks):
+        if not isinstance(check, dict):
+            errors.append(f"production_readiness_plan.health_checks[{index}] must be structured, not prose")
+            continue
+        _validate_named_ref(check.get("signal_ref"), f"production_readiness_plan.health_checks[{index}].signal_ref", errors)
+    for index, signal in enumerate(monitoring_signals):
+        if not isinstance(signal, dict):
+            errors.append(f"production_readiness_plan.monitoring_signals[{index}] must be structured, not prose")
+            continue
+        _validate_named_ref(signal.get("source_ref"), f"production_readiness_plan.monitoring_signals[{index}].source_ref", errors)
+        _validate_named_ref(signal.get("evidence_ref"), f"production_readiness_plan.monitoring_signals[{index}].evidence_ref", errors)
+    return errors
+
+
+def validate_incident_support_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("incident-support-plan.schema.json")
+    if not schema:
+        return ["incident_support_plan schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            plan,
+            "incident_support_plan",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    triggers = plan.get("incident_triggers") if isinstance(plan.get("incident_triggers"), list) else []
+    severity_model = plan.get("severity_model") if isinstance(plan.get("severity_model"), list) else []
+    escalation_path = plan.get("escalation_path") if isinstance(plan.get("escalation_path"), list) else []
+    recovery_actions = plan.get("recovery_actions") if isinstance(plan.get("recovery_actions"), list) else []
+    communication = plan.get("communication_boundary") if isinstance(plan.get("communication_boundary"), dict) else {}
+
+    if not triggers:
+        errors.append("incident_support_plan.incident_triggers must be non-empty")
+    if not severity_model:
+        errors.append("incident_support_plan.severity_model must be non-empty")
+    if not escalation_path:
+        errors.append("incident_support_plan.escalation_path must be non-empty")
+    if not recovery_actions:
+        errors.append("incident_support_plan.recovery_actions must be non-empty")
+    if not isinstance(plan.get("communication_boundary"), dict):
+        errors.append("incident_support_plan.communication_boundary must be structured, not prose")
+    if communication.get("private_details_forbidden") is not True:
+        errors.append("incident_support_plan.communication_boundary.private_details_forbidden must be true")
+
+    for index, trigger in enumerate(triggers):
+        if not isinstance(trigger, dict):
+            errors.append(f"incident_support_plan.incident_triggers[{index}] must be structured, not prose")
+            continue
+        _validate_named_ref(trigger.get("signal_ref"), f"incident_support_plan.incident_triggers[{index}].signal_ref", errors)
+    for index, step in enumerate(escalation_path):
+        if not isinstance(step, dict):
+            errors.append(f"incident_support_plan.escalation_path[{index}] must be structured, not prose")
+            continue
+        _validate_named_ref(step.get("handoff_ref"), f"incident_support_plan.escalation_path[{index}].handoff_ref", errors)
+    for index, action in enumerate(recovery_actions):
+        if not isinstance(action, dict):
+            errors.append(f"incident_support_plan.recovery_actions[{index}] must be structured, not prose")
+            continue
+        _validate_named_ref(action.get("procedure_ref"), f"incident_support_plan.recovery_actions[{index}].procedure_ref", errors)
+        _validate_named_ref(action.get("validation_ref"), f"incident_support_plan.recovery_actions[{index}].validation_ref", errors)
+    _validate_named_ref(
+        communication.get("communication_channel_ref"),
+        "incident_support_plan.communication_boundary.communication_channel_ref",
+        errors,
+    )
+    _validate_lifecycle_refs(_list_items(plan.get("evidence_refs")), "incident_support_plan.evidence_refs", errors)
+    return errors
+
+
 def _contains_internal_coordination_request(text: Any) -> bool:
     normalized = str(text or "").strip().lower()
     return any(term in normalized for term in INTERNAL_COORDINATION_TERMS)
@@ -3727,6 +3859,8 @@ def _validate_vfinal_schema_backed_plan_gate(
         should_validate = True
     if material_product_context and field == "user_docs_onboarding_plan" and _non_empty_dict(plan):
         should_validate = True
+    if material_product_context and field in {"production_readiness_plan", "incident_support_plan"} and _non_empty_dict(plan):
+        should_validate = True
 
     if should_validate and gate not in {"strict", "production"}:
         errors.append(f"{field}.gate_enforcement must be strict or production for OVERKILL_VFINAL cards")
@@ -4084,6 +4218,20 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
             data,
             "user_docs_onboarding_plan",
             validate_user_docs_onboarding_plan,
+        )
+    )
+    errors.extend(
+        _validate_vfinal_schema_backed_plan_gate(
+            data,
+            "production_readiness_plan",
+            validate_production_readiness_plan,
+        )
+    )
+    errors.extend(
+        _validate_vfinal_schema_backed_plan_gate(
+            data,
+            "incident_support_plan",
+            validate_incident_support_plan,
         )
     )
     return errors

--- a/templates/incident-support-plan.json
+++ b/templates/incident-support-plan.json
@@ -1,8 +1,49 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/incident-support-plan.schema.json",
-  "severity": "SEV-3",
-  "owner": "incident-owner",
-  "communication_path": "status update and owner note",
-  "resolution_or_next_action": "fix, rollback or keep blocked with owner",
-  "evidence_refs": ["incident-support-plan.md"]
+  "gate_enforcement": "production",
+  "incident_triggers": [
+    {
+      "trigger_id": "release-regression",
+      "signal_ref": "scripts/release_integration_preflight.py",
+      "condition": "release preflight or post-release smoke blocks",
+      "owner": "release-ops-worker"
+    }
+  ],
+  "severity_model": [
+    {
+      "severity": "SEV-3",
+      "impact": "release is blocked or degraded before customer-impacting production claim",
+      "response_slo": "owner triages before release continues",
+      "escalation_owner": "human-gate-clerk"
+    }
+  ],
+  "owner": "release-ops-worker",
+  "escalation_path": [
+    {
+      "step": "block-release",
+      "owner": "release-ops-worker",
+      "condition": "validation, safety or support evidence is missing or failing",
+      "handoff_ref": "templates/human-gate-record.json"
+    }
+  ],
+  "communication_boundary": {
+    "public_status_allowed": true,
+    "private_details_forbidden": true,
+    "communication_channel_ref": "external:operator-support-route",
+    "update_cadence": "on every blocking state change"
+  },
+  "recovery_actions": [
+    {
+      "action_id": "rollback-release",
+      "action_type": "rollback",
+      "owner": "release-ops-worker",
+      "procedure_ref": "docs/operations/validation-and-release.md",
+      "validation_ref": "scripts/release_integration_preflight.py"
+    }
+  ],
+  "evidence_refs": [
+    "templates/incident-support-plan.json",
+    "docs/operations/validation-and-release.md"
+  ],
+  "learnback_target": "factory_maturity_scorecard"
 }

--- a/templates/production-readiness-plan.json
+++ b/templates/production-readiness-plan.json
@@ -1,10 +1,55 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/production-readiness-plan.schema.json",
-  "release_path": "staged release with explicit gate",
-  "rollback_path": "revert deployment and restore previous version",
-  "monitoring": ["health check", "error rate", "latency", "alert owner"],
-  "incident_owner": "release-owner",
-  "support_path": "documented support channel and escalation",
+  "gate_enforcement": "production",
+  "release_owner": "release-ops-worker",
+  "release_path": {
+    "release_channel": "staged-public-release",
+    "release_artifact_ref": "templates/production-readiness-plan.json",
+    "pre_release_smoke_ref": "scripts/release_integration_preflight.py",
+    "approval_rule_ref": "templates/production-promotion-ladder.json"
+  },
+  "rollback_path": {
+    "rollback_owner": "release-ops-worker",
+    "rollback_trigger": "Any blocking regression in validation, public safety, secret safety or support readiness.",
+    "rollback_procedure_ref": "docs/operations/validation-and-release.md",
+    "rollback_validation_ref": "scripts/release_integration_preflight.py",
+    "max_time_to_restore": "bounded to the release owner runbook"
+  },
+  "health_checks": [
+    {
+      "check_id": "release-smoke",
+      "signal_ref": "scripts/release_integration_preflight.py",
+      "pass_condition": "preflight result is PASS",
+      "owner": "release-ops-worker",
+      "cadence": "before every release"
+    }
+  ],
+  "monitoring_signals": [
+    {
+      "signal_id": "public-safety",
+      "source_ref": "scripts/public_safety_scan.py",
+      "alert_condition": "public safety scan fails",
+      "owner": "release-ops-worker",
+      "evidence_ref": "scripts/public_safety_scan.py"
+    }
+  ],
+  "release_approval_rule": {
+    "authority": "human-gate-clerk",
+    "required_before": "production_release",
+    "human_gate_required": true,
+    "evidence_ref": "templates/human-gate-record.json"
+  },
+  "support_handoff": {
+    "support_owner": "release-ops-worker",
+    "support_channel_ref": "external:operator-support-route",
+    "escalation_policy_ref": "templates/incident-support-plan.json",
+    "response_slo": "owner acknowledges blocking release incidents before promotion continues",
+    "handoff_evidence_ref": "templates/incident-support-plan.json"
+  },
+  "incident_owner": "release-ops-worker",
   "production_promotion_ladder_ref": "templates/production-promotion-ladder.json",
-  "evidence_refs": ["production-readiness-plan.md"]
+  "evidence_refs": [
+    "templates/production-readiness-plan.json",
+    "templates/production-promotion-ladder.json"
+  ]
 }

--- a/templates/vfinal-factory-card.json
+++ b/templates/vfinal-factory-card.json
@@ -1090,20 +1090,100 @@
   },
   "production_readiness_plan": {
     "$schema": "https://overkill-factory.dev/schemas/production-readiness-plan.schema.json",
-    "release_path": "staged release with explicit gate",
-    "rollback_path": "revert bounded slice or run the approved mitigation",
-    "monitoring": ["incident/support plan"],
+    "gate_enforcement": "production",
+    "release_owner": "release-ops-worker",
+    "release_path": {
+      "release_channel": "staged-public-release",
+      "release_artifact_ref": "templates/vfinal-factory-card.json#production_readiness_plan",
+      "pre_release_smoke_ref": "scripts/release_integration_preflight.py",
+      "approval_rule_ref": "templates/production-promotion-ladder.json"
+    },
+    "rollback_path": {
+      "rollback_owner": "release-ops-worker",
+      "rollback_trigger": "Any blocking regression in validation, safety or support readiness.",
+      "rollback_procedure_ref": "docs/operations/validation-and-release.md",
+      "rollback_validation_ref": "scripts/release_integration_preflight.py",
+      "max_time_to_restore": "bounded to the release owner runbook"
+    },
+    "health_checks": [
+      {
+        "check_id": "release-smoke",
+        "signal_ref": "scripts/release_integration_preflight.py",
+        "pass_condition": "preflight result is PASS",
+        "owner": "release-ops-worker",
+        "cadence": "before release"
+      }
+    ],
+    "monitoring_signals": [
+      {
+        "signal_id": "public-safety",
+        "source_ref": "scripts/public_safety_scan.py",
+        "alert_condition": "public safety scan fails",
+        "owner": "release-ops-worker",
+        "evidence_ref": "scripts/public_safety_scan.py"
+      }
+    ],
+    "release_approval_rule": {
+      "authority": "human-gate-clerk",
+      "required_before": "production_release",
+      "human_gate_required": true,
+      "evidence_ref": "templates/human-gate-record.json"
+    },
+    "support_handoff": {
+      "support_owner": "release-ops-worker",
+      "support_channel_ref": "external:operator-support-route",
+      "escalation_policy_ref": "templates/incident-support-plan.json",
+      "response_slo": "owner acknowledges blocking release incidents before promotion continues",
+      "handoff_evidence_ref": "templates/incident-support-plan.json"
+    },
     "incident_owner": "release-ops-worker",
-    "support_path": "documented support channel and escalation",
     "production_promotion_ladder_ref": "templates/production-promotion-ladder.json",
-    "evidence_refs": ["templates/production-promotion-ladder.json"]
+    "evidence_refs": ["templates/vfinal-factory-card.json#production_readiness_plan", "templates/production-promotion-ladder.json"]
   },
   "incident_support_plan": {
     "$schema": "https://overkill-factory.dev/schemas/incident-support-plan.schema.json",
-    "support_owner": "release-ops-worker",
-    "incident_triggers": ["release failure", "gate bypass", "private leak"],
-    "triage_steps": ["block release", "capture evidence", "create learnback"],
-    "escalation": ["human gate when material risk exists"],
+    "gate_enforcement": "production",
+    "incident_triggers": [
+      {
+        "trigger_id": "release-failure",
+        "signal_ref": "scripts/release_integration_preflight.py",
+        "condition": "release preflight or post-release smoke blocks",
+        "owner": "release-ops-worker"
+      }
+    ],
+    "severity_model": [
+      {
+        "severity": "SEV-3",
+        "impact": "release is blocked or degraded before customer-impacting production claim",
+        "response_slo": "owner triages before release continues",
+        "escalation_owner": "human-gate-clerk"
+      }
+    ],
+    "owner": "release-ops-worker",
+    "escalation_path": [
+      {
+        "step": "block-release",
+        "owner": "release-ops-worker",
+        "condition": "validation, safety or support evidence is missing or failing",
+        "handoff_ref": "templates/human-gate-record.json"
+      }
+    ],
+    "communication_boundary": {
+      "public_status_allowed": true,
+      "private_details_forbidden": true,
+      "communication_channel_ref": "external:operator-support-route",
+      "update_cadence": "on every blocking state change"
+    },
+    "recovery_actions": [
+      {
+        "action_id": "rollback-release",
+        "action_type": "rollback",
+        "owner": "release-ops-worker",
+        "procedure_ref": "docs/operations/validation-and-release.md",
+        "validation_ref": "scripts/release_integration_preflight.py"
+      }
+    ],
+    "evidence_refs": ["templates/vfinal-factory-card.json#incident_support_plan"],
     "learnback_target": "factory_maturity_scorecard"
   },
   "user_docs_onboarding_plan": {

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1243,6 +1243,56 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertIn("sdlc_feedback_loop_ref must be public-safe", errors)
 
+    def test_vfinal_production_readiness_plan_rejects_prose_only_ops(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["production_readiness_plan"] = {
+            "$schema": "https://overkill-factory.dev/schemas/production-readiness-plan.schema.json",
+            "gate_enforcement": "production",
+            "release_path": "ship it when tests pass",
+            "rollback_path": "revert if needed",
+            "monitoring": ["watch errors"],
+            "incident_owner": "release-ops-worker",
+            "support_path": "ask the maintainer",
+            "production_promotion_ladder_ref": "templates/production-promotion-ladder.json",
+            "evidence_refs": ["templates/production-readiness-plan.json"],
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertTrue(any("production_readiness_plan.release_path" in error for error in errors), errors)
+        self.assertTrue(any("production_readiness_plan.rollback_path" in error for error in errors), errors)
+        self.assertTrue(any("production_readiness_plan.health_checks" in error for error in errors), errors)
+        self.assertTrue(any("production_readiness_plan.monitoring_signals" in error for error in errors), errors)
+        self.assertTrue(any("production_readiness_plan.support_handoff" in error for error in errors), errors)
+
+    def test_vfinal_incident_support_plan_rejects_prose_only_incident_path(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["incident_support_plan"] = {
+            "$schema": "https://overkill-factory.dev/schemas/incident-support-plan.schema.json",
+            "gate_enforcement": "production",
+            "severity": "SEV-3",
+            "owner": "release-ops-worker",
+            "communication_path": "status update",
+            "resolution_or_next_action": "fix or rollback",
+            "evidence_refs": ["templates/incident-support-plan.json"],
+        }
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertTrue(any("incident_support_plan.incident_triggers" in error for error in errors), errors)
+        self.assertTrue(any("incident_support_plan.severity_model" in error for error in errors), errors)
+        self.assertTrue(any("incident_support_plan.escalation_path" in error for error in errors), errors)
+        self.assertTrue(any("incident_support_plan.recovery_actions" in error for error in errors), errors)
+        self.assertTrue(any("incident_support_plan.communication_boundary" in error for error in errors), errors)
+
+    def test_vfinal_structured_production_and_incident_plans_validate(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertFalse(any("production_readiness_plan." in error for error in errors), errors)
+        self.assertFalse(any("incident_support_plan." in error for error in errors), errors)
+
     def test_vfinal_material_execution_requires_autonomy_and_model_routing_decision(self) -> None:
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
         card.pop("autonomy_mode", None)


### PR DESCRIPTION
## Summary
- Replace prose-only production readiness fields with structured release, rollback, health, monitoring, approval, support and evidence gates.
- Replace prose-only incident support fields with structured triggers, severity model, escalation, communication boundary, recovery actions and evidence refs.
- Wire both plans into `factoryctl validate-card` for material `OVERKILL_VFINAL` work.
- Update templates, vFinal card, public method docs and regression tests.

## Validation
- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest tests.test_factoryctl tests.test_open_source_docs tests.test_public_json_artifact_validator -q`
- `python -m unittest discover -s tests -q`
- `python scripts\factoryctl.py validate-card templates\vfinal-factory-card.json`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py --git-ref HEAD`
- `python scripts\secret_safety_scan.py`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\release_integration_preflight.py`

## Scope
- Closes #211 after CI confirms.
- Does not touch #84/cockpit.
- Adds no private evidence, historical artifacts, screenshots, or raw audit material to the public repo.