### PR TITLE
Improve issue 84 local cockpit UX

### DIFF
--- a/ui/issue-84-local-cockpit/README.md
+++ b/ui/issue-84-local-cockpit/README.md
@@ -1,6 +1,8 @@
 # Local-First Factory Web Cockpit
 
-A local, read-only cockpit for inspecting Overkill Factory work from public-safe StatusSnapshot data. It does not mutate Hermes, approve gates, close issues, deploy, or claim production readiness.
+A local cockpit for operating the Overkill Factory from public-safe StatusSnapshot data. It can filter work, inspect gates/evidence, record local operator actions and download local receipts.
+
+It does not mutate Hermes, approve gates, close issues, deploy, push to GitHub, or claim production readiness. External effects stay outside this static local surface.
 
 Build the bundled fixture-only dataset:
 

--- a/ui/issue-84-local-cockpit/app.js
+++ b/ui/issue-84-local-cockpit/app.js
@@ -1,10 +1,14 @@
 const DATA_URL = "data/status-cockpit.json";
 const root = document.querySelector("[data-cockpit-root]");
+const globalSearch = document.querySelector("#globalSearch");
+const themeToggle = document.querySelector("#themeToggle");
+
 const state = {
   data: null,
   selectedId: null,
   stateFilter: "all",
   query: "",
+  receipts: [],
 };
 
 function node(tag, attributes = {}, children = []) {
@@ -37,19 +41,22 @@ function node(tag, attributes = {}, children = []) {
   return element;
 }
 
-function clearRoot() {
-  root.replaceChildren();
-}
-
 function setBusy(value) {
   root.setAttribute("aria-busy", value ? "true" : "false");
 }
 
-function pill(label, value, extraClass = "pill") {
-  return node("span", { className: extraClass }, [label ? `${label}: ${value}` : value]);
+function clearRoot() {
+  root.replaceChildren();
 }
 
-function sectionTitle(eyebrow, title, copy) {
+function setTheme(theme, persist = true) {
+  const next = theme === "dark" ? "dark" : "light";
+  document.documentElement.dataset.theme = next;
+  if (persist) localStorage.setItem("of-cockpit-theme", next);
+  if (themeToggle) themeToggle.textContent = next === "dark" ? "Claro" : "Escuro";
+}
+
+function titleBlock(eyebrow, title, copy) {
   const children = [];
   if (eyebrow) children.push(node("p", { className: "eyebrow", text: eyebrow }));
   children.push(node("h2", { text: title }));
@@ -57,27 +64,111 @@ function sectionTitle(eyebrow, title, copy) {
   return children;
 }
 
+function pill(label, value, extraClass = "pill") {
+  const text = label ? `${label}: ${value || "-"}` : value || "-";
+  return node("span", { className: extraClass }, [text]);
+}
+
+function selectedSnapshot() {
+  return state.data.snapshots.find((snapshot) => snapshot.id === state.selectedId) || state.data.snapshots[0];
+}
+
+function stateLabel(value) {
+  const labels = {
+    success: "aprovado",
+    empty: "vazio",
+    loading: "carregando",
+    error: "erro",
+    blocked: "bloqueado",
+    stale: "desatualizado",
+    missing: "faltando",
+    contradictory: "contraditório",
+    private_unavailable: "privado",
+    superseded: "superado",
+    security_negative: "segurança",
+    "missing-gate": "gate faltando",
+    manual_estimate: "estimado",
+  };
+  return labels[value] || value || "-";
+}
+
+function stateUiLabel(value) {
+  const labels = {
+    loading_snapshot: "Carregando",
+    empty_no_snapshots: "Sem snapshots",
+    success_current_snapshot: "Atual",
+    input_error_or_parse_failure: "Erro de entrada",
+    blocked_gate: "Bloqueado",
+    stale_snapshot: "Desatualizado",
+    contradictory_state: "Contraditório",
+    private_evidence_unavailable: "Evidência privada",
+    review_pending_failed_passed: "Revisão",
+    long_dense_data: "Dados densos",
+  };
+  return labels[value] || value || "-";
+}
+
+function actionLabel(value) {
+  const labels = {
+    block: "bloquear",
+    blocked: "bloquear",
+    review: "revisar",
+    refresh: "atualizar",
+    inspect: "inspecionar",
+    continue: "acompanhar",
+    fix: "corrigir",
+  };
+  return labels[value] || value || "acompanhar";
+}
+
+function snapshotTitle(snapshot) {
+  const byState = {
+    success_current_snapshot: "Projeção atual",
+    empty_no_snapshots: "Sem snapshot disponível",
+    loading_snapshot: "Atualização em curso",
+    input_error_or_parse_failure: "Erro de leitura",
+    blocked_gate: "Gate bloqueado",
+    stale_snapshot: "Snapshot desatualizado",
+    contradictory_state: "Estado contraditório",
+    private_evidence_unavailable: "Evidência privada indisponível",
+    review_pending_failed_passed: "Revisão pendente",
+    long_dense_data: "Lista densa",
+  };
+  return byState[snapshot.state_ui] || snapshot.title || snapshot.id;
+}
+
+function shortRef(snapshotOrRef) {
+  if (typeof snapshotOrRef === "object" && snapshotOrRef && snapshotOrRef.id) return snapshotOrRef.id;
+  const value = String(snapshotOrRef || "");
+  const match = value.match(/(FX\d+)/);
+  return match ? match[1] : value;
+}
+
+function formatCount(value) {
+  return String(Number(value || 0));
+}
+
 function renderLoading() {
   setBusy(true);
   clearRoot();
   root.appendChild(
-    node("section", { className: "loading-panel", "aria-label": "Loading local cockpit data" }, [
-      node("p", { className: "eyebrow", text: "Loading snapshot" }),
-      node("h2", { text: "Reading local StatusSnapshot projections" }),
-      node("p", { text: "The cockpit is waiting for the local JSON bundle. No success, review, release or completion state is inferred yet." }),
+    node("section", { className: "loading-panel", "aria-label": "Carregando dados locais" }, [
+      node("p", { className: "eyebrow", text: "Carregando" }),
+      node("h2", { text: "Lendo snapshots locais" }),
+      node("p", { text: "Nenhum estado de gate, revisão ou publicação é inferido antes do JSON público carregar." }),
     ]),
   );
 }
 
-function renderEmpty(reason = "No local snapshots were found in the cockpit data bundle.") {
+function renderEmpty(reason = "Nenhum snapshot público foi encontrado.") {
   setBusy(false);
   clearRoot();
   root.appendChild(
-    node("section", { className: "empty-panel", "data-state-ui": "empty_no_snapshots", "data-current-state": "empty", "aria-label": "No snapshots" }, [
-      node("p", { className: "eyebrow", text: "Empty / no snapshots" }),
-      node("h2", { text: "No canonical snapshot available" }),
+    node("section", { className: "empty-panel", "data-state-ui": "empty_no_snapshots", "data-current-state": "empty", "aria-label": "Sem snapshots" }, [
+      node("p", { className: "eyebrow", text: "Vazio" }),
+      node("h2", { text: "Sem snapshot local" }),
       node("p", { text: reason }),
-      node("p", { className: "subtle", text: "Next safe action: regenerate the public-safe local data bundle, then request independent Product Face proof. This surface has no mutation controls." }),
+      node("p", { className: "subtle", text: "Próximo passo: gerar o pacote público e revisar antes de operar." }),
     ]),
   );
 }
@@ -86,11 +177,11 @@ function renderError(error) {
   setBusy(false);
   clearRoot();
   root.appendChild(
-    node("section", { className: "error-panel", "data-state-ui": "input_error_or_parse_failure", "data-current-state": "error", role: "alert", "aria-label": "Input parse error" }, [
-      node("p", { className: "eyebrow", text: "Input error / parse failure" }),
-      node("h2", { text: "The local cockpit data could not be parsed" }),
+    node("section", { className: "error-panel", "data-state-ui": "input_error_or_parse_failure", "data-current-state": "error", role: "alert", "aria-label": "Erro ao ler dados" }, [
+      node("p", { className: "eyebrow", text: "Erro" }),
+      node("h2", { text: "O cockpit não conseguiu ler os dados locais" }),
       node("p", { text: error && error.message ? error.message : String(error) }),
-      node("p", { className: "subtle", text: "No gate, review, done, release or issue-completion claim is inferred from invalid input." }),
+      node("p", { className: "subtle", text: "Nada é aprovado, fechado ou publicado a partir de input inválido." }),
     ]),
   );
 }
@@ -99,6 +190,37 @@ function metric(label, value) {
   return node("article", { className: "metric" }, [
     node("span", { text: label }),
     node("strong", { text: value }),
+  ]);
+}
+
+function renderSummary() {
+  const metrics = state.data.metrics;
+  const running = state.data.snapshots.filter((snapshot) => !["success", "empty"].includes(snapshot.current_state)).length;
+  return node("section", { className: "summary-grid", "aria-label": "Resumo da fábrica" }, [
+    metric("Frentes", formatCount(metrics.total_snapshots)),
+    metric("Bloqueios", formatCount(metrics.blocked_or_review_count)),
+    metric("Rodando", formatCount(running)),
+    metric("Privado bruto", formatCount(metrics.raw_private_payload_count)),
+  ]);
+}
+
+function renderFactoryLine() {
+  const counts = state.data.metrics.state_ui_counts || {};
+  const stages = [
+    ["Entrada", counts.loading_snapshot || 0, "snapshots"],
+    ["Triagem", counts.blocked_gate || 0, "bloqueios"],
+    ["Construção", counts.long_dense_data || 0, "densos"],
+    ["Validação", counts.review_pending_failed_passed || 0, "revisões"],
+    ["Prova", counts.success_current_snapshot || 0, "atuais"],
+    ["Risco", counts.contradictory_state || 0, "conflitos"],
+  ];
+  return node("section", { className: "panel", "aria-label": "Linha de produção" }, [
+    ...titleBlock("Linha de produção", "Fábrica agora"),
+    node("div", { className: "factory-line" }, stages.map(([label, value, unit]) => node("article", { className: "stage" }, [
+      node("b", { text: label }),
+      node("strong", { text: value }),
+      node("span", { text: unit }),
+    ]))),
   ]);
 }
 
@@ -113,27 +235,18 @@ function stateCountFor(stateId) {
   return counts[stateId] || 0;
 }
 
-function renderCommandStrip() {
-  const metrics = state.data.metrics;
-  return node("section", { className: "command-strip", "aria-label": "Cockpit summary metrics" }, [
-    metric("Fixture snapshots", metrics.status_fixture_projections),
-    metric("Adapter reports", metrics.adapter_report_projections),
-    metric("Blocked / review", metrics.blocked_or_review_count),
-    metric("Private payloads", metrics.raw_private_payload_count),
-  ]);
-}
-
 function renderStateFilters() {
-  const buttons = [node("button", {
-    className: "state-filter",
-    type: "button",
-    "aria-pressed": state.stateFilter === "all" ? "true" : "false",
-    onClick: () => {
-      state.stateFilter = "all";
-      renderApp();
-    },
-  }, [node("strong", { text: "All states" }), node("br"), node("span", { className: "subtle", text: `${state.data.snapshots.length} projections` })])];
-
+  const buttons = [
+    node("button", {
+      className: "state-filter",
+      type: "button",
+      "aria-pressed": state.stateFilter === "all" ? "true" : "false",
+      onClick: () => {
+        state.stateFilter = "all";
+        renderApp();
+      },
+    }, [node("strong", { text: "Todos" }), node("span", { className: "subtle", text: `${state.data.snapshots.length} frentes` })]),
+  ];
   state.data.state_registry.forEach((entry) => {
     buttons.push(node("button", {
       className: "state-filter",
@@ -142,15 +255,14 @@ function renderStateFilters() {
       "aria-pressed": state.stateFilter === entry.id ? "true" : "false",
       onClick: () => {
         state.stateFilter = entry.id;
-        const selected = filteredSnapshots()[0];
-        if (selected) state.selectedId = selected.id;
+        const first = filteredSnapshots()[0];
+        if (first) state.selectedId = first.id;
         renderApp();
       },
-    }, [node("strong", { text: entry.label }), node("br"), node("span", { className: "subtle", text: `${stateCountFor(entry.id)} matches · ${entry.demo_query}` })]));
+    }, [node("strong", { text: stateUiLabel(entry.id) }), node("span", { className: "subtle", text: `${stateCountFor(entry.id)} itens` })]));
   });
-
-  return node("section", { className: "panel state-rail", "aria-label": "State filters" }, [
-    ...sectionTitle("State rail", "Required states"),
+  return node("aside", { className: "state-rail", "aria-label": "Filtros de estado" }, [
+    ...titleBlock("Navegação", "Estados"),
     node("div", { className: "state-filter-grid" }, buttons),
   ]);
 }
@@ -164,9 +276,38 @@ function filteredSnapshots() {
       || (state.stateFilter === "long_dense_data" && snapshot.density && snapshot.density.is_dense);
     if (!filterMatch) return false;
     if (!query) return true;
-    const haystack = [snapshot.id, snapshot.title, snapshot.current_state, snapshot.state_ui, snapshot.phase, snapshot.next_safe_action.label].join(" ").toLowerCase();
+    const haystack = [
+      snapshot.id,
+      snapshot.title,
+      snapshot.current_state,
+      snapshot.state_ui,
+      snapshot.phase,
+      snapshot.next_safe_action.label,
+      snapshot.input_ref,
+    ].join(" ").toLowerCase();
     return haystack.includes(query);
   });
+}
+
+function updateQuery(value) {
+  state.query = value;
+  if (globalSearch && globalSearch.value !== value) globalSearch.value = value;
+  renderApp();
+}
+
+function renderToolbar() {
+  return node("section", { className: "toolbar", "aria-label": "Controles da fila" }, [
+    node("input", {
+      type: "search",
+      value: state.query,
+      placeholder: "Título, estado ou evidência",
+      "aria-label": "Buscar na fila",
+      onInput: (event) => updateQuery(event.target.value),
+    }),
+    node("button", { type: "button", dataset: { action: "new-front" }, onClick: () => localAction("Nova frente local") }, ["Nova frente"]),
+    node("button", { type: "button", dataset: { action: "refresh" }, onClick: () => localAction("Snapshot atualizado") }, ["Atualizar"]),
+    node("button", { type: "button", dataset: { action: "download-receipt" }, onClick: () => downloadReceipt() }, ["Baixar recibo"]),
+  ]);
 }
 
 function renderSnapshotList() {
@@ -174,20 +315,10 @@ function renderSnapshotList() {
   if (!snapshots.find((snapshot) => snapshot.id === state.selectedId) && snapshots[0]) {
     state.selectedId = snapshots[0].id;
   }
-  const input = node("input", {
-    type: "search",
-    value: state.query,
-    placeholder: "Search source, state, blocker or next action",
-    "aria-label": "Search snapshots",
-    onInput: (event) => {
-      state.query = event.target.value;
-      renderApp();
-    },
-  });
-
   const rows = snapshots.map((snapshot) => node("button", {
     className: "snapshot-row",
     type: "button",
+    dataset: { snapshotId: snapshot.id },
     "data-state-ui": snapshot.state_ui,
     "data-current-state": snapshot.current_state,
     "aria-current": snapshot.id === state.selectedId ? "true" : "false",
@@ -196,35 +327,35 @@ function renderSnapshotList() {
       renderApp();
     },
   }, [
-    node("span", { className: "snapshot-status" }, [
-      pill("", snapshot.current_state, "state-pill current-pill"),
-      pill("", snapshot.review.status, "pill"),
-    ]),
+    node("span", { className: "snapshot-status" }, [pill("", stateLabel(snapshot.current_state), "state-pill current-pill")]),
     node("span", { className: "snapshot-title-cell" }, [
-      node("strong", { text: snapshot.title }),
-      node("span", { className: "subtle", text: snapshot.input_ref }),
+      node("strong", { text: snapshotTitle(snapshot) }),
+      node("span", { className: "subtle", text: shortRef(snapshot) }),
     ]),
     node("span", { className: "snapshot-phase", text: snapshot.phase }),
-    node("span", { className: "snapshot-action", text: snapshot.next_safe_action.action_type }),
+    node("span", { className: "snapshot-action", text: actionLabel(snapshot.next_safe_action.action_type) }),
   ]));
-
-  return node("aside", { className: "panel", "aria-label": "Snapshot list" }, [
-    ...sectionTitle("Local sources", "Snapshots & work queue"),
-    node("div", { className: "search-row" }, [input]),
-    rows.length ? node("div", { className: "snapshot-list" }, [
+  return node("section", { className: "panel", id: "queue", "aria-label": "Fila da fábrica" }, [
+    ...titleBlock("Fila", "Frentes", `${snapshots.length} itens visíveis`),
+    node("div", { className: "queue-table" }, [
       node("div", { className: "snapshot-head", "aria-hidden": "true" }, [
-        node("span", { text: "State" }),
-        node("span", { text: "Source" }),
-        node("span", { text: "Phase" }),
-        node("span", { text: "Action" }),
+        node("span", { text: "Estado" }),
+        node("span", { text: "Frente" }),
+        node("span", { text: "Etapa" }),
+        node("span", { text: "Ação" }),
       ]),
-      ...rows,
-    ]) : node("p", { className: "subtle", text: "No snapshot matches the current filter." }),
+      ...(rows.length ? rows : [node("p", { className: "subtle", text: "Nada encontrado." })]),
+    ]),
   ]);
 }
 
 function kv(label, value) {
-  return node("div", { className: "kv" }, [node("span", { text: label }), node("strong", { text: value || "—" })]);
+  return node("div", { className: "kv" }, [node("span", { text: label }), node("strong", { text: value || "-" })]);
+}
+
+function refList(refs) {
+  if (!refs || !refs.length) return node("p", { className: "subtle", text: "Sem refs públicas." });
+  return node("p", { className: "pill-row" }, refs.map((ref) => node("code", { className: "ref-code", text: ref })));
 }
 
 function renderObjectList(title, items, formatter, emptyCopy) {
@@ -234,107 +365,155 @@ function renderObjectList(title, items, formatter, emptyCopy) {
   return node("section", { className: "stack", "aria-label": title }, [node("h3", { text: title }), content]);
 }
 
-function refList(refs) {
-  if (!refs || !refs.length) return node("p", { className: "subtle", text: "No public refs listed." });
-  return node("p", { className: "pill-row" }, refs.map((ref) => node("code", { className: "ref-code", text: ref })));
+function localAction(label) {
+  const selected = selectedSnapshot();
+  const receipt = {
+    at: new Date().toISOString(),
+    item: selected ? selected.id : "local",
+    action: label,
+    scope: "local",
+  };
+  state.receipts.unshift(receipt);
+  state.receipts = state.receipts.slice(0, 6);
+  renderApp();
+}
+
+function downloadReceipt() {
+  const selected = selectedSnapshot();
+  const payload = {
+    record_type: "local_cockpit_receipt",
+    item: selected ? selected.id : null,
+    action: "export_local_receipt",
+    scope: "local-only",
+    created_at: new Date().toISOString(),
+    selected_state: selected ? selected.current_state : null,
+    receipts: state.receipts,
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = node("a", { href: url, download: `cockpit-receipt-${payload.item || "local"}.json` });
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  localAction("Recibo baixado");
+}
+
+function renderActions(selected) {
+  const blocked = selected.current_state !== "success";
+  const title = blocked ? "Gate humano" : "Sem gate humano";
+  const primary = blocked ? "Pedir evidência" : "Baixar recibo";
+  return node("section", { className: "detail-card action-card", id: "commands", "data-state-ui": selected.state_ui, "data-current-state": selected.current_state, "aria-label": "Ações locais" }, [
+    node("p", { className: "eyebrow", text: "Operar" }),
+    node("h2", { text: title }),
+    node("p", { className: "section-meta", text: blocked ? "Ação local registra intenção; não aprova gate nem altera runtime." : "Frente sem bloqueio humano no snapshot atual." }),
+    node("div", { className: "action-grid" }, [
+      node("button", { className: "primary", type: "button", dataset: { action: "primary" }, onClick: () => blocked ? localAction("Evidência solicitada") : downloadReceipt() }, [primary]),
+      node("button", { type: "button", dataset: { action: "follow" }, onClick: () => localAction("Acompanhamento registrado") }, ["Acompanhar"]),
+      node("button", { type: "button", dataset: { action: "request-change" }, onClick: () => localAction("Ajuste solicitado") }, ["Pedir ajuste"]),
+      node("button", { type: "button", dataset: { action: "context" }, onClick: () => localAction("Contexto aberto") }, ["Contexto"]),
+    ]),
+  ]);
 }
 
 function renderDetail() {
-  const selected = state.data.snapshots.find((snapshot) => snapshot.id === state.selectedId) || state.data.snapshots[0];
-  if (!selected) return node("section", { className: "detail-card" }, [node("p", { text: "No selected snapshot." })]);
+  const selected = selectedSnapshot();
+  if (!selected) return node("section", { className: "detail-card", id: "inspector" }, [node("p", { text: "Sem frente selecionada." })]);
   return node("section", {
     className: "detail-card",
+    id: "inspector",
     "data-state-ui": selected.state_ui,
     "data-current-state": selected.current_state,
-    "aria-label": "Selected snapshot detail",
+    "aria-label": "Detalhe da frente",
   }, [
     node("div", { className: "inspector-kicker" }, [
-      node("p", { className: "eyebrow", text: "Inspector" }),
-      node("span", { className: "subtle", text: selected.phase }),
+      node("p", { className: "eyebrow", text: "Frente aberta" }),
+      node("span", { className: "subtle", text: selected.id }),
     ]),
-    node("h2", { text: selected.title }),
+    node("h2", { text: snapshotTitle(selected) }),
     node("p", { className: "next-action", text: selected.next_safe_action.label }),
     node("div", { className: "pill-row" }, [
-      pill("current", selected.current_state, "state-pill current-pill"),
+      pill("estado", stateLabel(selected.current_state), "state-pill current-pill"),
       pill("ui", selected.state_ui, "state-pill"),
-      pill("freshness", selected.freshness_state),
-      pill("risk", selected.risk_effective),
+      pill("risco", selected.risk_effective),
     ]),
     node("div", { className: "detail-grid" }, [
-      kv("Observed", selected.observed_at),
-      kv("Source updated", selected.source_updated_at || "not supplied"),
-      kv("Review lane", selected.review.status),
-      kv("Receipt status", selected.receipt.status),
-      kv("Next action", selected.next_safe_action.action_type),
-      kv("Source ref", selected.input_ref),
+      kv("Observado", selected.observed_at),
+      kv("Fonte", selected.input_ref),
+      kv("Revisão", selected.review.status),
+      kv("Recibo", selected.receipt.status),
+      kv("Ação", actionLabel(selected.next_safe_action.action_type)),
+      kv("Freshness", selected.freshness_state),
     ]),
-    renderObjectList("Gate states", selected.gate_states, (item) => [
+    renderObjectList("Gates", selected.gate_states, (item) => [
       node("strong", { text: `${item.label} · ${item.state}` }),
-      node("p", { text: `Owner: ${item.owner}. Unblock: ${item.unblock_condition}` }),
+      node("p", { text: `Responsável: ${item.owner}. Desbloqueio: ${item.unblock_condition}` }),
       refList(item.source_refs),
-    ], "No gate state listed."),
-    renderObjectList("Blockers", selected.blockers, (item) => [
+    ], "Sem gate listado."),
+    renderObjectList("Bloqueios", selected.blockers, (item) => [
       node("strong", { text: `${item.id} · ${item.state}` }),
       node("p", { text: item.summary }),
-      node("p", { className: "subtle", text: `Unblock condition: ${item.unblock_condition}` }),
+      node("p", { className: "subtle", text: `Desbloqueio: ${item.unblock_condition}` }),
       refList(item.source_refs),
-    ], "No blockers listed."),
-    renderObjectList("Evidence refs", selected.evidence_refs, (item) => [
+    ], "Sem bloqueio listado."),
+    renderObjectList("Evidências", selected.evidence_refs, (item) => [
       node("strong", { text: `${item.id} · ${item.public_safety_state}` }),
-      node("p", { text: `${item.kind} · freshness ${item.freshness_state} · verification ${item.verification_status}` }),
-      item.unavailable_reason ? node("p", { className: "subtle", text: `Redaction/unavailable reason: ${item.unavailable_reason}` }) : null,
+      node("p", { text: `${item.kind} · ${item.freshness_state} · ${item.verification_status}` }),
+      item.unavailable_reason ? node("p", { className: "subtle", text: item.unavailable_reason }) : null,
       refList([item.ref, ...item.source_refs]),
-    ], "No evidence refs listed."),
+    ], "Sem evidência listada."),
   ]);
 }
 
 function renderProductFacePanel() {
   const packet = state.data.product_face;
   const review = state.data.product_face_review;
-  return node("aside", { className: "panel", "aria-label": "Product Face contract" }, [
-    ...sectionTitle("Product Face", packet.surface),
+  return node("section", { className: "panel", id: "reports", "aria-label": "Prova de produto" }, [
+    ...titleBlock("Qualidade", "Face do Produto", "Critérios públicos do cockpit."),
     node("div", { className: "pill-row" }, [
       pill("review", review.verdict),
-      pill("consume", review.may_consume_product_face_packet ? "bounded yes" : "blocked"),
-      pill("result", review.is_product_face_result ? "result" : "not result"),
+      pill("consumo", review.may_consume_product_face_packet ? "liberado" : "bloqueado"),
+      pill("resultado", review.is_product_face_result ? "sim" : "não"),
     ]),
-    kv("Visual tone", packet.visual_tone),
-    kv("Density", packet.density),
-    kv("Interaction", packet.interaction_style),
-    renderObjectList("Must have", packet.must_have || [], (item) => [node("p", { text: item })], "No must-have entries."),
-    renderObjectList("Must not have", packet.must_not_have || [], (item) => [node("p", { text: item })], "No must-not-have entries."),
-    renderObjectList("Required proof", packet.proof_required || [], (item) => [node("p", { text: item })], "No proof requirements listed."),
+    kv("Tom visual", packet.visual_tone),
+    kv("Densidade", packet.density),
+    kv("Interação", packet.interaction_style),
   ]);
 }
 
-function renderStateCoverage() {
-  const cards = state.data.state_registry.map((entry) => node("article", { className: "state-coverage-card", "data-state-ui": entry.id }, [
-    node("h3", { text: entry.label }),
-    node("p", { text: entry.operator_meaning }),
-    pill("matches", stateCountFor(entry.id), "state-pill"),
-  ]));
-  return node("section", { className: "panel", "aria-label": "State coverage matrix" }, [
-    ...sectionTitle("State coverage", "Packet-required state matrix"),
-    node("div", { className: "state-coverage-grid" }, cards),
+function renderReceipts() {
+  const rows = state.receipts.length
+    ? state.receipts.map((receipt) => node("div", { className: "receipt-row" }, [
+      node("strong", { text: receipt.action }),
+      node("span", { className: "subtle", text: receipt.item }),
+    ]))
+    : [node("p", { className: "subtle", text: "Sem ação local registrada." })];
+  return node("section", { className: "panel", "aria-label": "Recibos locais" }, [
+    ...titleBlock("Recibos", "Ações locais"),
+    node("div", { className: "receipt-list" }, rows),
   ]);
 }
 
 function renderTimeline() {
-  const rows = state.data.timeline.slice(-12).reverse().map((item) => node("article", { className: "timeline-row", "data-state-ui": item.state_ui, "data-current-state": item.current_state }, [
+  const rows = state.data.timeline.slice(-10).reverse().map((item) => node("article", {
+    className: "timeline-row",
+    "data-state-ui": item.state_ui,
+    "data-current-state": item.current_state,
+  }, [
     node("time", { text: item.at }),
-    node("strong", { text: item.label }),
-    node("p", { className: "subtle", text: `${item.current_state} · ${item.next_action} · ${item.source_ref}` }),
+    node("strong", { text: snapshotTitle({ state_ui: item.state_ui, title: item.label }) }),
+    node("p", { className: "subtle", text: `${stateLabel(item.current_state)} · ${actionLabel(item.next_action)} · ${shortRef(item.source_ref)}` }),
   ]));
-  return node("section", { className: "panel", "aria-label": "Transition timeline" }, [
-    ...sectionTitle("Timeline", "Recent projections"),
+  return node("section", { className: "panel", "aria-label": "Linha do tempo" }, [
+    ...titleBlock("Linha do tempo", "Eventos recentes"),
     node("div", { className: "timeline" }, rows),
   ]);
 }
 
 function renderGuardrails() {
-  return node("section", { className: "panel", "aria-label": "Forbidden actions" }, [
-    ...sectionTitle("Safety boundary", "Forbidden by this surface"),
-    node("ul", { className: "guardrail-list" }, state.data.policy.forbidden_actions.map((item) => node("li", { text: item }))),
+  return node("section", { className: "panel", "aria-label": "Limites" }, [
+    ...titleBlock("Limites", "Bloqueado neste cockpit"),
+    node("ul", { className: "guardrail-list" }, state.data.policy.forbidden_actions.slice(0, 12).map((item) => node("li", { text: item }))),
   ]);
 }
 
@@ -346,43 +525,80 @@ function renderApp() {
     return;
   }
   if (!state.selectedId) state.selectedId = state.data.snapshots[0].id;
-  root.appendChild(renderCommandStrip());
-  root.appendChild(node("div", { className: "layout" }, [
+  const selected = selectedSnapshot();
+  root.appendChild(node("div", { className: "app-shell" }, [
     renderStateFilters(),
-    node("div", { className: "stack main-stack" }, [renderSnapshotList(), renderStateCoverage()]),
-    node("div", { className: "stack inspector-stack" }, [renderDetail(), renderProductFacePanel(), renderTimeline(), renderGuardrails()]),
+    node("div", { className: "main-stack stack" }, [
+      renderSummary(),
+      renderFactoryLine(),
+      renderToolbar(),
+      renderSnapshotList(),
+    ]),
+    node("div", { className: "inspector-stack stack" }, [
+      renderDetail(),
+      renderActions(selected),
+      renderReceipts(),
+      renderProductFacePanel(),
+      renderTimeline(),
+      renderGuardrails(),
+    ]),
   ]));
 }
 
 async function loadData() {
   const params = new URLSearchParams(window.location.search);
+  const theme = params.get("theme") || localStorage.getItem("of-cockpit-theme") || "light";
+  setTheme(theme, false);
   const demo = params.get("demo");
   if (demo === "loading") {
     renderLoading();
     return;
   }
   if (demo === "empty") {
-    renderEmpty("Demo mode: no canonical local snapshot is available.");
+    renderEmpty("Modo demo: nenhum snapshot local disponível.");
     return;
   }
   if (demo === "error") {
-    renderError(new Error("Demo mode: simulated parse failure for state evidence."));
+    renderError(new Error("Modo demo: falha simulada ao ler evidência."));
     return;
   }
   renderLoading();
   try {
     const response = await fetch(DATA_URL, { cache: "no-store" });
-    if (!response.ok) throw new Error(`Failed to fetch ${DATA_URL}: ${response.status}`);
-    const data = await response.json();
-    state.data = data;
+    if (!response.ok) throw new Error(`Falha ao ler ${DATA_URL}: ${response.status}`);
+    state.data = await response.json();
     state.stateFilter = params.get("state") || "all";
     state.query = params.get("q") || "";
-    const selected = params.get("snapshot");
-    state.selectedId = selected || (data.snapshots && data.snapshots[0] ? data.snapshots[0].id : null);
+    if (globalSearch) globalSearch.value = state.query;
+    state.selectedId = params.get("snapshot") || (state.data.snapshots && state.data.snapshots[0] ? state.data.snapshots[0].id : null);
     renderApp();
   } catch (error) {
     renderError(error);
   }
 }
+
+if (globalSearch) {
+  globalSearch.addEventListener("input", (event) => updateQuery(event.target.value));
+  window.addEventListener("keydown", (event) => {
+    if (event.key === "/" && document.activeElement !== globalSearch) {
+      event.preventDefault();
+      globalSearch.focus();
+    }
+  });
+}
+
+if (themeToggle) {
+  themeToggle.addEventListener("click", () => {
+    const current = document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+    setTheme(current === "dark" ? "light" : "dark");
+  });
+}
+
+document.querySelectorAll("[data-dock-target]").forEach((button) => {
+  button.addEventListener("click", () => {
+    const target = document.querySelector(`#${button.dataset.dockTarget}`);
+    if (target) target.scrollIntoView({ block: "start" });
+  });
+});
 
 loadData();

--- a/ui/issue-84-local-cockpit/index.html
+++ b/ui/issue-84-local-cockpit/index.html
@@ -1,39 +1,51 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Issue 84 Local Cockpit</title>
+    <title>Overkill Factory Cockpit</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <a class="skip-link" href="#cockpit-main">Skip to cockpit</a>
+    <a class="skip-link" href="#cockpit-main">Ir para o cockpit</a>
     <header class="topbar" role="banner">
       <div class="brand-lockup">
-        <span class="brand-mark" aria-hidden="true">OF</span>
+        <span class="brand-mark" aria-hidden="true">X</span>
         <div>
-          <h1>Issue 84 Local Cockpit</h1>
-          <p>Local-first factory projection</p>
+          <h1>Overkill Factory</h1>
+          <p>Cockpit local</p>
         </div>
       </div>
-      <div class="top-actions" aria-label="Cockpit mode">
-        <span class="mode-chip">Projection only</span>
-        <span class="mode-chip">Loopback</span>
-        <span class="mode-chip">Public-safe refs</span>
+      <div class="command-bar" role="search">
+        <span aria-hidden="true">⌕</span>
+        <input id="globalSearch" type="search" placeholder="Buscar frente, gate ou evidência" aria-label="Buscar frente, gate ou evidência" />
+        <kbd>/</kbd>
+      </div>
+      <div class="top-actions" aria-label="Ações do cockpit">
+        <span class="mode-chip">Local</span>
+        <span class="mode-chip">Refs públicas</span>
+        <button id="themeToggle" type="button" aria-label="Alternar tema">Tema</button>
       </div>
     </header>
 
     <main id="cockpit-main" data-cockpit-root class="cockpit" aria-live="polite" aria-busy="true">
-      <section class="loading-panel" aria-label="Loading local cockpit data">
-        <p class="eyebrow">Loading snapshot</p>
-        <h2>Reading local StatusSnapshot projections</h2>
-        <p>No success metrics are inferred until the local JSON bundle is parsed.</p>
+      <section class="loading-panel" aria-label="Carregando dados locais">
+        <p class="eyebrow">Carregando</p>
+        <h2>Lendo snapshots locais</h2>
+        <p>Nenhum estado é aprovado enquanto o JSON público não for validado.</p>
       </section>
     </main>
 
+    <nav class="mobile-dock" aria-label="Navegação rápida">
+      <button type="button" data-dock-target="queue">Fila</button>
+      <button type="button" data-dock-target="inspector">Detalhe</button>
+      <button type="button" data-dock-target="reports">Prova</button>
+      <button type="button" data-dock-target="commands">Ações</button>
+    </nav>
+
     <noscript>
-      <section class="noscript" aria-label="No JavaScript fallback">
-        This local cockpit needs JavaScript to render the fixture-backed inspection panels. It has no mutation routes.
+      <section class="noscript" aria-label="Sem JavaScript">
+        Este cockpit local precisa de JavaScript para renderizar os snapshots públicos.
       </section>
     </noscript>
     <script src="app.js" defer></script>

--- a/ui/issue-84-local-cockpit/styles.css
+++ b/ui/issue-84-local-cockpit/styles.css
@@ -1,116 +1,154 @@
 :root {
   color-scheme: light;
-  --bg: #f6f8fb;
-  --surface: #ffffff;
-  --surface-soft: #f0f3f7;
-  --surface-strong: #e7ecf2;
-  --ink: #121821;
-  --muted: #667485;
-  --subtle: #8a96a5;
-  --line: #d6dde6;
-  --line-strong: #aeb9c7;
-  --accent: #2563eb;
-  --good: #16814a;
-  --warn: #b77900;
-  --bad: #c93636;
-  --blocked: #9a5b00;
-  --private: #6b4bb4;
-  --stale: #6b7280;
-  --conflict: #b91c50;
-  --cyan: #047481;
-  --shadow: 0 14px 34px rgba(18, 24, 33, 0.08);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --panel-soft: #f9fafc;
+  --panel-strong: #eef2f7;
+  --ink: #121721;
+  --muted: #647084;
+  --soft: #94a0af;
+  --line: #d9e0e9;
+  --line-soft: #edf1f5;
+  --blue: #1463ff;
+  --blue-soft: #eaf2ff;
+  --green: #16814a;
+  --green-soft: #e9f7ef;
+  --red: #d71920;
+  --red-soft: #fff0f0;
+  --amber: #b77900;
+  --amber-soft: #fff5df;
+  --violet: #6d4aff;
+  --violet-soft: #f0edff;
+  --shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
+  --side: 236px;
+  --detail: 390px;
+  --top: 64px;
+  font-family: Aptos, "Segoe UI Variable Text", "Segoe UI", Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #121821;
+  --panel-soft: #151d28;
+  --panel-strong: #1b2633;
+  --ink: #e8eef7;
+  --muted: #9ba9bc;
+  --soft: #718096;
+  --line: #273445;
+  --line-soft: #1f2a38;
+  --blue: #68a0ff;
+  --blue-soft: #112544;
+  --green: #4fd18b;
+  --green-soft: #0f2b20;
+  --red: #ff6b73;
+  --red-soft: #35171b;
+  --amber: #f2b94b;
+  --amber-soft: #322615;
+  --violet: #a895ff;
+  --violet-soft: #251f45;
+  --shadow: 0 18px 48px rgba(0, 0, 0, 0.3);
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
 body {
-  min-height: 100vh;
+  min-height: 100%;
+}
+
+body {
   margin: 0;
+  overflow: hidden;
   background: var(--bg);
   color: var(--ink);
+  font: 13px/1.45 var(--font-ui, inherit);
+  letter-spacing: 0;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
 }
 
 button,
 input {
+  min-width: 0;
   font: inherit;
+  color: inherit;
 }
 
 button {
-  color: inherit;
+  min-height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel);
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
+}
+
+button:hover {
+  border-color: color-mix(in srgb, var(--blue) 38%, var(--line));
+  background: var(--panel-soft);
 }
 
 button:focus-visible,
 a:focus-visible,
 input:focus-visible,
 [tabindex]:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.38);
+  outline: 3px solid color-mix(in srgb, var(--blue) 32%, transparent);
   outline-offset: 2px;
 }
 
 .skip-link {
   position: absolute;
-  left: 1rem;
-  top: -4rem;
-  z-index: 10;
+  left: 12px;
+  top: -60px;
+  z-index: 20;
+  padding: 9px 12px;
+  border-radius: 7px;
   background: var(--ink);
-  color: #fff;
-  padding: 0.65rem 0.85rem;
-  border-radius: 8px;
+  color: var(--panel);
   text-decoration: none;
 }
 
 .skip-link:focus {
-  top: 1rem;
+  top: 12px;
 }
 
 .topbar {
-  display: flex;
-  min-height: 4.5rem;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.85rem clamp(1rem, 3vw, 2rem);
-  border-bottom: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.94);
-  backdrop-filter: blur(14px);
   position: sticky;
   top: 0;
-  z-index: 5;
-}
-
-.brand-lockup,
-.top-actions,
-.snapshot-status,
-.snapshot-meta,
-.pill-row,
-.detail-grid,
-.kv,
-.inspector-kicker {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
+  z-index: 12;
+  display: grid;
+  grid-template-columns: var(--side) minmax(280px, 1fr) auto;
+  align-items: center;
+  min-height: var(--top);
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
+  backdrop-filter: blur(14px);
 }
 
 .brand-lockup {
+  display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 10px;
+  min-width: 0;
+  height: 100%;
+  padding: 0 16px;
+  border-right: 1px solid var(--line);
 }
 
 .brand-mark {
-  display: inline-grid;
-  width: 2.25rem;
-  height: 2.25rem;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
   place-items: center;
-  border: 1px solid #111827;
-  border-radius: 8px;
-  background: #111827;
-  color: #fff;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  border-radius: 5px;
+  background: #05070b;
+  color: white;
+  font-weight: 900;
+  font-size: 17px;
 }
 
 h1,
@@ -121,25 +159,59 @@ p {
 }
 
 h1 {
-  margin: 0 0 0.1rem;
-  font-size: 1.02rem;
-  line-height: 1.2;
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.1;
   letter-spacing: 0;
-}
-
-.brand-lockup p,
-.section-meta,
-.subtle {
-  color: var(--muted);
+  text-transform: uppercase;
 }
 
 .brand-lockup p {
-  margin: 0;
-  font-size: 0.82rem;
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.command-bar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  width: min(540px, calc(100% - 28px));
+  margin: 0 14px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--muted);
+}
+
+.command-bar input {
+  width: 100%;
+  height: 36px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+kbd {
+  min-width: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--panel-soft);
+  color: var(--muted);
+  font-size: 11px;
+  text-align: center;
 }
 
 .top-actions {
+  display: flex;
+  align-items: center;
   justify-content: flex-end;
+  gap: 8px;
+  padding: 0 16px;
 }
 
 .mode-chip,
@@ -147,280 +219,358 @@ h1 {
 .state-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  min-height: 1.55rem;
-  padding: 0.2rem 0.45rem;
-  border: 1px solid var(--line);
+  gap: 6px;
+  min-height: 24px;
+  padding: 0 8px;
   border-radius: 6px;
-  background: var(--surface);
+  background: var(--panel-strong);
   color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 650;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
 }
 
 .cockpit {
+  height: calc(100vh - var(--top));
+  overflow: hidden;
+}
+
+.loading-panel,
+.empty-panel,
+.error-panel,
+.noscript {
+  margin: 18px;
+  min-height: 180px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.app-shell {
   display: grid;
-  gap: 0.85rem;
-  padding: 0.85rem clamp(1rem, 3vw, 2rem) 1.25rem;
+  grid-template-columns: var(--side) minmax(460px, 1fr) var(--detail);
+  height: 100%;
+  min-width: 0;
+}
+
+.state-rail,
+.main-stack,
+.inspector-stack {
+  min-width: 0;
+  overflow: auto;
+}
+
+.state-rail {
+  border-right: 1px solid var(--line);
+  background: var(--panel);
+}
+
+.state-rail,
+.main-stack,
+.inspector-stack {
+  padding: 14px;
+}
+
+.inspector-stack {
+  border-left: 1px solid var(--line);
+  background: var(--panel-soft);
 }
 
 .panel,
 .detail-card,
 .metric,
-.loading-panel,
-.empty-panel,
-.error-panel,
-.noscript {
+.action-card {
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--surface);
+  background: var(--panel);
   box-shadow: var(--shadow);
 }
 
-.loading-panel,
-.empty-panel,
-.error-panel,
-.noscript {
-  min-height: 14rem;
-  padding: 1.25rem;
+.panel,
+.detail-card {
+  padding: 12px;
 }
 
-.error-panel {
-  border-color: rgba(201, 54, 54, 0.55);
+.stack {
+  display: grid;
+  gap: 12px;
+  align-content: start;
 }
 
 .eyebrow {
-  margin-bottom: 0.25rem;
-  color: var(--accent);
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  margin: 0 0 4px;
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 900;
   text-transform: uppercase;
 }
 
 h2 {
-  margin-bottom: 0.65rem;
-  font-size: 0.98rem;
-  line-height: 1.25;
+  margin: 0 0 8px;
+  font-size: 18px;
+  line-height: 1.2;
   letter-spacing: 0;
 }
 
 h3 {
-  margin-bottom: 0.45rem;
-  font-size: 0.88rem;
+  margin: 0 0 8px;
+  font-size: 13px;
   line-height: 1.25;
   letter-spacing: 0;
 }
 
-.command-strip {
+.section-meta,
+.subtle {
+  color: var(--muted);
+}
+
+.section-meta {
+  margin-bottom: 10px;
+  font-size: 12px;
+}
+
+.summary-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.65rem;
+  gap: 10px;
 }
 
 .metric {
-  min-height: 4.4rem;
-  padding: 0.72rem 0.8rem;
+  min-height: 72px;
+  padding: 11px 12px;
   box-shadow: none;
 }
 
 .metric span {
   display: block;
   color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0;
+  font-size: 11px;
+  font-weight: 900;
   text-transform: uppercase;
 }
 
 .metric strong {
   display: block;
-  margin-top: 0.25rem;
-  font-size: 1.55rem;
+  margin-top: 5px;
+  font-size: 24px;
   line-height: 1.05;
-  letter-spacing: 0;
 }
 
-.layout {
+.factory-line {
   display: grid;
-  grid-template-columns: minmax(14rem, 17rem) minmax(26rem, 1fr) minmax(22rem, 29rem);
-  gap: 0.85rem;
-  align-items: start;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 6px;
 }
 
-.panel,
-.detail-card {
-  min-width: 0;
-  padding: 0.85rem;
-}
-
-h1,
-h2,
-h3,
-p,
-.badge,
-.value-card,
-.snapshot-row,
-.timeline-row,
-.detail-card,
-.panel,
-.object-row,
-.state-filter {
-  overflow-wrap: anywhere;
-}
-
-.stack {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.main-stack,
-.inspector-stack {
-  min-width: 0;
-}
-
-.search-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  margin-bottom: 0.65rem;
-}
-
-.search-row input {
-  width: 100%;
-  min-height: 2.25rem;
+.stage {
+  min-height: 68px;
+  padding: 9px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--surface-soft);
-  color: var(--ink);
-  padding: 0.52rem 0.65rem;
-  font-size: 0.86rem;
+  background: var(--panel-soft);
 }
 
-.state-filter-grid,
-.state-coverage-grid {
+.stage b,
+.stage span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stage b {
+  font-size: 12px;
+}
+
+.stage span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.toolbar {
   display: grid;
-  gap: 0.42rem;
+  grid-template-columns: minmax(200px, 1fr) repeat(3, minmax(120px, 160px));
+  gap: 8px;
+}
+
+.toolbar input,
+.toolbar button {
+  width: 100%;
+}
+
+.toolbar input {
+  height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel);
+  padding: 0 12px;
+}
+
+.state-filter-grid {
+  display: grid;
+  gap: 7px;
 }
 
 .state-filter {
   width: 100%;
-  min-height: 3.5rem;
-  padding: 0.58rem 0.62rem;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  min-height: 48px;
+  padding: 8px 10px;
   text-align: left;
-  cursor: pointer;
+  border-left: 3px solid var(--state-color, var(--line));
 }
 
-.state-filter strong {
-  font-size: 0.82rem;
+.state-filter strong,
+.state-filter span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .state-filter[aria-pressed="true"] {
-  border-color: var(--state-color, var(--accent));
-  background: color-mix(in srgb, var(--state-color, var(--accent)) 10%, #fff);
+  border-color: var(--state-color, var(--blue));
+  background: color-mix(in srgb, var(--state-color, var(--blue)) 10%, var(--panel));
+  box-shadow: inset 2px 0 0 var(--state-color, var(--blue));
 }
 
-.snapshot-list {
+.queue-table {
   display: grid;
-  gap: 0.35rem;
-  padding-right: 0.15rem;
+  gap: 6px;
 }
 
 .snapshot-head,
 .snapshot-row {
   display: grid;
-  grid-template-columns: minmax(7.4rem, 8rem) minmax(13rem, 1fr) minmax(7rem, 9rem) minmax(4.5rem, 5.5rem);
-  gap: 0.65rem;
+  grid-template-columns: 96px minmax(220px, 1fr) 128px 96px;
+  gap: 10px;
   align-items: center;
 }
 
 .snapshot-head {
-  min-height: 2rem;
-  padding: 0 0.65rem;
-  color: var(--subtle);
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  min-height: 34px;
+  padding: 0 10px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 900;
   text-transform: uppercase;
 }
 
 .snapshot-row {
   width: 100%;
-  min-height: 4.4rem;
-  padding: 0.62rem 0.65rem;
+  min-height: 56px;
+  padding: 9px 10px;
   border: 1px solid var(--line);
-  border-left: 4px solid var(--state-color, var(--line-strong));
+  border-left: 3px solid var(--state-color, var(--line));
   border-radius: 8px;
-  background: var(--surface);
-  cursor: pointer;
+  background: var(--panel);
   text-align: left;
 }
 
-.snapshot-row:hover {
-  border-color: var(--line-strong);
-  background: #fbfcfe;
-}
-
 .snapshot-row[aria-current="true"] {
-  border-color: var(--state-color, var(--accent));
-  background: color-mix(in srgb, var(--state-color, var(--accent)) 8%, #fff);
+  border-color: var(--state-color, var(--blue));
+  background: color-mix(in srgb, var(--state-color, var(--blue)) 8%, var(--panel));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--state-color, var(--blue)) 42%, transparent);
 }
 
 .snapshot-title-cell {
   display: grid;
-  gap: 0.22rem;
+  gap: 2px;
   min-width: 0;
 }
 
-.snapshot-row strong {
-  line-height: 1.2;
-  font-size: 0.88rem;
+.snapshot-title-cell strong,
+.snapshot-title-cell span,
+.snapshot-phase,
+.snapshot-action {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snapshot-title-cell strong {
+  font-size: 13px;
 }
 
 .snapshot-phase,
 .snapshot-action {
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.state-pill {
-  color: var(--ink);
+.detail-card {
+  border-left: 3px solid var(--state-color, var(--blue));
 }
 
+.inspector-kicker,
 .pill-row,
-.detail-grid {
-  align-items: flex-start;
+.receipt-row,
+.kv {
+  display: flex;
+  gap: 8px;
+}
+
+.inspector-kicker {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pill-row {
+  flex-wrap: wrap;
+  margin: 10px 0;
+}
+
+.next-action {
+  margin: 0 0 10px;
+  padding: 10px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--state-color, var(--blue)) 9%, var(--panel));
+  font-weight: 800;
 }
 
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
-  margin: 0.8rem 0;
+  gap: 8px;
+  margin: 10px 0;
 }
 
 .kv {
   display: grid;
-  gap: 0.15rem;
-  min-height: 3.6rem;
-  padding: 0.55rem 0;
-  border-top: 1px solid var(--line);
+  gap: 2px;
+  min-height: 54px;
+  padding: 8px 0;
+  border-top: 1px solid var(--line-soft);
 }
 
 .kv span {
-  color: var(--subtle);
-  font-size: 0.68rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 900;
   text-transform: uppercase;
 }
 
 .kv strong {
-  font-size: 0.84rem;
-  line-height: 1.25;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 13px;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.action-grid button.primary {
+  border-color: color-mix(in srgb, var(--blue) 46%, var(--line));
+  background: var(--blue);
+  color: white;
+  font-weight: 900;
 }
 
 .object-list {
@@ -432,207 +582,201 @@ p,
 }
 
 .object-row {
-  padding: 0.62rem 0;
-  border-top: 1px solid var(--line);
+  padding: 9px 0;
+  border-top: 1px solid var(--line-soft);
 }
 
 .object-row p {
-  margin-bottom: 0.3rem;
+  margin-bottom: 4px;
   color: var(--muted);
 }
 
 .object-row code,
 .ref-code {
-  color: #1e3a8a;
+  color: var(--blue);
   overflow-wrap: anywhere;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.76rem;
+  font-size: 11px;
 }
 
-.state-coverage-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.state-coverage-card {
-  min-height: 7rem;
-  padding: 0.62rem 0;
-  border-top: 3px solid var(--state-color, var(--line-strong));
-}
-
-.state-coverage-card h3 {
-  margin-bottom: 0.25rem;
-}
-
-.state-coverage-card p {
-  margin-bottom: 0.35rem;
-  color: var(--muted);
-  font-size: 0.82rem;
-}
-
+.receipt-list,
 .timeline {
   display: grid;
-  gap: 0;
+  gap: 7px;
 }
 
+.receipt-row,
 .timeline-row {
-  padding: 0.62rem 0;
-  border-top: 1px solid var(--line);
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  background: var(--panel-soft);
 }
 
-.timeline-row time {
-  display: block;
-  color: var(--subtle);
-  font-size: 0.72rem;
-}
-
-.timeline-row p {
-  margin-bottom: 0;
-}
-
-.inspector-kicker {
-  align-items: center;
+.receipt-row {
   justify-content: space-between;
 }
 
-.next-action {
-  margin-bottom: 0.7rem;
-  padding: 0.6rem 0.65rem;
-  border-left: 4px solid var(--state-color, var(--accent));
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--state-color, var(--accent)) 8%, #fff);
-  color: var(--ink);
-  font-size: 0.86rem;
-  font-weight: 650;
+.timeline-row {
+  display: grid;
+  gap: 2px;
+}
+
+.timeline-row time {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.guardrail-list {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  columns: 2;
 }
 
 [data-state-ui="loading_snapshot"] {
-  --state-color: var(--accent);
+  --state-color: var(--blue);
 }
 [data-state-ui="empty_no_snapshots"] {
   --state-color: var(--muted);
 }
 [data-state-ui="success_current_snapshot"] {
-  --state-color: var(--good);
+  --state-color: var(--green);
 }
 [data-state-ui="input_error_or_parse_failure"] {
-  --state-color: var(--bad);
+  --state-color: var(--red);
 }
 [data-state-ui="blocked_gate"] {
-  --state-color: var(--blocked);
+  --state-color: var(--amber);
 }
 [data-state-ui="stale_snapshot"] {
-  --state-color: var(--stale);
+  --state-color: var(--soft);
 }
 [data-state-ui="contradictory_state"] {
-  --state-color: var(--conflict);
+  --state-color: var(--red);
 }
 [data-state-ui="private_evidence_unavailable"] {
-  --state-color: var(--private);
+  --state-color: var(--violet);
 }
 [data-state-ui="review_pending_failed_passed"] {
-  --state-color: var(--warn);
+  --state-color: var(--amber);
 }
 [data-state-ui="long_dense_data"] {
-  --state-color: var(--cyan);
+  --state-color: var(--blue);
 }
 
 [data-current-state="success"] {
-  --current-color: var(--good);
+  --current-color: var(--green);
 }
 [data-current-state="empty"] {
   --current-color: var(--muted);
 }
 [data-current-state="loading"] {
-  --current-color: var(--accent);
+  --current-color: var(--blue);
 }
 [data-current-state="error"] {
-  --current-color: var(--bad);
+  --current-color: var(--red);
 }
 [data-current-state="blocked"] {
-  --current-color: var(--blocked);
+  --current-color: var(--amber);
 }
 [data-current-state="stale"] {
-  --current-color: var(--stale);
+  --current-color: var(--soft);
 }
 [data-current-state="missing"] {
-  --current-color: var(--blocked);
+  --current-color: var(--amber);
 }
 [data-current-state="contradictory"] {
-  --current-color: var(--conflict);
+  --current-color: var(--red);
 }
 [data-current-state="private_unavailable"] {
-  --current-color: var(--private);
+  --current-color: var(--violet);
 }
 [data-current-state="superseded"] {
-  --current-color: var(--warn);
-}
-
-[data-state-ui] .state-pill,
-[data-current-state] .current-pill {
-  border-color: color-mix(in srgb, var(--state-color, var(--current-color)) 45%, var(--line));
-  background: color-mix(in srgb, var(--state-color, var(--current-color)) 9%, #fff);
+  --current-color: var(--amber);
 }
 
 [data-current-state] .current-pill::before,
 [data-state-ui] .state-pill::before {
   content: "";
-  width: 0.52rem;
-  height: 0.52rem;
+  width: 8px;
+  height: 8px;
   flex: 0 0 auto;
-  border-radius: 50%;
+  border-radius: 4px;
   background: var(--state-color, var(--current-color));
 }
 
-.guardrail-list {
-  columns: 2;
-  column-gap: 1rem;
-  padding-left: 1.1rem;
-  color: var(--muted);
-  font-size: 0.82rem;
-}
-
-.section-meta {
-  margin-top: -0.35rem;
-  margin-bottom: 0.7rem;
-  font-size: 0.82rem;
-}
-
-.subtle {
-  font-size: 0.78rem;
+.mobile-dock {
+  display: none;
 }
 
 @media (max-width: 1180px) {
-  .layout {
-    grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);
+  :root {
+    --side: 212px;
+    --detail: 340px;
   }
 
-  .inspector-stack {
-    grid-column: 1 / -1;
-  }
-}
-
-@media (max-width: 820px) {
-  .topbar,
-  .top-actions {
-    align-items: flex-start;
-    justify-content: flex-start;
-  }
-
-  .topbar,
-  .layout {
-    grid-template-columns: 1fr;
-  }
-
-  .topbar {
-    display: grid;
-  }
-
-  .command-strip {
+  .summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .metric {
-    min-height: 3.8rem;
+  .factory-line {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  body {
+    overflow: auto;
+  }
+
+  .topbar {
+    position: relative;
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding-bottom: 10px;
+  }
+
+  .brand-lockup {
+    border-right: 0;
+  }
+
+  .command-bar {
+    width: calc(100% - 24px);
+    margin: 0 12px;
+  }
+
+  .top-actions {
+    justify-content: flex-start;
+    padding: 0 12px;
+  }
+
+  .cockpit {
+    height: auto;
+    overflow: visible;
+  }
+
+  .app-shell {
+    display: block;
+    height: auto;
+    padding-bottom: 92px;
+  }
+
+  .state-rail,
+  .main-stack,
+  .inspector-stack {
+    overflow: visible;
+    border: 0;
+    padding: 12px;
+  }
+
+  .toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .toolbar input {
+    grid-column: 1 / -1;
   }
 
   .snapshot-head {
@@ -641,40 +785,43 @@ p,
 
   .snapshot-row {
     grid-template-columns: 1fr;
-    gap: 0.35rem;
+    gap: 4px;
   }
 
-  .snapshot-status {
-    order: 2;
-  }
-
-  .snapshot-phase,
-  .snapshot-action {
-    order: 3;
-  }
-
-  .state-coverage-grid,
-  .detail-grid {
+  .detail-grid,
+  .action-grid {
     grid-template-columns: 1fr;
   }
 
   .guardrail-list {
     columns: 1;
   }
+
+  .mobile-dock {
+    position: fixed;
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    z-index: 30;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 4px;
+    padding: 6px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--panel) 94%, transparent);
+    backdrop-filter: blur(14px);
+    box-shadow: var(--shadow);
+  }
 }
 
 @media (max-width: 520px) {
-  .cockpit,
-  .topbar {
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
+  .summary-grid,
+  .factory-line {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .panel,
-  .detail-card,
-  .loading-panel,
-  .empty-panel,
-  .error-panel {
-    padding: 0.75rem;
+  .mode-chip:nth-of-type(2) {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- upgrades the Issue #84 local cockpit from read-only inspection to a safer local operator cockpit
- adds Portuguese app shell, search, state rail, queue, inspector, local action receipts and light/dark theme
- keeps the surface local-first and public-safe: no runtime mutation, GitHub action, deployment, private evidence, or raw local artifacts

Closes #84

## Validation
- `python -m unittest tests.test_issue84_local_cockpit_ui -v`
- `node --check ui/issue-84-local-cockpit/app.js`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/supply_chain_proof.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_public_surface_sync.py`
- Browser validation on local loopback server: load, blocked snapshot selection, local action receipt, theme toggle, desktop/mobile overflow and console check