### PR TITLE
Add Product Face state journey drivers

### DIFF
--- a/docs/product-face/proof-runner.md
+++ b/docs/product-face/proof-runner.md
@@ -121,6 +121,9 @@ Useful options:
   be proven before product acceptance.
 - `--journey "open target" --journey "inspect mobile viewport"` to declare
   journeys that must be proven before product acceptance.
+- `--driver templates/product-face-state-journey-driver.json` to execute named
+  browser journeys, setup steps and assertions instead of merely declaring
+  coverage.
 - `--strict` to treat accessibility and overlap warnings as blocking.
 - `--force-fallback` to register bounded static evidence without a browser.
 - `--card` to bind the result to the exact factory card/slice that will later
@@ -152,13 +155,26 @@ performance note. Without Playwright, it writes a `WAIVED` result with
 rendered screenshot, console, layout, accessibility tree or performance claim
 was captured.
 
-The repo runner does not drive arbitrary product states or user journeys by
-itself. It records requested states and journeys as `declared_states` and
-`declared_journeys`, but only the actually captured initial render/default
-browser journey can appear in `checked_states`, `user_journeys_checked`,
-`visual_artifacts` and `usage_evidence_matrix`. If extra states or journeys are
-declared without a state driver or separate proof artifact, the result is
-`WAIVED`, not a reusable Product Face PASS.
+The repo runner can drive named product states and journeys when a
+`product_face_state_journey_driver` is supplied with `--driver`. The driver is a
+small public-safe contract, not a full E2E framework. It supports bounded
+browser actions such as `goto`, `click`, `fill`, `wait_for_selector`,
+`assert_visible`, `assert_text` and `screenshot`. The runner records a
+`state_journey_driver` summary and a `driver_execution` record in the
+`product_face_result`, then uses only successfully executed journeys/states to
+populate `checked_states`, `user_journeys_checked`, `visual_artifacts` and
+`usage_evidence_matrix`.
+
+Without `--driver`, the runner still records requested states and journeys as
+`declared_states` and `declared_journeys`, but only the actually captured
+initial render/default browser journey can appear in executable proof fields.
+If extra states or journeys are declared without a driver or separate proof
+artifact, the result is `WAIVED`, not a reusable Product Face PASS.
+
+Driver values must be public-safe. Do not put secrets, private screenshots,
+absolute local paths, raw logs or generated proof history into the public repo.
+Keep execution outputs under `.tmp`, a private evidence store or a release
+artifact, and reference them through the result emitted by the runner.
 
 For product-facing completion, Receipt Five must include `product_face_result`.
 A Product Face Packet is planning; a Product Face Result is proof. Browser
@@ -192,6 +208,7 @@ python scripts/product_face_proof.py \
   --viewport mobile=390x844 \
   --state initial-render \
   --journey "open target" \
+  --driver templates/product-face-state-journey-driver.json \
   --packet-ref examples/minimal-hermes-project/card.md#product_face_packet \
   --packet-comparison-basis "Screens, states and viewports match the Product Face Packet." \
   --source-promise-coverage-basis "The checked journey covers the stated product promise." \

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -121,6 +121,54 @@
         "additionalProperties": true
       }
     },
