### PR TITLE
Add non-core pack activation ledger

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -74,6 +74,7 @@ Open the JSON files after that, when you need exact contracts.
 | `agents/hermes-profile-bindings.public.json` | Hermes profile name, queue policy, skill refs, result schema, receipt field and adapter binding. |
 | `agents/worker-permission-classes.public.json` | Permission class and authority boundary for every worker. |
 | `agents/capability-packs.public.json` | Product-type coverage and whether a requested surface can execute. |
+| `agents/capability-pack-activation-ledger.public.json` | Current activation state and proof requirements for non-core capability packs. |
 | `agents/worker-contract.schema.json` | Schema for the worker contract shape. |
 
 These files are not narrative documentation. They are public-safe contracts

--- a/agents/capability-pack-activation-ledger.public.json
+++ b/agents/capability-pack-activation-ledger.public.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/capability-pack-activation-ledger.schema.json",
+  "record_type": "capability_pack_activation_ledger",
+  "version": "factory-v1-preflight-2026-06-16",
+  "activation_entries": [
+    {
+      "pack_id": "mobile-app-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "mobile.architecture-packet",
+        "mobile.device-smoke",
+        "mobile.lifecycle-permissions",
+        "mobile.product-face-result"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the exact approved mobile runtime, device matrix and store/release boundary.",
+      "blocked_when": ["No activated mobile builder and mobile QA profile bindings exist."],
+      "next_activation_evidence": ["mobile profile bindings", "simulator/device smoke", "mobile QA eval", "human activation gate"]
+    },
+    {
+      "pack_id": "desktop-app-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "desktop.runtime-decision",
+        "desktop.packaging-proof",
+        "desktop.update-rollback-proof",
+        "desktop.qa-proof"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved desktop runtime, operating-system target and packaging/update path.",
+      "blocked_when": ["No activated desktop runtime/package worker binding exists."],
+      "next_activation_evidence": ["desktop profile binding", "installer smoke", "update/rollback eval", "human activation gate"]
+    },
+    {
+      "pack_id": "game-product-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "game.design-packet",
+        "game.runtime-choice",
+        "game.playable-smoke",
+        "game.performance-budget",
+        "game.playtest-review"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved game runtime, asset pipeline and playtest proof boundary.",
+      "blocked_when": ["No activated game runtime, design and QA worker profile bindings exist."],
+      "next_activation_evidence": ["game runtime profile", "playable smoke", "performance proof", "playtest eval", "human activation gate"]
+    },
+    {
+      "pack_id": "ai-ml-product-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "ai.model-contract",
+        "ai.eval-plan",
+        "ai.data-policy",
+        "ai.safety-review",
+        "ai.regression-eval"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved model/data/eval boundary with explicit safety limits.",
+      "blocked_when": ["No activated AI/ML product builder or model-eval binding exists."],
+      "next_activation_evidence": ["model/data contract", "eval harness", "safety review", "regression eval", "human activation gate"]
+    },
+    {
+      "pack_id": "fintech-payments-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "fintech.ledger-model",
+        "fintech.idempotency-proof",
+        "fintech.reconciliation-proof",
+        "fintech.risk-matrix",
+        "fintech.human-gate"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved ledger, reconciliation and money-movement boundary.",
+      "blocked_when": ["No payments ledger profile, risk specialist and human money-movement gate exist."],
+      "next_activation_evidence": ["ledger invariant tests", "idempotency proof", "reconciliation proof", "risk review", "human activation gate"]
+    },
+    {
+      "pack_id": "regulated-domain-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "regulated.domain-risk-packet",
+        "regulated.compliance-owner",
+        "regulated.scope-boundary",
+        "regulated.human-gate"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved jurisdiction, product class and compliance boundary.",
+      "blocked_when": ["No domain compliance specialist and jurisdiction-specific human gate exist."],
+      "next_activation_evidence": ["jurisdiction packet", "compliance owner", "scope boundary", "human activation gate"]
+    },
+    {
+      "pack_id": "data-analytics-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "analytics.metric-definitions",
+        "analytics.data-quality",
+        "analytics.lineage",
+        "analytics.dashboard-proof"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved metric, lineage, data-quality and dashboard correctness boundary.",
+      "blocked_when": ["No activated analytics builder and data-quality eval binding exists."],
+      "next_activation_evidence": ["metric contract", "data-quality checks", "lineage proof", "dashboard proof", "human activation gate"]
+    },
+    {
+      "pack_id": "browser-extension-pack",
+      "registry_status": "pack_template",
+      "activation_state": "template_only",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "extension.permission-review",
+        "extension.browser-smoke",
+        "extension.service-worker-content-script",
+        "extension.packaging-proof"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only the approved browser, permission model and extension-store packaging boundary.",
+      "blocked_when": ["No browser extension builder binding and permission/package proof exist."],
+      "next_activation_evidence": ["permission review", "browser smoke", "service-worker/content-script proof", "packaging proof", "human activation gate"]
+    },
+    {
+      "pack_id": "hardware-iot-pack",
+      "registry_status": "blocked_until_installed",
+      "activation_state": "blocked_until_installed",
+      "material_execution_allowed_by_default": false,
+      "activation_contract_required": true,
+      "smoke_path_required": true,
+      "eval_path_required": true,
+      "profile_binding_refs_required": true,
+      "structured_proofs_required": [
+        "hardware.safety-packet",
+        "hardware.device-test-plan",
+        "hardware.domain-expert-review"
+      ],
+      "human_activation_gate_required": true,
+      "allowed_activation_scope": "Only after a named hardware/IoT specialist, physical test bench and safety owner exist.",
+      "blocked_when": ["No physical-device specialist, safety test bench or recovery model exists."],
+      "next_activation_evidence": ["hardware specialist profile", "device test plan", "safety proof", "domain expert review", "human activation gate"]
+    }
+  ]
+}

