### PR TITLE
Generalize production full-product worker graph

### DIFF
--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -62,6 +62,28 @@ map to the published public object. Run it only after the public object has been
 published or refreshed; before publication it may correctly report the remote
 map as out of sync.
 
+## Full Product Worker Graph
+
+Production completion uses a product-scoped worker graph. The default contract
+is the public QVG validation product:
+
+```bash
+python scripts/production_full_product_worker_graph.py --no-write
+```
+
+For another product, provide a graph contract instead of editing the script:
+
+```bash
+python scripts/production_full_product_worker_graph.py \
+  --graph-contract path/to/production-full-product-graph.contract.json \
+  --out .tmp/factory-runs/production/full-product-worker-graph.json
+```
+
+The contract binds the graph to Product SOT, selected capability packs, delivery
+quality profile, risk class, promotion ladder, environment class and evidence
+lanes. Strict lanes must prove the same `product_id` as the contract; a PASS for
+one product cannot be reused for another product by changing prose.
+
 ## Full Validation Battery
 
 For a stronger local pass:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -111,3 +111,18 @@ python scripts/factory_self_improvement.py governance-audit --out .tmp/ai-codeba
 
 These commands do not dispatch Hermes, activate workers, post GitHub comments or
 approve gates. They prepare public-safe plans and candidates for review.
+
+### `scripts/production_full_product_worker_graph.py`
+
+Builds a production-scoped worker graph from a product contract. Use the default
+QVG contract for the public validation product, or pass `--graph-contract` for a
+different Product SOT/capability-pack set.
+
+```bash
+python scripts/production_full_product_worker_graph.py --no-write
+python scripts/production_full_product_worker_graph.py --graph-contract path/to/production-full-product-graph.contract.json
+```
+
+The script validates evidence lanes. It does not create missing worker evidence,
+approve human gates, release production, or make Product Face proof reusable by
+declaration alone.

--- a/schemas/full-product-worker-graph.schema.json
+++ b/schemas/full-product-worker-graph.schema.json
@@ -9,6 +9,7 @@
     "graph_kind",
     "graph_mode",
     "product_id",
+    "product_target",
     "result",
     "blocking_findings",
     "evidence_kind",
@@ -50,8 +51,43 @@
     "product_name": {
       "type": "string"
     },