+    "state_journey_driver": {
+      "type": "object",
+      "required": ["driver_ref", "status", "execution_ref", "journeys_executed", "states_executed"],
+      "properties": {
+        "driver_ref": { "type": "string", "minLength": 3 },
+        "status": { "enum": ["PASS", "FAIL"] },
+        "execution_ref": { "type": "string", "minLength": 3 },
+        "journeys_executed": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "states_executed": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "driver_execution": {
+      "type": "object",
+      "required": ["record_type", "driver_ref", "executions"],
+      "properties": {
+        "record_type": { "const": "product_face_state_journey_driver_execution" },
+        "driver_ref": { "type": "string", "minLength": 3 },
+        "executions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["journey", "state", "viewport", "status", "steps", "evidence_refs"],
+            "properties": {
+              "journey": { "type": "string", "minLength": 1 },
+              "state": { "type": "string", "minLength": 1 },
+              "viewport": { "type": "string", "minLength": 1 },
+              "data_condition": { "type": "string" },
+              "status": { "enum": ["PASS", "FAIL"] },
+              "steps": { "type": "array" },
+              "evidence_refs": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "failure": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
     "surface_evidence_profile": {
       "$ref": "#/$defs/surface_evidence_profile"
     },

--- a/schemas/product-face-state-journey-driver.schema.json
+++ b/schemas/product-face-state-journey-driver.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/product-face-state-journey-driver.schema.json",
+  "title": "Overkill Factory Product Face State/Journey Driver",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "target_binding",
+    "public_artifact_policy",
+    "journeys"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/product-face-state-journey-driver.schema.json"
+    },
+    "record_type": {
+      "const": "product_face_state_journey_driver"
+    },
+    "target_binding": {
+      "type": "object",
+      "required": ["target_ref"],
+      "properties": {
+        "target_ref": { "type": "string", "minLength": 3 },
+        "card_ref": { "type": "string", "minLength": 3 },
+        "product_face_packet_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "timeout_ms": {
+      "type": "integer",
+      "minimum": 100
+    },
+    "retry": {
+      "type": "object",
+      "properties": {
+        "attempts": { "type": "integer", "minimum": 1 },
+        "delay_ms": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "public_artifact_policy": {
+      "type": "object",
+      "required": ["no_private_screenshots_in_repo", "no_secrets_in_values", "proof_output_location"],
+      "properties": {
+        "no_private_screenshots_in_repo": { "type": "boolean" },
+        "no_secrets_in_values": { "type": "boolean" },
+        "proof_output_location": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "journeys": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "state", "steps"],
+        "properties": {
+          "journey_id": { "type": "string", "minLength": 3 },
+          "name": { "type": "string", "minLength": 3 },
+          "state": { "type": "string", "minLength": 3 },
+          "required_for_pass": { "type": "boolean" },
+          "data_condition": { "type": "string", "minLength": 3 },
+          "viewport_names": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 2 }
+          },
+          "timeout_ms": { "type": "integer", "minimum": 100 },
+          "state_setup": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/driver_step" }
+          },
+          "steps": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/$defs/driver_step" }
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "$defs": {
+    "driver_step": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "enum": [
+            "goto",
+            "click",
+            "fill",
+            "wait",
+            "wait_for_selector",
+            "assert_visible",
+            "assert_text",
+            "screenshot"
+          ]
+        },
+        "selector": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" },
+        "text": { "type": "string", "minLength": 1 },
+        "ms": { "type": "integer", "minimum": 0 },
+        "full_page": { "type": "boolean" },
+        "note": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -5083,6 +5083,28 @@ def validate_product_face_result(result: dict[str, Any]) -> list[str]:
         errors.append("product_face_result PASS cannot include uncaptured_states")
     if is_pass and _list_items(result.get("uncaptured_journeys")):
         errors.append("product_face_result PASS cannot include uncaptured_journeys")
+    state_journey_driver = result.get("state_journey_driver")
+    if is_pass and isinstance(state_journey_driver, dict):
+        if str(state_journey_driver.get("status") or "").upper() != "PASS":
+            errors.append("product_face_result PASS requires state_journey_driver.status=PASS")
+        if not _non_empty_text(state_journey_driver.get("execution_ref")):
+            errors.append("product_face_result PASS requires state_journey_driver.execution_ref")
+        if not _non_empty_string_list(state_journey_driver.get("journeys_executed")):
+            errors.append("product_face_result PASS requires state_journey_driver.journeys_executed")
+        if not _non_empty_string_list(state_journey_driver.get("states_executed")):
+            errors.append("product_face_result PASS requires state_journey_driver.states_executed")
+    driver_execution = result.get("driver_execution")
+    if is_pass and isinstance(driver_execution, dict):
+        executions = driver_execution.get("executions")
+        if not isinstance(executions, list) or not executions:
+            errors.append("product_face_result PASS driver_execution.executions must be non-empty")
+        else:
+            for index, execution in enumerate(executions):
+                if not isinstance(execution, dict):
+                    errors.append(f"product_face_result.driver_execution.executions[{index}] must be an object")
+                    continue
+                if str(execution.get("status") or "").upper() != "PASS":
+                    errors.append(f"product_face_result PASS driver_execution.executions[{index}].status must be PASS")
     for field in ("screenshots", "viewports", "checked_states", "user_journeys_checked", "evidence_refs"):
         if not _non_empty_string_list(result.get(field)):
             errors.append(f"product_face_result {field} must be a non-empty string array")

--- a/scripts/product_face_proof.py
+++ b/scripts/product_face_proof.py
@@ -55,6 +55,17 @@ BROWSER_CAPTURED_STATE_ALIASES = {
     "page loaded",
 }
 BROWSER_CAPTURED_JOURNEYS = ("open target", "inspect configured viewports")
+DRIVER_STEP_ACTIONS = {
+    "goto",
+    "click",
+    "fill",
+    "wait",
+    "wait_for_selector",
+    "assert_visible",
+    "assert_text",
+    "screenshot",
+}
+DRIVER_SELECTOR_ACTIONS = {"click", "fill", "wait_for_selector", "assert_visible", "assert_text"}
 
 
 class PlaywrightUnavailable(RuntimeError):
@@ -274,6 +285,192 @@ def apply_capture_scope(result: dict[str, Any], scope: dict[str, Any]) -> None:
             "Provide Product Face state/journey drivers or separate proof artifacts for uncaptured coverage, "
             "then rerun before product acceptance."
         )
+    else:
+        result["checked_states"] = result["captured_states"] or result["checked_states"]
+        result["user_journeys_checked"] = result["captured_journeys"] or result["user_journeys_checked"]
+        result["journeys"] = result["user_journeys_checked"]
+
+
+def load_state_journey_driver(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    driver = load_json_like(path)
+    validate_state_journey_driver(driver)
+    driver["_driver_ref"] = repo_ref(path)
+    return driver
+
+
+def validate_state_journey_driver(driver: Any) -> None:
+    if not isinstance(driver, dict):
+        raise ValueError("Product Face state/journey driver must be a JSON object")
+    if driver.get("record_type") != "product_face_state_journey_driver":
+        raise ValueError("Product Face state/journey driver record_type must be product_face_state_journey_driver")
+    journeys = driver.get("journeys")
+    if not isinstance(journeys, list) or not journeys:
+        raise ValueError("Product Face state/journey driver requires at least one journey")
+    for journey_index, journey in enumerate(journeys):
+        if not isinstance(journey, dict):
+            raise ValueError(f"driver.journeys[{journey_index}] must be an object")
+        for field in ("name", "state"):
+            if not str(journey.get(field) or "").strip():
+                raise ValueError(f"driver.journeys[{journey_index}].{field} is required")
+        for block_name in ("state_setup", "steps"):
+            steps = journey.get(block_name, [])
+            if block_name == "steps" and not steps:
+                raise ValueError(f"driver.journeys[{journey_index}].steps requires at least one step")
+            if not isinstance(steps, list):
+                raise ValueError(f"driver.journeys[{journey_index}].{block_name} must be a list")
+            for step_index, step in enumerate(steps):
+                if not isinstance(step, dict):
+                    raise ValueError(f"driver.journeys[{journey_index}].{block_name}[{step_index}] must be an object")
+                action = str(step.get("action") or "").strip()
+                if action not in DRIVER_STEP_ACTIONS:
+                    raise ValueError(
+                        f"driver.journeys[{journey_index}].{block_name}[{step_index}].action "
+                        f"must be one of: {', '.join(sorted(DRIVER_STEP_ACTIONS))}"
+                    )
+                if action in DRIVER_SELECTOR_ACTIONS and not str(step.get("selector") or "").strip():
+                    raise ValueError(
+                        f"driver.journeys[{journey_index}].{block_name}[{step_index}].selector is required for {action}"
+                    )
+                if action == "fill" and "value" not in step:
+                    raise ValueError(f"driver.journeys[{journey_index}].{block_name}[{step_index}].value is required")
+                if action == "assert_text" and not str(step.get("text") or "").strip():
+                    raise ValueError(f"driver.journeys[{journey_index}].{block_name}[{step_index}].text is required")
+                if action == "goto" and not str(step.get("url") or "").strip():
+                    raise ValueError(f"driver.journeys[{journey_index}].{block_name}[{step_index}].url is required")
+
+
+def driver_capture_scope(
+    *,
+    states: list[str],
+    journeys: list[str],
+    driver: dict[str, Any],
+    executions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    driver_journeys = [
+        str(journey.get("name") or "").strip()
+        for journey in driver.get("journeys", [])
+        if isinstance(journey, dict)
+    ]
+    driver_states = [
+        str(journey.get("state") or "").strip()
+        for journey in driver.get("journeys", [])
+        if isinstance(journey, dict)
+    ]
+    declared_states = _unique_non_empty(states) or _unique_non_empty(driver_states) or ["initial-render"]
+    declared_journeys = _unique_non_empty(journeys) or _unique_non_empty(driver_journeys)
+    passed = [execution for execution in executions if execution.get("status") == "PASS"]
+    captured_states = _unique_non_empty([str(execution.get("state") or "") for execution in passed])
+    captured_journeys = _unique_non_empty([str(execution.get("journey") or "") for execution in passed])
+    captured_state_keys = {_normalized_label(state) for state in captured_states}
+    captured_journey_keys = {_normalized_label(journey) for journey in captured_journeys}
+    return {
+        "mode": "product_face_state_journey_driver",
+        "declared_states": declared_states,
+        "declared_journeys": declared_journeys,
+        "captured_states": captured_states,
+        "captured_journeys": captured_journeys,
+        "uncaptured_states": [state for state in declared_states if _normalized_label(state) not in captured_state_keys],
+        "uncaptured_journeys": [
+            journey for journey in declared_journeys if _normalized_label(journey) not in captured_journey_keys
+        ],
+        "basis": "Product Face state/journey driver executed named journeys, setup steps and assertions in the browser.",
+    }
+
+
+def state_journey_driver_status(executions: list[dict[str, Any]], capture_scope: dict[str, Any]) -> str:
+    if (
+        not executions
+        or any(item.get("status") != "PASS" for item in executions)
+        or capture_scope["uncaptured_states"]
+        or capture_scope["uncaptured_journeys"]
+    ):
+        return "FAIL"
+    return "PASS"
+
+
+def run_driver_step(page: Any, step: dict[str, Any], *, timeout_ms: int, screenshot_path: Path | None = None) -> None:
+    action = str(step.get("action") or "").strip()
+    selector = str(step.get("selector") or "").strip()
+    if action == "goto":
+        page.goto(str(step.get("url") or ""), wait_until="networkidle", timeout=timeout_ms)
+    elif action == "click":
+        page.locator(selector).click(timeout=timeout_ms)
+    elif action == "fill":
+        page.locator(selector).fill(str(step.get("value") or ""), timeout=timeout_ms)
+    elif action == "wait":
+        page.wait_for_timeout(int(step.get("ms") or 250))
+    elif action == "wait_for_selector":
+        page.wait_for_selector(selector, timeout=timeout_ms)
+    elif action == "assert_visible":
+        page.wait_for_selector(selector, state="visible", timeout=timeout_ms)
+    elif action == "assert_text":
+        page.wait_for_selector(selector, timeout=timeout_ms)
+        actual = str(page.locator(selector).text_content(timeout=timeout_ms) or "")
+        expected = str(step.get("text") or "")
+        if expected not in actual:
+            raise AssertionError(f"selector {selector!r} text did not contain {expected!r}")
+    elif action == "screenshot":
+        if screenshot_path is None:
+            raise ValueError("screenshot step requires a screenshot path")
+        page.screenshot(path=str(screenshot_path), full_page=bool(step.get("full_page", True)))
+    else:
+        raise ValueError(f"unsupported Product Face driver action: {action}")
+
+
+def execute_state_journey_driver(
+    *,
+    page: Any,
+    driver: dict[str, Any],
+    viewport: Viewport,
+    screenshot_dir: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    executions: list[dict[str, Any]] = []
+    screenshot_refs: list[str] = []
+    default_timeout = int(driver.get("timeout_ms") or 5000)
+    for journey_index, journey in enumerate(driver.get("journeys", [])):
+        viewport_names = {str(item).strip() for item in journey.get("viewport_names", []) if str(item).strip()}
+        if viewport_names and viewport.name not in viewport_names and viewport.label not in viewport_names:
+            continue
+        journey_name = str(journey.get("name") or "").strip()
+        state_name = str(journey.get("state") or "").strip()
+        timeout_ms = int(journey.get("timeout_ms") or default_timeout)
+        execution: dict[str, Any] = {
+            "journey": journey_name,
+            "state": state_name,
+            "viewport": viewport.label,
+            "data_condition": str(journey.get("data_condition") or "driver-controlled proof data"),
+            "status": "PASS",
+            "steps": [],
+            "evidence_refs": list(journey.get("evidence_refs") or []),
+        }
+        try:
+            for block_name in ("state_setup", "steps"):
+                for step_index, step in enumerate(journey.get(block_name, [])):
+                    step_action = str(step.get("action") or "").strip()
+                    step_record = {
+                        "block": block_name,
+                        "index": step_index,
+                        "action": step_action,
+                        "selector": str(step.get("selector") or ""),
+                    }
+                    screenshot_path = None
+                    if step_action == "screenshot":
+                        safe_journey = re.sub(r"[^a-zA-Z0-9_-]+", "-", journey_name.lower()).strip("-") or "journey"
+                        screenshot_path = screenshot_dir / f"driver-{viewport.name}-{journey_index}-{safe_journey}-{step_index}.png"
+                    run_driver_step(page, step, timeout_ms=timeout_ms, screenshot_path=screenshot_path)
+                    if screenshot_path is not None:
+                        ref = repo_ref(screenshot_path)
+                        screenshot_refs.append(ref)
+                        execution["evidence_refs"].append(ref)
+                        step_record["evidence_ref"] = ref
+                    execution["steps"].append(step_record)
+        except Exception as exc:
+            execution["status"] = "FAIL"
+            execution["failure"] = redact_text(str(exc)[:1000])
+        executions.append(execution)
+    return executions, screenshot_refs
 
 
 def repo_ref(path: Path) -> str:
@@ -1001,6 +1198,7 @@ def run_playwright(
     states: list[str],
     journeys: list[str],
     strict: bool,
+    state_journey_driver: dict[str, Any] | None = None,
     card_ref: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     try:
@@ -1015,6 +1213,8 @@ def run_playwright(
     console_messages: list[dict[str, str]] = []
     page_errors: list[str] = []
     viewport_results: dict[str, Any] = {}
+    driver_executions: list[dict[str, Any]] = []
+    driver_screenshots: list[str] = []
     screenshot_dir = output_dir / "screenshots"
     screenshot_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1034,6 +1234,15 @@ def run_playwright(
                 page.on("pageerror", lambda err: page_errors.append(str(err)[:1000]))
                 page.goto(target_url, wait_until="networkidle", timeout=15000)
                 page.wait_for_timeout(250)
+                if state_journey_driver is not None:
+                    executions, driver_refs = execute_state_journey_driver(
+                        page=page,
+                        driver=state_journey_driver,
+                        viewport=viewport,
+                        screenshot_dir=screenshot_dir,
+                    )
+                    driver_executions.extend(executions)
+                    driver_screenshots.extend(driver_refs)
                 screenshot_path = screenshot_dir / f"{viewport.name}.png"
                 page.screenshot(path=str(screenshot_path), full_page=True)
                 screenshots.append(repo_ref(screenshot_path))
@@ -1043,9 +1252,20 @@ def run_playwright(
         finally:
             browser.close()
 
+    if state_journey_driver is not None:
+        capture_scope = driver_capture_scope(
+            states=states,
+            journeys=journeys,
+            driver=state_journey_driver,
+            executions=driver_executions,
+        )
+        captured_states = list(capture_scope["captured_states"])
+        captured_journeys = list(capture_scope["captured_journeys"])
+
     captured_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     console_path = output_dir / "console.json"
     state_path = output_dir / "state.json"
+    driver_path = output_dir / "state-journey-driver-execution.json"
     write_json(
         console_path,
         {
@@ -1078,6 +1298,8 @@ def run_playwright(
         item for item in console_messages if item.get("type") in {"error", "assert"}
     ]
     blocking = bool(page_errors or console_errors or a11y_issues or overlap_issues)
+    if any(execution.get("status") != "PASS" for execution in driver_executions):
+        blocking = True
     result = base_result(
         target_ref=target_ref,
         viewports=viewports,
@@ -1100,7 +1322,7 @@ def run_playwright(
                 target_ref=target_ref,
                 viewports=viewports,
                 states=captured_states,
-                screenshot_refs=screenshots,
+                screenshot_refs=[*screenshots, *driver_screenshots],
                 captured_at=captured_at,
             ),
             "a11y": {
@@ -1131,12 +1353,12 @@ def run_playwright(
             },
             "performance_note": "; ".join(perf_notes)
             + "; browser-local static proof only, not a production performance benchmark",
-            "evidence_refs": [repo_ref(state_path), repo_ref(console_path), *screenshots],
+            "evidence_refs": [repo_ref(state_path), repo_ref(console_path), *screenshots, *driver_screenshots],
             "usage_evidence_matrix": build_usage_evidence_matrix(
                 viewports=viewports,
                 states=captured_states,
                 journeys=captured_journeys,
-                evidence_refs=[repo_ref(state_path), repo_ref(console_path), *screenshots],
+                evidence_refs=[repo_ref(state_path), repo_ref(console_path), *screenshots, *driver_screenshots],
                 data_condition="browser-local rendered state fixture",
                 a11y_status="warn" if a11y_issues else "pass",
                 performance_status="pass",
@@ -1148,6 +1370,33 @@ def run_playwright(
             ),
         }
     )
+    if state_journey_driver is not None:
+        driver_record = {
+            "$schema": "https://overkill-factory.dev/schemas/product-face-state-journey-driver-execution.schema.json",
+            "record_type": "product_face_state_journey_driver_execution",
+            "driver_ref": state_journey_driver.get("_driver_ref", "external:product-face-state-journey-driver"),
+            "executions": driver_executions,
+        }
+        write_json(driver_path, driver_record)
+        result["state_journey_driver"] = {
+            "driver_ref": state_journey_driver.get("_driver_ref", "external:product-face-state-journey-driver"),
+            "status": state_journey_driver_status(driver_executions, capture_scope),
+            "execution_ref": repo_ref(driver_path),
+            "journeys_executed": captured_journeys,
+            "states_executed": captured_states,
+        }
+        result["driver_execution"] = driver_record
+        result["evidence_refs"] = [*result["evidence_refs"], repo_ref(driver_path)]
+        result["usage_evidence_matrix"] = build_usage_evidence_matrix(
+            viewports=viewports,
+            states=captured_states,
+            journeys=captured_journeys,
+            evidence_refs=[repo_ref(driver_path), *driver_screenshots],
+            data_condition="driver-controlled proof data",
+            a11y_status="warn" if a11y_issues else "pass",
+            performance_status="pass",
+            basis="Journey, state and viewport were executed through the Product Face state/journey driver.",
+        )
     apply_capture_scope(result, capture_scope)
     return result
 
@@ -1269,6 +1518,7 @@ def build_product_face_proof(
     strict: bool = True,
     force_fallback: bool = False,
     allow_external_file: bool = False,
+    driver: Path | None = None,
     card: Path | None = None,
     reusable_for_product: bool = False,
     product_id: str | None = None,
@@ -1293,8 +1543,13 @@ def build_product_face_proof(
     output_dir = out if out.suffix == "" else out.parent
     output_dir.mkdir(parents=True, exist_ok=True)
     viewports = viewports or [Viewport(name, *size) for name, size in DEFAULT_VIEWPORTS.items()]
-    states = states or ["initial-render"]
-    journeys = journeys or ["open target", "inspect configured viewports"]
+    state_journey_driver = load_state_journey_driver(driver)
+    if state_journey_driver is None:
+        states = states or ["initial-render"]
+        journeys = journeys or ["open target", "inspect configured viewports"]
+    else:
+        states = states or []
+        journeys = journeys or []
     target_url, target_path = resolve_target(target, allow_external_file=allow_external_file)
     target_ref = repo_ref(target_path) if target_path else target
     card_ref = card_ref_from_card(load_json_like(card)) if card else None
@@ -1321,6 +1576,7 @@ def build_product_face_proof(
                 states=states,
                 journeys=journeys,
                 strict=strict,
+                state_journey_driver=state_journey_driver,
                 card_ref=card_ref,
             )
         except PlaywrightUnavailable as exc:
@@ -1396,6 +1652,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--strict", action="store_true", default=True, help="Treat a11y and overlap warnings as blocking findings. Enabled by default.")
     parser.add_argument("--force-fallback", action="store_true", help="Skip Playwright and write bounded static fallback evidence.")
     parser.add_argument("--allow-external-file", action="store_true", help="Allow absolute file targets outside this repo; output is redacted.")
+    parser.add_argument("--driver", type=Path, help="Product Face state/journey driver JSON for executable journeys.")
     parser.add_argument("--card", type=Path, help="Factory card to bind this Product Face result to.")
     parser.add_argument("--reusable-for-product", action="store_true", help="Mark this PASS proof reusable for the named product scope.")
     parser.add_argument("--product-id", help="Stable product id required with --reusable-for-product.")
@@ -1466,6 +1723,7 @@ def main(argv: list[str] | None = None) -> int:
             strict=args.strict,
             force_fallback=args.force_fallback,
             allow_external_file=args.allow_external_file,
+            driver=args.driver,
             card=args.card,
             reusable_for_product=args.reusable_for_product,
             product_id=args.product_id,

--- a/templates/product-face-state-journey-driver.json
+++ b/templates/product-face-state-journey-driver.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/product-face-state-journey-driver.schema.json",
+  "record_type": "product_face_state_journey_driver",
+  "target_binding": {
+    "target_ref": "external:replace-with-local-or-public-url",
+    "card_ref": "external:replace-with-card-ref",
+    "product_face_packet_ref": "external:replace-with-product-face-packet-ref"
+  },
+  "timeout_ms": 5000,
+  "retry": {
+    "attempts": 1,
+    "delay_ms": 0
+  },
+  "public_artifact_policy": {
+    "no_private_screenshots_in_repo": true,
+    "no_secrets_in_values": true,
+    "proof_output_location": ".tmp/factory-runs/product-face"
+  },
+  "journeys": [
+    {
+      "journey_id": "initial-readiness",
+      "name": "initial readiness",
+      "state": "loaded",
+      "required_for_pass": true,
+      "data_condition": "public-safe fixture data",
+      "viewport_names": ["desktop", "mobile"],
+      "state_setup": [
+        {
+          "action": "wait_for_selector",
+          "selector": "main"
+        }
+      ],
+      "steps": [
+        {
+          "action": "assert_visible",
+          "selector": "main"
+        },
+        {
+          "action": "assert_text",
+          "selector": "main",
+          "text": "replace with expected public copy"
+        },
+        {
+          "action": "screenshot",
+          "full_page": true
+        }
+      ],
+      "evidence_refs": ["external:driver-owned-proof-output"]
+    }
+  ]
+}

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1454,6 +1454,36 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertEqual(factoryctl.validate_card(card), [])
 
+    def test_product_face_result_pass_rejects_failed_state_journey_driver(self) -> None:
+        result = product_face_result_fixture(
+            state_journey_driver={
+                "driver_ref": "templates/product-face-state-journey-driver.json",
+                "status": "FAIL",
+                "execution_ref": "reports/product-face/state-journey-driver-execution.json",
+                "journeys_executed": ["login success"],
+                "states_executed": ["success"],
+            },
+            driver_execution={
+                "record_type": "product_face_state_journey_driver_execution",
+                "driver_ref": "templates/product-face-state-journey-driver.json",
+                "executions": [
+                    {
+                        "journey": "login success",
+                        "state": "success",
+                        "viewport": "desktop 1440x900",
+                        "status": "FAIL",
+                        "steps": [],
+                        "evidence_refs": ["reports/product-face/state-journey-driver-execution.json"],
+                    }
+                ],
+            },
+        )
+
+        errors = factoryctl.validate_product_face_result(result)
+
+        self.assertIn("product_face_result PASS requires state_journey_driver.status=PASS", errors)
+        self.assertIn("product_face_result PASS driver_execution.executions[0].status must be PASS", errors)
+
     def test_terminal_product_face_result_ref_external_cannot_claim_full_acceptance(self) -> None:
         card = self.terminal_product_face_ref_card()
         card["product_face_result_ref"] = "external:operator-owned-product-face-result"

--- a/tests/test_product_face_proof.py
+++ b/tests/test_product_face_proof.py
@@ -32,6 +32,76 @@ def reference_dimension_basis() -> dict[str, str]:
     }
 
 
+def valid_driver() -> dict:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/product-face-state-journey-driver.schema.json",
+        "record_type": "product_face_state_journey_driver",
+        "target_binding": {"target_ref": "external:unit-target"},
+        "timeout_ms": 1000,
+        "public_artifact_policy": {
+            "no_private_screenshots_in_repo": True,
+            "no_secrets_in_values": True,
+            "proof_output_location": ".tmp/factory-runs/product-face",
+        },
+        "journeys": [
+            {
+                "journey_id": "login-success",
+                "name": "login success",
+                "state": "success",
+                "required_for_pass": True,
+                "data_condition": "public fixture user",
+                "state_setup": [{"action": "wait_for_selector", "selector": "#email"}],
+                "steps": [
+                    {"action": "fill", "selector": "#email", "value": "operator@example.com"},
+                    {"action": "click", "selector": "#submit"},
+                    {"action": "assert_text", "selector": "#status", "text": "Ready"},
+                    {"action": "screenshot", "full_page": True},
+                ],
+            }
+        ],
+    }
+
+
+class FakeLocator:
+    def __init__(self, page: "FakeDriverPage", selector: str) -> None:
+        self.page = page
+        self.selector = selector
+
+    def click(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.page.calls.append(("click", self.selector))
+
+    def fill(self, value: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.page.calls.append(("fill", self.selector, value))
+
+    def text_content(self, **kwargs) -> str:  # type: ignore[no-untyped-def]
+        return self.page.text_by_selector.get(self.selector, "")
+
+
+class FakeDriverPage:
+    def __init__(self, *, fail_selectors: set[str] | None = None) -> None:
+        self.calls: list[tuple] = []
+        self.fail_selectors = fail_selectors or set()
+        self.text_by_selector = {"#status": "Ready"}
+
+    def locator(self, selector: str) -> FakeLocator:
+        return FakeLocator(self, selector)
+
+    def wait_for_selector(self, selector: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.calls.append(("wait_for_selector", selector))
+        if selector in self.fail_selectors:
+            raise TimeoutError(f"missing selector {selector}")
+
+    def wait_for_timeout(self, ms: int) -> None:
+        self.calls.append(("wait", ms))
+
+    def goto(self, url: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        self.calls.append(("goto", url))
+
+    def screenshot(self, *, path: str, full_page: bool = True) -> None:
+        self.calls.append(("screenshot", path, full_page))
+        Path(path).write_bytes(b"fake-png")
+
+
 class ProductFaceProofTest(unittest.TestCase):
     def test_public_product_face_result_template_validates_semantically(self) -> None:
         result = json.loads((ROOT / "templates" / "product-face-result.json").read_text(encoding="utf-8"))
@@ -218,6 +288,111 @@ class ProductFaceProofTest(unittest.TestCase):
         self.assertEqual(result["uncaptured_states"], ["loading", "success"])
         self.assertEqual(result["uncaptured_journeys"], ["purchase flow"])
         self.assertIn("state/journey drivers", result["next_action"])
+
+    def test_state_journey_driver_executes_valid_journey(self) -> None:
+        driver = valid_driver()
+        product_face_proof.validate_state_journey_driver(driver)
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            executions, screenshots = product_face_proof.execute_state_journey_driver(
+                page=FakeDriverPage(),
+                driver=driver,
+                viewport=product_face_proof.Viewport("desktop", 1440, 900),
+                screenshot_dir=Path(tmp),
+            )
+
+        scope = product_face_proof.driver_capture_scope(
+            states=[],
+            journeys=[],
+            driver=driver,
+            executions=executions,
+        )
+
+        self.assertEqual(executions[0]["status"], "PASS")
+        self.assertEqual(scope["captured_states"], ["success"])
+        self.assertEqual(scope["captured_journeys"], ["login success"])
+        self.assertTrue(screenshots)
+
+    def test_state_journey_driver_rejects_missing_selector_action(self) -> None:
+        driver = valid_driver()
+        driver["journeys"][0]["steps"][1] = {"action": "click"}
+
+        with self.assertRaisesRegex(ValueError, "selector is required"):
+            product_face_proof.validate_state_journey_driver(driver)
+
+    def test_state_journey_driver_failure_blocks_capture(self) -> None:
+        driver = valid_driver()
+        driver["journeys"][0]["steps"][2] = {"action": "assert_visible", "selector": "#never"}
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            executions, _ = product_face_proof.execute_state_journey_driver(
+                page=FakeDriverPage(fail_selectors={"#never"}),
+                driver=driver,
+                viewport=product_face_proof.Viewport("desktop", 1440, 900),
+                screenshot_dir=Path(tmp),
+            )
+
+        scope = product_face_proof.driver_capture_scope(
+            states=["success"],
+            journeys=["login success"],
+            driver=driver,
+            executions=executions,
+        )
+        result = product_face_proof.base_result(
+            target_ref="external:unit-target",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=scope["captured_states"],
+            journeys=scope["captured_journeys"],
+            tool_or_profile="unit-test",
+        )
+        result["state_journey_driver"] = {
+            "driver_ref": "templates/product-face-state-journey-driver.json",
+            "status": "FAIL",
+            "execution_ref": "external:driver-execution",
+            "journeys_executed": scope["captured_journeys"],
+            "states_executed": scope["captured_states"],
+        }
+
+        product_face_proof.apply_capture_scope(result, scope)
+
+        self.assertEqual(executions[0]["status"], "FAIL")
+        self.assertEqual(result["result"], "WAIVED")
+        self.assertTrue(result["blocking_findings"])
+
+    def test_state_journey_driver_state_setup_failure_blocks_capture(self) -> None:
+        driver = valid_driver()
+        driver["journeys"][0]["state_setup"] = [{"action": "wait_for_selector", "selector": "#missing-setup"}]
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            executions, _ = product_face_proof.execute_state_journey_driver(
+                page=FakeDriverPage(fail_selectors={"#missing-setup"}),
+                driver=driver,
+                viewport=product_face_proof.Viewport("desktop", 1440, 900),
+                screenshot_dir=Path(tmp),
+            )
+
+        self.assertEqual(executions[0]["status"], "FAIL")
+        self.assertIn("missing-setup", executions[0]["failure"])
+
+    def test_declared_driver_journey_cannot_pass_without_execution(self) -> None:
+        driver = valid_driver()
+        scope = product_face_proof.driver_capture_scope(
+            states=["success"],
+            journeys=["login success"],
+            driver=driver,
+            executions=[],
+        )
+        result = product_face_proof.base_result(
+            target_ref="external:unit-target",
+            viewports=[product_face_proof.Viewport("desktop", 1440, 900)],
+            states=[],
+            journeys=[],
+            tool_or_profile="unit-test",
+        )
+
+        product_face_proof.apply_capture_scope(result, scope)
+
+        self.assertEqual(result["result"], "WAIVED")
+        self.assertEqual(result["uncaptured_states"], ["success"])
+        self.assertEqual(result["uncaptured_journeys"], ["login success"])
+        self.assertEqual(product_face_proof.state_journey_driver_status([], scope), "FAIL")
 
     def test_visual_artifacts_are_emitted_only_for_captured_states(self) -> None:
         scope = product_face_proof.browser_capture_scope(


### PR DESCRIPTION
Closes #272.

## Summary
- Adds a public-safe `product_face_state_journey_driver` contract and template.
- Extends `product_face_proof.py` with bounded executable browser actions for named states and journeys.
- Records driver execution evidence in `product_face_result` while keeping generated outputs in `.tmp` or external evidence refs.
- Tightens `factoryctl` so PASS cannot hide failed or empty driver execution.

## Validation
- `python -m unittest tests.test_product_face_proof -q`
- `python -m unittest tests.test_factoryctl -q`
- `python -m unittest tests.test_public_json_artifact_validator -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_worker_profiles.py`

## Release preflight note
`python scripts\release_integration_preflight.py` is currently `BLOCKED` only because this release-candidate work is not integrated into the target release ref yet (`release_ref_has_no_unintegrated_worktree_entries`). Public/head/origin-main safety scans inside the preflight passed.