--- a/agents/capability-packs.public.json
+++ b/agents/capability-packs.public.json
@@ -9,6 +9,7 @@
     "Pack templates are not execution approval; they become usable only after specialist workers, permissions, evals, review and Hermes binding are created.",
     "If a surface is unknown and capability_coverage_required=true, the card must block until a pack is created or explicitly waived by a human gate."
   ],
+  "activation_ledger_ref": "agents/capability-pack-activation-ledger.public.json",
   "packs": {
     "web-saas-core": {
       "pack_id": "web-saas-core",

--- a/docs/agents/capability-packs.md
+++ b/docs/agents/capability-packs.md
@@ -96,6 +96,14 @@ The template lives at `templates/capability-pack-contract.json`.
 non-core pack activation shape, but it is deliberately blocked until real
 public-safe smoke and eval refs replace the placeholders.
 
+`agents/capability-pack-activation-ledger.public.json` is the current activation
+ledger for non-core packs. It states whether each specialized pack is
+`activated`, `template_only` or `blocked_until_installed`, and names the smoke,
+eval, profile-binding and structured-proof requirements that must exist before
+material execution can use the pack. If the ledger does not mark a non-core
+pack as activated, `factoryctl` requires a bounded human activation gate plus
+activation scope/rationale in the `capability_pack_contract`.
+
 Core packs can still require surface-specific proof through
 `templates/product-delivery-quality-profile.json`. API/data surfaces must prove
 contract, auth, error semantics, migrations, fixtures, retention and operational

--- a/schemas/capability-pack-activation-ledger.schema.json
+++ b/schemas/capability-pack-activation-ledger.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/capability-pack-activation-ledger.schema.json",
+  "title": "Overkill Factory Capability Pack Activation Ledger",
+  "type": "object",
+  "required": ["$schema", "record_type", "version", "activation_entries"],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/capability-pack-activation-ledger.schema.json"
+    },
+    "record_type": { "const": "capability_pack_activation_ledger" },
+    "version": { "type": "string", "minLength": 3 },
+    "activation_entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "pack_id",
+          "registry_status",
+          "activation_state",
+          "material_execution_allowed_by_default",
+          "activation_contract_required",
+          "smoke_path_required",
+          "eval_path_required",
+          "profile_binding_refs_required",
+          "structured_proofs_required",
+          "human_activation_gate_required",
+          "allowed_activation_scope",
+          "blocked_when",
+          "next_activation_evidence"
+        ],
+        "properties": {
+          "pack_id": { "type": "string", "minLength": 3 },
+          "registry_status": {
+            "enum": ["pack_template", "blocked_until_installed", "pack_ready", "core_ready"]
+          },
+          "activation_state": {
+            "enum": ["activated", "blocked_until_installed", "template_only"]
+          },
+          "material_execution_allowed_by_default": { "type": "boolean" },
+          "activation_contract_required": { "type": "boolean" },
+          "smoke_path_required": { "type": "boolean" },
+          "eval_path_required": { "type": "boolean" },
+          "profile_binding_refs_required": { "type": "boolean" },
+          "structured_proofs_required": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "human_activation_gate_required": { "type": "boolean" },
+          "allowed_activation_scope": { "type": "string", "minLength": 3 },
+          "blocked_when": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "next_activation_evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/capability-pack-contract.schema.json
+++ b/schemas/capability-pack-contract.schema.json
@@ -161,6 +161,22 @@
         "type": "string"
       }
     },
