### PR TITLE
Prepare Factory v1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ public releases.
 
 ## Unreleased
 
+- No unreleased public changes.
+
+## 1.0.0 - 2026-06-16
+
 - Added the operator-first CLI path: `factoryctl doctor`, `factoryctl init` and
   `factoryctl run minimal`.
 - Added public docs site navigation, CLI reference, Hermes install guide,
@@ -15,6 +19,20 @@ public releases.
 - Replaced dead public metadata URLs with canonical GitHub metadata, added a
   `.github/` entrypoint README and tightened public-safety scanning around
   metadata-only repository URLs and generated local build output.
+- Added factory-owned recovery, status, readiness, truth and blocker paths so
+  non-human blocks route back into explicit repair actions instead of hidden
+  operator work.
+- Added Product Face proof profiles, executable state/journey drivers and
+  stricter Product Face PASS validation.
+- Added capability-pack activation, full-product worker graph contracts and
+  production/release preflight checks for public-safe repository releases.
+- Added public-surface synchronization checks so docs and the published visual
+  map can be verified against the repository source of truth.
+
+Known boundary: the public repository release validates the factory kernel,
+schemas, docs, CLI, examples and public safety. Private runtime/cockpit
+production readiness still requires operator-owned Hermes evidence and real
+approval records outside the public repo.
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -178,14 +178,17 @@ as a place to add files.
 
 ## Current Status
 
-The public repository has validated schemas, worker profiles, Hermes profile
-bindings, adapter hooks, safety scans, a packaged CLI and a runnable public
-example. The adapter patch and transition hook are public, and the local
-validation suite is the required first check before publication or release work.
+Factory v1 is the public kernel release. The repository has validated schemas,
+worker profiles, Hermes profile bindings, adapter hooks, safety scans, a
+packaged CLI, a runnable public example, Product Face proof drivers,
+capability-pack activation checks, production worker graph contracts and public
+surface synchronization checks.
 
-The project is still not a hosted service and not a production launch. A user
-must connect it to their own Hermes runtime, configure any real tools they want
-workers to use, and provide real approval records for high-risk work.
+The project is still not a hosted service and not a production launch for a
+user's product. A user must connect it to their own Hermes runtime, configure
+any real tools they want workers to use, and provide real approval records for
+high-risk work. Private runtime or cockpit production readiness evidence stays
+outside the public repo.
 
 ## Documentation Authority
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "0.1.0"
+version = "1.0.0"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "Overkill Factory contributors" }]
 keywords = ["agents", "hermes", "governance", "kanban", "product-engineering"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- Bumps package version to `1.0.0` and updates public status to Factory v1 kernel release.
- Moves the accumulated public work from `Unreleased` into `CHANGELOG.md` for `1.0.0 - 2026-06-16`.
- Keeps the known boundary explicit: public repo v1 validates the factory kernel, while private runtime/cockpit production readiness requires operator-owned Hermes evidence and real approvals outside this repo.

## Validation
- `python scripts\validate_document_governance.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python -m unittest tests.test_open_source_docs tests.test_public_json_artifact_validator -q`
- `git diff --check`

## Release boundary
This PR prepares the public GitHub release metadata only. It does not add generated evidence, private runtime receipts, screenshots, local paths or cockpit execution history to the public repo.