+    "contract_ref": {
+      "type": "string",
+      "minLength": 3
+    },
     "product_target": {
       "type": "object"
+    },
+    "product_sot_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "selected_capability_pack_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "product_delivery_quality_profile_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "risk_class": {
+      "type": "string",
+      "minLength": 2
+    },
+    "promotion_ladder_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "environment_class": {
+      "type": "string",
+      "minLength": 3
+    },
+    "approval_scope": {
+      "type": "string",
+      "minLength": 3
     },
     "result": {
       "enum": ["PASS", "FAIL"]

--- a/schemas/production-full-product-graph-contract.schema.json
+++ b/schemas/production-full-product-graph-contract.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/production-full-product-graph-contract.schema.json",
+  "title": "Overkill Factory Production Full Product Graph Contract",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "product_id",
+    "product_name",
+    "source_ref",
+    "product_sot_ref",
+    "selected_capability_pack_refs",
+    "product_delivery_quality_profile_ref",
+    "risk_class",
+    "promotion_ladder_ref",
+    "approval_scope",
+    "environment_class",
+    "lanes"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/production-full-product-graph-contract.schema.json"
+    },
+    "record_type": {
+      "const": "production_full_product_graph_contract"
+    },
+    "product_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "product_name": {
+      "type": "string",
+      "minLength": 3
+    },
+    "source_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "product_sot_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "selected_capability_pack_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
+    },
+    "product_delivery_quality_profile_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "risk_class": {
+      "type": "string",
+      "minLength": 2
+    },
+    "promotion_ladder_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "approval_scope": {
+      "type": "string",
+      "minLength": 3
+    },
+    "environment_class": {
+      "type": "string",
+      "minLength": 3
+    },
+    "graph_kind": {
+      "type": "string",
+      "minLength": 3
+    },
+    "release_gate_upstream_excluded_lanes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 2
+      }
+    },
+    "lanes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["lane_id", "path", "scope", "reusable_policy"],
+        "properties": {
+          "lane_id": {
+            "type": "string",
+            "minLength": 2
+          },
+          "worker_id": {
+            "type": "string",
+            "minLength": 2
+          },
+          "path": {
+            "type": "string",
+            "minLength": 3
+          },
+          "kind": {
+            "type": "string",
+            "minLength": 3
+          },
+          "record_type": {
+            "type": "string",
+            "minLength": 3
+          },
+          "proof_kind": {
+            "type": "string",
+            "minLength": 3
+          },
+          "scope": {
+            "enum": ["product", "supporting"]
+          },
+          "reusable_policy": {
+            "enum": ["strict", "supporting"]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/production_full_product_worker_graph.py
+++ b/scripts/production_full_product_worker_graph.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build the production-scoped worker graph for the public validation product."""
+"""Build a production-scoped full-product worker graph from a product contract."""
 
 from __future__ import annotations
 
@@ -14,8 +14,10 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUT = ROOT / ".tmp" / "factory-runs" / "production" / "full-product-worker-graph.json"
 DEFAULT_MD_OUT = ROOT / ".tmp" / "factory-runs" / "production" / "full-product-worker-graph.md"
-PRODUCT_SOURCE = ROOT / "products" / "qvg-public-validation-product"
-RELEASE_GATE_UPSTREAM_EXCLUDED_LANES = {"human_gate", "release_ops"}
+DEFAULT_GRAPH_CONTRACT = ROOT / "templates" / "production-full-product-graph-qvg.contract.json"
+DEFAULT_PRODUCT_ID = "qvg-public-validation-product"
+DEFAULT_PRODUCT_SOURCE_REF = "products/qvg-public-validation-product"
+DEFAULT_RELEASE_GATE_UPSTREAM_EXCLUDED_LANES = {"human_gate", "release_ops"}
 
 
 LANES: tuple[dict[str, Any], ...] = (
@@ -95,11 +97,37 @@ LANES: tuple[dict[str, Any], ...] = (
 )
 
 
+def default_contract() -> dict[str, Any]:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/production-full-product-graph-contract.schema.json",
+        "record_type": "production_full_product_graph_contract",
+        "product_id": DEFAULT_PRODUCT_ID,
+        "product_name": "Quasar Vault Guard public validation product",
+        "source_ref": DEFAULT_PRODUCT_SOURCE_REF,
+        "product_sot_ref": "products/qvg-public-validation-product/README.md",
+        "selected_capability_pack_refs": [
+            "capability-packs/product-face.json",
+            "capability-packs/solana-quasar.json",
+            "capability-packs/production-release.json",
+        ],
+        "product_delivery_quality_profile_ref": "quality-profiles/production-public-validation.json",
+        "risk_class": "R4",
+        "promotion_ladder_ref": "promotion-ladders/public-repository-production.json",
+        "approval_scope": "Full reusable worker graph for the public Quasar Vault Guard validation product.",
+        "environment_class": "public-production-validation-graph",
+        "graph_kind": "production_full_product_worker_graph",
+        "release_gate_upstream_excluded_lanes": sorted(DEFAULT_RELEASE_GATE_UPSTREAM_EXCLUDED_LANES),
+        "lanes": [dict(lane) for lane in LANES],
+    }
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
-def source_sha256(path: Path = PRODUCT_SOURCE) -> str:
+def source_sha256(path: Path) -> str | None:
+    if not path.exists() or not path.is_dir():
+        return None
     digest = hashlib.sha256()
     for item in sorted(path.rglob("*")):
         if item.is_file():
@@ -127,17 +155,92 @@ def load_json(rel_path: str) -> dict[str, Any]:
     return json.loads((ROOT / rel_path).read_text(encoding="utf-8"))
 
 
-def product_target() -> dict[str, str]:
+def load_graph_contract(path: Path | None = None) -> dict[str, Any]:
+    if path is None:
+        path = DEFAULT_GRAPH_CONTRACT
+    if path.exists():
+        contract = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(contract, dict):
+            raise ValueError("production graph contract must be a JSON object")
+        return contract
+    if path.resolve() != DEFAULT_GRAPH_CONTRACT.resolve():
+        raise FileNotFoundError(f"production graph contract not found: {repo_ref(path)}")
+    return default_contract()
+
+
+def validate_graph_contract(contract: dict[str, Any]) -> None:
+    if contract.get("record_type") != "production_full_product_graph_contract":
+        raise ValueError("production graph contract record_type must be production_full_product_graph_contract")
+    required = (
+        "product_id",
+        "product_name",
+        "source_ref",
+        "product_sot_ref",
+        "selected_capability_pack_refs",
+        "product_delivery_quality_profile_ref",
+        "risk_class",
+        "promotion_ladder_ref",
+        "approval_scope",
+        "environment_class",
+        "lanes",
+    )
+    for field in required:
+        if contract.get(field) in (None, "", [], {}):
+            raise ValueError(f"production graph contract requires {field}")
+    if not isinstance(contract.get("lanes"), list) or not contract["lanes"]:
+        raise ValueError("production graph contract requires at least one lane")
+
+
+def contract_source_sha256(contract: dict[str, Any]) -> str | None:
+    source_ref = str(contract.get("source_ref") or "").strip()
+    if not source_ref or source_ref.startswith(("external:", "http://", "https://")):
+        return None
+    return source_sha256(ROOT / source_ref)
+
+
+def product_target(contract: dict[str, Any]) -> dict[str, Any]:
+    target: dict[str, Any] = {
+        "product_id": str(contract["product_id"]),
+        "source_ref": str(contract["source_ref"]),
+        "approval_scope": str(contract["approval_scope"]),
+        "environment_class": str(contract["environment_class"]),
+    }
+    source_hash = contract_source_sha256(contract)
+    if source_hash:
+        target["source_sha256"] = source_hash
+    return target
+
+
+def graph_lanes(contract: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    return tuple(dict(lane) for lane in contract.get("lanes", []))
+
+
+def release_gate_excluded_lanes(contract: dict[str, Any]) -> set[str]:
+    values = contract.get("release_gate_upstream_excluded_lanes", sorted(DEFAULT_RELEASE_GATE_UPSTREAM_EXCLUDED_LANES))
+    if not isinstance(values, list):
+        return set(DEFAULT_RELEASE_GATE_UPSTREAM_EXCLUDED_LANES)
+    return {str(value) for value in values if str(value).strip()}
+
+
+def contract_ref(path: Path | None) -> str:
+    if path is None:
+        return repo_ref(DEFAULT_GRAPH_CONTRACT) if DEFAULT_GRAPH_CONTRACT.exists() else "builtin:qvg-production-graph-contract"
+    return repo_ref(path)
+
+
+def legacy_product_target() -> dict[str, Any]:
     return {
-        "product_id": "qvg-public-validation-product",
-        "source_ref": "products/qvg-public-validation-product",
-        "source_sha256": source_sha256(),
+        "product_id": DEFAULT_PRODUCT_ID,
+        "source_ref": DEFAULT_PRODUCT_SOURCE_REF,
+        "source_sha256": source_sha256(ROOT / DEFAULT_PRODUCT_SOURCE_REF),
         "approval_scope": "Full reusable worker graph for the public Quasar Vault Guard validation product.",
         "environment_class": "public-production-validation-graph",
     }
 
 
-def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
+def validate_lane(lane: dict[str, Any], contract: dict[str, Any] | None = None) -> dict[str, Any]:
+    contract = contract or default_contract()
+    expected_product_id = str(contract["product_id"])
     rel_path = str(lane["path"])
     path = ROOT / rel_path
     errors: list[str] = []
@@ -173,7 +276,7 @@ def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
         if lane.get("reusable_policy") == "strict":
             if not isinstance(target, dict):
                 errors.append("strict lane product_target is missing")
-            elif target.get("product_id") != "qvg-public-validation-product":
+            elif target.get("product_id") != expected_product_id:
                 errors.append("strict lane product_id does not match")
     provenance: dict[str, Any] = {
         "ref": rel_path,
@@ -207,17 +310,31 @@ def validate_lane(lane: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def filter_lanes_for_mode(lanes: tuple[dict[str, Any], ...], graph_mode: str) -> tuple[tuple[dict[str, Any], ...], list[str]]:
+def filter_lanes_for_mode(
+    lanes: tuple[dict[str, Any], ...],
+    graph_mode: str,
+    excluded_lanes: set[str] | None = None,
+) -> tuple[tuple[dict[str, Any], ...], list[str]]:
     if graph_mode != "release_gate_upstream":
         return lanes, []
-    selected = tuple(lane for lane in lanes if lane["lane_id"] not in RELEASE_GATE_UPSTREAM_EXCLUDED_LANES)
-    omitted = [lane["lane_id"] for lane in lanes if lane["lane_id"] in RELEASE_GATE_UPSTREAM_EXCLUDED_LANES]
+    excluded_lanes = excluded_lanes or DEFAULT_RELEASE_GATE_UPSTREAM_EXCLUDED_LANES
+    selected = tuple(lane for lane in lanes if lane["lane_id"] not in excluded_lanes)
+    omitted = [lane["lane_id"] for lane in lanes if lane["lane_id"] in excluded_lanes]
     return selected, omitted
 
 
-def build_graph(lanes: tuple[dict[str, Any], ...] = LANES, *, graph_mode: str = "full_product") -> dict[str, Any]:
-    selected_lanes, omitted_lanes = filter_lanes_for_mode(lanes, graph_mode)
-    lane_results = [validate_lane(lane) for lane in selected_lanes]
+def build_graph(
+    lanes: tuple[dict[str, Any], ...] | None = None,
+    *,
+    contract: dict[str, Any] | None = None,
+    graph_mode: str = "full_product",
+    contract_path: Path | None = None,
+) -> dict[str, Any]:
+    contract = contract or default_contract()
+    validate_graph_contract(contract)
+    lanes = lanes or graph_lanes(contract)
+    selected_lanes, omitted_lanes = filter_lanes_for_mode(lanes, graph_mode, release_gate_excluded_lanes(contract))
+    lane_results = [validate_lane(lane, contract) for lane in selected_lanes]
     blocking = [
         f"{lane['lane_id']}: " + "; ".join(lane["validation_errors"])
         for lane in lane_results
@@ -228,11 +345,19 @@ def build_graph(lanes: tuple[dict[str, Any], ...] = LANES, *, graph_mode: str = 
         "$schema": "https://overkill-factory.dev/schemas/full-product-worker-graph.schema.json",
         "record_type": "full_product_worker_graph",
         "created_at": utc_now(),
-        "graph_kind": "production_public_validation_product_graph",
+        "graph_kind": str(contract.get("graph_kind") or "production_full_product_worker_graph"),
         "graph_mode": graph_mode,
-        "product_id": "qvg-public-validation-product",
-        "product_name": "Quasar Vault Guard public validation product",
-        "product_target": product_target(),
+        "contract_ref": contract_ref(contract_path),
+        "product_id": str(contract["product_id"]),
+        "product_name": str(contract["product_name"]),
+        "product_target": product_target(contract),
+        "product_sot_ref": str(contract["product_sot_ref"]),
+        "selected_capability_pack_refs": [str(ref) for ref in contract["selected_capability_pack_refs"]],
+        "product_delivery_quality_profile_ref": str(contract["product_delivery_quality_profile_ref"]),
+        "risk_class": str(contract["risk_class"]),
+        "promotion_ladder_ref": str(contract["promotion_ladder_ref"]),
+        "environment_class": str(contract["environment_class"]),
+        "approval_scope": str(contract["approval_scope"]),
         "result": "PASS" if passed else "FAIL",
         "blocking_findings": not passed,
         "evidence_kind": "real",
@@ -249,7 +374,7 @@ def build_graph(lanes: tuple[dict[str, Any], ...] = LANES, *, graph_mode: str = 
         "production_blockers": blocking or ["none"],
         "evidence_refs": [str(lane["path"]) for lane in selected_lanes],
         "policy_decision": (
-            "The public validation product has a reconciled production-scoped worker graph."
+            f"{contract['product_id']} has a reconciled production-scoped worker graph."
             if passed and not omitted_lanes
             else "The release gate upstream graph is reusable for release validation; run the full graph after release-ops evidence is written."
             if passed
@@ -291,10 +416,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-write", action="store_true")
     parser.add_argument("--require-pass", action="store_true")
     parser.add_argument("--release-gate-upstream", action="store_true")
+    parser.add_argument("--graph-contract", type=Path, default=DEFAULT_GRAPH_CONTRACT)
     args = parser.parse_args(argv)
 
     graph_mode = "release_gate_upstream" if args.release_gate_upstream else "full_product"
-    graph = build_graph(graph_mode=graph_mode)
+    contract = load_graph_contract(args.graph_contract)
+    graph = build_graph(contract=contract, graph_mode=graph_mode, contract_path=args.graph_contract)
     if not args.no_write:
         write_json(args.out, graph)
         write_markdown(args.md_out, graph)

--- a/templates/production-full-product-graph-qvg.contract.json
+++ b/templates/production-full-product-graph-qvg.contract.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/production-full-product-graph-contract.schema.json",
+  "record_type": "production_full_product_graph_contract",
+  "product_id": "qvg-public-validation-product",
+  "product_name": "Quasar Vault Guard public validation product",
+  "source_ref": "products/qvg-public-validation-product",
+  "product_sot_ref": "products/qvg-public-validation-product/README.md",
+  "selected_capability_pack_refs": [
+    "capability-packs/product-face.json",
+    "capability-packs/solana-quasar.json",
+    "capability-packs/production-release.json"
+  ],
+  "product_delivery_quality_profile_ref": "quality-profiles/production-public-validation.json",
+  "risk_class": "R4",
+  "promotion_ladder_ref": "promotion-ladders/public-repository-production.json",
+  "approval_scope": "Full reusable worker graph for the public Quasar Vault Guard validation product.",
+  "environment_class": "public-production-validation-graph",
+  "graph_kind": "production_full_product_worker_graph",
+  "release_gate_upstream_excluded_lanes": ["human_gate", "release_ops"],
+  "lanes": [
+    {
+      "lane_id": "hermes_orchestration",
+      "worker_id": "factory-orchestrator",
+      "path": ".tmp/factory-runs/hermes-live/multi-profile-dispatch-summary.md",
+      "kind": "file",
+      "scope": "supporting",
+      "reusable_policy": "supporting"
+    },
+    {
+      "lane_id": "product_face",
+      "worker_id": "product-face",
+      "path": ".tmp/factory-runs/production/product-face/product-face-result.json",
+      "record_type": "product_face_result",
+      "scope": "product",
+      "reusable_policy": "strict"
+    },
+    {
+      "lane_id": "security",
+      "worker_id": "codex-security",
+      "path": ".tmp/factory-runs/security/codex-security-full-scan-2026-06-06.md",
+      "kind": "file",
+      "scope": "supporting",
+      "reusable_policy": "supporting"
+    },
+    {
+      "lane_id": "quasar_auditor",
+      "worker_id": "solana-quasar-auditor",
+      "path": ".tmp/factory-runs/production/quasar/auditor-result.json",
+      "record_type": "auditor_result",
+      "scope": "product",
+      "reusable_policy": "strict"
+    },
+    {
+      "lane_id": "cu_svm_economic",
+      "worker_id": "solana-quasar-auditor",
+      "path": ".tmp/factory-runs/production/quasar/cu-svm-economic-proof.json",
+      "record_type": "cu_svm_economic_proof",
+      "proof_kind": "production_quasar_cu_svm_economic",
+      "scope": "product",
+      "reusable_policy": "strict"
+    },
+    {
+      "lane_id": "remote_proof",
+      "worker_id": "remote-proof-runner",
+      "path": ".tmp/factory-runs/production/remote-proof/managed-testbox-result.json",
+      "record_type": "remote_proof_result",
+      "scope": "supporting",
+      "reusable_policy": "strict"
+    },
+    {
+      "lane_id": "human_gate",
+      "worker_id": "human-gate-clerk",
+      "path": ".tmp/factory-runs/production/release/human-gate-record.json",
+      "record_type": "human_gate_record",
+      "scope": "supporting",
+      "reusable_policy": "strict"
+    },
+    {
+      "lane_id": "release_ops",
+      "worker_id": "release-ops-worker",
+      "path": ".tmp/factory-runs/production/release/release-ops-result.json",
+      "record_type": "release_ops_result",
+      "scope": "supporting",
+      "reusable_policy": "strict"
+    },
+    {
+      "lane_id": "supply_chain",
+      "worker_id": "supply-chain-gate",
+      "path": ".tmp/factory-runs/supply-chain/supply-chain-proof.json",
+      "record_type": "supply_chain_result",
+      "scope": "supporting",
+      "reusable_policy": "supporting"
+    }
+  ]
+}

--- a/tests/test_production_full_product_worker_graph.py
+++ b/tests/test_production_full_product_worker_graph.py
@@ -18,6 +18,28 @@ SPEC.loader.exec_module(module)
 
 
 class ProductionFullProductWorkerGraphTest(unittest.TestCase):
+    def generic_contract(self, tmpdir: str, lanes: list[dict]) -> dict:
+        source_dir = Path(tmpdir) / "generic-api-product"
+        source_dir.mkdir()
+        (source_dir / "README.md").write_text("Generic API product source.\n", encoding="utf-8")
+        return {
+            "$schema": "https://overkill-factory.dev/schemas/production-full-product-graph-contract.schema.json",
+            "record_type": "production_full_product_graph_contract",
+            "product_id": "generic-api-product",
+            "product_name": "Generic API product",
+            "source_ref": source_dir.relative_to(ROOT).as_posix(),
+            "product_sot_ref": "external:generic-api-product-sot",
+            "selected_capability_pack_refs": ["capability-packs/api-data.json"],
+            "product_delivery_quality_profile_ref": "quality-profiles/api-production.json",
+            "risk_class": "R2",
+            "promotion_ladder_ref": "promotion-ladders/api-production.json",
+            "approval_scope": "Reusable full-product graph for a generic API product.",
+            "environment_class": "production-readiness",
+            "graph_kind": "production_full_product_worker_graph",
+            "release_gate_upstream_excluded_lanes": ["human_gate", "release_ops"],
+            "lanes": lanes,
+        }
+
     def test_graph_blocks_missing_strict_lane_from_explicit_fixture(self) -> None:
         lane = {
             "lane_id": "remote_proof",
@@ -143,6 +165,73 @@ class ProductionFullProductWorkerGraphTest(unittest.TestCase):
         self.assertNotIn(human_gate_lane["path"], upstream_graph["evidence_refs"])
         self.assertNotIn(release_lane["path"], upstream_graph["evidence_refs"])
         self.assertEqual(upstream_graph["blocking_summary"], [])
+
+    def test_generic_non_qvg_contract_can_build_pass_graph(self) -> None:
+        tmp_root = ROOT / ".tmp"
+        tmp_root.mkdir(exist_ok=True)
+        with TemporaryDirectory(dir=tmp_root) as tmpdir:
+            proof = Path(tmpdir) / "api-proof.json"
+            proof.write_text(
+                (
+                    '{"record_type":"remote_proof_result","result":"PASS","evidence_kind":"real",'
+                    '"reusable_for_product":true,"product_target":{"product_id":"generic-api-product"},'
+                    '"evidence_refs":["external:api-proof"]}'
+                ),
+                encoding="utf-8",
+            )
+            lanes = [
+                {
+                    "lane_id": "api_proof",
+                    "worker_id": "backend-api-builder",
+                    "path": proof.relative_to(ROOT).as_posix(),
+                    "record_type": "remote_proof_result",
+                    "scope": "product",
+                    "reusable_policy": "strict",
+                }
+            ]
+            contract = self.generic_contract(tmpdir, lanes)
+
+            result = module.build_graph(contract=contract)
+
+        self.assertEqual(result["result"], "PASS")
+        self.assertEqual(result["product_id"], "generic-api-product")
+        self.assertEqual(result["product_target"]["product_id"], "generic-api-product")
+        self.assertEqual(result["selected_capability_pack_refs"], ["capability-packs/api-data.json"])
+        self.assertEqual(result["risk_class"], "R2")
+        self.assertEqual(result["lanes_total"], 1)
+        self.assertEqual(result["blocking_summary"], [])
+
+    def test_generic_contract_rejects_strict_lane_for_wrong_product(self) -> None:
+        tmp_root = ROOT / ".tmp"
+        tmp_root.mkdir(exist_ok=True)
+        with TemporaryDirectory(dir=tmp_root) as tmpdir:
+            proof = Path(tmpdir) / "api-proof.json"
+            proof.write_text(
+                (
+                    '{"record_type":"remote_proof_result","result":"PASS","evidence_kind":"real",'
+                    '"reusable_for_product":true,"product_target":{"product_id":"wrong-product"},'
+                    '"evidence_refs":["external:api-proof"]}'
+                ),
+                encoding="utf-8",
+            )
+            lane = {
+                "lane_id": "api_proof",
+                "worker_id": "backend-api-builder",
+                "path": proof.relative_to(ROOT).as_posix(),
+                "record_type": "remote_proof_result",
+                "scope": "product",
+                "reusable_policy": "strict",
+            }
+            contract = self.generic_contract(tmpdir, [lane])
+
+            result = module.validate_lane(lane, contract)
+
+        self.assertEqual(result["status"], "FAIL")
+        self.assertIn("strict lane product_id does not match", result["validation_errors"])
+
+    def test_explicit_missing_graph_contract_does_not_fallback_to_qvg(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            module.load_graph_contract(ROOT / ".tmp" / "missing-production-graph-contract.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #208.

## Summary
- Turns the production full-product worker graph into a contract-driven primitive via `--graph-contract`.
- Adds a public schema for production graph contracts and keeps QVG as the default public validation contract/template.
- Makes strict lane validation compare evidence `product_target.product_id` against the active contract, not a hardcoded QVG id.
- Adds non-QVG graph tests plus fail-closed behavior for missing explicit contracts.
- Documents the production graph contract path in validation/release and CLI reference docs.

## Validation
- `python -m unittest tests.test_production_full_product_worker_graph tests.test_production_release_gate tests.test_public_json_artifact_validator -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\supply_chain_proof.py --check --no-write`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_worker_profiles.py`

## Release preflight note
`python scripts\release_integration_preflight.py` is `BLOCKED` only because this branch is not integrated into the target release ref yet (`release_ref_has_no_unintegrated_worktree_entries`). Worktree/head/origin-main public-safety materializers passed inside the preflight.