### PR TITLE
Add product surface proof profiles

### DIFF
--- a/agents/capability-packs.public.json
+++ b/agents/capability-packs.public.json
@@ -67,8 +67,45 @@
       "required_before_execution": true,
       "activation_rule": "Available by default for ordinary web/product software when no specialized template-only surface is present.",
       "evidence_required": ["factoryctl gate report", "worker packets", "Receipt Five"],
-      "structured_proofs_required": ["generic.scope-fit", "generic.operator-usability", "web.runtime-smoke"],
+      "delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
+      "structured_proofs_required": [
+        "generic.scope-fit",
+        "generic.operator-usability",
+        "web.runtime-smoke",
+        "api.contract-schema",
+        "api.auth-permission-boundary",
+        "api.error-semantics",
+        "api.compatibility-versioning",
+        "data.migration-rollback",
+        "data.seed-fixture-behavior",
+        "data.retention-privacy-boundary",
+        "data.operational-safety"
+      ],
       "reference_sources": ["ring dev-team", "gstack qa/review/ship", "aiox-core development agents"]
+    },
+    "cli-tui-product-pack": {
+      "pack_id": "cli-tui-product-pack",
+      "status": "core_ready",
+      "plain_purpose": "Covers executable CLI and TUI products with command contracts, terminal UX, transcripts, packaging and release proof.",
+      "covers_surfaces": ["cli", "tui", "terminal", "console", "command_line", "command-line"],
+      "existing_workers": ["docs-os-worker", "test-automation-builder", "qa-verification-worker", "release-ops-worker"],
+      "missing_worker_templates": [],
+      "required_before_execution": true,
+      "activation_rule": "Available by default for CLI/TUI products after Product Face routes the surface to cli_tui and proof coverage is required through the delivery quality profile.",
+      "evidence_required": ["install/run smoke", "help output", "golden transcript", "error-state transcript", "cross-platform terminal proof", "package/release readiness"],
+      "delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
+      "structured_proofs_required": [
+        "cli.install-run-smoke",
+        "cli.help-output",
+        "cli.golden-transcript",
+        "cli.error-state-transcript",
+        "cli.cross-platform-shell",
+        "cli.package-release-readiness"
+      ],
+      "input_contract": ["command contract", "install/run path", "target shells and platforms", "expected success and error states"],
+      "output_contract": ["validated command transcript", "documented help UX", "terminal error-state proof", "package/release readiness evidence"],
+      "local_smoke_path": "python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json",
+      "reference_sources": ["docs/product-face/proof-runner.md", "templates/product-delivery-quality-profile.json"]
     },
     "cloud-native-core": {
       "pack_id": "cloud-native-core",
@@ -93,6 +130,7 @@
       "required_before_execution": true,
       "activation_rule": "Available by default after agent_eval_plan, permission class and reviewer separation exist.",
       "evidence_required": ["agent eval plan", "permission class", "security handoff", "profile/binding refs"],
+      "delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
       "structured_proofs_required": ["agent.eval-plan", "agent.permission-boundary", "agent.profile-binding"],
       "reference_sources": ["ring prompt-reviewer", "mattpocock/skills", "orca workflow/review"]
     },

--- a/docs/agents/capability-packs.md
+++ b/docs/agents/capability-packs.md
@@ -47,6 +47,7 @@ These packs are ready in the public Factory:
 | Pack | Covers |
 | --- | --- |
 | `web-saas-core` | Web apps, SaaS, APIs, persistence, auth, integrations, tests, docs, release and monitoring. |
+| `cli-tui-product-pack` | Executable CLI/TUI products with command contracts, terminal transcripts, help UX and package/release proof. |
 | `cloud-native-core` | CI/CD, runtime, deploy wiring, cloud security, observability and rollback planning. |
 | `agent-runtime-core` | Hermes, Factory adapter, profiles, skills, tools, memory, MCP and agentic workflow changes. |
 | `solana-quasar-core` | Quasar-first Solana/onchain program work, wallet transactions, signer boundaries and onchain QA. |
@@ -94,6 +95,14 @@ The template lives at `templates/capability-pack-contract.json`.
 `templates/capability-pack-activation-example.json` shows a complete
 non-core pack activation shape, but it is deliberately blocked until real
 public-safe smoke and eval refs replace the placeholders.
