### PR TITLE
Add Factory v1 completion gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ Factory v1 is the public kernel release. The repository has validated schemas,
 worker profiles, Hermes profile bindings, adapter hooks, safety scans, a
 packaged CLI, a runnable public example, Product Face proof drivers,
 capability-pack activation checks, production worker graph contracts and public
-surface synchronization checks.
+surface synchronization checks. The finish line for this public kernel is the
+Factory v1 Completion Gate: current route coverage, release preflight, GitHub
+checks, open PRs and open v1 blockers must pass before v1 can be closed.
+Remaining non-blocking findings must be explicitly classified as `vnext` or
+`not_planned`, not left as endless audit drift.
 
 The project is still not a hosted service and not a production launch for a
 user's product. A user must connect it to their own Hermes runtime, configure

--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -62,6 +62,28 @@ map to the published public object. Run it only after the public object has been
 published or refreshed; before publication it may correctly report the remote
 map as out of sync.
 
+## Factory v1 Completion Gate
+
+Use this after the release preflight and GitHub checks are current, when the
+question is whether the public Factory v1 kernel can be closed instead of
+continuing an open-ended audit:
+
+```bash
+factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
+factoryctl v1-completion-gate \
+  --release-preflight .tmp/factory-runs/release/release-integration-preflight.json \
+  --github-actions-result PASS \
+  --open-v1-blockers 0 \
+  --open-prs 0 \
+  --out .tmp/factory-runs/v1-completion/factory-v1-completion-gate.json
+```
+
+A `PASS` here means the public Factory v1 kernel may be closed. It does not
+claim product-specific completion, hosted service release, mainnet release or
+universal runtime proof. New findings after this gate must be classified as
+`v1_blocker`, `vnext` or `not_planned`; only a real v1 blocker reopens the v1
+finish line.
+
 ## Full Product Worker Graph
 
 Production completion uses a product-scoped worker graph. The default contract
@@ -100,6 +122,7 @@ python scripts/validate_public_surface_sync.py
 python scripts/public_safety_scan.py
 python scripts/secret_safety_scan.py
 python scripts/supply_chain_proof.py --check --no-write
+factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 python scripts/factory_completion_audit.py --no-write --require-complete
 python -m unittest discover -s tests -p "test_*.py" -q
 ```
@@ -133,6 +156,8 @@ A release claim needs:
 - independent review when required;
 - real human gate records for high-risk or release authority;
 - public-safety pass before public publication.
+- a Factory v1 Completion Gate `PASS` before claiming the public Factory v1
+  kernel is closed.
 
 Release authority cannot be satisfied by a string ref alone. A production or
 R4 release gate must dereference and validate the human gate record before it

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,6 +44,8 @@ factoryctl intake --route-class bug_repair --request-type bug --signal-type bug_
 factoryctl validate-signal-intake templates/universal-signal-intake.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
+factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
+factoryctl validate-v1-completion-gate templates/factory-v1-completion-gate.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
 factoryctl recovery-plan --card examples/minimal-hermes-project/card.md --receipt .tmp/receipt.json --worker-results-dir .tmp/worker-results
@@ -65,6 +67,13 @@ policy and Hermes boundary. `intake` builds a valid Universal Signal Intake
 from that registry without executing work. `validate-signal-corpus` and
 `signal-coverage` prove that the public Golden Corpus covers every known route
 without treating contract coverage as production readiness.
+
+`v1-completion-gate` is the finish-line gate for the public Factory v1 kernel.
+It does not search forever for new work. It requires current release preflight,
+GitHub check state, open PR count and open v1 blocker count, then classifies
+remaining findings as `v1_blocker`, `vnext` or `not_planned`. `PASS` allows
+closing Factory v1 public kernel work; it does not claim product-specific
+completion, hosted service release or universal runtime proof.
 
 `help-next` reads the card, workflow catalog and gate report, then separates the
 factory's next action from bounded user decisions. With `--receipt` or

--- a/schemas/factory-v1-completion-gate.schema.json
+++ b/schemas/factory-v1-completion-gate.schema.json
@@ -1,0 +1,280 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-v1-completion-gate.schema.json",
+  "title": "Factory v1 Completion Gate",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "gate_id",
+    "created_at",
+    "factory_method_version",
+    "target",
+    "decision",
+    "completion_claim_allowed",
+    "completion_claim_scope",
+    "required_evidence",
+    "route_coverage",
+    "representative_signals",
+    "gates",
+    "finding_policy",
+    "classified_findings",
+    "public_private_boundary",
+    "limits",
+    "next_required_actions"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-v1-completion-gate.schema.json"
+    },
+    "record_type": {
+      "const": "factory_v1_completion_gate"
+    },
+    "gate_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "target": {
+      "type": "object",
+      "required": ["target_type", "target_ref", "release_scope", "owner"],
+      "properties": {
+        "target_type": {
+          "enum": ["public_repo", "release_candidate", "local_validation_run"]
+        },
+        "target_ref": {
+          "type": "string",
+          "minLength": 3
+        },
+        "release_scope": {
+          "enum": ["factory_v1_public_kernel", "factory_vnext", "product_specific_release"]
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "decision": {
+      "enum": ["PASS", "BLOCKED"]
+    },
+    "completion_claim_allowed": {
+      "type": "boolean"
+    },
+    "completion_claim_scope": {
+      "type": "object",
+      "required": [
+        "factory_v1_public_kernel",
+        "product_specific_completion",
+        "universal_runtime_proof",
+        "hosted_service_release"
+      ],
+      "properties": {
+        "factory_v1_public_kernel": { "type": "boolean" },
+        "product_specific_completion": { "const": false },
+        "universal_runtime_proof": { "const": false },
+        "hosted_service_release": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "required_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "evidence_id",
+          "status",
+          "evidence_ref",
+          "blocks_v1_when_missing",
+          "produced_by"
+        ],
+        "properties": {
+          "evidence_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "status": {
+            "enum": ["PASS", "BOUNDED", "BLOCKED", "MISSING", "FAIL", "UNKNOWN"]
+          },
+          "evidence_ref": {
+            "type": "string",
+            "minLength": 3
+          },
+          "blocks_v1_when_missing": {
+            "type": "boolean"
+          },
+          "produced_by": {
+            "type": "string",
+            "minLength": 3
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 3
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "route_coverage": {
+      "type": "object",
+      "required": [
+        "registry_ref",
+        "corpus_ref",
+        "scorecard_ref",
+        "signal_coverage_result",
+        "route_count",
+        "covered_route_count",
+        "missing_route_classes"
+      ],
+      "properties": {
+        "registry_ref": { "type": "string", "minLength": 3 },
+        "corpus_ref": { "type": "string", "minLength": 3 },
+        "scorecard_ref": { "type": "string", "minLength": 3 },
+        "signal_coverage_result": { "enum": ["PASS", "BLOCKED"] },
+        "route_count": { "type": "integer", "minimum": 0 },
+        "covered_route_count": { "type": "integer", "minimum": 0 },
+        "missing_route_classes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "representative_signals": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "case_id",
+          "route_class",
+          "request_type",
+          "signal_type",
+          "classification",
+          "covered_by_ref"
+        ],
+        "properties": {
+          "case_id": { "type": "string", "minLength": 3 },
+          "route_class": { "type": "string", "minLength": 3 },
+          "request_type": { "type": "string", "minLength": 3 },
+          "signal_type": { "type": "string", "minLength": 3 },
+          "classification": { "const": "v1_representative_signal" },
+          "covered_by_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["gate_id", "status", "owner", "evidence_refs", "blocks_v1", "next_action"],
+        "properties": {
+          "gate_id": { "type": "string", "minLength": 3 },
+          "status": { "enum": ["PASS", "BOUNDED", "BLOCKED", "MISSING", "FAIL", "UNKNOWN"] },
+          "owner": { "type": "string", "minLength": 3 },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "blocks_v1": { "type": "boolean" },
+          "next_action": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "finding_policy": {
+      "type": "object",
+      "required": [
+        "no_open_ended_audit",
+        "new_findings_must_be_classified",
+        "accepted_destinations",
+        "v1_blocker_definition",
+        "vnext_definition",
+        "not_planned_definition",
+        "reopen_v1_only_when"
+      ],
+      "properties": {
+        "no_open_ended_audit": { "const": true },
+        "new_findings_must_be_classified": { "const": true },
+        "accepted_destinations": {
+          "type": "array",
+          "minItems": 3,
+          "items": { "enum": ["v1_blocker", "vnext", "not_planned"] }
+        },
+        "v1_blocker_definition": { "type": "string", "minLength": 12 },
+        "vnext_definition": { "type": "string", "minLength": 12 },
+        "not_planned_definition": { "type": "string", "minLength": 12 },
+        "reopen_v1_only_when": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 6 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "classified_findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "finding_id",
+          "title",
+          "classification",
+          "status",
+          "rationale",
+          "owner",
+          "evidence_refs"
+        ],
+        "properties": {
+          "finding_id": { "type": "string", "minLength": 3 },
+          "title": { "type": "string", "minLength": 3 },
+          "classification": { "enum": ["v1_blocker", "vnext", "not_planned"] },
+          "status": { "enum": ["open", "resolved", "closed", "rejected"] },
+          "rationale": { "type": "string", "minLength": 6 },
+          "owner": { "type": "string", "minLength": 3 },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_runtime_evidence_stays_local"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_runtime_evidence_stays_local": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 6 }
+    },
+    "next_required_actions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -89,6 +89,9 @@ DEFAULT_HERMES_EVIDENCE_OUT = ROOT / ".tmp" / "factory-runs" / "hermes-evidence"
 DEFAULT_PREPILOT_CHECKLIST_OUT = ROOT / ".tmp" / "factory-runs" / "prepilot" / "loose-end-checklist.json"
 DEFAULT_SIGNAL_CORPUS_PATH = ROOT / "templates" / "universal-signal-golden-corpus.json"
 DEFAULT_SIGNAL_COVERAGE_OUT = ROOT / ".tmp" / "factory-runs" / "signal-coverage" / "factory-signal-coverage-scorecard.json"
+DEFAULT_FACTORY_READINESS_SCORECARD_PATH = ROOT / "templates" / "factory-readiness-scorecard.json"
+DEFAULT_V1_COMPLETION_GATE_OUT = ROOT / ".tmp" / "factory-runs" / "v1-completion" / "factory-v1-completion-gate.json"
+DEFAULT_RELEASE_INTEGRATION_PREFLIGHT = ROOT / ".tmp" / "factory-runs" / "release" / "release-integration-preflight.json"
 PRIVATE_RUNTIME_REF_RE = re.compile(
     r"((?<![A-Za-z])[A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
     re.IGNORECASE,
@@ -6297,6 +6300,476 @@ def validate_factory_readiness_scorecard(scorecard: dict[str, Any]) -> list[str]
     return errors
 
 
+V1_COMPLETION_BLOCKING_STATUSES = {"BLOCKED", "MISSING", "FAIL", "UNKNOWN"}
+V1_COMPLETION_FINDING_DESTINATIONS = {"v1_blocker", "vnext", "not_planned"}
+
+
+def _normalized_gate_status(value: Any) -> str:
+    status = str(value or "UNKNOWN").strip().upper()
+    return status if status in {"PASS", "BOUNDED", "BLOCKED", "MISSING", "FAIL", "UNKNOWN"} else "UNKNOWN"
+
+
+def _evidence_status_for_count(count: int, *, zero_is_pass: bool = True) -> str:
+    if count == 0 and zero_is_pass:
+        return "PASS"
+    return "BLOCKED"
+
+
+def _release_preflight_status(release_preflight: dict[str, Any] | None) -> str:
+    if release_preflight is None:
+        return "MISSING"
+    result = str(release_preflight.get("result") or "UNKNOWN").strip().upper()
+    return "PASS" if result == "PASS" else "BLOCKED"
+
+
+def _readiness_nonblocking_findings(readiness: dict[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    dimensions = readiness.get("dimensions") if isinstance(readiness.get("dimensions"), list) else []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        status = str(dimension.get("status") or "").strip().upper()
+        if status == "PASS":
+            continue
+        dimension_id = str(dimension.get("dimension_id") or "unknown-dimension").strip()
+        blocks = dimension.get("blocks_autonomous_execution") is True or status == "BLOCKED"
+        findings.append(
+            {
+                "finding_id": f"readiness-{dimension_id}",
+                "title": f"Readiness dimension is {status}: {dimension_id}",
+                "classification": "v1_blocker" if blocks else "vnext",
+                "status": "open",
+                "rationale": (
+                    "This dimension blocks Factory v1 closure."
+                    if blocks
+                    else "This is useful follow-up work, but it does not invalidate the Factory v1 public kernel promise."
+                ),
+                "owner": str(dimension.get("owner") or "factory-orchestrator"),
+                "evidence_refs": _list_items(dimension.get("evidence_refs")) or ["templates/factory-readiness-scorecard.json"],
+            }
+        )
+    return findings
+
+
+def _representative_signal_cases(corpus: dict[str, Any]) -> list[dict[str, Any]]:
+    cases = corpus.get("cases") if isinstance(corpus.get("cases"), list) else []
+    representative: list[dict[str, Any]] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        case_id = str(case.get("case_id") or "").strip()
+        route_class = str(case.get("route_class") or "").strip()
+        request_type = str(case.get("request_type") or "").strip()
+        signal_type = str(case.get("signal_type") or "").strip()
+        if not (case_id and route_class and request_type and signal_type):
+            continue
+        representative.append(
+            {
+                "case_id": case_id,
+                "route_class": route_class,
+                "request_type": request_type,
+                "signal_type": signal_type,
+                "classification": "v1_representative_signal",
+                "covered_by_ref": f"templates/universal-signal-golden-corpus.json#{case_id}",
+            }
+        )
+    return representative
+
+
+def _evidence_item(
+    evidence_id: str,
+    status: str,
+    evidence_ref: str,
+    *,
+    blocks_v1_when_missing: bool,
+    produced_by: str,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "evidence_id": evidence_id,
+        "status": _normalized_gate_status(status),
+        "evidence_ref": evidence_ref,
+        "blocks_v1_when_missing": blocks_v1_when_missing,
+        "produced_by": produced_by,
+        "reason": reason,
+    }
+
+
+def _gate_item(
+    gate_id: str,
+    status: str,
+    owner: str,
+    evidence_refs: list[str],
+    *,
+    blocks_v1: bool,
+    next_action: str,
+) -> dict[str, Any]:
+    return {
+        "gate_id": gate_id,
+        "status": _normalized_gate_status(status),
+        "owner": owner,
+        "evidence_refs": evidence_refs,
+        "blocks_v1": blocks_v1,
+        "next_action": next_action,
+    }
+
+
+def build_factory_v1_completion_gate(
+    *,
+    readiness_scorecard: dict[str, Any],
+    signal_corpus: dict[str, Any],
+    release_preflight: dict[str, Any] | None,
+    github_actions_result: str,
+    open_v1_blockers: int,
+    open_prs: int,
+    target_ref: str = "external:public-origin-main",
+    created_at: str | None = None,
+    signal_coverage_ref: str = "external:public-current-signal-coverage-scorecard",
+    release_preflight_ref: str = "external:public-current-release-integration-preflight",
+    github_actions_ref: str = "external:public-current-github-actions-checks",
+    open_v1_blockers_ref: str = "external:public-current-v1-blocker-query",
+    open_prs_ref: str = "external:public-current-open-pr-query",
+) -> dict[str, Any]:
+    signal_coverage = build_factory_signal_coverage_scorecard(signal_corpus)
+    readiness_errors = validate_factory_readiness_scorecard(readiness_scorecard)
+    signal_errors = validate_factory_signal_coverage_scorecard(signal_coverage)
+    release_status = _release_preflight_status(release_preflight)
+    actions_status = _normalized_gate_status(github_actions_result)
+    blocker_status = _evidence_status_for_count(open_v1_blockers)
+    pr_status = _evidence_status_for_count(open_prs)
+    readiness_findings = _readiness_nonblocking_findings(readiness_scorecard)
+
+    route_coverage_status = "PASS" if not signal_errors and signal_coverage.get("result") == "PASS" else "BLOCKED"
+    if not readiness_findings:
+        readiness_status = "PASS"
+    elif any(item["classification"] == "v1_blocker" for item in readiness_findings):
+        readiness_status = "BLOCKED"
+    else:
+        readiness_status = "BOUNDED"
+    if readiness_errors:
+        readiness_status = "BLOCKED"
+
+    required_evidence = [
+        _evidence_item(
+            "route_registry",
+            "PASS",
+            "templates/factory-route-registry.json",
+            blocks_v1_when_missing=True,
+            produced_by="factoryctl route-registry",
+            reason="The route registry is the canonical list of known signal routes.",
+        ),
+        _evidence_item(
+            "golden_signal_corpus",
+            "PASS" if not validate_universal_signal_golden_corpus(signal_corpus) else "BLOCKED",
+            "templates/universal-signal-golden-corpus.json",
+            blocks_v1_when_missing=True,
+            produced_by="factoryctl validate-signal-corpus",
+            reason="The Golden Corpus must cover representative signals for every route.",
+        ),
+        _evidence_item(
+            "signal_coverage_scorecard",
+            route_coverage_status,
+            signal_coverage_ref,
+            blocks_v1_when_missing=True,
+            produced_by="factoryctl signal-coverage",
+            reason="Route, artifact, worker, recovery and Hermes coverage must pass.",
+        ),
+        _evidence_item(
+            "factory_readiness_scorecard",
+            readiness_status,
+            "templates/factory-readiness-scorecard.json",
+            blocks_v1_when_missing=False,
+            produced_by="factoryctl validate-readiness-scorecard",
+            reason="Non-blocking bounded dimensions can move to vNext; blocking dimensions stop v1.",
+        ),
+        _evidence_item(
+            "release_integration_preflight",
+            release_status,
+            release_preflight_ref,
+            blocks_v1_when_missing=True,
+            produced_by="scripts/release_integration_preflight.py",
+            reason="The current release ref must pass release integration preflight.",
+        ),
+        _evidence_item(
+            "github_actions",
+            actions_status,
+            github_actions_ref,
+            blocks_v1_when_missing=True,
+            produced_by="GitHub Actions",
+            reason="The current public PR or main ref must be green.",
+        ),
+        _evidence_item(
+            "open_v1_blockers",
+            blocker_status,
+            open_v1_blockers_ref,
+            blocks_v1_when_missing=True,
+            produced_by="GitHub issue query",
+            reason="Open v1 blockers keep the release open.",
+        ),
+        _evidence_item(
+            "open_prs",
+            pr_status,
+            open_prs_ref,
+            blocks_v1_when_missing=True,
+            produced_by="GitHub PR query",
+            reason="Unexpected open PRs must be integrated, closed or reclassified.",
+        ),
+    ]
+
+    gates = [
+        _gate_item(
+            "canonical_route_system",
+            route_coverage_status,
+            "factory-orchestrator",
+            ["templates/factory-route-registry.json", "templates/universal-signal-golden-corpus.json", signal_coverage_ref],
+            blocks_v1=route_coverage_status != "PASS",
+            next_action="Fix route, corpus or coverage drift before closing v1.",
+        ),
+        _gate_item(
+            "readiness_boundary",
+            readiness_status,
+            "factory-orchestrator",
+            ["templates/factory-readiness-scorecard.json"],
+            blocks_v1=readiness_status == "BLOCKED",
+            next_action="Classify non-blocking readiness work as vNext and fix blocking readiness gaps before closing v1.",
+        ),
+        _gate_item(
+            "release_integrity",
+            release_status,
+            "release-ops-worker",
+            [release_preflight_ref],
+            blocks_v1=release_status != "PASS",
+            next_action="Run and pass release integration preflight on the current ref.",
+        ),
+        _gate_item(
+            "github_publication_state",
+            "PASS" if actions_status == "PASS" and blocker_status == "PASS" and pr_status == "PASS" else "BLOCKED",
+            "factory-orchestrator",
+            [github_actions_ref, open_v1_blockers_ref, open_prs_ref],
+            blocks_v1=not (actions_status == "PASS" and blocker_status == "PASS" and pr_status == "PASS"),
+            next_action="Confirm GitHub Actions, open PRs and open v1 blockers before final closure.",
+        ),
+        _gate_item(
+            "finding_classification",
+            "BLOCKED" if any(item["classification"] == "v1_blocker" for item in readiness_findings) else "PASS",
+            "factory-orchestrator",
+            ["templates/factory-v1-completion-gate.json#finding_policy"],
+            blocks_v1=any(item["classification"] == "v1_blocker" for item in readiness_findings),
+            next_action="Every new finding must be classified as v1_blocker, vnext or not_planned.",
+        ),
+    ]
+
+    blocking_evidence = [
+        item
+        for item in required_evidence
+        if item["blocks_v1_when_missing"] and item["status"] in V1_COMPLETION_BLOCKING_STATUSES
+    ]
+    blocking_gates = [gate for gate in gates if gate["blocks_v1"]]
+    open_v1_findings = [
+        item
+        for item in readiness_findings
+        if item["classification"] == "v1_blocker" and item["status"] not in {"resolved", "closed", "rejected"}
+    ]
+    decision = "BLOCKED" if blocking_evidence or blocking_gates or open_v1_findings else "PASS"
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-v1-completion-gate.schema.json",
+        "record_type": "factory_v1_completion_gate",
+        "gate_id": "factory-v1-completion-gate-current",
+        "created_at": created_at or utc_now(),
+        "factory_method_version": "OVERKILL_VFINAL",
+        "target": {
+            "target_type": "local_validation_run",
+            "target_ref": target_ref,
+            "release_scope": "factory_v1_public_kernel",
+            "owner": "factory-orchestrator",
+        },
+        "decision": decision,
+        "completion_claim_allowed": decision == "PASS",
+        "completion_claim_scope": {
+            "factory_v1_public_kernel": decision == "PASS",
+            "product_specific_completion": False,
+            "universal_runtime_proof": False,
+            "hosted_service_release": False,
+        },
+        "required_evidence": required_evidence,
+        "route_coverage": {
+            "registry_ref": "templates/factory-route-registry.json",
+            "corpus_ref": "templates/universal-signal-golden-corpus.json",
+            "scorecard_ref": signal_coverage_ref,
+            "signal_coverage_result": str(signal_coverage.get("result") or "BLOCKED"),
+            "route_count": int(signal_coverage.get("route_count") or 0),
+            "covered_route_count": int(signal_coverage.get("covered_route_count") or 0),
+            "missing_route_classes": _list_items(signal_coverage.get("missing_route_classes")),
+        },
+        "representative_signals": _representative_signal_cases(signal_corpus),
+        "gates": gates,
+        "finding_policy": {
+            "no_open_ended_audit": True,
+            "new_findings_must_be_classified": True,
+            "accepted_destinations": ["v1_blocker", "vnext", "not_planned"],
+            "v1_blocker_definition": "The finding makes the public Factory v1 promise false, unsafe, uninstallable or unreleasable.",
+            "vnext_definition": "The finding improves the factory after v1 but does not invalidate the public Factory v1 promise.",
+            "not_planned_definition": "The finding is intentionally rejected because it adds complexity without changing the v1 promise.",
+            "reopen_v1_only_when": [
+                "public promise is false",
+                "public safety or secret boundary fails",
+                "first-value path is broken",
+                "release checks fail",
+                "known route coverage regresses",
+                "non-human recovery invariant regresses",
+            ],
+        },
+        "classified_findings": readiness_findings,
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_runtime_evidence_stays_local": True,
+        },
+        "limits": [
+            "PASS allows closing the Factory v1 public kernel, not claiming every possible product is production-proven.",
+            "Product-specific releases still need their own SOT, gates, worker evidence, human approvals and runtime proof.",
+            "Contract coverage is required but not misrepresented as universal live runtime proof.",
+            "vNext findings may remain open when they do not invalidate the Factory v1 public promise.",
+        ],
+        "next_required_actions": (
+            ["Close Factory v1 and move new non-blocking findings to vNext or not_planned."]
+            if decision == "PASS"
+            else [
+                gate["next_action"]
+                for gate in gates
+                if gate["blocks_v1"]
+            ]
+        ),
+    }
+
+
+def validate_factory_v1_completion_gate(gate: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-v1-completion-gate.schema.json")
+    if not schema:
+        return ["factory_v1_completion_gate schema is not bundled"]
+    errors.extend(validate_node(schema, gate, "factory_v1_completion_gate", schemas=schemas, root_schema=schema))
+
+    target = gate.get("target") if isinstance(gate.get("target"), dict) else {}
+    target_ref = str(target.get("target_ref") or "").strip()
+    if target_ref:
+        _validate_public_ref(target_ref, "factory_v1_completion_gate.target.target_ref", errors)
+
+    route_coverage = gate.get("route_coverage") if isinstance(gate.get("route_coverage"), dict) else {}
+    for field in ("registry_ref", "corpus_ref", "scorecard_ref"):
+        ref = str(route_coverage.get(field) or "").strip()
+        if ref:
+            _validate_public_ref(ref, f"factory_v1_completion_gate.route_coverage.{field}", errors)
+
+    expected_routes = set(registry_routes(load_route_registry()))
+    representative_signals = gate.get("representative_signals") if isinstance(gate.get("representative_signals"), list) else []
+    represented_routes = {
+        str(item.get("route_class") or "").strip()
+        for item in representative_signals
+        if isinstance(item, dict)
+    }
+    if gate.get("decision") == "PASS" and represented_routes != expected_routes:
+        missing = sorted(expected_routes - represented_routes)
+        extra = sorted(represented_routes - expected_routes)
+        if missing:
+            errors.append("factory_v1_completion_gate PASS missing representative route classes: " + ", ".join(missing))
+        if extra:
+            errors.append("factory_v1_completion_gate PASS has unknown representative route classes: " + ", ".join(extra))
+    for index, item in enumerate(representative_signals):
+        if not isinstance(item, dict):
+            continue
+        ref = str(item.get("covered_by_ref") or "").strip()
+        if ref:
+            _validate_public_ref(ref, f"factory_v1_completion_gate.representative_signals[{index}].covered_by_ref", errors)
+
+    blocking_evidence = []
+    evidence_items = gate.get("required_evidence") if isinstance(gate.get("required_evidence"), list) else []
+    for index, item in enumerate(evidence_items):
+        if not isinstance(item, dict):
+            continue
+        ref = str(item.get("evidence_ref") or "").strip()
+        if ref:
+            _validate_public_ref(ref, f"factory_v1_completion_gate.required_evidence[{index}].evidence_ref", errors)
+        status = _normalized_gate_status(item.get("status"))
+        if item.get("blocks_v1_when_missing") is True and status in V1_COMPLETION_BLOCKING_STATUSES:
+            blocking_evidence.append(str(item.get("evidence_id") or f"required_evidence[{index}]"))
+
+    blocking_gates = []
+    gates = gate.get("gates") if isinstance(gate.get("gates"), list) else []
+    for index, item in enumerate(gates):
+        if not isinstance(item, dict):
+            continue
+        _validate_lifecycle_refs(_list_items(item.get("evidence_refs")), f"factory_v1_completion_gate.gates[{index}].evidence_refs", errors)
+        status = _normalized_gate_status(item.get("status"))
+        if item.get("blocks_v1") is True and status in V1_COMPLETION_BLOCKING_STATUSES:
+            blocking_gates.append(str(item.get("gate_id") or f"gates[{index}]"))
+
+    findings = gate.get("classified_findings") if isinstance(gate.get("classified_findings"), list) else []
+    open_v1_findings = []
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            continue
+        _validate_lifecycle_refs(
+            _list_items(finding.get("evidence_refs")),
+            f"factory_v1_completion_gate.classified_findings[{index}].evidence_refs",
+            errors,
+        )
+        classification = str(finding.get("classification") or "").strip()
+        status = str(finding.get("status") or "").strip()
+        if classification not in V1_COMPLETION_FINDING_DESTINATIONS:
+            errors.append(f"factory_v1_completion_gate.classified_findings[{index}] has unknown classification")
+        if classification == "v1_blocker" and status not in {"resolved", "closed", "rejected"}:
+            open_v1_findings.append(str(finding.get("finding_id") or f"classified_findings[{index}]"))
+
+    policy = gate.get("finding_policy") if isinstance(gate.get("finding_policy"), dict) else {}
+    if policy.get("no_open_ended_audit") is not True:
+        errors.append("factory_v1_completion_gate finding policy must forbid open-ended audit")
+    if policy.get("new_findings_must_be_classified") is not True:
+        errors.append("factory_v1_completion_gate new findings must be classified")
+    destinations = set(_list_items(policy.get("accepted_destinations")))
+    if destinations != V1_COMPLETION_FINDING_DESTINATIONS:
+        errors.append("factory_v1_completion_gate accepted destinations must be v1_blocker, vnext and not_planned")
+
+    boundary = gate.get("public_private_boundary") if isinstance(gate.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("factory_v1_completion_gate requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("factory_v1_completion_gate must not embed raw private evidence")
+    if boundary.get("private_runtime_evidence_stays_local") is not True:
+        errors.append("factory_v1_completion_gate private runtime evidence must stay local")
+
+    decision = str(gate.get("decision") or "").strip()
+    completion_allowed = gate.get("completion_claim_allowed") is True
+    scope = gate.get("completion_claim_scope") if isinstance(gate.get("completion_claim_scope"), dict) else {}
+    if decision == "PASS":
+        if blocking_evidence:
+            errors.append("factory_v1_completion_gate PASS has blocking evidence: " + ", ".join(sorted(blocking_evidence)))
+        if blocking_gates:
+            errors.append("factory_v1_completion_gate PASS has blocking gates: " + ", ".join(sorted(blocking_gates)))
+        if open_v1_findings:
+            errors.append("factory_v1_completion_gate PASS has open v1 blockers: " + ", ".join(sorted(open_v1_findings)))
+        if not completion_allowed:
+            errors.append("factory_v1_completion_gate PASS requires completion_claim_allowed=true")
+        if scope.get("factory_v1_public_kernel") is not True:
+            errors.append("factory_v1_completion_gate PASS requires factory_v1_public_kernel=true")
+    if decision == "BLOCKED":
+        if completion_allowed:
+            errors.append("factory_v1_completion_gate BLOCKED cannot allow completion claim")
+        if scope.get("factory_v1_public_kernel") is not False:
+            errors.append("factory_v1_completion_gate BLOCKED requires factory_v1_public_kernel=false")
+
+    if scope.get("product_specific_completion") is not False:
+        errors.append("factory_v1_completion_gate cannot claim product-specific completion")
+    if scope.get("universal_runtime_proof") is not False:
+        errors.append("factory_v1_completion_gate cannot claim universal runtime proof")
+    if scope.get("hosted_service_release") is not False:
+        errors.append("factory_v1_completion_gate cannot claim hosted service release")
+
+    return errors
+
+
 AUTOMATION_GITHUB_AUTHORITIES = {"github_pr", "release_candidate", "production_operation"}
 AUTOMATION_REPO_BOUND_AUTHORITIES = {"bounded_edit", "local_commit", "github_pr", "release_candidate", "production_operation"}
 AUTOMATION_REPO_BOUND_TARGETS = {"repo", "factory_issue", "release"}
@@ -11067,6 +11540,42 @@ def command_validate_readiness_scorecard(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_v1_completion_gate(args: argparse.Namespace) -> int:
+    release_preflight = load_optional_json(args.release_preflight)
+    gate = build_factory_v1_completion_gate(
+        readiness_scorecard=load_json_like(args.readiness_scorecard),
+        signal_corpus=load_json_like(args.signal_corpus),
+        release_preflight=release_preflight,
+        github_actions_result=args.github_actions_result,
+        open_v1_blockers=args.open_v1_blockers,
+        open_prs=args.open_prs,
+        target_ref=args.target_ref,
+        created_at=args.created_at,
+        signal_coverage_ref=args.signal_coverage_ref,
+        release_preflight_ref=args.release_preflight_ref,
+        github_actions_ref=args.github_actions_ref,
+        open_v1_blockers_ref=args.open_v1_blockers_ref,
+        open_prs_ref=args.open_prs_ref,
+    )
+    errors = validate_factory_v1_completion_gate(gate)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, gate)
+    return 0 if gate["decision"] == "PASS" else 1
+
+
+def command_validate_v1_completion_gate(args: argparse.Namespace) -> int:
+    errors = validate_factory_v1_completion_gate(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_automation_target(args: argparse.Namespace) -> int:
     errors = validate_factory_automation_run_target(load_json_like(args.path))
     if errors:
@@ -11457,6 +11966,30 @@ def build_parser() -> argparse.ArgumentParser:
     validate_factory_readiness_scorecard_parser = sub.add_parser("validate-factory-readiness-scorecard")
     validate_factory_readiness_scorecard_parser.add_argument("path", type=Path)
     validate_factory_readiness_scorecard_parser.set_defaults(func=command_validate_readiness_scorecard)
+
+    v1_completion_gate_parser = sub.add_parser(
+        "v1-completion-gate",
+        help="Build the Factory v1 finish-line gate from current public-safe release evidence.",
+    )
+    v1_completion_gate_parser.add_argument("--readiness-scorecard", type=Path, default=DEFAULT_FACTORY_READINESS_SCORECARD_PATH)
+    v1_completion_gate_parser.add_argument("--signal-corpus", type=Path, default=DEFAULT_SIGNAL_CORPUS_PATH)
+    v1_completion_gate_parser.add_argument("--release-preflight", type=Path, default=DEFAULT_RELEASE_INTEGRATION_PREFLIGHT)
+    v1_completion_gate_parser.add_argument("--github-actions-result", choices=["PASS", "FAIL", "UNKNOWN"], default="UNKNOWN")
+    v1_completion_gate_parser.add_argument("--open-v1-blockers", type=int, default=0)
+    v1_completion_gate_parser.add_argument("--open-prs", type=int, default=0)
+    v1_completion_gate_parser.add_argument("--target-ref", default="external:public-origin-main")
+    v1_completion_gate_parser.add_argument("--created-at")
+    v1_completion_gate_parser.add_argument("--signal-coverage-ref", default="external:public-current-signal-coverage-scorecard")
+    v1_completion_gate_parser.add_argument("--release-preflight-ref", default="external:public-current-release-integration-preflight")
+    v1_completion_gate_parser.add_argument("--github-actions-ref", default="external:public-current-github-actions-checks")
+    v1_completion_gate_parser.add_argument("--open-v1-blockers-ref", default="external:public-current-v1-blocker-query")
+    v1_completion_gate_parser.add_argument("--open-prs-ref", default="external:public-current-open-pr-query")
+    v1_completion_gate_parser.add_argument("--out", type=Path, default=DEFAULT_V1_COMPLETION_GATE_OUT)
+    v1_completion_gate_parser.set_defaults(func=command_v1_completion_gate)
+
+    validate_v1_completion_gate_parser = sub.add_parser("validate-v1-completion-gate")
+    validate_v1_completion_gate_parser.add_argument("path", type=Path)
+    validate_v1_completion_gate_parser.set_defaults(func=command_validate_v1_completion_gate)
 
     validate_automation_target_parser = sub.add_parser("validate-automation-target")
     validate_automation_target_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -128,6 +128,8 @@ FACTORY_READINESS_SCORECARD_DIMENSIONS = {
     "product_analytics_success_signals",
     "autonomy_risk_human_gates",
 }
+V1_COMPLETION_BLOCKING_STATUSES = {"BLOCKED", "MISSING", "FAIL", "UNKNOWN"}
+V1_COMPLETION_FINDING_DESTINATIONS = {"v1_blocker", "vnext", "not_planned"}
 UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS = route_required_artifacts()
 UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES = route_request_types()
 UNIVERSAL_SIGNAL_ROUTE_SIGNAL_TYPES = route_signal_types()
@@ -361,6 +363,126 @@ def validate_factory_readiness_scorecard_domain(data: dict[str, Any], at: str) -
         errors.append(f"{at}: factory_readiness_scorecard is not release approval")
 
     return errors
+
+
+def validate_factory_v1_completion_gate_domain(data: dict[str, Any], at: str) -> list[str]:
+    errors: list[str] = []
+    target = data.get("target") if isinstance(data.get("target"), dict) else {}
+    reason = public_artifact_ref_error(target.get("target_ref"))
+    if reason:
+        errors.append(f"{at}.target.target_ref: {reason}")
+
+    route_coverage = data.get("route_coverage") if isinstance(data.get("route_coverage"), dict) else {}
+    for field in ("registry_ref", "corpus_ref", "scorecard_ref"):
+        reason = public_artifact_ref_error(route_coverage.get(field))
+        if reason:
+            errors.append(f"{at}.route_coverage.{field}: {reason}")
+
+    expected_routes = set(UNIVERSAL_SIGNAL_ROUTE_REQUIRED_ARTIFACTS)
+    representative_signals = data.get("representative_signals") if isinstance(data.get("representative_signals"), list) else []
+    represented_routes = {
+        str(item.get("route_class") or "").strip()
+        for item in representative_signals
+        if isinstance(item, dict)
+    }
+    if data.get("decision") == "PASS":
+        missing_routes = sorted(expected_routes - represented_routes)
+        extra_routes = sorted(represented_routes - expected_routes)
+        if missing_routes:
+            errors.append(f"{at}: PASS missing representative route classes: {', '.join(missing_routes)}")
+        if extra_routes:
+            errors.append(f"{at}: PASS has unknown representative route classes: {', '.join(extra_routes)}")
+
+    for index, item in enumerate(representative_signals):
+        if not isinstance(item, dict):
+            continue
+        reason = public_artifact_ref_error(item.get("covered_by_ref"))
+        if reason:
+            errors.append(f"{at}.representative_signals[{index}].covered_by_ref: {reason}")
+
+    blocking_evidence: list[str] = []
+    evidence_items = data.get("required_evidence") if isinstance(data.get("required_evidence"), list) else []
+    for index, item in enumerate(evidence_items):
+        if not isinstance(item, dict):
+            continue
+        reason = public_artifact_ref_error(item.get("evidence_ref"))
+        if reason:
+            errors.append(f"{at}.required_evidence[{index}].evidence_ref: {reason}")
+        status = str(item.get("status") or "").strip().upper()
+        if item.get("blocks_v1_when_missing") is True and status in V1_COMPLETION_BLOCKING_STATUSES:
+            blocking_evidence.append(str(item.get("evidence_id") or f"required_evidence[{index}]"))
+
+    blocking_gates: list[str] = []
+    gates = data.get("gates") if isinstance(data.get("gates"), list) else []
+    for index, gate in enumerate(gates):
+        if not isinstance(gate, dict):
+            continue
+        for ref_index, ref in enumerate(text_items(gate.get("evidence_refs"))):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.gates[{index}].evidence_refs[{ref_index}]: {reason}")
+        status = str(gate.get("status") or "").strip().upper()
+        if gate.get("blocks_v1") is True and status in V1_COMPLETION_BLOCKING_STATUSES:
+            blocking_gates.append(str(gate.get("gate_id") or f"gates[{index}]"))
+
+    open_v1_findings: list[str] = []
+    findings = data.get("classified_findings") if isinstance(data.get("classified_findings"), list) else []
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            continue
+        classification = str(finding.get("classification") or "").strip()
+        status = str(finding.get("status") or "").strip()
+        if classification not in V1_COMPLETION_FINDING_DESTINATIONS:
+            errors.append(f"{at}.classified_findings[{index}]: unknown classification")
+        if classification == "v1_blocker" and status not in {"resolved", "closed", "rejected"}:
+            open_v1_findings.append(str(finding.get("finding_id") or f"classified_findings[{index}]"))
+        for ref_index, ref in enumerate(text_items(finding.get("evidence_refs"))):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.classified_findings[{index}].evidence_refs[{ref_index}]: {reason}")
+
+    policy = data.get("finding_policy") if isinstance(data.get("finding_policy"), dict) else {}
+    if policy.get("no_open_ended_audit") is not True:
+        errors.append(f"{at}: finding policy must forbid open-ended audit")
+    if policy.get("new_findings_must_be_classified") is not True:
+        errors.append(f"{at}: new findings must be classified")
+    destinations = set(text_items(policy.get("accepted_destinations")))
+    if destinations != V1_COMPLETION_FINDING_DESTINATIONS:
+        errors.append(f"{at}: accepted destinations must be v1_blocker, vnext and not_planned")
+
+    boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append(f"{at}: requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append(f"{at}: must not embed raw private evidence")
+    if boundary.get("private_runtime_evidence_stays_local") is not True:
+        errors.append(f"{at}: private runtime evidence must stay local")
+
+    decision = str(data.get("decision") or "").strip()
+    completion_allowed = data.get("completion_claim_allowed") is True
+    scope = data.get("completion_claim_scope") if isinstance(data.get("completion_claim_scope"), dict) else {}
+    if decision == "PASS":
+        if blocking_evidence:
+            errors.append(f"{at}: PASS has blocking evidence: {', '.join(sorted(blocking_evidence))}")
+        if blocking_gates:
+            errors.append(f"{at}: PASS has blocking gates: {', '.join(sorted(blocking_gates))}")
+        if open_v1_findings:
+            errors.append(f"{at}: PASS has open v1 blockers: {', '.join(sorted(open_v1_findings))}")
+        if not completion_allowed:
+            errors.append(f"{at}: PASS requires completion_claim_allowed=true")
+        if scope.get("factory_v1_public_kernel") is not True:
+            errors.append(f"{at}: PASS requires factory_v1_public_kernel=true")
+    if decision == "BLOCKED":
+        if completion_allowed:
+            errors.append(f"{at}: BLOCKED cannot allow completion claim")
+        if scope.get("factory_v1_public_kernel") is not False:
+            errors.append(f"{at}: BLOCKED requires factory_v1_public_kernel=false")
+    for field in ("product_specific_completion", "universal_runtime_proof", "hosted_service_release"):
+        if scope.get(field) is not False:
+            errors.append(f"{at}: cannot claim {field}")
+
+    return errors
+
 
 ANNOTATION_SCHEMA_KEYWORDS = {
     "$comment",
@@ -944,6 +1066,8 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
+    if data.get("record_type") == "factory_v1_completion_gate":
+        errors.extend(validate_factory_v1_completion_gate_domain(data, at))
     if data.get("record_type") == "factory_automation_run_target":
         trigger = data.get("trigger") if isinstance(data.get("trigger"), dict) else {}
         target = data.get("target") if isinstance(data.get("target"), dict) else {}

--- a/templates/factory-v1-completion-gate.json
+++ b/templates/factory-v1-completion-gate.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-v1-completion-gate.schema.json",
+  "record_type": "factory_v1_completion_gate",
+  "gate_id": "factory-v1-completion-gate-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "target": {
+    "target_type": "public_repo",
+    "target_ref": "external:public-current-public-overkill-factory-ref",
+    "release_scope": "factory_v1_public_kernel",
+    "owner": "factory-orchestrator"
+  },
+  "decision": "BLOCKED",
+  "completion_claim_allowed": false,
+  "completion_claim_scope": {
+    "factory_v1_public_kernel": false,
+    "product_specific_completion": false,
+    "universal_runtime_proof": false,
+    "hosted_service_release": false
+  },
+  "required_evidence": [
+    {
+      "evidence_id": "route_registry",
+      "status": "PASS",
+      "evidence_ref": "templates/factory-route-registry.json",
+      "blocks_v1_when_missing": true,
+      "produced_by": "factoryctl route-registry",
+      "reason": "The route registry is the single public source of known signal routes."
+    },
+    {
+      "evidence_id": "golden_signal_corpus",
+      "status": "PASS",
+      "evidence_ref": "templates/universal-signal-golden-corpus.json",
+      "blocks_v1_when_missing": true,
+      "produced_by": "factoryctl validate-signal-corpus",
+      "reason": "The corpus covers representative inputs for every known route."
+    },
+    {
+      "evidence_id": "signal_coverage_scorecard",
+      "status": "PASS",
+      "evidence_ref": "external:public-current-signal-coverage-scorecard",
+      "blocks_v1_when_missing": true,
+      "produced_by": "factoryctl signal-coverage",
+      "reason": "Coverage proves routes, artifacts, workers, recovery and Hermes boundaries are represented."
+    },
+    {
+      "evidence_id": "factory_readiness_scorecard",
+      "status": "BOUNDED",
+      "evidence_ref": "templates/factory-readiness-scorecard.json",
+      "blocks_v1_when_missing": false,
+      "produced_by": "factoryctl validate-readiness-scorecard",
+      "reason": "Bounded non-blocking dimensions are allowed for vNext but cannot hide v1 blockers."
+    },
+    {
+      "evidence_id": "release_integration_preflight",
+      "status": "MISSING",
+      "evidence_ref": "external:public-current-release-integration-preflight",
+      "blocks_v1_when_missing": true,
+      "produced_by": "scripts/release_integration_preflight.py",
+      "reason": "The current public ref must pass release integration before v1 can close."
+    },
+    {
+      "evidence_id": "github_actions",
+      "status": "UNKNOWN",
+      "evidence_ref": "external:public-current-github-actions-checks",
+      "blocks_v1_when_missing": true,
+      "produced_by": "GitHub Actions",
+      "reason": "The current PR or main ref must have green checks before v1 can close."
+    },
+    {
+      "evidence_id": "open_v1_blockers",
+      "status": "UNKNOWN",
+      "evidence_ref": "external:public-current-v1-blocker-query",
+      "blocks_v1_when_missing": true,
+      "produced_by": "GitHub issue query",
+      "reason": "Open v1 blockers keep the release open; vNext and not-planned findings do not."
+    },
+    {
+      "evidence_id": "open_prs",
+      "status": "UNKNOWN",
+      "evidence_ref": "external:public-current-open-pr-query",
+      "blocks_v1_when_missing": true,
+      "produced_by": "GitHub PR query",
+      "reason": "Unexpected open PRs must be merged, closed or reclassified before final closure."
+    }
+  ],
+  "route_coverage": {
+    "registry_ref": "templates/factory-route-registry.json",
+    "corpus_ref": "templates/universal-signal-golden-corpus.json",
+    "scorecard_ref": "external:public-current-signal-coverage-scorecard",
+    "signal_coverage_result": "PASS",
+    "route_count": 14,
+    "covered_route_count": 14,
+    "missing_route_classes": []
+  },
+  "representative_signals": [
+    {
+      "case_id": "product-paper-to-product-creation",
+      "route_class": "product_creation",
+      "request_type": "product_new",
+      "signal_type": "product_paper",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#product-paper-to-product-creation"
+    },
+    {
+      "case_id": "feature-idea-to-feature-delivery",
+      "route_class": "feature_delivery",
+      "request_type": "feature",
+      "signal_type": "feature_idea",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#feature-idea-to-feature-delivery"
+    },
+    {
+      "case_id": "bug-report-to-bug-repair",
+      "route_class": "bug_repair",
+      "request_type": "bug",
+      "signal_type": "bug_report",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#bug-report-to-bug-repair"
+    },
+    {
+      "case_id": "incident-to-incident-response",
+      "route_class": "incident_response",
+      "request_type": "incident",
+      "signal_type": "incident",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#incident-to-incident-response"
+    },
+    {
+      "case_id": "existing-repository-to-brownfield-discovery",
+      "route_class": "brownfield_discovery",
+      "request_type": "refactor",
+      "signal_type": "existing_repository",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#existing-repository-to-brownfield-discovery"
+    },
+    {
+      "case_id": "release-request-to-release-promotion",
+      "route_class": "release_promotion",
+      "request_type": "release",
+      "signal_type": "release_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#release-request-to-release-promotion"
+    },
+    {
+      "case_id": "research-request-to-research-validation",
+      "route_class": "research_validation",
+      "request_type": "feature",
+      "signal_type": "research_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#research-request-to-research-validation"
+    },
+    {
+      "case_id": "documentation-request-to-docs-onboarding",
+      "route_class": "docs_onboarding",
+      "request_type": "doc",
+      "signal_type": "documentation_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#documentation-request-to-docs-onboarding"
+    },
+    {
+      "case_id": "security-review-to-security-remediation",
+      "route_class": "security_remediation",
+      "request_type": "security",
+      "signal_type": "security_review_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#security-review-to-security-remediation"
+    },
+    {
+      "case_id": "integration-request-to-critical-integration",
+      "route_class": "critical_integration",
+      "request_type": "integration",
+      "signal_type": "integration_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#integration-request-to-critical-integration"
+    },
+    {
+      "case_id": "migration-request-to-migration-execution",
+      "route_class": "migration_execution",
+      "request_type": "migration",
+      "signal_type": "migration_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#migration-request-to-migration-execution"
+    },
+    {
+      "case_id": "ux-request-to-product-experience",
+      "route_class": "ux_product_experience",
+      "request_type": "ux_ui",
+      "signal_type": "ux_ui_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#ux-request-to-product-experience"
+    },
+    {
+      "case_id": "analytics-request-to-analytics-data",
+      "route_class": "analytics_data",
+      "request_type": "data_analytics",
+      "signal_type": "analytics_request",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#analytics-request-to-analytics-data"
+    },
+    {
+      "case_id": "agent-change-to-agent-quality-change",
+      "route_class": "agent_quality_change",
+      "request_type": "agent_skill",
+      "signal_type": "agent_skill_or_model_change",
+      "classification": "v1_representative_signal",
+      "covered_by_ref": "templates/universal-signal-golden-corpus.json#agent-change-to-agent-quality-change"
+    }
+  ],
+  "gates": [
+    {
+      "gate_id": "canonical_route_system",
+      "status": "PASS",
+      "owner": "factory-orchestrator",
+      "evidence_refs": [
+        "templates/factory-route-registry.json",
+        "templates/universal-signal-golden-corpus.json"
+      ],
+      "blocks_v1": false,
+      "next_action": "Keep route registry and corpus synchronized through validators."
+    },
+    {
+      "gate_id": "release_integrity",
+      "status": "MISSING",
+      "owner": "release-ops-worker",
+      "evidence_refs": ["external:public-current-release-integration-preflight"],
+      "blocks_v1": true,
+      "next_action": "Run release integration preflight on the current ref."
+    },
+    {
+      "gate_id": "github_publication_state",
+      "status": "UNKNOWN",
+      "owner": "factory-orchestrator",
+      "evidence_refs": [
+        "external:public-current-github-actions-checks",
+        "external:public-current-open-pr-query",
+        "external:public-current-v1-blocker-query"
+      ],
+      "blocks_v1": true,
+      "next_action": "Confirm checks, PRs and v1 blocker query before closing v1."
+    },
+    {
+      "gate_id": "finding_classification",
+      "status": "PASS",
+      "owner": "factory-orchestrator",
+      "evidence_refs": ["templates/factory-v1-completion-gate.json#finding_policy"],
+      "blocks_v1": false,
+      "next_action": "Classify every new finding as v1_blocker, vnext or not_planned."
+    }
+  ],
+  "finding_policy": {
+    "no_open_ended_audit": true,
+    "new_findings_must_be_classified": true,
+    "accepted_destinations": ["v1_blocker", "vnext", "not_planned"],
+    "v1_blocker_definition": "The finding makes the public Factory v1 promise false, unsafe, uninstallable or unreleasable.",
+    "vnext_definition": "The finding improves the factory after v1 but does not invalidate the public Factory v1 promise.",
+    "not_planned_definition": "The finding is intentionally rejected because it adds complexity without changing the v1 promise.",
+    "reopen_v1_only_when": [
+      "public promise is false",
+      "public safety or secret boundary fails",
+      "first-value path is broken",
+      "release checks fail",
+      "known route coverage regresses",
+      "non-human recovery invariant regresses"
+    ]
+  },
+  "classified_findings": [],
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_runtime_evidence_stays_local": true
+  },
+  "limits": [
+    "This template is not a live release proof.",
+    "PASS allows closing the Factory v1 public kernel, not claiming every possible product is production-proven.",
+    "Product-specific releases still need their own SOT, gates, worker evidence, human approvals and runtime proof.",
+    "vNext findings may remain open when they do not invalidate the Factory v1 public promise."
+  ],
+  "next_required_actions": [
+    "Run factoryctl v1-completion-gate with current release preflight, GitHub Actions state, open PR count and open v1 blocker count."
+  ]
+}

--- a/tests/test_factory_v1_completion_gate.py
+++ b/tests/test_factory_v1_completion_gate.py
@@ -1,0 +1,168 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FACTORYCTL_PATH = ROOT / "scripts" / "factoryctl.py"
+FACTORYCTL_SPEC = importlib.util.spec_from_file_location("factoryctl_v1_completion_gate", FACTORYCTL_PATH)
+assert FACTORYCTL_SPEC is not None
+factoryctl = importlib.util.module_from_spec(FACTORYCTL_SPEC)
+assert FACTORYCTL_SPEC.loader is not None
+sys.modules["factoryctl_v1_completion_gate"] = factoryctl
+FACTORYCTL_SPEC.loader.exec_module(factoryctl)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts_v1_gate", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+assert VALIDATOR_SPEC.loader is not None
+sys.modules["validate_public_json_artifacts_v1_gate"] = public_json_validator
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+def load_template(name: str) -> dict:
+    return json.loads((ROOT / "templates" / name).read_text(encoding="utf-8"))
+
+
+def release_preflight_pass() -> dict:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/release-integration-preflight.schema.json",
+        "record_type": "release_integration_preflight",
+        "created_at": "2026-06-17T00:00:00Z",
+        "result": "PASS",
+        "branch": {"current": "main", "is_main": True},
+        "counts": {
+            "status_entries": 0,
+            "generated_status_entries": 0,
+            "unintegrated_release_entries": 0,
+            "release_candidate_entries": 0,
+            "generated_receipt_entries": 0,
+            "needs_human_review_entries": 0,
+            "safe_cleanup_candidates": 0
+        },
+        "checks": {
+            "fresh_preflight_materialization_provided": True,
+            "preflight_materializers_passed": True,
+            "worktree_public_safety_passed": True,
+            "head_public_safety_passed": True,
+            "origin_main_public_safety_passed": True,
+            "preflight_evidence_refs_exist": True,
+            "worktree_inventory_has_no_unknown_entries": True,
+            "worktree_inventory_has_no_cleanup_candidates": True,
+            "worktree_has_release_candidate_material": False,
+            "release_ref_has_no_unintegrated_worktree_entries": True,
+            "current_branch_is_not_dirty_main": True
+        },
+        "release_candidate_plan": {
+            "safe_to_prepare_candidate_branch": False,
+            "recommended_branch": "not_required",
+            "why": "Current release ref has no unintegrated release work.",
+            "steps": [],
+            "must_not_do": []
+        },
+        "blocking_items": [],
+        "attention_items": [],
+        "evidence_refs": ["external:public-release-preflight"],
+        "missing_evidence_refs": [],
+        "next_required_actions": [],
+        "limits": ["Public-safe release integration receipt."]
+    }
+
+
+class FactoryV1CompletionGateTest(unittest.TestCase):
+    def test_template_is_valid_blocked_gate_not_live_proof(self) -> None:
+        gate = load_template("factory-v1-completion-gate.json")
+        schemas = public_json_validator.load_schemas()
+        schema = schemas["factory-v1-completion-gate.schema.json"]
+
+        schema_errors = public_json_validator.validate_node(schema, gate, "$", schemas=schemas, root_schema=schema)
+        domain_errors = public_json_validator.validate_factory_v1_completion_gate_domain(gate, "$")
+
+        self.assertEqual(schema_errors, [])
+        self.assertEqual(domain_errors, [])
+        self.assertEqual(gate["decision"], "BLOCKED")
+        self.assertFalse(gate["completion_claim_allowed"])
+
+    def test_build_gate_passes_when_current_release_inputs_are_green(self) -> None:
+        gate = factoryctl.build_factory_v1_completion_gate(
+            readiness_scorecard=load_template("factory-readiness-scorecard.json"),
+            signal_corpus=load_template("universal-signal-golden-corpus.json"),
+            release_preflight=release_preflight_pass(),
+            github_actions_result="PASS",
+            open_v1_blockers=0,
+            open_prs=0,
+            created_at="2026-06-17T00:00:00+00:00",
+        )
+
+        errors = factoryctl.validate_factory_v1_completion_gate(gate)
+        represented_routes = {item["route_class"] for item in gate["representative_signals"]}
+
+        self.assertEqual(errors, [])
+        self.assertEqual(gate["decision"], "PASS")
+        self.assertTrue(gate["completion_claim_allowed"])
+        self.assertEqual(represented_routes, set(factoryctl.registry_routes(factoryctl.load_route_registry())))
+        self.assertTrue(any(item["classification"] == "vnext" for item in gate["classified_findings"]))
+
+    def test_gate_blocks_when_v1_blocker_is_open(self) -> None:
+        gate = factoryctl.build_factory_v1_completion_gate(
+            readiness_scorecard=load_template("factory-readiness-scorecard.json"),
+            signal_corpus=load_template("universal-signal-golden-corpus.json"),
+            release_preflight=release_preflight_pass(),
+            github_actions_result="PASS",
+            open_v1_blockers=0,
+            open_prs=0,
+            created_at="2026-06-17T00:00:00+00:00",
+        )
+        gate["classified_findings"].append(
+            {
+                "finding_id": "manual-public-promise-break",
+                "title": "Public promise would be false",
+                "classification": "v1_blocker",
+                "status": "open",
+                "rationale": "This must reopen v1 until fixed.",
+                "owner": "factory-orchestrator",
+                "evidence_refs": ["external:public-v1-blocker"]
+            }
+        )
+
+        errors = factoryctl.validate_factory_v1_completion_gate(gate)
+
+        self.assertTrue(any("PASS has open v1 blockers" in error for error in errors), errors)
+
+    def test_v1_completion_gate_cli_writes_pass_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            release_path = tmp / "release-preflight.json"
+            out = tmp / "factory-v1-completion-gate.json"
+            release_path.write_text(json.dumps(release_preflight_pass()), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "v1-completion-gate",
+                    "--release-preflight",
+                    str(release_path),
+                    "--github-actions-result",
+                    "PASS",
+                    "--open-v1-blockers",
+                    "0",
+                    "--open-prs",
+                    "0",
+                    "--created-at",
+                    "2026-06-17T00:00:00+00:00",
+                    "--out",
+                    str(out),
+                ]
+            )
+            gate = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(gate["decision"], "PASS")
+        self.assertEqual(factoryctl.validate_factory_v1_completion_gate(gate), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a public Factory v1 Completion Gate contract, template, CLI builder and validator.
- Converts endless audit drift into a hard finish-line rule: every new finding must be classified as `v1_blocker`, `vnext` or `not_planned`.
- Requires current route coverage, release preflight, GitHub Actions state, open PR count and open v1 blocker count before claiming Factory v1 public kernel closure.
- Updates README and release/CLI docs with the new closure path.

## Scope Notes
- This does not touch issue #84 or cockpit implementation.
- The committed template is blocked by default and is not a live release proof.
- Generated live gate outputs stay under `.tmp` and are not committed.
- A PASS means the public Factory v1 kernel can close; it does not claim product-specific completion, hosted service release, mainnet release or universal runtime proof.

## Local Validation
- `python -m unittest discover -s tests -q`
- `python -m unittest tests.test_factory_v1_completion_gate tests.test_factory_route_registry -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/release_integration_preflight.py`
- `python scripts/factoryctl.py validate-v1-completion-gate templates/factory-v1-completion-gate.json`
- package smoke outside checkout including `factoryctl validate-v1-completion-gate`