+    "activation_ledger_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "human_activation_gate_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "activation_scope": {
+      "type": "string",
+      "minLength": 12
+    },
+    "activation_rationale": {
+      "type": "string",
+      "minLength": 12
+    },
     "structured_proofs_required": {
       "type": "array",
       "items": {

--- a/schemas/capability-pack-registry.schema.json
+++ b/schemas/capability-pack-registry.schema.json
@@ -13,6 +13,7 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 8 }
     },
+    "activation_ledger_ref": { "type": "string", "minLength": 3 },
     "packs": {
       "type": "object",
       "minProperties": 1,

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -63,6 +63,8 @@ PROFILE_BINDINGS_PATH = ROOT / "agents" / "hermes-profile-bindings.public.json"
 PROFILE_READINESS_PATH = ROOT / "agents" / "worker-profile-readiness.public.json"
 PROFILE_READINESS_REF = "agents/worker-profile-readiness.public.json"
 CAPABILITY_PACKS_PATH = ROOT / "agents" / "capability-packs.public.json"
+CAPABILITY_PACK_ACTIVATION_LEDGER_REF = "agents/capability-pack-activation-ledger.public.json"
+CAPABILITY_PACK_ACTIVATION_LEDGER_PATH = ROOT / CAPABILITY_PACK_ACTIVATION_LEDGER_REF
 DEFAULT_WORKFLOW_CATALOG = ROOT / "docs" / "factory-workflow.catalog.json"
 CANONICAL_RUNTIME_ENFORCEMENT_PATH = CODE_ROOT / "scripts" / "canonical_runtime_enforcement.py"
 DEFAULT_MINIMAL_CARD = ROOT / "examples" / "minimal-hermes-project" / "card.md"
@@ -1277,6 +1279,20 @@ def load_capability_packs() -> dict[str, dict[str, Any]]:
     return {str(pack_id): pack for pack_id, pack in packs.items() if isinstance(pack, dict)}
 
 
+def load_capability_pack_activation_ledger() -> dict[str, dict[str, Any]]:
+    if not CAPABILITY_PACK_ACTIVATION_LEDGER_PATH.exists():
+        return {}
+    data = json.loads(CAPABILITY_PACK_ACTIVATION_LEDGER_PATH.read_text(encoding="utf-8"))
+    entries = data.get("activation_entries", [])
+    if not isinstance(entries, list):
+        raise ValueError("capability pack activation ledger must contain activation_entries")
+    return {
+        str(entry.get("pack_id")): entry
+        for entry in entries
+        if isinstance(entry, dict) and str(entry.get("pack_id") or "").strip()
+    }
+
+
 def _activated_capability_pack_ids(contract: Any) -> set[str]:
     if not isinstance(contract, dict):
         return set()
@@ -1339,9 +1355,35 @@ def validate_activated_capability_contract(
     if missing_capabilities:
         errors.append("capability_pack_contract.missing_capabilities must be empty before material execution")
     packs = load_capability_packs()
+    activation_ledger = load_capability_pack_activation_ledger()
     required_pack_proofs: set[str] = set()
     for pack_id in contract_pack_ids.intersection(candidate_pack_ids):
-        required_pack_proofs.update(_pack_structured_proof_ids(packs.get(pack_id, {})))
+        pack = packs.get(pack_id, {})
+        required_pack_proofs.update(_pack_structured_proof_ids(pack))
+        registry_status = str(pack.get("status") or "").strip()
+        if registry_status not in CAPABILITY_READY_STATES:
+            ledger_entry = activation_ledger.get(pack_id)
+            if not ledger_entry:
+                errors.append(f"capability_pack_contract activation ledger entry missing for non-core pack {pack_id!r}")
+                continue
+            if str(contract.get("activation_ledger_ref") or "").strip() != CAPABILITY_PACK_ACTIVATION_LEDGER_REF:
+                errors.append(
+                    "capability_pack_contract.activation_ledger_ref must be "
+                    f"{CAPABILITY_PACK_ACTIVATION_LEDGER_REF} for non-core pack activation"
+                )
+            ledger_proofs = set(_list_items(ledger_entry.get("structured_proofs_required")))
+            missing_ledger_proofs = sorted(ledger_proofs - set(contract_structured_proofs))
+            if missing_ledger_proofs:
+                errors.append(
+                    "capability_pack_contract.structured_proofs_required missing activation ledger proof ids: "
+                    + ", ".join(missing_ledger_proofs)
+                )
+            if str(ledger_entry.get("activation_state") or "").strip() != "activated":
+                for field in ("human_activation_gate_ref", "activation_scope", "activation_rationale"):
+                    if not _non_empty_text(contract.get(field)):
+                        errors.append(
+                            f"capability_pack_contract.{field} is required when activation ledger state is not activated"
+                        )
     if required_pack_proofs:
         if not contract_structured_proofs:
             errors.append("capability_pack_contract.structured_proofs_required must mirror activated registry proof ids")

--- a/tests/test_capability_packs.py
+++ b/tests/test_capability_packs.py
@@ -43,6 +43,10 @@ def activated_game_contract() -> dict:
         "permission_class": "bounded-worker",
         "missing_capabilities": [],
         "execution_rule": "Game execution is allowed only after playable smoke, performance budget and game QA proof exist.",
+        "activation_ledger_ref": "agents/capability-pack-activation-ledger.public.json",
+        "human_activation_gate_ref": "external:game-pack-human-activation-gate",
+        "activation_scope": "Bounded activation for this test game runtime, asset pipeline and QA surface only.",
+        "activation_rationale": "Human-approved activation path supplies smoke, eval, profile bindings and structured proof coverage.",
         "structured_proofs_required": [
             "game.design-packet",
             "game.performance-budget",
@@ -172,6 +176,61 @@ class CapabilityPacksTest(unittest.TestCase):
         errors = factoryctl.validate_capability_coverage(card)
 
         self.assertEqual(errors, [])
+
+    def test_activation_ledger_covers_non_core_template_packs(self) -> None:
+        packs = json.loads((ROOT / "agents" / "capability-packs.public.json").read_text(encoding="utf-8"))["packs"]
+        ledger = json.loads((ROOT / "agents" / "capability-pack-activation-ledger.public.json").read_text(encoding="utf-8"))
+        entries = {entry["pack_id"]: entry for entry in ledger["activation_entries"]}
+        non_core_pack_ids = [
+            pack_id
+            for pack_id, pack in packs.items()
+            if pack["status"] in {"pack_template", "blocked_until_installed"}
+        ]
+
+        self.assertTrue(non_core_pack_ids)
+        for pack_id in non_core_pack_ids:
+            with self.subTest(pack_id=pack_id):
+                self.assertIn(pack_id, entries)
+                self.assertEqual(entries[pack_id]["registry_status"], packs[pack_id]["status"])
+                self.assertFalse(entries[pack_id]["material_execution_allowed_by_default"])
+                self.assertTrue(entries[pack_id]["activation_contract_required"])
+                self.assertTrue(entries[pack_id]["smoke_path_required"])
+                self.assertTrue(entries[pack_id]["eval_path_required"])
+                self.assertTrue(entries[pack_id]["profile_binding_refs_required"])
+                self.assertTrue(entries[pack_id]["allowed_activation_scope"])
+                self.assertEqual(
+                    set(entries[pack_id]["structured_proofs_required"]),
+                    set(packs[pack_id]["structured_proofs_required"]),
+                )
+
+    def test_template_pack_activation_requires_ledger_and_human_activation_gate(self) -> None:
+        card = base_card()
+        card["surfaces"] = ["game", "3d", "asset-pipeline"]
+        contract = activated_game_contract()
+        contract.pop("activation_ledger_ref")
+        contract.pop("human_activation_gate_ref")
+        contract.pop("activation_scope")
+        contract.pop("activation_rationale")
+        card["capability_pack_contract"] = contract
+
+        errors = factoryctl.validate_capability_coverage(card)
+
+        self.assertIn(
+            "capability_pack_contract.activation_ledger_ref must be agents/capability-pack-activation-ledger.public.json for non-core pack activation",
+            errors,
+        )
+        self.assertIn(
+            "capability_pack_contract.human_activation_gate_ref is required when activation ledger state is not activated",
+            errors,
+        )
+        self.assertIn(
+            "capability_pack_contract.activation_scope is required when activation ledger state is not activated",
+            errors,
+        )
+        self.assertIn(
+            "capability_pack_contract.activation_rationale is required when activation ledger state is not activated",
+            errors,
+        )
 
     def test_activated_pack_rejects_partial_surface_coverage(self) -> None:
         card = base_card()

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -386,6 +386,10 @@ def activated_game_contract_fixture() -> dict:
         "permission_class": "bounded-worker",
         "missing_capabilities": [],
         "execution_rule": "Game execution is allowed only after playable smoke, performance budget and game QA proof exist.",
+        "activation_ledger_ref": "agents/capability-pack-activation-ledger.public.json",
+        "human_activation_gate_ref": "external:game-pack-human-activation-gate",
+        "activation_scope": "Bounded activation for this test game runtime, asset pipeline and QA surface only.",
+        "activation_rationale": "Human-approved activation path supplies smoke, eval, profile bindings and structured proof coverage.",
         "structured_proofs_required": [
             "game.design-packet",
             "game.performance-budget",

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -43,6 +43,10 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             "permission_class": "bounded-worker",
             "missing_capabilities": [],
             "execution_rule": "Game execution is allowed only after playable smoke, performance budget and game QA proof exist.",
+            "activation_ledger_ref": "agents/capability-pack-activation-ledger.public.json",
+            "human_activation_gate_ref": "external:game-pack-human-activation-gate",
+            "activation_scope": "Bounded activation for this test game runtime, asset pipeline and QA surface only.",
+            "activation_rationale": "Human-approved activation path supplies smoke, eval, profile bindings and structured proof coverage.",
             "structured_proofs_required": [
                 "game.design-packet",
                 "game.performance-budget",
@@ -79,6 +83,10 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             "permission_class": "bounded-worker",
             "missing_capabilities": [],
             "execution_rule": f"{pack_id} execution is allowed only after its structured proofs exist.",
+            "activation_ledger_ref": "agents/capability-pack-activation-ledger.public.json",
+            "human_activation_gate_ref": f"external:{pack_id}-human-activation-gate",
+            "activation_scope": f"Bounded activation for this {pack_id} test surface only.",
+            "activation_rationale": "Human-approved activation path supplies smoke, eval, profile bindings and structured proof coverage.",
             "structured_proofs_required": proofs,
             "worker_mapping": {
                 "build": ["domain-builder"],


### PR DESCRIPTION
## Summary
- add a public-safe activation ledger for non-core capability packs
- make factoryctl fail closed for non-core packs unless activation references the ledger, carries required structured proofs, and has a bounded human activation path when the ledger is not globally activated
- document the activation boundary and cover registry/ledger drift with focused tests

## Validation
- python -m unittest tests.test_capability_packs tests.test_product_method_sot_planning tests.test_factoryctl -q
- python -m unittest discover -s tests -q
- python scripts/validate_public_json_artifacts.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/supply_chain_proof.py
- python scripts/release_integration_preflight.py

Closes #207