+
+Core packs can still require surface-specific proof through
+`templates/product-delivery-quality-profile.json`. API/data surfaces must prove
+contract, auth, error semantics, migrations, fixtures, retention and operational
+data safety. CLI/TUI surfaces must prove command transcripts, help output,
+error states, install/run and shell behavior. A user-facing agentic product must
+be classified as `user_facing_agentic_product`; internal `agent-runtime-core`
+readiness does not satisfy that product proof by itself.
 
 ## Activation Flow
 

--- a/docs/agents/worker-profiles.md
+++ b/docs/agents/worker-profiles.md
@@ -57,6 +57,7 @@ Ready packs:
 | Pack | Coverage |
 | --- | --- |
 | `web-saas-core` | ordinary web, SaaS, API, data, auth, integration, tests, docs, release and monitoring work. |
+| `cli-tui-product-pack` | CLI/TUI command products, terminal UX, transcripts, install/run and package/release proof. |
 | `cloud-native-core` | CI/CD, runtime, cloud, monitoring, rollback and production operations boundaries. |
 | `agent-runtime-core` | Hermes, Factory, profiles, skills, memory, tools, MCP and autonomous workflow changes. |
 | `solana-quasar-core` | Quasar-first Solana/onchain program work, wallet transaction boundaries and onchain QA. |

--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -38,6 +38,15 @@ The repo runner in `scripts/product_face_proof.py` is a `web_visual_ui` runner.
 It should not be used to claim CLI/TUI, docs/onboarding or agentic-interface
 PASS without the matching profile evidence.
 
+Surface evidence is only the visible/product-face layer. Product completion
+also consumes `templates/product-delivery-quality-profile.json` for
+surface-specific domain proof. CLI/TUI products need install/run, help, golden
+transcript, error-state and cross-platform shell proof. API/data products need
+contract, auth, error, migration, fixture, retention and operational safety
+proof. User-facing agentic products must be classified separately from internal
+agent runtime infrastructure and carry task, control, permission, memory/data,
+abuse and recovery proof.
+
 ## Surface Taxonomy
 
 Product Experience OS routes surface families before Product Face PASS. The

--- a/schemas/factory-card.schema.json
+++ b/schemas/factory-card.schema.json
@@ -140,6 +140,28 @@
       "enum": ["full_product", "child_slice", "bug", "release", "incident", "doc", "migration", "integration"]
     },
     "complete_product_required": { "type": "boolean" },
+    "product_classification": {
+      "enum": [
+        "generic_software_product",
+        "api_data_product",
+        "cli_tui_product",
+        "agent_runtime_infrastructure",
+        "user_facing_agentic_product"
+      ]
+    },
+    "product_classifications": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "generic_software_product",
+          "api_data_product",
+          "cli_tui_product",
+          "agent_runtime_infrastructure",
+          "user_facing_agentic_product"
+        ]
+      },
+      "uniqueItems": true
+    },
     "current_execution_slice": { "type": "string" },
     "full_product_sot_scope_coverage": { "type": "object" },
     "full_product_sot_scope_coverage_ref": { "type": "string" },

--- a/schemas/product-delivery-quality-profile.schema.json
+++ b/schemas/product-delivery-quality-profile.schema.json
@@ -60,7 +60,35 @@
           "owner_worker": { "type": "string", "minLength": 3 },
           "reviewer_role": { "type": "string", "minLength": 3 },
           "evidence_kind": { "enum": ["contract", "runtime", "review", "domain", "human_gate"] },
-          "human_gate_required": { "type": "boolean" }
+          "human_gate_required": { "type": "boolean" },
+          "applies_to_surfaces": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 2 },
+            "uniqueItems": true
+          },
+          "applies_to_surface_evidence_profiles": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+            },
+            "uniqueItems": true
+          },
+          "applies_to_product_classifications": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "generic_software_product",
+                "api_data_product",
+                "cli_tui_product",
+                "agent_runtime_infrastructure",
+                "user_facing_agentic_product"
+              ]
+            },
+            "uniqueItems": true
+          }
         },
         "additionalProperties": true
       }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -521,6 +521,13 @@ PRODUCT_DELIVERY_QUALITY_PROFILE_REQUIRED_FIELDS = (
     "waiver_policy",
     "evidence_refs",
 )
