### PR TITLE
Add systemic signal coverage contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Overkill Factory provides:
 
 - a card contract for describing phase, risk, scope, runtime, security and done
   evidence;
+- a Universal Signal Intake contract, Route Registry, Golden Corpus and signal
+  coverage scorecard for routing papers, bugs, repos, incidents, research,
+  UX, analytics and agent changes without chat-only state;
 - a worker registry and Hermes profile bindings for routing work to the right
   role;
 - a capability pack registry for checking whether the product type has ready
@@ -108,6 +111,8 @@ python -m pip install -e .
 factoryctl doctor
 factoryctl run minimal
 factoryctl init --out ../my-product-factory --project-name my-product
+factoryctl route-registry --route-class product_creation
+factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 ```
 
 Then read `docs/getting-started/install-in-hermes.md` and connect generated

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,11 @@ factoryctl init --out ../my-product-factory --project-name my-product
 
 ```bash
 factoryctl validate-card examples/minimal-hermes-project/card.md
+factoryctl route-registry --route-class product_creation
+factoryctl intake --route-class bug_repair --request-type bug --signal-type bug_report --summary "Public-safe bug report enters reproduction and regression gates." --source-ref external:source-card-bug-001 --out .tmp/bug-intake.json
 factoryctl validate-signal-intake templates/universal-signal-intake.json
+factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
+factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
 factoryctl recovery-plan --card examples/minimal-hermes-project/card.md --receipt .tmp/receipt.json --worker-results-dir .tmp/worker-results
@@ -54,6 +58,13 @@ signal: paper, idea, bug, repo, incident, release, research, UX, analytics,
 security, docs, migration, refactor or agent/model change. It requires a known
 route, required artifacts, public-safe references, explicit non-human recovery
 and execution blocked until the factory has enough source and scope.
+
+`route-registry` exposes the canonical route matrix used by the validators:
+route class, request types, signal types, required artifacts, workers, recovery
+policy and Hermes boundary. `intake` builds a valid Universal Signal Intake
+from that registry without executing work. `validate-signal-corpus` and
+`signal-coverage` prove that the public Golden Corpus covers every known route
+without treating contract coverage as production readiness.
 
 `help-next` reads the card, workflow catalog and gate report, then separates the
 factory's next action from bounded user decisions. With `--receipt` or