+PRODUCT_CLASSIFICATIONS = {
+    "generic_software_product",
+    "api_data_product",
+    "cli_tui_product",
+    "agent_runtime_infrastructure",
+    "user_facing_agentic_product",
+}
 REASONING_POLICY_REQUIRED_FIELDS = (
     "record_type",
     "reasoning_class",
@@ -2842,6 +2849,26 @@ def validate_user_facing_autonomy_contract(card: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_product_classification_contract(card: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    classifications = _card_product_classifications(card)
+    unknown = sorted(classifications - PRODUCT_CLASSIFICATIONS)
+    if unknown:
+        errors.append("product_classification contains unknown values: " + ", ".join(unknown))
+
+    expected_profiles = set(_expected_surface_evidence_profiles(card))
+    if "agentic_interface" in expected_profiles:
+        if "user_facing_agentic_product" not in classifications:
+            errors.append(
+                "product_classification must include user_facing_agentic_product for agentic_interface surfaces"
+            )
+        if classifications == {"agent_runtime_infrastructure"}:
+            errors.append(
+                "agent_runtime_infrastructure alone cannot classify a user-facing agentic product surface"
+            )
+    return errors
+
+
 def _status_value(value: Any) -> str:
     if isinstance(value, dict):
         return str(value.get("status") or "").strip().lower()
@@ -3327,6 +3354,29 @@ def _expected_surface_evidence_profiles(card: dict[str, Any]) -> list[str]:
     return sorted(profiles)
 
 
+def _card_product_classifications(card: dict[str, Any]) -> set[str]:
+    containers: list[dict[str, Any]] = [card]
+    for field in (
+        "product_creation_plan",
+        "product_context_packet",
+        "product_experience_plan",
+        "product_face_packet",
+    ):
+        value = card.get(field)
+        if isinstance(value, dict):
+            containers.append(value)
+
+    classifications: set[str] = set()
+    for container in containers:
+        for field in ("product_classification", "product_classifications"):
+            value = container.get(field)
+            if isinstance(value, list):
+                classifications.update(_normalized_contract_token(item) for item in value)
+            elif _non_empty_text(value):
+                classifications.add(_normalized_contract_token(value))
+    return {item for item in classifications if item}
+
+
 def risk(card: dict[str, Any]) -> str:
     return str(card.get("risk_effective", "")).strip().upper()
 
@@ -3467,6 +3517,16 @@ def validate_product_delivery_quality_profile(profile: dict[str, Any]) -> list[s
         for phase in required_at:
             if phase not in {"before_implementation", "before_completion", "before_promotion"}:
                 errors.append(f"product_delivery_quality_profile.required_proofs[{index}].required_at has unknown phase {phase!r}")
+        for field in ("applies_to_surfaces", "applies_to_surface_evidence_profiles", "applies_to_product_classifications"):
+            value = proof.get(field)
+            if value is not None and not _non_empty_string_list(value):
+                errors.append(f"product_delivery_quality_profile.required_proofs[{index}].{field} must be a non-empty array")
+        for classification in _list_items(proof.get("applies_to_product_classifications")):
+            if _normalized_contract_token(classification) not in PRODUCT_CLASSIFICATIONS:
+                errors.append(
+                    f"product_delivery_quality_profile.required_proofs[{index}].applies_to_product_classifications "
+                    f"has unknown classification {classification!r}"
+                )
 
     for index, dimension in enumerate(profile.get("quality_dimensions", []) if isinstance(profile.get("quality_dimensions"), list) else []):
         if not isinstance(dimension, dict):
@@ -3548,10 +3608,43 @@ def _product_delivery_quality_profile_ref_errors(card: dict[str, Any]) -> list[s
     return errors
 
 
-def _delivery_profile_required_proof_ids(profile: dict[str, Any], phase: str) -> list[str]:
+def _proof_applies_to_card(proof: dict[str, Any], card: dict[str, Any] | None) -> bool:
+    if card is None:
+        return True
+    card_surfaces = {_normalized_contract_token(surface) for surface in normalized_surfaces(card)}
+    card_surfaces.update(_surface_profile_tokens(card))
+    card_profiles = set(_expected_surface_evidence_profiles(card))
+    card_classifications = _card_product_classifications(card)
+
+    surface_filter = {_normalized_contract_token(item) for item in _list_items(proof.get("applies_to_surfaces"))}
+    if surface_filter and not (surface_filter & card_surfaces):
+        return False
+
+    profile_filter = set(_list_items(proof.get("applies_to_surface_evidence_profiles")))
+    if profile_filter and not (profile_filter & card_profiles):
+        return False
+
+    classification_filter = {
+        _normalized_contract_token(item)
+        for item in _list_items(proof.get("applies_to_product_classifications"))
+    }
+    if classification_filter and not (classification_filter & card_classifications):
+        return False
+
+    return True
+
+
+def _delivery_profile_required_proof_ids(
+    profile: dict[str, Any],
+    phase: str,
+    *,
+    card: dict[str, Any] | None = None,
+) -> list[str]:
     proof_ids: list[str] = []
     for proof in profile.get("required_proofs", []) if isinstance(profile.get("required_proofs"), list) else []:
         if not isinstance(proof, dict):
+            continue
+        if not _proof_applies_to_card(proof, card):
             continue
         if phase in _list_items(proof.get("required_at")) and _non_empty_text(proof.get("proof_id")):
             proof_ids.append(str(proof["proof_id"]).strip())
@@ -3576,7 +3669,7 @@ def _required_domain_proof_ids(card: dict[str, Any], phase: str) -> list[str]:
     proof_ids: list[str] = []
     profile = _product_delivery_quality_profile(card)
     if profile:
-        proof_ids.extend(_delivery_profile_required_proof_ids(profile, phase))
+        proof_ids.extend(_delivery_profile_required_proof_ids(profile, phase, card=card))
     if phase in {"before_implementation", "before_completion", "before_promotion"}:
         proof_ids.extend(_activated_capability_pack_structured_proof_ids(card))
     plan = card.get("product_experience_plan") if isinstance(card.get("product_experience_plan"), dict) else {}
@@ -3591,7 +3684,7 @@ def _required_delivery_profile_proof_ids(card: dict[str, Any], phase: str) -> li
     profile = _product_delivery_quality_profile(card)
     if not profile:
         return []
-    return _delivery_profile_required_proof_ids(profile, phase)
+    return _delivery_profile_required_proof_ids(profile, phase, card=card)
 
 
 def _validate_delivery_profile_proof_coverage(
@@ -4205,6 +4298,7 @@ def validate_vfinal_card_contract(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_scale_slo_readiness_contract(data))
     errors.extend(validate_production_promotion_ladder_contract(data))
     errors.extend(validate_user_facing_autonomy_contract(data))
+    errors.extend(validate_product_classification_contract(data))
     errors.extend(validate_material_autonomy_routing_contract(data))
     errors.extend(
         _validate_vfinal_schema_backed_plan_gate(
@@ -5809,6 +5903,7 @@ def validate_usage_evidence_matrix_against_card(result: dict[str, Any], card: di
 def validate_product_face_result_against_card(result: dict[str, Any], card: dict[str, Any]) -> list[str]:
     errors = validate_product_face_result(result)
     errors.extend(_surface_evidence_profile_route_errors_for_card(card))
+    errors.extend(validate_product_classification_contract(card))
     errors.extend(_product_delivery_quality_profile_ref_errors(card))
     result_status = str(result.get("result") or "").upper()
     if result_status == "WAIVED":

--- a/templates/product-delivery-quality-profile.json
+++ b/templates/product-delivery-quality-profile.json
@@ -3,7 +3,18 @@
   "record_type": "product_delivery_quality_profile",
   "profile_id": "generic-software-product-v1",
   "archetype": "generic software product",
-  "applies_to_surfaces": ["code", "frontend", "backend", "api", "docs"],
+  "applies_to_surfaces": [
+    "code",
+    "frontend",
+    "backend",
+    "api",
+    "data",
+    "database",
+    "docs",
+    "cli",
+    "tui",
+    "agentic_interface"
+  ],
   "quality_dimensions": [
     {
       "dimension_id": "scope-fit",
@@ -14,6 +25,13 @@
       "dimension_id": "operator-usability",
       "bar": "A target user or operator can use the delivered surface, workflow or docs without private context.",
       "block_when": ["The result needs private chat context, hidden assumptions or manual operator assembly."]
+    },
+    {
+      "dimension_id": "surface-specific-proof",
+      "bar": "Each selected product surface has proof for its own usage model instead of inheriting generic code or UI evidence.",
+      "block_when": [
+        "A CLI/TUI, API/data or user-facing agentic product is accepted with only generic tests, screenshots or internal runtime proof."
+      ]
     }
   ],
   "required_proofs": [
@@ -34,6 +52,223 @@
       "reviewer_role": "independent-reviewer",
       "evidence_kind": "review",
       "human_gate_required": false
+    },
+    {
+      "proof_id": "cli.install-run-smoke",
+      "name": "CLI/TUI install and run smoke proof",
+      "required_at": ["before_implementation", "before_completion"],
+      "owner_worker": "qa-verification-worker",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["cli_tui"]
+    },
+    {
+      "proof_id": "cli.help-output",
+      "name": "CLI/TUI help output proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "docs-os-worker",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["cli_tui"]
+    },
+    {
+      "proof_id": "cli.golden-transcript",
+      "name": "CLI/TUI golden path transcript proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "test-automation-builder",
+      "reviewer_role": "qa-verification-worker",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["cli_tui"]
+    },
+    {
+      "proof_id": "cli.error-state-transcript",
+      "name": "CLI/TUI error-state transcript proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "test-automation-builder",
+      "reviewer_role": "qa-verification-worker",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["cli_tui"]
+    },
+    {
+      "proof_id": "cli.cross-platform-shell",
+      "name": "CLI/TUI cross-platform shell behavior proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "qa-verification-worker",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["cli_tui"]
+    },
+    {
+      "proof_id": "cli.package-release-readiness",
+      "name": "CLI/TUI package and release readiness proof",
+      "required_at": ["before_promotion"],
+      "owner_worker": "release-ops-worker",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["cli_tui"]
+    },
+    {
+      "proof_id": "api.contract-schema",
+      "name": "API contract and schema proof",
+      "required_at": ["before_implementation", "before_completion"],
+      "owner_worker": "backend-api-builder",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "contract",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["api", "backend", "server", "service"]
+    },
+    {
+      "proof_id": "api.auth-permission-boundary",
+      "name": "API auth and permission boundary proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "backend-api-builder",
+      "reviewer_role": "appsec-owasp-specialist",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["api", "auth", "session", "backend", "service"]
+    },
+    {
+      "proof_id": "api.error-semantics",
+      "name": "API error semantics proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "backend-api-builder",
+      "reviewer_role": "qa-verification-worker",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["api", "backend", "server", "service"]
+    },
+    {
+      "proof_id": "api.compatibility-versioning",
+      "name": "API compatibility and versioning proof",
+      "required_at": ["before_promotion"],
+      "owner_worker": "backend-api-builder",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "contract",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["api", "backend", "service"]
+    },
+    {
+      "proof_id": "data.migration-rollback",
+      "name": "Data migration and rollback proof",
+      "required_at": ["before_completion", "before_promotion"],
+      "owner_worker": "data-persistence-builder",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["database", "data", "schema", "migration", "storage", "persistence", "rls"]
+    },
+    {
+      "proof_id": "data.seed-fixture-behavior",
+      "name": "Data seed and fixture behavior proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "data-persistence-builder",
+      "reviewer_role": "qa-verification-worker",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["database", "data", "schema", "storage", "persistence"]
+    },
+    {
+      "proof_id": "data.retention-privacy-boundary",
+      "name": "Data retention and privacy boundary proof",
+      "required_at": ["before_completion", "before_promotion"],
+      "owner_worker": "data-persistence-builder",
+      "reviewer_role": "appsec-owasp-specialist",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["database", "data", "storage", "persistence", "rls"]
+    },
+    {
+      "proof_id": "data.operational-safety",
+      "name": "Operational data safety proof",
+      "required_at": ["before_promotion"],
+      "owner_worker": "detection-monitoring-worker",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surfaces": ["database", "data", "migration", "storage", "persistence"]
+    },
+    {
+      "proof_id": "agentic.task-success",
+      "name": "User-facing agentic task success proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "skill-eval-distiller",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
+    },
+    {
+      "proof_id": "agentic.user-control",
+      "name": "User control and stop/resume proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "product-face",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
+    },
+    {
+      "proof_id": "agentic.approval-boundary",
+      "name": "User-facing agent approval boundary proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "agentic-ai-security-specialist",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
+    },
+    {
+      "proof_id": "agentic.tool-permission-limits",
+      "name": "User-facing agent tool permission limits proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "agentic-ai-security-specialist",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
+    },
+    {
+      "proof_id": "agentic.memory-data-boundary",
+      "name": "User-facing agent memory and data boundary proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "memory-steward",
+      "reviewer_role": "agentic-ai-security-specialist",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
+    },
+    {
+      "proof_id": "agentic.abuse-safety-handling",
+      "name": "User-facing agent abuse and safety handling proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "agentic-ai-security-specialist",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "review",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
+    },
+    {
+      "proof_id": "agentic.recovery-error-behavior",
+      "name": "User-facing agent recovery and error behavior proof",
+      "required_at": ["before_completion"],
+      "owner_worker": "qa-verification-worker",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "runtime",
+      "human_gate_required": false,
+      "applies_to_surface_evidence_profiles": ["agentic_interface"],
+      "applies_to_product_classifications": ["user_facing_agentic_product"]
     }
   ],
   "waiver_policy": {

--- a/templates/product-implementation-readiness.json
+++ b/templates/product-implementation-readiness.json
@@ -16,6 +16,8 @@
       "evidence_refs": ["templates/full-product-sot-scope-coverage.json"],
       "owner": "factory-orchestrator",
       "reviewer": "independent-reviewer",
+      "reviewer_role": "independent-reviewer",
+      "evidence_kind": "contract",
       "basis": "The ready work unit maps to Product SOT scope and does not redefine complete-product scope."
     }
   ],

--- a/tests/test_capability_packs.py
+++ b/tests/test_capability_packs.py
@@ -64,6 +64,7 @@ class CapabilityPacksTest(unittest.TestCase):
 
         for pack_id in [
             "web-saas-core",
+            "cli-tui-product-pack",
             "operator-onboarding-pack",
             "public-docs-knowledge-pack",
             "local-web-cockpit-pack",
@@ -84,6 +85,7 @@ class CapabilityPacksTest(unittest.TestCase):
 
         for pack_id in [
             "web-saas-core",
+            "cli-tui-product-pack",
             "operator-onboarding-pack",
             "public-docs-knowledge-pack",
             "mobile-app-pack",
@@ -114,6 +116,14 @@ class CapabilityPacksTest(unittest.TestCase):
 
     def test_ready_core_surfaces_pass_capability_coverage(self) -> None:
         card = base_card()
+
+        errors = factoryctl.validate_capability_coverage(card)
+
+        self.assertEqual(errors, [])
+
+    def test_cli_tui_surfaces_pass_with_core_pack(self) -> None:
+        card = base_card()
+        card["surfaces"] = ["cli", "tui"]
 
         errors = factoryctl.validate_capability_coverage(card)
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -2879,6 +2879,103 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
 
+    def test_cli_tui_surface_with_delivery_profile_requires_cli_domain_proofs(self) -> None:
+        card = product_surface_card_fixture("cli", "cli_tui")
+        card["product_delivery_quality_profile_ref"] = "templates/product-delivery-quality-profile.json"
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("cli_tui", "cli"),
+            surface_evidence_profiles=[surface_profile("cli_tui", "cli")],
+            cli_tui_evidence={
+                "golden_path_transcript_refs": ["reports/cli/golden-path.txt"],
+                "help_output_refs": ["reports/cli/help.txt"],
+                "error_state_refs": ["reports/cli/error-state.txt"],
+                "install_run_refs": ["reports/cli/install-run.txt"],
+                "cross_platform_terminal_refs": ["reports/cli/windows.txt", "reports/cli/linux.txt"],
+            },
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_face_result.domain_proof_coverage missing required product delivery proof ids: "
+            "cli.cross-platform-shell, cli.error-state-transcript, cli.golden-transcript, "
+            "cli.help-output, cli.install-run-smoke",
+            errors,
+        )
+
+    def test_cli_tui_surface_with_delivery_profile_accepts_cli_domain_proofs(self) -> None:
+        card = product_surface_card_fixture("cli", "cli_tui")
+        card["product_delivery_quality_profile_ref"] = "templates/product-delivery-quality-profile.json"
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("cli_tui", "cli"),
+            surface_evidence_profiles=[surface_profile("cli_tui", "cli")],
+            cli_tui_evidence={
+                "golden_path_transcript_refs": ["reports/cli/golden-path.txt"],
+                "help_output_refs": ["reports/cli/help.txt"],
+                "error_state_refs": ["reports/cli/error-state.txt"],
+                "install_run_refs": ["reports/cli/install-run.txt"],
+                "cross_platform_terminal_refs": ["reports/cli/windows.txt", "reports/cli/linux.txt"],
+            },
+            domain_proof_coverage=[
+                {
+                    "proof_id": "generic.operator-usability",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/product-face/operator-usability.json"],
+                    "reviewer": "product-face-reviewer",
+                    "reviewer_role": "independent-reviewer",
+                    "evidence_kind": "review",
+                    "basis": "Operator can understand current state, evidence and next action.",
+                },
+                {
+                    "proof_id": "cli.install-run-smoke",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/cli/install-run.txt"],
+                    "reviewer": "independent-reviewer",
+                    "reviewer_role": "independent-reviewer",
+                    "evidence_kind": "runtime",
+                    "basis": "Install and run path passed on the declared terminal target.",
+                },
+                {
+                    "proof_id": "cli.help-output",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/cli/help.txt"],
+                    "reviewer": "independent-reviewer",
+                    "reviewer_role": "independent-reviewer",
+                    "evidence_kind": "review",
+                    "basis": "Help output covers first use and main commands.",
+                },
+                {
+                    "proof_id": "cli.golden-transcript",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/cli/golden-path.txt"],
+                    "reviewer": "qa-verification-worker",
+                    "reviewer_role": "qa-verification-worker",
+                    "evidence_kind": "runtime",
+                    "basis": "Golden transcript proves the primary CLI journey.",
+                },
+                {
+                    "proof_id": "cli.error-state-transcript",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/cli/error-state.txt"],
+                    "reviewer": "qa-verification-worker",
+                    "reviewer_role": "qa-verification-worker",
+                    "evidence_kind": "runtime",
+                    "basis": "Error transcript proves actionable failure behavior.",
+                },
+                {
+                    "proof_id": "cli.cross-platform-shell",
+                    "status": "PASS",
+                    "evidence_refs": ["reports/cli/windows.txt", "reports/cli/linux.txt"],
+                    "reviewer": "independent-reviewer",
+                    "reviewer_role": "independent-reviewer",
+                    "evidence_kind": "runtime",
+                    "basis": "Declared shell targets passed without platform-only assumptions.",
+                },
+            ],
+        )
+
+        self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
+
     def test_docs_onboarding_surface_cannot_pass_with_prose_only_product_face(self) -> None:
         card = product_surface_card_fixture("docs", "docs_onboarding")
         result = product_face_result_fixture(
@@ -2946,6 +3043,7 @@ class FactoryCtlTest(unittest.TestCase):
 
     def test_agentic_surface_requires_task_state_control_and_recovery_evidence(self) -> None:
         card = product_surface_card_fixture("agentic_interface", "agentic_interface")
+        card["product_classification"] = "user_facing_agentic_product"
         result = product_face_result_fixture(
             surface_evidence_profile=surface_profile("agentic_interface", "agentic_interface"),
             surface_evidence_profiles=[surface_profile("agentic_interface", "agentic_interface")],
@@ -2959,6 +3057,32 @@ class FactoryCtlTest(unittest.TestCase):
         )
 
         self.assertEqual(factoryctl.validate_product_face_result_against_card(result, card), [])
+
+    def test_agentic_surface_rejects_runtime_infrastructure_classification_only(self) -> None:
+        card = product_surface_card_fixture("agentic_interface", "agentic_interface")
+        card["product_classification"] = "agent_runtime_infrastructure"
+        result = product_face_result_fixture(
+            surface_evidence_profile=surface_profile("agentic_interface", "agentic_interface"),
+            surface_evidence_profiles=[surface_profile("agentic_interface", "agentic_interface")],
+            agentic_interface_evidence={
+                "task_transcript_refs": ["reports/agentic/task-transcript.json"],
+                "state_transition_refs": ["reports/agentic/state-transitions.json"],
+                "approval_boundary_refs": ["reports/agentic/approval-boundaries.json"],
+                "user_control_refs": ["reports/agentic/user-control.json"],
+                "recovery_error_refs": ["reports/agentic/recovery-error.json"],
+            },
+        )
+
+        errors = factoryctl.validate_product_face_result_against_card(result, card)
+
+        self.assertIn(
+            "product_classification must include user_facing_agentic_product for agentic_interface surfaces",
+            errors,
+        )
+        self.assertIn(
+            "agent_runtime_infrastructure alone cannot classify a user-facing agentic product surface",
+            errors,
+        )
 
     def test_auditor_preflight_cannot_claim_pass(self) -> None:
         bad = {

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -243,6 +243,48 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             factoryctl.validate_card(card),
         )
 
+    def test_api_data_surface_requires_api_contract_proof_before_implementation(self) -> None:
+        card = self.vfinal_card()
+        card["surfaces"] = ["api", "database"]
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+
+        errors = factoryctl.validate_product_creation_readiness_contract(card)
+
+        self.assertIn(
+            "product_implementation_readiness.delivery_profile_proof_coverage missing required product delivery proof ids: api.contract-schema",
+            errors,
+        )
+
+    def test_api_data_surface_accepts_api_contract_proof_before_implementation(self) -> None:
+        card = self.vfinal_card()
+        card["surfaces"] = ["api", "database"]
+        card["product_creation_plan"] = factoryctl.load_json_like(ROOT / "templates" / "product-creation-plan.json")
+        card["product_implementation_readiness"] = factoryctl.load_json_like(
+            ROOT / "templates" / "product-implementation-readiness.json"
+        )
+        card["product_implementation_readiness"]["delivery_profile_proof_coverage"].append(
+            {
+                "proof_id": "api.contract-schema",
+                "status": "PASS",
+                "evidence_refs": ["reports/api/contract-schema.json"],
+                "owner": "backend-api-builder",
+                "reviewer": "independent-reviewer",
+                "reviewer_role": "independent-reviewer",
+                "evidence_kind": "contract",
+                "basis": "API contract and schema are defined before material implementation.",
+            }
+        )
+
+        errors = factoryctl.validate_product_creation_readiness_contract(card)
+
+        self.assertNotIn(
+            "product_implementation_readiness.delivery_profile_proof_coverage missing required product delivery proof ids: api.contract-schema",
+            errors,
+        )
+
     def test_product_delivery_before_promotion_proofs_block_done_promotion_when_missing(self) -> None:
         card = self.vfinal_card()
         profile = factoryctl.load_json_like(ROOT / "templates" / "product-delivery-quality-profile.json")


### PR DESCRIPTION
## Summary

This PR closes the product-surface proof-profile gap for Factory v1.

It keeps the implementation lean by extending the existing Product Delivery Quality Profile and capability-pack registry instead of introducing a parallel runner or a second methodology router.

## What changed

- Added `cli-tui-product-pack` as a core-ready executable surface pack for CLI/TUI products.
- Extended `templates/product-delivery-quality-profile.json` with conditional proof requirements for:
  - CLI/TUI: install/run, help output, golden transcript, error transcript, cross-platform shell, package/release readiness.
  - API/Data: API schema/contract, auth boundary, error semantics, compatibility, migration/rollback, seed/fixtures, retention/privacy, operational data safety.
  - User-facing agentic products: task success, user control, approval/tool boundaries, memory/data boundary, abuse handling and recovery behavior.
- Added explicit `product_classification` / `product_classifications` support to distinguish `agent_runtime_infrastructure` from `user_facing_agentic_product`.
- Updated `factoryctl` so required proof IDs are filtered by the actual card surface, Product Face evidence profile and product classification.
- Updated public docs and tests for the new proof behavior.

## Why this is not overengineering

This reuses the existing gears:

- capability pack registry decides whether a surface is supported;
- Product Experience / Product Face routes the surface evidence profile;
- Product Delivery Quality Profile decides which proof IDs must exist;
- `factoryctl` validates readiness/completion/promotion gates.

No new runtime, runner, or hidden process was added.

## Validation

- `python -m json.tool` on changed JSON/schema files
- `python -m unittest tests.test_factoryctl tests.test_capability_packs tests.test_product_method_sot_planning -q`
- `python scripts/factoryctl.py validate-card templates/vfinal-factory-card.json`
- `python scripts/validate_public_json_artifacts.py`
- `python -m unittest discover -s tests -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/release_integration_preflight.py`

Closes #206
Closes #233
Closes #234