--- a/examples/local-web-cockpit-factory-slice/universal-signal-intake.json
+++ b/examples/local-web-cockpit-factory-slice/universal-signal-intake.json
@@ -129,6 +129,18 @@
       "required_before_execution": true
     },
     {
+      "worker_id": "frontend-builder",
+      "role": "surface-builder",
+      "reason": "Owns the implementation path for the visible cockpit surface after Product Face gates pass.",
+      "required_before_execution": true
+    },
+    {
+      "worker_id": "qa-verification-worker",
+      "role": "product-proof-owner",
+      "reason": "Verifies the cockpit states, journeys and Product Face evidence before completion.",
+      "required_before_execution": true
+    },
+    {
       "worker_id": "security-orchestrator",
       "role": "boundary-owner",
       "reason": "Prevents raw private evidence, chat memory or unsafe runtime state from becoming cockpit input.",

--- a/schemas/brownfield-os-plan.schema.json
+++ b/schemas/brownfield-os-plan.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/brownfield-os-plan.schema.json",
+  "title": "Overkill Factory Brownfield OS Plan",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "plan_id",
+    "legacy_system_map",
+    "behavior_baseline",
+    "compatibility_matrix",
+    "regression_plan",
+    "rollback_cutover_plan",
+    "data_risk_map",
+    "ownership",
+    "acceptance_boundary",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/brownfield-os-plan.schema.json"
+    },
+    "record_type": {
+      "const": "brownfield_os_plan"
+    },
+    "plan_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "legacy_system_map": {
+      "type": "object",
+      "required": ["system_refs", "entrypoints", "owned_boundaries", "unknowns"],
+      "properties": {
+        "system_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "entrypoints": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "owned_boundaries": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "unknowns": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "behavior_baseline": {
+      "type": "object",
+      "required": ["baseline_command_refs", "known_good_behaviors", "current_failures"],
+      "properties": {
+        "baseline_command_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "known_good_behaviors": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "current_failures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "compatibility_matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["surface", "compatibility_rule", "breakage_detection"],
+        "properties": {
+          "surface": { "type": "string", "minLength": 3 },
+          "compatibility_rule": { "type": "string", "minLength": 6 },
+          "breakage_detection": { "type": "string", "minLength": 6 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "regression_plan": {
+      "type": "object",
+      "required": ["must_preserve", "test_refs", "review_owner"],
+      "properties": {
+        "must_preserve": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "test_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "review_owner": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "rollback_cutover_plan": {
+      "type": "object",
+      "required": ["rollback_trigger", "rollback_command_or_plan_ref", "cutover_gate"],
+      "properties": {
+        "rollback_trigger": { "type": "string", "minLength": 6 },
+        "rollback_command_or_plan_ref": { "type": "string", "minLength": 3 },
+        "cutover_gate": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "data_risk_map": {
+      "type": "object",
+      "required": ["data_touched", "migration_required", "backup_or_restore_ref"],
+      "properties": {
+        "data_touched": { "type": "boolean" },
+        "migration_required": { "type": "boolean" },
+        "backup_or_restore_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "ownership": {
+      "type": "object",
+      "required": ["route_owner", "regression_owner", "rollback_owner"],
+      "properties": {
+        "route_owner": { "type": "string", "minLength": 3 },
+        "regression_owner": { "type": "string", "minLength": 3 },
+        "rollback_owner": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "acceptance_boundary": {
+      "type": "object",
+      "required": [
+        "execution_blocked_without_baseline",
+        "completion_blocked_without_regression",
+        "promotion_blocked_without_rollback"
+      ],
+      "properties": {
+        "execution_blocked_without_baseline": { "const": true },
+        "completion_blocked_without_regression": { "const": true },
+        "promotion_blocked_without_rollback": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["public_safe_refs_only", "raw_private_evidence_embedded", "private_context_retained_outside_public_repo"],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-route-registry.schema.json
+++ b/schemas/factory-route-registry.schema.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-route-registry.schema.json",
+  "title": "Overkill Factory Route Registry",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "registry_id",
+    "factory_method_version",
+    "routes",
+    "coverage_policy",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-route-registry.schema.json"
+    },
+    "record_type": {
+      "const": "factory_route_registry"
+    },
+    "registry_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "route_class",
+          "request_types",
+          "signal_types",
+          "scope_intents",
+          "selected_method_family",
+          "required_artifacts",
+          "required_gates",
+          "required_workers",
+          "recovery_policy",
+          "hermes_boundary"
+        ],
+        "properties": {
+          "route_class": {
+            "enum": [
+              "product_creation",
+              "feature_delivery",
+              "bug_repair",
+              "incident_response",
+              "brownfield_discovery",
+              "release_promotion",
+              "research_validation",
+              "docs_onboarding",
+              "security_remediation",
+              "critical_integration",
+              "migration_execution",
+              "ux_product_experience",
+              "analytics_data",
+              "agent_quality_change"
+            ]
+          },
+          "request_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "product_new",
+                "slice",
+                "feature",
+                "bug",
+                "incident",
+                "release",
+                "migration",
+                "refactor",
+                "integration",
+                "doc",
+                "security",
+                "ux_ui",
+                "data_analytics",
+                "agent_skill"
+              ]
+            },
+            "uniqueItems": true
+          },
+          "signal_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "scope_intents": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "selected_method_family": {
+            "enum": [
+              "spec_first",
+              "test_first",
+              "behavior_first",
+              "discovery_first",
+              "prototype_first",
+              "legacy_diagnosis",
+              "incident_first",
+              "research_first",
+              "docs_first",
+              "security_first",
+              "design_first",
+              "analytics_first",
+              "agent_eval_first"
+            ]
+          },
+          "required_artifacts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "required_gates": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "required_workers": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "quality_profile_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "recovery_policy": {
+            "type": "object",
+            "required": [
+              "non_human_block_recovery_required",
+              "factory_owned_repair_allowed",
+              "max_attempts_minimum",
+              "until",
+              "runtime_authority",
+              "local_state_authority"
+            ],
+            "properties": {
+              "non_human_block_recovery_required": {
+                "const": true
+              },
+              "factory_owned_repair_allowed": {
+                "const": true
+              },
+              "max_attempts_minimum": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "until": {
+                "type": "string",
+                "minLength": 6
+              },
+              "runtime_authority": {
+                "const": "hermes_kanban"
+              },
+              "local_state_authority": {
+                "const": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "hermes_boundary": {
+            "type": "object",
+            "required": [
+              "runtime_authority",
+              "uses_native_kanban_primitives",
+              "local_state_authority",
+              "factory_may_project_status",
+              "factory_may_create_tasks_only_through_adapter"
+            ],
+            "properties": {
+              "runtime_authority": {
+                "const": "hermes_kanban"
+              },
+              "uses_native_kanban_primitives": {
+                "const": true
+              },
+              "local_state_authority": {
+                "const": false
+              },
+              "factory_may_project_status": {
+                "const": true
+              },
+              "factory_may_create_tasks_only_through_adapter": {
+                "const": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "coverage_policy": {
+      "type": "object",
+      "required": [
+        "golden_corpus_required",
+        "all_routes_require_signal_case",
+        "all_routes_require_recovery_policy",
+        "all_routes_require_hermes_boundary"
+      ],
+      "properties": {
+        "golden_corpus_required": {
+          "const": true
+        },
+        "all_routes_require_signal_case": {
+          "const": true
+        },
+        "all_routes_require_recovery_policy": {
+          "const": true
+        },
+        "all_routes_require_hermes_boundary": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "private_context_retained_outside_public_repo": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-signal-coverage-scorecard.schema.json
+++ b/schemas/factory-signal-coverage-scorecard.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-signal-coverage-scorecard.schema.json",
+  "title": "Overkill Factory Signal Coverage Scorecard",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "scorecard_id",
+    "registry_ref",
+    "corpus_ref",
+    "result",
+    "route_count",
+    "covered_route_count",
+    "dimensions",
+    "missing_route_classes",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-signal-coverage-scorecard.schema.json"
+    },
+    "record_type": {
+      "const": "factory_signal_coverage_scorecard"
+    },
+    "scorecard_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "registry_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "corpus_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "result": {
+      "enum": ["PASS", "BLOCKED"]
+    },
+    "route_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "covered_route_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "dimensions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["dimension_id", "status", "basis", "blocking_findings"],
+        "properties": {
+          "dimension_id": {
+            "enum": [
+              "route_class_coverage",
+              "request_signal_fit",
+              "artifact_coverage",
+              "worker_coverage",
+              "recovery_invariant",
+              "hermes_boundary",
+              "public_safety"
+            ]
+          },
+          "status": {
+            "enum": ["PASS", "BLOCKED"]
+          },
+          "basis": {
+            "type": "string",
+            "minLength": 6
+          },
+          "blocking_findings": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "missing_route_classes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3
+      },
+      "uniqueItems": true
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "private_context_retained_outside_public_repo": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -239,7 +239,14 @@
         "required": ["mode", "dry_run"]
       },
       "then": {
-        "required": ["idempotency_contract"]
+        "required": [
+          "main_task_id",
+          "worker_task_ids",
+          "recovery_promoted_worker_task_ids",
+          "recovery_retry_blocked_worker_task_ids",
+          "recovery_attempts",
+          "idempotency_contract"
+        ]
       }
     }
   ],

--- a/schemas/product-delivery-quality-profile.schema.json
+++ b/schemas/product-delivery-quality-profile.schema.json
@@ -71,7 +71,18 @@
             "type": "array",
             "minItems": 1,
             "items": {
-              "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+              "enum": [
+                "web_visual_ui",
+                "native_mobile",
+                "desktop_app",
+                "browser_extension",
+                "design_system_component",
+                "game_playable",
+                "cli_tui",
+                "docs_onboarding",
+                "agentic_interface",
+                "api_data_product"
+              ]
             },
             "uniqueItems": true
           },

--- a/schemas/product-experience-plan.schema.json
+++ b/schemas/product-experience-plan.schema.json
@@ -45,12 +45,34 @@
       "uniqueItems": true
     },
     "surface_evidence_profile": {
-      "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+      "enum": [
+        "web_visual_ui",
+        "native_mobile",
+        "desktop_app",
+        "browser_extension",
+        "design_system_component",
+        "game_playable",
+        "cli_tui",
+        "docs_onboarding",
+        "agentic_interface",
+        "api_data_product"
+      ]
     },
     "surface_evidence_profiles": {
       "type": "array",
       "items": {
-        "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+        "enum": [
+          "web_visual_ui",
+          "native_mobile",
+          "desktop_app",
+          "browser_extension",
+          "design_system_component",
+          "game_playable",
+          "cli_tui",
+          "docs_onboarding",
+          "agentic_interface",
+          "api_data_product"
+        ]
       },
       "uniqueItems": true
     },

--- a/schemas/product-face-packet.schema.json
+++ b/schemas/product-face-packet.schema.json
@@ -37,12 +37,34 @@
       "uniqueItems": true
     },
     "surface_evidence_profile": {
-      "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+      "enum": [
+        "web_visual_ui",
+        "native_mobile",
+        "desktop_app",
+        "browser_extension",
+        "design_system_component",
+        "game_playable",
+        "cli_tui",
+        "docs_onboarding",
+        "agentic_interface",
+        "api_data_product"
+      ]
     },
     "surface_evidence_profiles": {
       "type": "array",
       "items": {
-        "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+        "enum": [
+          "web_visual_ui",
+          "native_mobile",
+          "desktop_app",
+          "browser_extension",
+          "design_system_component",
+          "game_playable",
+          "cli_tui",
+          "docs_onboarding",
+          "agentic_interface",
+          "api_data_product"
+        ]
       },
       "uniqueItems": true
     },

--- a/schemas/product-face-result.schema.json
+++ b/schemas/product-face-result.schema.json
@@ -614,14 +614,36 @@
       "required": ["profile_id", "surface"],
       "properties": {
         "profile_id": {
-          "enum": ["web_visual_ui", "cli_tui", "docs_onboarding", "agentic_interface"]
+          "enum": [
+            "web_visual_ui",
+            "native_mobile",
+            "desktop_app",
+            "browser_extension",
+            "design_system_component",
+            "game_playable",
+            "cli_tui",
+            "docs_onboarding",
+            "agentic_interface",
+            "api_data_product"
+          ]
         },
         "surface": {
           "type": "string",
           "minLength": 2
         },
         "evidence_kind": {
-          "enum": ["visual_ui", "command_transcript", "reader_success", "task_transcript"]
+          "enum": [
+            "visual_ui",
+            "device_lifecycle",
+            "desktop_packaging",
+            "extension_permission",
+            "component_variant",
+            "playable_loop",
+            "command_transcript",
+            "reader_success",
+            "task_transcript",
+            "contract_data"
+          ]
         },
         "evidence_refs": {
           "type": "array",

--- a/schemas/product-quality-pack.schema.json
+++ b/schemas/product-quality-pack.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/product-quality-pack.schema.json",
+  "title": "Overkill Factory Product Quality Pack",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "pack_id",
+    "delivery_quality_profile_ref",
+    "reference_quality_packet_ref",
+    "surface_evidence_profiles",
+    "required_quality_gates",
+    "domain_proofs",
+    "waiver_policy",
+    "acceptance_boundary",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/product-quality-pack.schema.json"
+    },
+    "record_type": {
+      "const": "product_quality_pack"
+    },
+    "pack_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "delivery_quality_profile_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "reference_quality_packet_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "surface_evidence_profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "web_visual_ui",
+          "native_mobile",
+          "desktop_app",
+          "browser_extension",
+          "design_system_component",
+          "game_playable",
+          "cli_tui",
+          "docs_onboarding",
+          "agentic_interface",
+          "api_data_product"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "required_quality_gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["gate_id", "owner_worker", "blocks_completion_when_missing"],
+        "properties": {
+          "gate_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "owner_worker": {
+            "type": "string",
+            "minLength": 3
+          },
+          "blocks_completion_when_missing": {
+            "const": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "domain_proofs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["proof_id", "surface_evidence_profile", "required_before", "cannot_be_waived_for_full_acceptance"],
+        "properties": {
+          "proof_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "surface_evidence_profile": {
+            "type": "string",
+            "minLength": 3
+          },
+          "required_before": {
+            "enum": ["implementation", "completion", "promotion"]
+          },
+          "cannot_be_waived_for_full_acceptance": {
+            "const": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "waiver_policy": {
+      "type": "object",
+      "required": [
+        "waivers_allowed",
+        "human_owner_required",
+        "cannot_claim_full_product_acceptance_with_waiver"
+      ],
+      "properties": {
+        "waivers_allowed": {
+          "type": "boolean"
+        },
+        "human_owner_required": {
+          "const": true
+        },
+        "cannot_claim_full_product_acceptance_with_waiver": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "acceptance_boundary": {
+      "type": "object",
+      "required": [
+        "full_acceptance_requires_all_applicable_domain_proofs",
+        "product_face_result_is_required_for_visible_surfaces",
+        "design_reference_comparison_required"
+      ],
+      "properties": {
+        "full_acceptance_requires_all_applicable_domain_proofs": {
+          "const": true
+        },
+        "product_face_result_is_required_for_visible_surfaces": {
+          "const": true
+        },
+        "design_reference_comparison_required": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "private_context_retained_outside_public_repo": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/specialist-decision-packet.schema.json
+++ b/schemas/specialist-decision-packet.schema.json
@@ -11,9 +11,11 @@
     "claim_conflict_gap_ledger",
     "resolutions",
     "impacts",
+    "decision_closure",
     "unresolved_risk",
     "human_decisions_required",
     "public_safety_policy",
+    "public_private_boundary",
     "evidence_refs"
   ],
   "properties": {
@@ -27,7 +29,16 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["claim_id", "classification", "statement", "status", "evidence_refs"],
+        "required": [
+          "claim_id",
+          "classification",
+          "statement",
+          "status",
+          "evidence_strength",
+          "freshness_status",
+          "contradiction_state",
+          "evidence_refs"
+        ],
         "properties": {
           "claim_id": { "type": "string", "minLength": 3 },
           "classification": {
@@ -45,9 +56,12 @@
           },
           "statement": { "type": "string", "minLength": 3 },
           "status": { "enum": ["accepted", "rejected", "blocked", "deferred"] },
+          "evidence_strength": { "enum": ["primary", "official", "strong", "bounded", "weak", "blocked"] },
+          "freshness_status": { "enum": ["fresh", "bounded", "stale", "unknown"] },
+          "contradiction_state": { "enum": ["none", "resolved", "open_blocking"] },
           "evidence_refs": { "type": "array", "items": { "type": "string" } }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       }
     },
     "resolutions": {
@@ -73,16 +87,45 @@
     "impacts": {
       "type": "object",
       "required": ["sot", "architecture", "method_router", "gates", "proof"],
-      "additionalProperties": true
+      "properties": {
+        "sot": { "type": "array", "items": { "type": "string", "minLength": 3 } },
+        "architecture": { "type": "array", "items": { "type": "string", "minLength": 3 } },
+        "method_router": { "type": "array", "items": { "type": "string", "minLength": 3 } },
+        "gates": { "type": "array", "items": { "type": "string", "minLength": 3 } },
+        "proof": { "type": "array", "items": { "type": "string", "minLength": 3 } }
+      },
+      "additionalProperties": false
+    },
+    "decision_closure": {
+      "type": "object",
+      "required": ["terminal_state", "method_or_architecture_may_proceed", "blocked_next_action"],
+      "properties": {
+        "terminal_state": {
+          "enum": ["accepted_decision", "blocker", "deferred_with_owner", "human_decision_request", "explicit_rejection"]
+        },
+        "method_or_architecture_may_proceed": { "type": "boolean" },
+        "blocked_next_action": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
     },
     "unresolved_risk": { "type": "array", "items": { "type": "string" } },
     "human_decisions_required": { "type": "array", "items": { "type": "string" } },
     "public_safety_policy": { "type": "string", "minLength": 8 },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["public_safe_refs_only", "raw_private_evidence_embedded", "private_context_retained_outside_public_repo"],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    },
     "evidence_refs": {
       "type": "array",
       "minItems": 1,
       "items": { "type": "string", "minLength": 3 }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/schemas/specialist-research-plan.schema.json
+++ b/schemas/specialist-research-plan.schema.json
@@ -14,10 +14,15 @@
     "allowed_sources",
     "forbidden_sources",
     "source_quality_bar",
+    "source_evidence_matrix",
+    "freshness_policy",
+    "contradiction_policy",
     "expected_output_type",
+    "decision_closure",
     "stop_rule",
     "risk_if_skipped",
     "public_safety_policy",
+    "public_private_boundary",
     "evidence_refs"
   ],
   "properties": {
@@ -34,11 +39,82 @@
     "forbidden_sources": { "type": "array", "minItems": 1, "items": { "type": "string" } },
     "source_quality_bar": { "type": "string", "minLength": 8 },
     "freshness_requirement": { "type": "string" },
+    "freshness_policy": {
+      "type": "object",
+      "required": ["freshness_required", "stale_source_blocks_decision", "refresh_trigger"],
+      "properties": {
+        "freshness_required": { "const": true },
+        "stale_source_blocks_decision": { "const": true },
+        "refresh_trigger": { "type": "string", "minLength": 8 }
+      },
+      "additionalProperties": false
+    },
+    "source_evidence_matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source_ref", "source_type", "freshness_status", "use_allowed", "claims_informed"],
+        "properties": {
+          "source_ref": { "type": "string", "minLength": 3 },
+          "source_type": {
+            "enum": ["primary", "official_docs", "standard", "operator_approved_benchmark", "secondary"]
+          },
+          "freshness_status": {
+            "enum": ["fresh", "bounded", "stale", "unknown"]
+          },
+          "use_allowed": { "type": "boolean" },
+          "claims_informed": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "contradiction_policy": {
+      "type": "object",
+      "required": ["conflicts_block_decision", "owner", "required_resolution"],
+      "properties": {
+        "conflicts_block_decision": { "const": true },
+        "owner": { "type": "string", "minLength": 3 },
+        "required_resolution": { "type": "string", "minLength": 8 }
+      },
+      "additionalProperties": false
+    },
     "copy_license_policy": { "type": "string" },
     "expected_output_type": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "decision_closure": {
+      "type": "object",
+      "required": ["must_end_as", "architecture_or_decomposition_blocked_until_decision", "decision_packet_required"],
+      "properties": {
+        "must_end_as": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": ["accepted_decision", "blocker", "deferred_with_owner", "human_decision_request", "explicit_rejection"]
+          },
+          "uniqueItems": true
+        },
+        "architecture_or_decomposition_blocked_until_decision": { "const": true },
+        "decision_packet_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
     "stop_rule": { "type": "string", "minLength": 8 },
     "risk_if_skipped": { "type": "string", "minLength": 8 },
     "public_safety_policy": { "type": "string", "minLength": 8 },
+    "public_private_boundary": {
+      "type": "object",
+      "required": ["public_safe_refs_only", "raw_private_evidence_embedded", "private_context_retained_outside_public_repo"],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    },
     "reference_quality_packet_refs": { "type": "array", "items": { "type": "string" } },
     "evidence_refs": {
       "type": "array",
@@ -46,5 +122,5 @@
       "items": { "type": "string", "minLength": 3 }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/schemas/universal-signal-golden-corpus.schema.json
+++ b/schemas/universal-signal-golden-corpus.schema.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/universal-signal-golden-corpus.schema.json",
+  "title": "Overkill Factory Universal Signal Golden Corpus",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "corpus_id",
+    "registry_ref",
+    "factory_method_version",
+    "cases",
+    "coverage_policy",
+    "public_private_boundary"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/universal-signal-golden-corpus.schema.json"
+    },
+    "record_type": {
+      "const": "universal_signal_golden_corpus"
+    },
+    "corpus_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "registry_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "case_id",
+          "signal_type",
+          "request_type",
+          "route_class",
+          "expected_method_family",
+          "expected_required_artifact_types",
+          "expected_required_worker_ids",
+          "expected_recovery_policy",
+          "expected_hermes_boundary",
+          "acceptance"
+        ],
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "signal_type": {
+            "type": "string",
+            "minLength": 3
+          },
+          "request_type": {
+            "type": "string",
+            "minLength": 3
+          },
+          "route_class": {
+            "type": "string",
+            "minLength": 3
+          },
+          "expected_method_family": {
+            "type": "string",
+            "minLength": 3
+          },
+          "expected_required_artifact_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "expected_required_worker_ids": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            },
+            "uniqueItems": true
+          },
+          "expected_recovery_policy": {
+            "type": "object",
+            "required": [
+              "non_human_block_recovery_required",
+              "factory_owned_repair_allowed",
+              "runtime_authority",
+              "local_state_authority"
+            ],
+            "properties": {
+              "non_human_block_recovery_required": {
+                "const": true
+              },
+              "factory_owned_repair_allowed": {
+                "const": true
+              },
+              "runtime_authority": {
+                "const": "hermes_kanban"
+              },
+              "local_state_authority": {
+                "const": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "expected_hermes_boundary": {
+            "type": "object",
+            "required": [
+              "uses_native_kanban_primitives",
+              "runtime_authority",
+              "local_state_authority"
+            ],
+            "properties": {
+              "uses_native_kanban_primitives": {
+                "const": true
+              },
+              "runtime_authority": {
+                "const": "hermes_kanban"
+              },
+              "local_state_authority": {
+                "const": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "acceptance": {
+            "type": "object",
+            "required": [
+              "route_known",
+              "execution_blocked_until_gates_pass",
+              "operator_not_required_to_coordinate_internal_repair"
+            ],
+            "properties": {
+              "route_known": {
+                "const": true
+              },
+              "execution_blocked_until_gates_pass": {
+                "const": true
+              },
+              "operator_not_required_to_coordinate_internal_repair": {
+                "const": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "coverage_policy": {
+      "type": "object",
+      "required": [
+        "must_cover_every_route_class",
+        "must_cover_recovery_invariant",
+        "must_cover_hermes_boundary"
+      ],
+      "properties": {
+        "must_cover_every_route_class": {
+          "const": true
+        },
+        "must_cover_recovery_invariant": {
+          "const": true
+        },
+        "must_cover_hermes_boundary": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": {
+          "const": true
+        },
+        "raw_private_evidence_embedded": {
+          "const": false
+        },
+        "private_context_retained_outside_public_repo": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factory_route_registry.py
+++ b/scripts/factory_route_registry.py
@@ -1,0 +1,96 @@
+"""Canonical route registry for Overkill Factory public contracts."""
+
+from __future__ import annotations
+
+import json
+import sysconfig
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ROUTE_REGISTRY_PATH = ROOT / "templates" / "factory-route-registry.json"
+
+
+def route_registry_candidates() -> list[Path]:
+    data_root = Path(sysconfig.get_path("data") or "")
+    return [
+        DEFAULT_ROUTE_REGISTRY_PATH,
+        ROOT / "share" / "overkill-factory" / "templates" / "factory-route-registry.json",
+        data_root / "share" / "overkill-factory" / "templates" / "factory-route-registry.json",
+    ]
+
+
+def load_route_registry(path: Path | None = None) -> dict[str, Any]:
+    if path is not None:
+        registry_path = path
+    else:
+        registry_path = next(
+            (candidate for candidate in route_registry_candidates() if candidate.exists()),
+            DEFAULT_ROUTE_REGISTRY_PATH,
+        )
+    return json.loads(registry_path.read_text(encoding="utf-8"))
+
+
+def registry_routes(registry: dict[str, Any] | None = None) -> dict[str, dict[str, Any]]:
+    data = registry or load_route_registry()
+    routes = data.get("routes") if isinstance(data.get("routes"), list) else []
+    return {
+        str(route.get("route_class")): route
+        for route in routes
+        if isinstance(route, dict) and str(route.get("route_class") or "").strip()
+    }
+
+
+def route_required_artifacts(registry: dict[str, Any] | None = None) -> dict[str, set[str]]:
+    return {
+        route_class: {
+            str(item)
+            for item in route.get("required_artifacts", [])
+            if str(item).strip()
+        }
+        for route_class, route in registry_routes(registry).items()
+    }
+
+
+def route_request_types(registry: dict[str, Any] | None = None) -> dict[str, set[str]]:
+    return {
+        route_class: {
+            str(item)
+            for item in route.get("request_types", [])
+            if str(item).strip()
+        }
+        for route_class, route in registry_routes(registry).items()
+    }
+
+
+def route_signal_types(registry: dict[str, Any] | None = None) -> dict[str, set[str]]:
+    return {
+        route_class: {
+            str(item)
+            for item in route.get("signal_types", [])
+            if str(item).strip()
+        }
+        for route_class, route in registry_routes(registry).items()
+    }
+
+
+def route_method_families(registry: dict[str, Any] | None = None) -> dict[str, str]:
+    return {
+        route_class: str(route.get("selected_method_family") or "")
+        for route_class, route in registry_routes(registry).items()
+    }
+
+
+def route_required_gates(registry: dict[str, Any] | None = None) -> dict[str, list[str]]:
+    return {
+        route_class: [str(item) for item in route.get("required_gates", []) if str(item).strip()]
+        for route_class, route in registry_routes(registry).items()
+    }
+
+
+def route_required_workers(registry: dict[str, Any] | None = None) -> dict[str, list[str]]:
+    return {
+        route_class: [str(item) for item in route.get("required_workers", []) if str(item).strip()]
+        for route_class, route in registry_routes(registry).items()
+    }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -29,6 +29,17 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from public_refs import contains_private_kanban_task_marker, public_safe_kanban_ref, sanitize_public_refs  # noqa: E402
+from factory_route_registry import (  # noqa: E402
+    DEFAULT_ROUTE_REGISTRY_PATH,
+    load_route_registry,
+    registry_routes,
+    route_method_families,
+    route_request_types,
+    route_required_artifacts,
+    route_required_gates,
+    route_required_workers,
+    route_signal_types,
+)
 from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
 
 
@@ -76,6 +87,8 @@ DEFAULT_EVIDENCE_GRAPH_OUT = ROOT / ".tmp" / "factory-runs" / "evidence" / "evid
 DEFAULT_READINESS_LEDGER_OUT = ROOT / ".tmp" / "factory-runs" / "readiness" / "readiness-truth-ledger.json"
 DEFAULT_HERMES_EVIDENCE_OUT = ROOT / ".tmp" / "factory-runs" / "hermes-evidence" / "sanitized-package.json"
 DEFAULT_PREPILOT_CHECKLIST_OUT = ROOT / ".tmp" / "factory-runs" / "prepilot" / "loose-end-checklist.json"
+DEFAULT_SIGNAL_CORPUS_PATH = ROOT / "templates" / "universal-signal-golden-corpus.json"
+DEFAULT_SIGNAL_COVERAGE_OUT = ROOT / ".tmp" / "factory-runs" / "signal-coverage" / "factory-signal-coverage-scorecard.json"
 PRIVATE_RUNTIME_REF_RE = re.compile(
     r"((?<![A-Za-z])[A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
     re.IGNORECASE,
@@ -126,53 +139,10 @@ VFINAL_REQUEST_TYPES = {
     "agent_skill",
 }
 
-UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS = {
-    "product_creation": {
-        "source_ledger",
-        "outcome_contract",
-        "product_sot",
-        "full_product_sot_scope_coverage",
-        "method_contract",
-        "product_creation_plan",
-        "product_implementation_readiness",
-        "sdlc_feedback_loop",
-    },
-    "feature_delivery": {"source_ledger", "outcome_contract", "method_contract", "spec_graph", "qa_plan"},
-    "bug_repair": {"source_ledger", "bug_reproduction", "diagnosis", "regression_check", "receipt_five"},
-    "incident_response": {"incident_support_plan", "severity_model", "mitigation_plan", "evidence_record", "learnback"},
-    "brownfield_discovery": {"source_ledger", "legacy_system_map", "baseline", "regression_plan", "rollback_plan"},
-    "release_promotion": {"production_readiness_plan", "promotion_ladder", "rollback_path", "monitoring_signals"},
-    "research_validation": {"specialist_research_plan", "specialist_decision_packet", "sdlc_feedback_loop"},
-    "docs_onboarding": {"user_docs_onboarding_plan", "reader_success_path", "docs_verification"},
-    "security_remediation": {"security_architecture_plan", "security_scan_packet", "review_result"},
-    "critical_integration": {"integration_contract", "dependency_gate", "contract_tests", "fallback_plan"},
-    "migration_execution": {"legacy_system_map", "migration_plan", "regression_plan", "rollback_plan"},
-    "ux_product_experience": {
-        "product_experience_plan",
-        "product_face_packet",
-        "professional_design_process",
-        "product_face_result",
-    },
-    "analytics_data": {"data_metrics_plan", "event_contract", "dashboard_health_proof", "privacy_limits"},
-    "agent_quality_change": {"agent_eval_plan", "reasoning_policy", "worker_profile_readiness", "learnback"},
-}
-
-UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES = {
-    "product_creation": {"product_new"},
-    "feature_delivery": {"feature", "slice"},
-    "bug_repair": {"bug"},
-    "incident_response": {"incident"},
-    "brownfield_discovery": {"migration", "refactor", "integration"},
-    "release_promotion": {"release"},
-    "research_validation": {"feature", "product_new", "security", "ux_ui", "data_analytics", "agent_skill"},
-    "docs_onboarding": {"doc"},
-    "security_remediation": {"security"},
-    "critical_integration": {"integration"},
-    "migration_execution": {"migration"},
-    "ux_product_experience": {"ux_ui", "product_new", "feature"},
-    "analytics_data": {"data_analytics", "product_new", "feature"},
-    "agent_quality_change": {"agent_skill"},
-}
+UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS = route_required_artifacts()
+UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES = route_request_types()
+UNIVERSAL_SIGNAL_ROUTE_SIGNAL_TYPES = route_signal_types()
+UNIVERSAL_SIGNAL_ROUTE_METHOD_FAMILIES = route_method_families()
 
 VFINAL_CORE_CONTRACTS = {
     "request_type",
@@ -2608,14 +2578,27 @@ def validate_specialist_research_contract(card: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if _research_required(card) and not _has_ref_or_object(card, "specialist_research_plan"):
         errors.append("specialist_research_plan or specialist_research_plan_ref is required when research_required is active")
+    plan = card.get("specialist_research_plan") if isinstance(card.get("specialist_research_plan"), dict) else {}
+    if plan:
+        schema = bundled_schemas().get("specialist-research-plan.schema.json")
+        if schema:
+            errors.extend(validate_node(schema, plan, "specialist_research_plan", schemas=bundled_schemas(), root_schema=schema))
     decision = card.get("specialist_decision_packet") if isinstance(card.get("specialist_decision_packet"), dict) else {}
     if decision:
+        schema = bundled_schemas().get("specialist-decision-packet.schema.json")
+        if schema:
+            errors.extend(validate_node(schema, decision, "specialist_decision_packet", schemas=bundled_schemas(), root_schema=schema))
         if not _non_empty_string_list(decision.get("resolutions")):
             errors.append("specialist_decision_packet.resolutions must turn research into an operational factory decision")
         impacts = decision.get("impacts") if isinstance(decision.get("impacts"), dict) else {}
         for field in ("sot", "architecture", "method_router", "gates", "proof"):
             if field not in impacts:
                 errors.append(f"specialist_decision_packet.impacts.{field} is required")
+        closure = decision.get("decision_closure") if isinstance(decision.get("decision_closure"), dict) else {}
+        terminal_state = str(closure.get("terminal_state") or "").strip()
+        may_proceed = closure.get("method_or_architecture_may_proceed")
+        if terminal_state in {"blocker", "deferred_with_owner", "human_decision_request"} and may_proceed is True:
+            errors.append("specialist_decision_packet.decision_closure cannot allow method or architecture to proceed while research is blocked, deferred or human-gated")
     return errors
 
 
@@ -5589,6 +5572,7 @@ def validate_universal_signal_intake(intake: dict[str, Any]) -> list[str]:
     classification = intake.get("classification") if isinstance(intake.get("classification"), dict) else {}
     request_type = str(classification.get("request_type") or "").strip()
     route_class = str(classification.get("route_class") or "").strip()
+    signal_type = str(signal.get("signal_type") or "").strip()
     if request_type and request_type not in VFINAL_REQUEST_TYPES:
         errors.append("universal_signal_intake.classification.request_type must be one of " + ", ".join(sorted(VFINAL_REQUEST_TYPES)))
     allowed_request_types = UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES.get(route_class)
@@ -5596,6 +5580,12 @@ def validate_universal_signal_intake(intake: dict[str, Any]) -> list[str]:
         errors.append(
             "universal_signal_intake.classification.request_type is not valid for route_class "
             f"{route_class}: {request_type}"
+        )
+    allowed_signal_types = UNIVERSAL_SIGNAL_ROUTE_SIGNAL_TYPES.get(route_class)
+    if allowed_signal_types and signal_type and signal_type not in allowed_signal_types:
+        errors.append(
+            "universal_signal_intake.signal.signal_type is not valid for route_class "
+            f"{route_class}: {signal_type}"
         )
     if classification.get("can_start_execution") is not False:
         errors.append("universal_signal_intake classification cannot allow execution directly")
@@ -5607,6 +5597,13 @@ def validate_universal_signal_intake(intake: dict[str, Any]) -> list[str]:
         errors.append("universal_signal_intake.no_chat_only_state must be true")
 
     route = intake.get("route_decision") if isinstance(intake.get("route_decision"), dict) else {}
+    selected_method_family = str(route.get("selected_method_family") or "").strip()
+    expected_method_family = UNIVERSAL_SIGNAL_ROUTE_METHOD_FAMILIES.get(route_class)
+    if expected_method_family and selected_method_family and selected_method_family != expected_method_family:
+        errors.append(
+            "universal_signal_intake.route_decision.selected_method_family must match route registry "
+            f"for {route_class}: {expected_method_family}"
+        )
     for field in ("method_contract_ref", "sdlc_feedback_loop_ref", "factory_workflow_phase_ref", "fallback_route"):
         value = str(route.get(field) or "").strip()
         if value:
@@ -5647,6 +5644,32 @@ def validate_universal_signal_intake(intake: dict[str, Any]) -> list[str]:
                     "universal_signal_intake.required_artifacts"
                     f"[{index}].blocks_execution_when_missing must be true for required route artifact"
                 )
+        owner_worker = str(artifact.get("owner_worker") or "").strip()
+        if owner_worker and owner_worker not in WORKERS:
+            errors.append(
+                "universal_signal_intake.required_artifacts"
+                f"[{index}].owner_worker must be a registered worker: {owner_worker}"
+            )
+
+    required_workers = intake.get("required_workers") if isinstance(intake.get("required_workers"), list) else []
+    registry_required_workers = set(route_required_workers().get(route_class, []))
+    intake_worker_ids = {
+        str(worker.get("worker_id") or "").strip()
+        for worker in required_workers
+        if isinstance(worker, dict)
+    }
+    missing_workers = sorted(registry_required_workers - intake_worker_ids)
+    if missing_workers:
+        errors.append(
+            f"universal_signal_intake {route_class} route missing required workers: "
+            + ", ".join(missing_workers)
+        )
+    for index, worker in enumerate(required_workers):
+        if not isinstance(worker, dict):
+            continue
+        worker_id = str(worker.get("worker_id") or "").strip()
+        if worker_id and worker_id not in WORKERS:
+            errors.append(f"universal_signal_intake.required_workers[{index}].worker_id must be a registered worker: {worker_id}")
 
     boundary = intake.get("public_private_boundary") if isinstance(intake.get("public_private_boundary"), dict) else {}
     if boundary.get("public_safe_refs_only") is not True:
@@ -5668,6 +5691,428 @@ def validate_universal_signal_intake(intake: dict[str, Any]) -> list[str]:
     if handoff.get("factory_owned_next_step") is not True:
         errors.append("universal_signal_intake handoff.factory_owned_next_step must be true")
 
+    return errors
+
+
+DEFAULT_ARTIFACT_REFS = {
+    "source_ledger": "templates/reference-source-registry.json",
+    "outcome_contract": "templates/vfinal-factory-card.json#outcome_contract",
+    "product_sot": "templates/product-sot.json",
+    "full_product_sot_scope_coverage": "templates/full-product-sot-scope-coverage.json",
+    "method_contract": "templates/method-contract.json",
+    "product_creation_plan": "templates/product-creation-plan.json",
+    "product_implementation_readiness": "templates/product-implementation-readiness.json",
+    "sdlc_feedback_loop": "templates/factory-sdlc-feedback-loop.json",
+    "specialist_research_plan": "templates/specialist-research-plan.json",
+    "specialist_decision_packet": "templates/specialist-decision-packet.json",
+    "product_experience_plan": "templates/product-experience-plan.json",
+    "product_face_packet": "templates/product-face-packet.json",
+    "professional_design_process": "templates/professional-design-process.json",
+    "product_face_result": "templates/product-face-result.json",
+    "production_readiness_plan": "templates/production-readiness-plan.json",
+    "promotion_ladder": "templates/production-promotion-ladder.json",
+    "brownfield_os_plan": "templates/brownfield-os-plan.json",
+    "migration_plan": "templates/legacy-migration-plan.json",
+    "rollback_plan": "templates/legacy-migration-plan.json#rollback_plan",
+}
+
+DEFAULT_ARTIFACT_OWNERS = {
+    "source_ledger": "source-ledger-worker",
+    "outcome_contract": "product-sot-planner",
+    "product_sot": "product-sot-planner",
+    "full_product_sot_scope_coverage": "product-sot-planner",
+    "method_contract": "factory-orchestrator",
+    "product_creation_plan": "decomposition-planner",
+    "product_implementation_readiness": "factory-orchestrator",
+    "sdlc_feedback_loop": "skill-eval-distiller",
+    "specialist_research_plan": "source-ledger-worker",
+    "specialist_decision_packet": "product-architect",
+    "product_experience_plan": "product-face",
+    "product_face_packet": "product-face",
+    "professional_design_process": "product-face",
+    "product_face_result": "qa-verification-worker",
+    "production_readiness_plan": "release-ops-worker",
+    "promotion_ladder": "release-ops-worker",
+    "rollback_plan": "release-ops-worker",
+    "regression_plan": "qa-verification-worker",
+    "baseline": "qa-verification-worker",
+    "brownfield_os_plan": "product-architect",
+    "legacy_system_map": "product-architect",
+    "migration_plan": "data-persistence-builder",
+}
+
+ARTIFACT_REQUIRED_BEFORE = {
+    "source_ledger": "source_resolution",
+    "outcome_contract": "product_sot",
+    "product_sot": "method_contract",
+    "full_product_sot_scope_coverage": "method_contract",
+    "method_contract": "ready_gate",
+    "product_creation_plan": "ready_gate",
+    "product_implementation_readiness": "execution",
+    "sdlc_feedback_loop": "execution",
+    "specialist_research_plan": "method_contract",
+    "specialist_decision_packet": "method_contract",
+    "product_experience_plan": "execution",
+    "product_face_packet": "execution",
+    "professional_design_process": "execution",
+    "product_face_result": "completion",
+    "production_readiness_plan": "release",
+    "promotion_ladder": "release",
+    "rollback_plan": "release",
+    "brownfield_os_plan": "ready_gate",
+    "rollback_path": "release",
+    "monitoring_signals": "release",
+    "receipt_five": "completion",
+}
+
+
+def artifact_ref_for_type(artifact_type: str) -> str:
+    return DEFAULT_ARTIFACT_REFS.get(artifact_type, f"templates/{artifact_type.replace('_', '-')}.json")
+
+
+def artifact_owner_for_type(artifact_type: str, route: dict[str, Any]) -> str:
+    owner = DEFAULT_ARTIFACT_OWNERS.get(artifact_type)
+    if owner:
+        return owner
+    workers = route.get("required_workers") if isinstance(route.get("required_workers"), list) else []
+    return str(workers[0]) if workers else "factory-orchestrator"
+
+
+def artifact_required_before(artifact_type: str) -> str:
+    return ARTIFACT_REQUIRED_BEFORE.get(artifact_type, "execution")
+
+
+def slug_for_ref(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:64] or "signal"
+
+
+def build_universal_signal_intake(
+    *,
+    route_class: str,
+    request_type: str,
+    signal_type: str,
+    summary_public_safe: str,
+    signal_ref_public_safe: str,
+    target_surface: str,
+    owner: str,
+    source_class: str,
+    sensitivity_class: str,
+    freshness: str,
+    risk_initial: str,
+    materiality: str,
+    created_at: str | None = None,
+    intake_id: str | None = None,
+) -> dict[str, Any]:
+    routes = registry_routes(load_route_registry())
+    route = routes.get(route_class)
+    if not route:
+        raise ValueError(f"unknown route_class: {route_class}")
+    route_artifacts = list(route.get("required_artifacts") or [])
+    route_workers = [str(worker) for worker in route.get("required_workers", [])]
+    route_gates = [str(gate) for gate in route.get("required_gates", [])]
+    scope_intents = [str(scope) for scope in route.get("scope_intents", []) if str(scope).strip()]
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    source_slug = slug_for_ref(signal_ref_public_safe)
+    selected_method_family = str(route.get("selected_method_family") or "spec_first")
+    first_worker = route_workers[0] if route_workers else "factory-orchestrator"
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/universal-signal-intake.schema.json",
+        "record_type": "universal_signal_intake",
+        "intake_id": intake_id or f"intake-{route_class}-{source_slug}",
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "signal": {
+            "signal_type": signal_type,
+            "source_class": source_class,
+            "sensitivity_class": sensitivity_class,
+            "freshness": freshness,
+            "owner": owner,
+            "target_surface": target_surface,
+            "summary_public_safe": summary_public_safe,
+            "signal_ref_public_safe": signal_ref_public_safe,
+            "raw_private_embedded": False,
+        },
+        "classification": {
+            "request_type": request_type,
+            "route_class": route_class,
+            "scope_intent": scope_intents[0] if scope_intents else "child_slice",
+            "risk_initial": risk_initial,
+            "materiality": materiality,
+            "needs_product_sot": route_class in {"product_creation", "ux_product_experience", "analytics_data"},
+            "can_start_execution": False,
+        },
+        "normalization": {
+            "source_resolution_required": True,
+            "outcome_discovery_required": route_class in {"product_creation", "feature_delivery", "research_validation"},
+            "dedupe_key": f"{route_class}:{source_slug}",
+            "conflict_policy": "Conflicting or stale source claims stay blocked until source resolution assigns an owner and next action.",
+            "missing_info_policy": "Discoverable missing information is resolved by the factory; only authority, access, risk or preference gates reach the user.",
+            "no_chat_only_state": True,
+        },
+        "route_decision": {
+            "method_contract_ref": "templates/method-contract.json",
+            "sdlc_feedback_loop_ref": "templates/factory-sdlc-feedback-loop.json",
+            "factory_workflow_phase_ref": "docs/factory-workflow.catalog.json#F1",
+            "selected_method_family": selected_method_family,
+            "route_reason": f"Route registry selected {route_class} for {request_type} from {signal_type}.",
+            "fallback_route": "If any non-human gate blocks, return to the factory-owned repair route until the gate passes or a real human authority gate is required.",
+            "non_human_block_recovery": {
+                "required": True,
+                "factory_owned_repair_allowed": True,
+                "route_ref": "docs/factory-workflow.catalog.json#recovery",
+                "retry_policy": {
+                    "max_attempts": int((route.get("recovery_policy") or {}).get("max_attempts_minimum") or 1),
+                    "until": str((route.get("recovery_policy") or {}).get("until") or "the blocking gate passes"),
+                },
+            },
+        },
+        "required_artifacts": [
+            {
+                "artifact_type": str(artifact_type),
+                "artifact_ref": artifact_ref_for_type(str(artifact_type)),
+                "required_before": artifact_required_before(str(artifact_type)),
+                "owner_worker": artifact_owner_for_type(str(artifact_type), route),
+                "status": "required",
+                "blocks_execution_when_missing": True,
+            }
+            for artifact_type in route_artifacts
+        ],
+        "required_gates": [
+            {
+                "gate": gate,
+                "authority": first_worker,
+                "evidence_required": ["route artifact evidence", "gate verdict"],
+                "blocks_execution_when_missing": True,
+            }
+            for gate in route_gates
+        ],
+        "required_workers": [
+            {
+                "worker_id": worker_id,
+                "role": "route-required-worker",
+                "reason": f"Required by {route_class} route registry before execution.",
+                "required_before_execution": True,
+            }
+            for worker_id in route_workers
+        ],
+        "handoff": {
+            "next_artifact": str(route_artifacts[0]) if route_artifacts else "source_ledger",
+            "next_safe_action": "Materialize the next required artifact through the factory route before any execution.",
+            "user_decision_required": False,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+            "operator_instance_may_hold_private_source": True,
+        },
+        "acceptance": {
+            "intake_is_route_ready": True,
+            "execution_allowed": False,
+            "blocked_reason": "Intake classification is complete, but execution waits for required artifacts, gates, workers and recovery policy.",
+            "evidence_refs": [
+                "schemas/universal-signal-intake.schema.json",
+                "templates/factory-route-registry.json",
+                "docs/factory-workflow.catalog.json#F1",
+            ],
+        },
+    }
+
+
+def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("universal-signal-golden-corpus.schema.json")
+    if not schema:
+        return ["universal_signal_golden_corpus schema is not bundled"]
+    errors.extend(validate_node(schema, corpus, "universal_signal_golden_corpus", schemas=schemas, root_schema=schema))
+
+    registry_ref = str(corpus.get("registry_ref") or "").strip()
+    if registry_ref:
+        _validate_public_ref(registry_ref, "universal_signal_golden_corpus.registry_ref", errors)
+    boundary = corpus.get("public_private_boundary") if isinstance(corpus.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("universal_signal_golden_corpus requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("universal_signal_golden_corpus must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("universal_signal_golden_corpus private context must stay outside the public repo")
+
+    routes = registry_routes(load_route_registry())
+    cases = corpus.get("cases") if isinstance(corpus.get("cases"), list) else []
+    cases_by_route: dict[str, list[dict[str, Any]]] = {}
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        route_class = str(case.get("route_class") or "").strip()
+        cases_by_route.setdefault(route_class, []).append(case)
+
+    missing_routes = sorted(set(routes) - set(cases_by_route))
+    if missing_routes:
+        errors.append("universal_signal_golden_corpus missing route classes: " + ", ".join(missing_routes))
+    extra_routes = sorted(set(cases_by_route) - set(routes))
+    if extra_routes:
+        errors.append("universal_signal_golden_corpus references unknown route classes: " + ", ".join(extra_routes))
+
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            continue
+        route_class = str(case.get("route_class") or "").strip()
+        route = routes.get(route_class)
+        case_at = f"universal_signal_golden_corpus.cases[{index}]"
+        if not route:
+            continue
+        request_type = str(case.get("request_type") or "").strip()
+        signal_type = str(case.get("signal_type") or "").strip()
+        method_family = str(case.get("expected_method_family") or "").strip()
+        expected_artifacts = {
+            str(item)
+            for item in case.get("expected_required_artifact_types", [])
+            if str(item).strip()
+        }
+        expected_workers = {
+            str(item)
+            for item in case.get("expected_required_worker_ids", [])
+            if str(item).strip()
+        }
+        if request_type not in set(route.get("request_types") or []):
+            errors.append(f"{case_at}.request_type is not valid for {route_class}: {request_type}")
+        if signal_type not in set(route.get("signal_types") or []):
+            errors.append(f"{case_at}.signal_type is not valid for {route_class}: {signal_type}")
+        if method_family != str(route.get("selected_method_family") or ""):
+            errors.append(f"{case_at}.expected_method_family must match route registry for {route_class}")
+        route_artifacts = {str(item) for item in route.get("required_artifacts", [])}
+        missing_artifacts = sorted(route_artifacts - expected_artifacts)
+        extra_artifacts = sorted(expected_artifacts - route_artifacts)
+        if missing_artifacts:
+            errors.append(f"{case_at} missing artifact coverage for {route_class}: " + ", ".join(missing_artifacts))
+        if extra_artifacts:
+            errors.append(f"{case_at} has artifact coverage outside {route_class}: " + ", ".join(extra_artifacts))
+        route_workers = {str(item) for item in route.get("required_workers", [])}
+        missing_workers = sorted(route_workers - expected_workers)
+        extra_workers = sorted(expected_workers - route_workers)
+        if missing_workers:
+            errors.append(f"{case_at} missing worker coverage for {route_class}: " + ", ".join(missing_workers))
+        if extra_workers:
+            errors.append(f"{case_at} has worker coverage outside {route_class}: " + ", ".join(extra_workers))
+        recovery = case.get("expected_recovery_policy") if isinstance(case.get("expected_recovery_policy"), dict) else {}
+        route_recovery = route.get("recovery_policy") if isinstance(route.get("recovery_policy"), dict) else {}
+        if recovery.get("non_human_block_recovery_required") is not True:
+            errors.append(f"{case_at} recovery invariant must require non-human block recovery")
+        if recovery.get("factory_owned_repair_allowed") is not True:
+            errors.append(f"{case_at} recovery invariant must be factory-owned")
+        if recovery.get("runtime_authority") != route_recovery.get("runtime_authority"):
+            errors.append(f"{case_at} recovery runtime authority must match route registry")
+        if recovery.get("local_state_authority") is not False:
+            errors.append(f"{case_at} recovery must not claim local state authority")
+        hermes_boundary = case.get("expected_hermes_boundary") if isinstance(case.get("expected_hermes_boundary"), dict) else {}
+        route_hermes = route.get("hermes_boundary") if isinstance(route.get("hermes_boundary"), dict) else {}
+        if hermes_boundary.get("uses_native_kanban_primitives") is not True:
+            errors.append(f"{case_at} Hermes boundary must use native Kanban primitives")
+        if hermes_boundary.get("runtime_authority") != route_hermes.get("runtime_authority"):
+            errors.append(f"{case_at} Hermes runtime authority must match route registry")
+        if hermes_boundary.get("local_state_authority") is not False:
+            errors.append(f"{case_at} Hermes boundary must not claim local state authority")
+
+    return errors
+
+
+SIGNAL_COVERAGE_DIMENSIONS = [
+    ("route_class_coverage", "Every route class in the registry has at least one golden signal case."),
+    ("request_signal_fit", "Golden cases use request and signal types accepted by their route."),
+    ("artifact_coverage", "Golden cases cover every required artifact declared by each route."),
+    ("worker_coverage", "Golden cases cover every required worker declared by each route."),
+    ("recovery_invariant", "Every route proves factory-owned non-human recovery with Hermes runtime authority."),
+    ("hermes_boundary", "Every route keeps Hermes as runtime authority and avoids local shadow state."),
+    ("public_safety", "Coverage artifacts stay public-safe and contain no raw private evidence."),
+]
+
+
+def signal_coverage_dimension_for_error(error: str) -> str:
+    lowered = error.lower()
+    if "route class" in lowered:
+        return "route_class_coverage"
+    if "request_type" in lowered or "signal_type" in lowered or "method_family" in lowered:
+        return "request_signal_fit"
+    if "artifact" in lowered:
+        return "artifact_coverage"
+    if "worker" in lowered:
+        return "worker_coverage"
+    if "recovery" in lowered or "non-human" in lowered:
+        return "recovery_invariant"
+    if "hermes" in lowered or "runtime authority" in lowered or "local state authority" in lowered:
+        return "hermes_boundary"
+    return "public_safety"
+
+
+def build_factory_signal_coverage_scorecard(
+    corpus: dict[str, Any],
+    *,
+    registry_ref: str = "templates/factory-route-registry.json",
+    corpus_ref: str = "templates/universal-signal-golden-corpus.json",
+) -> dict[str, Any]:
+    routes = registry_routes(load_route_registry())
+    cases = corpus.get("cases") if isinstance(corpus.get("cases"), list) else []
+    covered_routes = {
+        str(case.get("route_class") or "").strip()
+        for case in cases
+        if isinstance(case, dict) and str(case.get("route_class") or "").strip() in routes
+    }
+    missing_route_classes = sorted(set(routes) - covered_routes)
+    validation_errors = validate_universal_signal_golden_corpus(corpus)
+    findings_by_dimension: dict[str, list[str]] = {dimension_id: [] for dimension_id, _ in SIGNAL_COVERAGE_DIMENSIONS}
+    for error in validation_errors:
+        findings_by_dimension[signal_coverage_dimension_for_error(error)].append(error)
+    dimensions = [
+        {
+            "dimension_id": dimension_id,
+            "status": "BLOCKED" if findings_by_dimension[dimension_id] else "PASS",
+            "basis": basis,
+            "blocking_findings": findings_by_dimension[dimension_id],
+        }
+        for dimension_id, basis in SIGNAL_COVERAGE_DIMENSIONS
+    ]
+    blocked = any(dimension["status"] == "BLOCKED" for dimension in dimensions)
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-signal-coverage-scorecard.schema.json",
+        "record_type": "factory_signal_coverage_scorecard",
+        "scorecard_id": "factory-signal-coverage-scorecard-v1",
+        "registry_ref": registry_ref,
+        "corpus_ref": corpus_ref,
+        "result": "BLOCKED" if blocked else "PASS",
+        "route_count": len(routes),
+        "covered_route_count": len(covered_routes),
+        "dimensions": dimensions,
+        "missing_route_classes": missing_route_classes,
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+        },
+    }
+
+
+def validate_factory_signal_coverage_scorecard(scorecard: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-signal-coverage-scorecard.schema.json")
+    if not schema:
+        return ["factory_signal_coverage_scorecard schema is not bundled"]
+    errors.extend(validate_node(schema, scorecard, "factory_signal_coverage_scorecard", schemas=schemas, root_schema=schema))
+    for field in ("registry_ref", "corpus_ref"):
+        value = str(scorecard.get(field) or "").strip()
+        if value:
+            _validate_public_ref(value, f"factory_signal_coverage_scorecard.{field}", errors)
+    boundary = scorecard.get("public_private_boundary") if isinstance(scorecard.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("factory_signal_coverage_scorecard requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("factory_signal_coverage_scorecard must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("factory_signal_coverage_scorecard private context must stay outside the public repo")
     return errors
 
 
@@ -10536,6 +10981,82 @@ def command_validate_signal_intake(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_route_registry(args: argparse.Namespace) -> int:
+    registry = load_route_registry(args.registry)
+    if args.route_class:
+        routes = registry_routes(registry)
+        route = routes.get(args.route_class)
+        if not route:
+            print(f"unknown route_class: {args.route_class}", file=sys.stderr)
+            return 1
+        write_json(args.out, route)
+        return 0
+    write_json(args.out, registry)
+    return 0
+
+
+def command_intake(args: argparse.Namespace) -> int:
+    intake = build_universal_signal_intake(
+        route_class=args.route_class,
+        request_type=args.request_type,
+        signal_type=args.signal_type,
+        summary_public_safe=args.summary,
+        signal_ref_public_safe=args.source_ref,
+        target_surface=args.target_surface,
+        owner=args.owner,
+        source_class=args.source_class,
+        sensitivity_class=args.sensitivity_class,
+        freshness=args.freshness,
+        risk_initial=args.risk_initial,
+        materiality=args.materiality,
+        created_at=args.created_at,
+        intake_id=args.intake_id,
+    )
+    errors = validate_universal_signal_intake(intake)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, intake)
+    return 0
+
+
+def command_validate_signal_corpus(args: argparse.Namespace) -> int:
+    errors = validate_universal_signal_golden_corpus(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+def command_signal_coverage(args: argparse.Namespace) -> int:
+    corpus = load_json_like(args.corpus)
+    scorecard = build_factory_signal_coverage_scorecard(
+        corpus,
+        registry_ref=args.registry_ref,
+        corpus_ref=args.corpus_ref,
+    )
+    errors = validate_factory_signal_coverage_scorecard(scorecard)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, scorecard)
+    return 0 if scorecard["result"] == "PASS" else 1
+
+
+def command_validate_signal_coverage(args: argparse.Namespace) -> int:
+    errors = validate_factory_signal_coverage_scorecard(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_readiness_scorecard(args: argparse.Namespace) -> int:
     errors = validate_factory_readiness_scorecard(load_json_like(args.path))
     if errors:
@@ -10889,6 +11410,45 @@ def build_parser() -> argparse.ArgumentParser:
     validate_signal_intake_parser = sub.add_parser("validate-signal-intake")
     validate_signal_intake_parser.add_argument("path", type=Path)
     validate_signal_intake_parser.set_defaults(func=command_validate_signal_intake)
+
+    route_registry_parser = sub.add_parser("route-registry", help="Show the canonical Universal Signal route registry.")
+    route_registry_parser.add_argument("--registry", type=Path, default=DEFAULT_ROUTE_REGISTRY_PATH)
+    route_registry_parser.add_argument("--route-class")
+    route_registry_parser.add_argument("--out", type=Path)
+    route_registry_parser.set_defaults(func=command_route_registry)
+
+    intake_parser = sub.add_parser("intake", help="Build a valid Universal Signal Intake contract without executing work.")
+    intake_parser.add_argument("--route-class", required=True)
+    intake_parser.add_argument("--request-type", required=True)
+    intake_parser.add_argument("--signal-type", required=True)
+    intake_parser.add_argument("--summary", required=True)
+    intake_parser.add_argument("--source-ref", required=True)
+    intake_parser.add_argument("--target-surface", default="operator-supplied-target")
+    intake_parser.add_argument("--owner", default="factory-orchestrator")
+    intake_parser.add_argument("--source-class", default="operator_supplied")
+    intake_parser.add_argument("--sensitivity-class", default="public_safe")
+    intake_parser.add_argument("--freshness", default="bounded")
+    intake_parser.add_argument("--risk-initial", default="R2")
+    intake_parser.add_argument("--materiality", default="material")
+    intake_parser.add_argument("--created-at")
+    intake_parser.add_argument("--intake-id")
+    intake_parser.add_argument("--out", type=Path)
+    intake_parser.set_defaults(func=command_intake)
+
+    validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
+    validate_signal_corpus_parser.add_argument("path", type=Path)
+    validate_signal_corpus_parser.set_defaults(func=command_validate_signal_corpus)
+
+    signal_coverage_parser = sub.add_parser("signal-coverage", help="Build route/signal coverage scorecard from the golden corpus.")
+    signal_coverage_parser.add_argument("--corpus", type=Path, default=DEFAULT_SIGNAL_CORPUS_PATH)
+    signal_coverage_parser.add_argument("--registry-ref", default="templates/factory-route-registry.json")
+    signal_coverage_parser.add_argument("--corpus-ref", default="templates/universal-signal-golden-corpus.json")
+    signal_coverage_parser.add_argument("--out", type=Path, default=DEFAULT_SIGNAL_COVERAGE_OUT)
+    signal_coverage_parser.set_defaults(func=command_signal_coverage)
+
+    validate_signal_coverage_parser = sub.add_parser("validate-signal-coverage")
+    validate_signal_coverage_parser.add_argument("path", type=Path)
+    validate_signal_coverage_parser.set_defaults(func=command_validate_signal_coverage)
 
     validate_readiness_scorecard_parser = sub.add_parser("validate-readiness-scorecard")
     validate_readiness_scorecard_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -22,6 +22,13 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from public_refs import contains_private_kanban_task_marker  # noqa: E402
+from factory_route_registry import (  # noqa: E402
+    route_method_families,
+    route_request_types,
+    route_required_artifacts,
+    route_required_workers,
+    route_signal_types,
+)
 
 SCHEMA_DIR = ROOT / "schemas"
 PUBLIC_SCHEMA_DIRS = [
@@ -121,36 +128,23 @@ FACTORY_READINESS_SCORECARD_DIMENSIONS = {
     "product_analytics_success_signals",
     "autonomy_risk_human_gates",
 }
-UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS = {
-    "product_creation": {
-        "source_ledger",
-        "outcome_contract",
-        "product_sot",
-        "full_product_sot_scope_coverage",
-        "method_contract",
-        "product_creation_plan",
-        "product_implementation_readiness",
-        "sdlc_feedback_loop",
-    },
-    "feature_delivery": {"source_ledger", "outcome_contract", "method_contract", "spec_graph", "qa_plan"},
-    "bug_repair": {"source_ledger", "bug_reproduction", "diagnosis", "regression_check", "receipt_five"},
-    "incident_response": {"incident_support_plan", "severity_model", "mitigation_plan", "evidence_record", "learnback"},
-    "brownfield_discovery": {"source_ledger", "legacy_system_map", "baseline", "regression_plan", "rollback_plan"},
-    "release_promotion": {"production_readiness_plan", "promotion_ladder", "rollback_path", "monitoring_signals"},
-    "research_validation": {"specialist_research_plan", "specialist_decision_packet", "sdlc_feedback_loop"},
-    "docs_onboarding": {"user_docs_onboarding_plan", "reader_success_path", "docs_verification"},
-    "security_remediation": {"security_architecture_plan", "security_scan_packet", "review_result"},
-    "critical_integration": {"integration_contract", "dependency_gate", "contract_tests", "fallback_plan"},
-    "migration_execution": {"legacy_system_map", "migration_plan", "regression_plan", "rollback_plan"},
-    "ux_product_experience": {
-        "product_experience_plan",
-        "product_face_packet",
-        "professional_design_process",
-        "product_face_result",
-    },
-    "analytics_data": {"data_metrics_plan", "event_contract", "dashboard_health_proof", "privacy_limits"},
-    "agent_quality_change": {"agent_eval_plan", "reasoning_policy", "worker_profile_readiness", "learnback"},
-}
+UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS = route_required_artifacts()
+UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES = route_request_types()
+UNIVERSAL_SIGNAL_ROUTE_SIGNAL_TYPES = route_signal_types()
+UNIVERSAL_SIGNAL_ROUTE_METHOD_FAMILIES = route_method_families()
+
+
+def public_worker_ids() -> set[str]:
+    path = ROOT / "agents" / "worker-registry.public.json"
+    if not path.exists():
+        return set()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    workers = data.get("workers") if isinstance(data.get("workers"), list) else []
+    return {
+        str(worker.get("worker_id") or "").strip()
+        for worker in workers
+        if isinstance(worker, dict) and str(worker.get("worker_id") or "").strip()
+    }
 
 
 def public_artifact_ref_error(ref: Any) -> str | None:
@@ -839,12 +833,33 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
         if classification.get("can_start_execution") is not False:
             errors.append(f"{at}: universal_signal_intake classification cannot allow execution directly")
         route_class = str(classification.get("route_class") or "").strip()
+        request_type = str(classification.get("request_type") or "").strip()
+        signal_type = str(signal.get("signal_type") or "").strip()
+        allowed_request_types = UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES.get(route_class)
+        if allowed_request_types and request_type and request_type not in allowed_request_types:
+            errors.append(
+                f"{at}: universal_signal_intake.classification.request_type is not valid "
+                f"for route_class {route_class}: {request_type}"
+            )
+        allowed_signal_types = UNIVERSAL_SIGNAL_ROUTE_SIGNAL_TYPES.get(route_class)
+        if allowed_signal_types and signal_type and signal_type not in allowed_signal_types:
+            errors.append(
+                f"{at}: universal_signal_intake.signal.signal_type is not valid "
+                f"for route_class {route_class}: {signal_type}"
+            )
         normalization = data.get("normalization") if isinstance(data.get("normalization"), dict) else {}
         if normalization.get("source_resolution_required") is not True:
             errors.append(f"{at}: universal_signal_intake source_resolution_required must be true")
         if normalization.get("no_chat_only_state") is not True:
             errors.append(f"{at}: universal_signal_intake no_chat_only_state must be true")
         route = data.get("route_decision") if isinstance(data.get("route_decision"), dict) else {}
+        selected_method_family = str(route.get("selected_method_family") or "").strip()
+        expected_method_family = UNIVERSAL_SIGNAL_ROUTE_METHOD_FAMILIES.get(route_class)
+        if expected_method_family and selected_method_family and selected_method_family != expected_method_family:
+            errors.append(
+                f"{at}: universal_signal_intake.route_decision.selected_method_family "
+                f"must match route registry for {route_class}: {expected_method_family}"
+            )
         for field in ("method_contract_ref", "sdlc_feedback_loop_ref", "factory_workflow_phase_ref", "fallback_route"):
             route_ref = str(route.get(field) or "").strip()
             reason = public_artifact_ref_error(route_ref)
@@ -887,6 +902,28 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                         f"{at}.required_artifacts[{index}].blocks_execution_when_missing "
                         "must be true for required route artifact"
                     )
+            owner_worker = str(artifact.get("owner_worker") or "").strip()
+            if owner_worker and owner_worker not in public_worker_ids():
+                errors.append(f"{at}.required_artifacts[{index}].owner_worker must be a registered worker: {owner_worker}")
+        registry_required_workers = set(route_required_workers().get(route_class, []))
+        required_workers = data.get("required_workers") if isinstance(data.get("required_workers"), list) else []
+        intake_worker_ids = {
+            str(worker.get("worker_id") or "").strip()
+            for worker in required_workers
+            if isinstance(worker, dict)
+        }
+        missing_workers = sorted(registry_required_workers - intake_worker_ids)
+        if missing_workers:
+            errors.append(
+                f"{at}: universal_signal_intake {route_class} route missing required workers: "
+                + ", ".join(missing_workers)
+            )
+        for index, worker in enumerate(required_workers):
+            if not isinstance(worker, dict):
+                continue
+            worker_id = str(worker.get("worker_id") or "").strip()
+            if worker_id and worker_id not in public_worker_ids():
+                errors.append(f"{at}.required_workers[{index}].worker_id must be a registered worker: {worker_id}")
         handoff = data.get("handoff") if isinstance(data.get("handoff"), dict) else {}
         if handoff.get("factory_owned_next_step") is not True:
             errors.append(f"{at}: universal_signal_intake handoff.factory_owned_next_step must be true")

--- a/templates/brownfield-os-plan.json
+++ b/templates/brownfield-os-plan.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/brownfield-os-plan.schema.json",
+  "record_type": "brownfield_os_plan",
+  "plan_id": "brownfield-os-plan-v1",
+  "legacy_system_map": {
+    "system_refs": ["external:source-card-existing-system"],
+    "entrypoints": ["public CLI, API, UI or job entrypoints must be listed before mutation"],
+    "owned_boundaries": ["boundaries the operator explicitly owns or may change"],
+    "unknowns": ["runtime behavior not yet baselined remains blocked"]
+  },
+  "behavior_baseline": {
+    "baseline_command_refs": ["external:source-card-baseline-command"],
+    "known_good_behaviors": ["existing behavior that must survive migration or refactor"],
+    "current_failures": []
+  },
+  "compatibility_matrix": [
+    {
+      "surface": "public contract",
+      "compatibility_rule": "Existing public behavior must remain compatible unless a human-gated SOT rebaseline approves change.",
+      "breakage_detection": "Regression plan must include a command, contract test or review that detects breakage."
+    }
+  ],
+  "regression_plan": {
+    "must_preserve": ["public behavior, data shape, auth boundary and documented workflows"],
+    "test_refs": ["external:source-card-regression-plan"],
+    "review_owner": "qa-verification-worker"
+  },
+  "rollback_cutover_plan": {
+    "rollback_trigger": "Any baseline, compatibility, data or public-safety regression blocks cutover.",
+    "rollback_command_or_plan_ref": "templates/legacy-migration-plan.json#rollback_plan",
+    "cutover_gate": "Brownfield rollback and regression gate"
+  },
+  "data_risk_map": {
+    "data_touched": false,
+    "migration_required": false,
+    "backup_or_restore_ref": "external:source-card-backup-or-not-applicable"
+  },
+  "ownership": {
+    "route_owner": "product-architect",
+    "regression_owner": "qa-verification-worker",
+    "rollback_owner": "release-ops-worker"
+  },
+  "acceptance_boundary": {
+    "execution_blocked_without_baseline": true,
+    "completion_blocked_without_regression": true,
+    "promotion_blocked_without_rollback": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  }
+}

--- a/templates/factory-route-registry.json
+++ b/templates/factory-route-registry.json
@@ -1,0 +1,392 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-route-registry.schema.json",
+  "record_type": "factory_route_registry",
+  "registry_id": "factory-route-registry-v1",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "routes": [
+    {
+      "route_class": "product_creation",
+      "request_types": ["product_new"],
+      "signal_types": ["product_paper", "prd_or_architecture", "mixed"],
+      "scope_intents": ["full_product"],
+      "selected_method_family": "spec_first",
+      "required_artifacts": [
+        "source_ledger",
+        "outcome_contract",
+        "product_sot",
+        "full_product_sot_scope_coverage",
+        "method_contract",
+        "product_creation_plan",
+        "product_implementation_readiness",
+        "sdlc_feedback_loop"
+      ],
+      "required_gates": ["Source Gate", "Product SOT Gate", "Ready Gate"],
+      "required_workers": ["factory-orchestrator", "source-ledger-worker", "product-sot-planner"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "required artifacts and gates pass or a human authority gate blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "feature_delivery",
+      "request_types": ["feature", "slice"],
+      "signal_types": ["feature_idea", "customer_feedback", "mixed"],
+      "scope_intents": ["child_slice"],
+      "selected_method_family": "behavior_first",
+      "required_artifacts": ["source_ledger", "outcome_contract", "method_contract", "spec_graph", "qa_plan"],
+      "required_gates": ["Source Gate", "Method Gate", "Ready Gate"],
+      "required_workers": ["factory-orchestrator", "decomposition-planner", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "feature acceptance criteria and regression proof pass or a human authority gate blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "bug_repair",
+      "request_types": ["bug"],
+      "signal_types": ["bug_report", "monitoring_alert", "customer_feedback"],
+      "scope_intents": ["bug"],
+      "selected_method_family": "test_first",
+      "required_artifacts": ["source_ledger", "bug_reproduction", "diagnosis", "regression_check", "receipt_five"],
+      "required_gates": ["Reproduction Gate", "Regression Gate", "Receipt Gate"],
+      "required_workers": ["qa-verification-worker", "test-automation-builder", "evidence-reconciler"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "bug reproduction and regression check pass or a human authority gate blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "incident_response",
+      "request_types": ["incident"],
+      "signal_types": ["incident", "monitoring_alert"],
+      "scope_intents": ["incident"],
+      "selected_method_family": "incident_first",
+      "required_artifacts": ["incident_support_plan", "severity_model", "mitigation_plan", "evidence_record", "learnback"],
+      "required_gates": ["Severity Gate", "Mitigation Gate", "Learnback Gate"],
+      "required_workers": ["detection-monitoring-worker", "release-ops-worker", "evidence-reconciler"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "mitigation, evidence and learnback are complete or a human incident owner blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "brownfield_discovery",
+      "request_types": ["migration", "refactor", "integration"],
+      "signal_types": ["existing_repository", "refactor_request", "integration_request", "migration_request"],
+      "scope_intents": ["migration", "integration"],
+      "selected_method_family": "legacy_diagnosis",
+      "required_artifacts": ["source_ledger", "brownfield_os_plan", "legacy_system_map", "baseline", "regression_plan", "rollback_plan"],
+      "required_gates": ["Brownfield Baseline Gate", "Regression Gate", "Rollback Gate"],
+      "required_workers": ["source-ledger-worker", "product-architect", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "baseline, regression and rollback proof exist or a human owner blocks legacy mutation",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "release_promotion",
+      "request_types": ["release"],
+      "signal_types": ["release_request"],
+      "scope_intents": ["release"],
+      "selected_method_family": "spec_first",
+      "required_artifacts": ["production_readiness_plan", "promotion_ladder", "rollback_path", "monitoring_signals"],
+      "required_gates": ["Production Readiness Gate", "Rollback Gate", "Release Gate"],
+      "required_workers": ["release-ops-worker", "detection-monitoring-worker", "evidence-reconciler"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "promotion evidence is green or a human release authority blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "research_validation",
+      "request_types": ["feature", "product_new", "security", "ux_ui", "data_analytics", "agent_skill"],
+      "signal_types": ["research_request", "external_research_signal", "dependency_or_runtime_change", "mixed"],
+      "scope_intents": ["child_slice", "full_product"],
+      "selected_method_family": "research_first",
+      "required_artifacts": ["specialist_research_plan", "specialist_decision_packet", "sdlc_feedback_loop"],
+      "required_gates": ["Source Quality Gate", "Specialist Decision Gate", "SOT Impact Gate"],
+      "required_workers": ["source-ledger-worker", "product-architect", "factory-orchestrator"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "claim ledger is resolved into SOT, gate or proof impact or a human decision blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "docs_onboarding",
+      "request_types": ["doc"],
+      "signal_types": ["documentation_request"],
+      "scope_intents": ["doc"],
+      "selected_method_family": "docs_first",
+      "required_artifacts": ["user_docs_onboarding_plan", "reader_success_path", "docs_verification"],
+      "required_gates": ["Docs Utility Gate", "First Run Gate"],
+      "required_workers": ["docs-os-worker", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "reader success path validates or a human docs owner blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "security_remediation",
+      "request_types": ["security"],
+      "signal_types": ["security_review_request", "dependency_or_runtime_change"],
+      "scope_intents": ["child_slice"],
+      "selected_method_family": "security_first",
+      "required_artifacts": ["security_architecture_plan", "security_scan_packet", "review_result"],
+      "required_gates": ["Security Architecture Gate", "Security Review Gate"],
+      "required_workers": ["security-orchestrator", "appsec-owasp-specialist", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "security findings are fixed or accepted by explicit human risk owner",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "critical_integration",
+      "request_types": ["integration"],
+      "signal_types": ["integration_request", "dependency_or_runtime_change"],
+      "scope_intents": ["integration"],
+      "selected_method_family": "spec_first",
+      "required_artifacts": ["integration_contract", "dependency_gate", "contract_tests", "fallback_plan"],
+      "required_gates": ["Dependency Gate", "Contract Test Gate", "Fallback Gate"],
+      "required_workers": ["product-architect", "backend-api-builder", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "contract tests and fallback plan pass or a human integration owner blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "migration_execution",
+      "request_types": ["migration"],
+      "signal_types": ["migration_request", "existing_repository"],
+      "scope_intents": ["migration"],
+      "selected_method_family": "legacy_diagnosis",
+      "required_artifacts": ["brownfield_os_plan", "legacy_system_map", "migration_plan", "regression_plan", "rollback_plan"],
+      "required_gates": ["Migration Plan Gate", "Regression Gate", "Rollback Gate"],
+      "required_workers": ["product-architect", "data-persistence-builder", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "migration tests and rollback proof pass or a human migration owner blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "ux_product_experience",
+      "request_types": ["ux_ui", "product_new", "feature"],
+      "signal_types": ["ux_ui_request", "feature_idea", "product_paper"],
+      "scope_intents": ["child_slice", "full_product"],
+      "selected_method_family": "design_first",
+      "required_artifacts": ["product_experience_plan", "product_face_packet", "professional_design_process", "product_face_result"],
+      "required_gates": ["Product Experience Gate", "Product Face Gate", "Independent Design Review Gate"],
+      "required_workers": ["product-face", "frontend-builder", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "Product Face evidence passes across required states and journeys or a human product authority blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "analytics_data",
+      "request_types": ["data_analytics", "product_new", "feature"],
+      "signal_types": ["analytics_request", "customer_feedback", "prd_or_architecture"],
+      "scope_intents": ["child_slice", "full_product"],
+      "selected_method_family": "analytics_first",
+      "required_artifacts": ["data_metrics_plan", "event_contract", "dashboard_health_proof", "privacy_limits"],
+      "required_gates": ["Data Contract Gate", "Privacy Gate", "Metrics Proof Gate"],
+      "required_workers": ["detection-monitoring-worker", "data-persistence-builder", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "data contracts, privacy limits and health proof pass or a human data owner blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    },
+    {
+      "route_class": "agent_quality_change",
+      "request_types": ["agent_skill"],
+      "signal_types": ["agent_skill_or_model_change", "dependency_or_runtime_change"],
+      "scope_intents": ["child_slice"],
+      "selected_method_family": "agent_eval_first",
+      "required_artifacts": ["agent_eval_plan", "reasoning_policy", "worker_profile_readiness", "learnback"],
+      "required_gates": ["Agent Eval Gate", "Worker Profile Readiness Gate", "Learnback Gate"],
+      "required_workers": ["skill-eval-distiller", "agent-runtime-builder", "qa-verification-worker"],
+      "quality_profile_refs": ["templates/product-delivery-quality-profile.json"],
+      "recovery_policy": {
+        "non_human_block_recovery_required": true,
+        "factory_owned_repair_allowed": true,
+        "max_attempts_minimum": 1,
+        "until": "agent eval, worker readiness and learnback pass or a human method owner blocks",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": false
+      },
+      "hermes_boundary": {
+        "runtime_authority": "hermes_kanban",
+        "uses_native_kanban_primitives": true,
+        "local_state_authority": false,
+        "factory_may_project_status": true,
+        "factory_may_create_tasks_only_through_adapter": true
+      }
+    }
+  ],
+  "coverage_policy": {
+    "golden_corpus_required": true,
+    "all_routes_require_signal_case": true,
+    "all_routes_require_recovery_policy": true,
+    "all_routes_require_hermes_boundary": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  }
+}

--- a/templates/product-quality-pack.json
+++ b/templates/product-quality-pack.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/product-quality-pack.schema.json",
+  "record_type": "product_quality_pack",
+  "pack_id": "product-quality-pack-v1",
+  "delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
+  "reference_quality_packet_ref": "templates/reference-quality-packet.json",
+  "surface_evidence_profiles": [
+    "web_visual_ui",
+    "native_mobile",
+    "desktop_app",
+    "browser_extension",
+    "design_system_component",
+    "game_playable",
+    "cli_tui",
+    "docs_onboarding",
+    "agentic_interface",
+    "api_data_product"
+  ],
+  "required_quality_gates": [
+    {
+      "gate_id": "product-experience-gate",
+      "owner_worker": "product-face",
+      "blocks_completion_when_missing": true
+    },
+    {
+      "gate_id": "reference-quality-gate",
+      "owner_worker": "product-face",
+      "blocks_completion_when_missing": true
+    },
+    {
+      "gate_id": "independent-quality-review-gate",
+      "owner_worker": "qa-verification-worker",
+      "blocks_completion_when_missing": true
+    }
+  ],
+  "domain_proofs": [
+    {
+      "proof_id": "web.visual-state-journey-proof",
+      "surface_evidence_profile": "web_visual_ui",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "mobile.device-lifecycle-proof",
+      "surface_evidence_profile": "native_mobile",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "desktop.packaging-update-proof",
+      "surface_evidence_profile": "desktop_app",
+      "required_before": "promotion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "extension.permission-store-proof",
+      "surface_evidence_profile": "browser_extension",
+      "required_before": "promotion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "design-system.variant-contract-proof",
+      "surface_evidence_profile": "design_system_component",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "game.playable-loop-proof",
+      "surface_evidence_profile": "game_playable",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "cli.transcript-error-proof",
+      "surface_evidence_profile": "cli_tui",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "docs.first-run-proof",
+      "surface_evidence_profile": "docs_onboarding",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "agentic.user-control-proof",
+      "surface_evidence_profile": "agentic_interface",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    },
+    {
+      "proof_id": "api.contract-data-proof",
+      "surface_evidence_profile": "api_data_product",
+      "required_before": "completion",
+      "cannot_be_waived_for_full_acceptance": true
+    }
+  ],
+  "waiver_policy": {
+    "waivers_allowed": true,
+    "human_owner_required": true,
+    "cannot_claim_full_product_acceptance_with_waiver": true
+  },
+  "acceptance_boundary": {
+    "full_acceptance_requires_all_applicable_domain_proofs": true,
+    "product_face_result_is_required_for_visible_surfaces": true,
+    "design_reference_comparison_required": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  }
+}

--- a/templates/specialist-decision-packet.json
+++ b/templates/specialist-decision-packet.json
@@ -10,6 +10,9 @@
       "classification": "accepted_decision",
       "statement": "This claim is accepted only for the scope stated in the Product SOT.",
       "status": "accepted",
+      "evidence_strength": "bounded",
+      "freshness_status": "bounded",
+      "contradiction_state": "none",
       "evidence_refs": ["templates/reference-source-registry.json"]
     }
   ],
@@ -21,8 +24,18 @@
     "gates": ["add any required gate or worker"],
     "proof": ["add specific tests, audits, benchmarks or promotion checks"]
   },
+  "decision_closure": {
+    "terminal_state": "accepted_decision",
+    "method_or_architecture_may_proceed": true,
+    "blocked_next_action": "No blocker remains in this template decision; replace with product-specific blocker when evidence is not decisive."
+  },
   "unresolved_risk": [],
   "human_decisions_required": [],
   "public_safety_policy": "Store the decision and refs, not raw research material.",
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  },
   "evidence_refs": ["templates/specialist-research-plan.json"]
 }

--- a/templates/specialist-research-plan.json
+++ b/templates/specialist-research-plan.json
@@ -12,11 +12,40 @@
   "forbidden_sources": ["raw private notes", "private links", "screenshots with private data", "copyrighted source dumps"],
   "source_quality_bar": "Use traceable primary or official sources before relying on summaries or generic search output.",
   "freshness_requirement": "Refresh whenever the source, dependency, standard or product SOT materially changes.",
+  "freshness_policy": {
+    "freshness_required": true,
+    "stale_source_blocks_decision": true,
+    "refresh_trigger": "Refresh when source material, dependency versions, standards or the Product SOT changes."
+  },
+  "source_evidence_matrix": [
+    {
+      "source_ref": "templates/reference-source-registry.json",
+      "source_type": "operator_approved_benchmark",
+      "freshness_status": "bounded",
+      "use_allowed": true,
+      "claims_informed": ["specialist decision impact", "proof requirement"]
+    }
+  ],
+  "contradiction_policy": {
+    "conflicts_block_decision": true,
+    "owner": "source-ledger-worker",
+    "required_resolution": "Conflicting claims must be accepted, rejected, deferred with owner or escalated to a human decision before architecture or decomposition."
+  },
   "copy_license_policy": "Do not copy source material unless license and allowed use are recorded in a reference packet.",
   "expected_output_type": ["specialist_decision_packet", "SOT impact", "gate impact", "proof requirement"],
+  "decision_closure": {
+    "must_end_as": ["accepted_decision", "blocker", "deferred_with_owner", "human_decision_request", "explicit_rejection"],
+    "architecture_or_decomposition_blocked_until_decision": true,
+    "decision_packet_required": true
+  },
   "stop_rule": "Stop when the decision can be made, explicitly blocked, deferred with owner, or escalated for human decision.",
   "risk_if_skipped": "The factory may build a persuasive but unsupported plan that cannot prove the Product SOT.",
   "public_safety_policy": "Publish only structured decisions and public-safe refs; keep raw notes and private captures outside the repo.",
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  },
   "reference_quality_packet_refs": ["templates/reference-quality-packet.json"],
   "evidence_refs": ["source-ledger.md"]
 }

--- a/templates/universal-signal-golden-corpus.json
+++ b/templates/universal-signal-golden-corpus.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/universal-signal-golden-corpus.schema.json",
+  "record_type": "universal_signal_golden_corpus",
+  "corpus_id": "universal-signal-golden-corpus-v1",
+  "registry_ref": "templates/factory-route-registry.json",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "cases": [
+    {
+      "case_id": "product-paper-to-product-creation",
+      "signal_type": "product_paper",
+      "request_type": "product_new",
+      "route_class": "product_creation",
+      "expected_method_family": "spec_first",
+      "expected_required_artifact_types": ["source_ledger", "outcome_contract", "product_sot", "full_product_sot_scope_coverage", "method_contract", "product_creation_plan", "product_implementation_readiness", "sdlc_feedback_loop"],
+      "expected_required_worker_ids": ["factory-orchestrator", "source-ledger-worker", "product-sot-planner"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "feature-idea-to-feature-delivery",
+      "signal_type": "feature_idea",
+      "request_type": "feature",
+      "route_class": "feature_delivery",
+      "expected_method_family": "behavior_first",
+      "expected_required_artifact_types": ["source_ledger", "outcome_contract", "method_contract", "spec_graph", "qa_plan"],
+      "expected_required_worker_ids": ["factory-orchestrator", "decomposition-planner", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "bug-report-to-bug-repair",
+      "signal_type": "bug_report",
+      "request_type": "bug",
+      "route_class": "bug_repair",
+      "expected_method_family": "test_first",
+      "expected_required_artifact_types": ["source_ledger", "bug_reproduction", "diagnosis", "regression_check", "receipt_five"],
+      "expected_required_worker_ids": ["qa-verification-worker", "test-automation-builder", "evidence-reconciler"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "incident-to-incident-response",
+      "signal_type": "incident",
+      "request_type": "incident",
+      "route_class": "incident_response",
+      "expected_method_family": "incident_first",
+      "expected_required_artifact_types": ["incident_support_plan", "severity_model", "mitigation_plan", "evidence_record", "learnback"],
+      "expected_required_worker_ids": ["detection-monitoring-worker", "release-ops-worker", "evidence-reconciler"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "existing-repository-to-brownfield-discovery",
+      "signal_type": "existing_repository",
+      "request_type": "refactor",
+      "route_class": "brownfield_discovery",
+      "expected_method_family": "legacy_diagnosis",
+      "expected_required_artifact_types": ["source_ledger", "brownfield_os_plan", "legacy_system_map", "baseline", "regression_plan", "rollback_plan"],
+      "expected_required_worker_ids": ["source-ledger-worker", "product-architect", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "release-request-to-release-promotion",
+      "signal_type": "release_request",
+      "request_type": "release",
+      "route_class": "release_promotion",
+      "expected_method_family": "spec_first",
+      "expected_required_artifact_types": ["production_readiness_plan", "promotion_ladder", "rollback_path", "monitoring_signals"],
+      "expected_required_worker_ids": ["release-ops-worker", "detection-monitoring-worker", "evidence-reconciler"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "research-request-to-research-validation",
+      "signal_type": "research_request",
+      "request_type": "feature",
+      "route_class": "research_validation",
+      "expected_method_family": "research_first",
+      "expected_required_artifact_types": ["specialist_research_plan", "specialist_decision_packet", "sdlc_feedback_loop"],
+      "expected_required_worker_ids": ["source-ledger-worker", "product-architect", "factory-orchestrator"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "documentation-request-to-docs-onboarding",
+      "signal_type": "documentation_request",
+      "request_type": "doc",
+      "route_class": "docs_onboarding",
+      "expected_method_family": "docs_first",
+      "expected_required_artifact_types": ["user_docs_onboarding_plan", "reader_success_path", "docs_verification"],
+      "expected_required_worker_ids": ["docs-os-worker", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "security-review-to-security-remediation",
+      "signal_type": "security_review_request",
+      "request_type": "security",
+      "route_class": "security_remediation",
+      "expected_method_family": "security_first",
+      "expected_required_artifact_types": ["security_architecture_plan", "security_scan_packet", "review_result"],
+      "expected_required_worker_ids": ["security-orchestrator", "appsec-owasp-specialist", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "integration-request-to-critical-integration",
+      "signal_type": "integration_request",
+      "request_type": "integration",
+      "route_class": "critical_integration",
+      "expected_method_family": "spec_first",
+      "expected_required_artifact_types": ["integration_contract", "dependency_gate", "contract_tests", "fallback_plan"],
+      "expected_required_worker_ids": ["product-architect", "backend-api-builder", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "migration-request-to-migration-execution",
+      "signal_type": "migration_request",
+      "request_type": "migration",
+      "route_class": "migration_execution",
+      "expected_method_family": "legacy_diagnosis",
+      "expected_required_artifact_types": ["brownfield_os_plan", "legacy_system_map", "migration_plan", "regression_plan", "rollback_plan"],
+      "expected_required_worker_ids": ["product-architect", "data-persistence-builder", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "ux-request-to-product-experience",
+      "signal_type": "ux_ui_request",
+      "request_type": "ux_ui",
+      "route_class": "ux_product_experience",
+      "expected_method_family": "design_first",
+      "expected_required_artifact_types": ["product_experience_plan", "product_face_packet", "professional_design_process", "product_face_result"],
+      "expected_required_worker_ids": ["product-face", "frontend-builder", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "analytics-request-to-analytics-data",
+      "signal_type": "analytics_request",
+      "request_type": "data_analytics",
+      "route_class": "analytics_data",
+      "expected_method_family": "analytics_first",
+      "expected_required_artifact_types": ["data_metrics_plan", "event_contract", "dashboard_health_proof", "privacy_limits"],
+      "expected_required_worker_ids": ["detection-monitoring-worker", "data-persistence-builder", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    },
+    {
+      "case_id": "agent-change-to-agent-quality-change",
+      "signal_type": "agent_skill_or_model_change",
+      "request_type": "agent_skill",
+      "route_class": "agent_quality_change",
+      "expected_method_family": "agent_eval_first",
+      "expected_required_artifact_types": ["agent_eval_plan", "reasoning_policy", "worker_profile_readiness", "learnback"],
+      "expected_required_worker_ids": ["skill-eval-distiller", "agent-runtime-builder", "qa-verification-worker"],
+      "expected_recovery_policy": {"non_human_block_recovery_required": true, "factory_owned_repair_allowed": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "expected_hermes_boundary": {"uses_native_kanban_primitives": true, "runtime_authority": "hermes_kanban", "local_state_authority": false},
+      "acceptance": {"route_known": true, "execution_blocked_until_gates_pass": true, "operator_not_required_to_coordinate_internal_repair": true}
+    }
+  ],
+  "coverage_policy": {
+    "must_cover_every_route_class": true,
+    "must_cover_recovery_invariant": true,
+    "must_cover_hermes_boundary": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  }
+}

--- a/tests/test_capability_packs.py
+++ b/tests/test_capability_packs.py
@@ -63,6 +63,28 @@ def activated_game_contract() -> dict:
 
 
 class CapabilityPacksTest(unittest.TestCase):
+    def test_product_quality_pack_template_validates(self) -> None:
+        schemas = factoryctl.bundled_schemas()
+        schema = schemas["product-quality-pack.schema.json"]
+        pack = json.loads((ROOT / "templates" / "product-quality-pack.json").read_text(encoding="utf-8"))
+
+        errors = factoryctl.validate_node(schema, pack, "product_quality_pack", schemas=schemas, root_schema=schema)
+
+        self.assertEqual(errors, [])
+        self.assertIn("native_mobile", pack["surface_evidence_profiles"])
+        self.assertIn("game_playable", pack["surface_evidence_profiles"])
+
+    def test_product_face_packet_accepts_non_web_surface_evidence_profiles(self) -> None:
+        schemas = factoryctl.bundled_schemas()
+        schema = schemas["product-face-packet.schema.json"]
+        packet = json.loads((ROOT / "templates" / "product-face-packet.json").read_text(encoding="utf-8"))
+        packet["surface_evidence_profile"] = "native_mobile"
+        packet["surface_evidence_profiles"] = ["native_mobile", "desktop_app", "browser_extension", "game_playable"]
+
+        errors = factoryctl.validate_node(schema, packet, "product_face_packet", schemas=schemas, root_schema=schema)
+
+        self.assertEqual(errors, [])
+
     def test_capability_pack_registry_contains_modular_product_domains(self) -> None:
         packs = json.loads((ROOT / "agents" / "capability-packs.public.json").read_text(encoding="utf-8"))["packs"]
 

--- a/tests/test_factory_route_registry.py
+++ b/tests/test_factory_route_registry.py
@@ -1,0 +1,202 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
+FACTORYCTL_SPEC = importlib.util.spec_from_file_location("factoryctl_route_registry", FACTORYCTL_PATH)
+assert FACTORYCTL_SPEC is not None
+factoryctl = importlib.util.module_from_spec(FACTORYCTL_SPEC)
+assert FACTORYCTL_SPEC.loader is not None
+sys.modules["factoryctl_route_registry"] = factoryctl
+FACTORYCTL_SPEC.loader.exec_module(factoryctl)
+
+import factory_route_registry as route_registry_module  # noqa: E402
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts_routes", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts_routes"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+ROUTE_REGISTRY_PATH = ROOT / "templates" / "factory-route-registry.json"
+GOLDEN_CORPUS_PATH = ROOT / "templates" / "universal-signal-golden-corpus.json"
+
+
+def route_registry() -> dict:
+    return json.loads(ROUTE_REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def golden_corpus() -> dict:
+    return json.loads(GOLDEN_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+class FactoryRouteRegistryTest(unittest.TestCase):
+    def test_route_registry_template_validates_against_schema(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        schema = schemas["factory-route-registry.schema.json"]
+
+        errors = public_json_validator.validate_node(schema, route_registry(), "$", schemas=schemas, root_schema=schema)
+
+        self.assertEqual(errors, [])
+
+    def test_route_registry_loader_finds_installed_data_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_root = Path(tmpdir)
+            installed_data = temp_root / "install-root"
+            installed_registry = installed_data / "share" / "overkill-factory" / "templates" / "factory-route-registry.json"
+            installed_registry.parent.mkdir(parents=True)
+            installed_registry.write_text(ROUTE_REGISTRY_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+            with mock.patch.object(route_registry_module, "DEFAULT_ROUTE_REGISTRY_PATH", temp_root / "missing.json"):
+                with mock.patch.object(route_registry_module, "ROOT", temp_root / "site-packages"):
+                    with mock.patch.object(route_registry_module.sysconfig, "get_path", return_value=str(installed_data)):
+                        loaded = route_registry_module.load_route_registry()
+
+        self.assertEqual(loaded["record_type"], "factory_route_registry")
+        self.assertEqual(
+            {route["route_class"] for route in loaded["routes"]},
+            {route["route_class"] for route in route_registry()["routes"]},
+        )
+
+    def test_route_registry_is_single_source_for_factoryctl_and_public_validator(self) -> None:
+        expected_artifacts = factoryctl.route_required_artifacts()
+        expected_request_types = factoryctl.route_request_types()
+
+        self.assertEqual(factoryctl.UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS, expected_artifacts)
+        self.assertEqual(public_json_validator.UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS, expected_artifacts)
+        self.assertEqual(factoryctl.UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES, expected_request_types)
+        self.assertEqual(public_json_validator.UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES, expected_request_types)
+
+    def test_route_classes_match_universal_signal_intake_schema(self) -> None:
+        schemas = public_json_validator.load_schemas()
+        intake_schema = schemas["universal-signal-intake.schema.json"]
+        route_enum = set(intake_schema["properties"]["classification"]["properties"]["route_class"]["enum"])
+        registry_route_classes = {route["route_class"] for route in route_registry()["routes"]}
+
+        self.assertEqual(registry_route_classes, route_enum)
+
+    def test_registry_workers_exist_in_public_worker_registry(self) -> None:
+        worker_registry = json.loads((ROOT / "agents" / "worker-registry.public.json").read_text(encoding="utf-8"))
+        worker_ids = {worker["worker_id"] for worker in worker_registry["workers"]}
+
+        missing = sorted(
+            worker_id
+            for route in route_registry()["routes"]
+            for worker_id in route["required_workers"]
+            if worker_id not in worker_ids
+        )
+
+        self.assertEqual(missing, [])
+
+    def test_all_routes_keep_hermes_as_runtime_authority(self) -> None:
+        for route in route_registry()["routes"]:
+            with self.subTest(route_class=route["route_class"]):
+                self.assertEqual(route["hermes_boundary"]["runtime_authority"], "hermes_kanban")
+                self.assertTrue(route["hermes_boundary"]["uses_native_kanban_primitives"])
+                self.assertFalse(route["hermes_boundary"]["local_state_authority"])
+                self.assertEqual(route["recovery_policy"]["runtime_authority"], "hermes_kanban")
+                self.assertFalse(route["recovery_policy"]["local_state_authority"])
+
+    def test_signal_intake_rejects_route_registry_mismatch(self) -> None:
+        intake = json.loads((ROOT / "templates" / "universal-signal-intake.json").read_text(encoding="utf-8"))
+        intake["signal"]["signal_type"] = "bug_report"
+        intake["route_decision"]["selected_method_family"] = "test_first"
+        intake["required_workers"] = []
+
+        errors = factoryctl.validate_universal_signal_intake(intake)
+
+        self.assertIn(
+            "universal_signal_intake.signal.signal_type is not valid for route_class product_creation: bug_report",
+            errors,
+        )
+        self.assertIn(
+            "universal_signal_intake.route_decision.selected_method_family must match route registry for product_creation: spec_first",
+            errors,
+        )
+        self.assertTrue(any("product_creation route missing required workers" in error for error in errors), errors)
+
+    def test_route_registry_cli_outputs_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "route.json"
+
+            result = factoryctl.main_with_args_for_test(["route-registry", "--route-class", "bug_repair", "--out", str(out)])
+            route = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(route["route_class"], "bug_repair")
+
+    def test_intake_cli_generates_valid_signal_intake(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "bug-intake.json"
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "intake",
+                    "--route-class",
+                    "bug_repair",
+                    "--request-type",
+                    "bug",
+                    "--signal-type",
+                    "bug_report",
+                    "--summary",
+                    "Public-safe bug report must enter the factory through reproduction and regression gates.",
+                    "--source-ref",
+                    "external:source-card-bug-report-001",
+                    "--target-surface",
+                    "existing-product",
+                    "--created-at",
+                    "2026-06-17T00:00:00+00:00",
+                    "--out",
+                    str(out),
+                ]
+            )
+
+            generated = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(factoryctl.validate_universal_signal_intake(generated), [])
+        self.assertEqual(generated["classification"]["route_class"], "bug_repair")
+        self.assertFalse(generated["acceptance"]["execution_allowed"])
+
+    def test_golden_corpus_validates_and_covers_all_routes(self) -> None:
+        errors = factoryctl.validate_universal_signal_golden_corpus(golden_corpus())
+        scorecard = factoryctl.build_factory_signal_coverage_scorecard(golden_corpus())
+
+        self.assertEqual(errors, [])
+        self.assertEqual(scorecard["result"], "PASS")
+        self.assertEqual(scorecard["route_count"], scorecard["covered_route_count"])
+        self.assertEqual(scorecard["missing_route_classes"], [])
+        self.assertEqual(factoryctl.validate_factory_signal_coverage_scorecard(scorecard), [])
+
+    def test_golden_corpus_rejects_missing_recovery_invariant(self) -> None:
+        corpus = golden_corpus()
+        corpus["cases"][0]["expected_recovery_policy"]["factory_owned_repair_allowed"] = False
+
+        errors = factoryctl.validate_universal_signal_golden_corpus(corpus)
+        scorecard = factoryctl.build_factory_signal_coverage_scorecard(corpus)
+
+        self.assertTrue(any("recovery invariant must be factory-owned" in error for error in errors), errors)
+        self.assertEqual(scorecard["result"], "BLOCKED")
+
+    def test_signal_coverage_cli_writes_pass_scorecard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "signal-coverage.json"
+
+            result = factoryctl.main_with_args_for_test(["signal-coverage", "--out", str(out)])
+            scorecard = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(scorecard["result"], "PASS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -234,6 +234,46 @@ def assert_live_adapter_result_schema(testcase: unittest.TestCase, result: dict[
 
 
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
+    def test_materialize_schema_requires_recovery_and_idempotency_fields_for_real_run(self) -> None:
+        schema = json.loads((ROOT / "schemas" / "hermes-live-adapter-result.schema.json").read_text(encoding="utf-8"))
+        result = {
+            "$schema": "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json",
+            "mode": "materialize",
+            "dry_run": False,
+            "board": TEST_BOARD,
+            "hook": {},
+            "idempotency_contract": {
+                "digest_algorithm": "sha256",
+                "canonicalization_version": "v1",
+                "volatile_fields_ignored": ["created_at"],
+                "digest_scope": "main_card_body_and_stable_worker_packet_contract",
+                "lineage_policy": "base_identity_is_logical_lineage_contract_key_is_runtime_identity",
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "main_task": {
+                    "idempotency_identity": {
+                        "card_id": "CARD-001",
+                        "task_role": "main",
+                        "base_idempotency_key": "overkill:CARD-001:main",
+                    },
+                    "contract_digest": "a" * 64,
+                    "idempotency_key": "overkill:CARD-001:main:aaaaaaaaaaaaaaaa",
+                    "runtime_history_query_keys": ["overkill:CARD-001:main", "CARD-001"],
+                    "previous_runtime_task_refs": [],
+                    "supersedes_idempotency_keys": [],
+                },
+                "worker_tasks": {},
+            },
+        }
+
+        errors = validator.validate_node(schema, result, "$", schemas={"hermes-live-adapter-result.schema.json": schema}, root_schema=schema)
+
+        self.assertIn("$.allOf[0]: missing required field main_task_id", errors)
+        self.assertIn("$.allOf[0]: missing required field worker_task_ids", errors)
+        self.assertIn("$.allOf[0]: missing required field recovery_promoted_worker_task_ids", errors)
+        self.assertIn("$.allOf[0]: missing required field recovery_retry_blocked_worker_task_ids", errors)
+        self.assertIn("$.allOf[0]: missing required field recovery_attempts", errors)
+
     def test_worker_idempotency_key_is_contract_bound_and_ignores_volatile_metadata(self) -> None:
         task_contract = {
             "worker_id": "codex-security",

--- a/tests/test_product_method_sot_planning.py
+++ b/tests/test_product_method_sot_planning.py
@@ -183,6 +183,55 @@ class ProductMethodSotPlanningTest(unittest.TestCase):
             errors,
         )
 
+    def test_specialist_research_templates_validate_as_decision_os(self) -> None:
+        schemas = factoryctl.bundled_schemas()
+        research_schema = schemas["specialist-research-plan.schema.json"]
+        decision_schema = schemas["specialist-decision-packet.schema.json"]
+        research_plan = factoryctl.load_json_like(ROOT / "templates" / "specialist-research-plan.json")
+        decision_packet = factoryctl.load_json_like(ROOT / "templates" / "specialist-decision-packet.json")
+
+        research_errors = factoryctl.validate_node(
+            research_schema,
+            research_plan,
+            "specialist_research_plan",
+            schemas=schemas,
+            root_schema=research_schema,
+        )
+        decision_errors = factoryctl.validate_node(
+            decision_schema,
+            decision_packet,
+            "specialist_decision_packet",
+            schemas=schemas,
+            root_schema=decision_schema,
+        )
+
+        self.assertEqual(research_errors, [])
+        self.assertEqual(decision_errors, [])
+        self.assertTrue(research_plan["decision_closure"]["architecture_or_decomposition_blocked_until_decision"])
+
+    def test_specialist_decision_closure_blocks_method_when_research_is_blocked(self) -> None:
+        card = self.vfinal_card()
+        card["specialist_decision_packet"] = factoryctl.load_json_like(ROOT / "templates" / "specialist-decision-packet.json")
+        card["specialist_decision_packet"]["decision_closure"]["terminal_state"] = "blocker"
+        card["specialist_decision_packet"]["decision_closure"]["method_or_architecture_may_proceed"] = True
+
+        errors = factoryctl.validate_card(card)
+
+        self.assertIn(
+            "specialist_decision_packet.decision_closure cannot allow method or architecture to proceed while research is blocked, deferred or human-gated",
+            errors,
+        )
+
+    def test_brownfield_os_plan_template_validates(self) -> None:
+        schemas = factoryctl.bundled_schemas()
+        schema = schemas["brownfield-os-plan.schema.json"]
+        plan = factoryctl.load_json_like(ROOT / "templates" / "brownfield-os-plan.json")
+
+        errors = factoryctl.validate_node(schema, plan, "brownfield_os_plan", schemas=schemas, root_schema=schema)
+
+        self.assertEqual(errors, [])
+        self.assertTrue(plan["acceptance_boundary"]["execution_blocked_without_baseline"])
+
     def test_onchain_production_ladder_requires_devnet_mainnet_and_human_authority_policy(self) -> None:
         card = self.vfinal_card()
         card["surfaces"] = ["solana", "production"]


### PR DESCRIPTION
## Summary
- Adds a canonical Factory Route Registry so signal routing, method family, artifacts, gates, workers, recovery policy, and Hermes boundary come from one public-safe source.
- Adds the Universal Signal Golden Corpus and signal coverage scorecard to prove all known route classes are covered by contracts.
- Adds Product Quality Pack, Brownfield OS, and Specialist Research OS 2.0 contracts so product delivery quality, existing-system work, and research closure are no longer loose methodology prose.
- Tightens Hermes/materialize conformance and recovery/idempotency requirements for real adapter runs.
- Adds `factoryctl` route discovery, intake generation, corpus validation, and signal coverage commands.

## Scope Notes
- Issue #84 cockpit implementation was not touched.
- The only cockpit-adjacent change is a public example contract alignment in `examples/local-web-cockpit-factory-slice/universal-signal-intake.json` so the example satisfies the new route registry.
- No private evidence, raw research dumps, screenshots, local paths, or historical audit artifacts are committed.

## Validation
- `python -m unittest discover -s tests -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/release_integration_preflight.py`
- `python scripts/factoryctl.py validate-signal-corpus templates/universal-signal-golden-corpus.json`
- `python scripts/factoryctl.py validate-signal-coverage .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json`
- CLI smoke: `route-registry`, `intake`, `validate-signal-intake`