### PR TITLE
Add public map fidelity gate

### DIFF
--- a/docs/public-surface.manifest.json
+++ b/docs/public-surface.manifest.json
@@ -49,6 +49,7 @@
         "source_refs_exist",
         "worker_count",
         "stage_count",
+        "map_fidelity",
         "risk_tiers",
         "source_of_truth_disclaimer",
         "no_runtime_proof_claim"
@@ -73,7 +74,66 @@
         "Mapa != Prova",
         "Hermes segue como fonte da verdade",
         "não provam entrega"
-      ]
+      ],
+      "fidelity_contract": {
+        "workflow_catalog_ref": "docs/factory-workflow.catalog.json",
+        "stage_agent_map_ref": "docs/agents/factory-stage-agent-map.md",
+        "required_workflow_phase_ids": [
+          "__all__"
+        ],
+        "required_template_refs": [
+          "templates/universal-signal-intake.json",
+          "templates/product-creation-plan.json",
+          "templates/product-implementation-readiness.json",
+          "templates/professional-design-process.json",
+          "templates/product-delivery-quality-profile.json"
+        ],
+        "required_terms": [
+          "Universal Signal Intake",
+          "full Product SOT scope coverage",
+          "Specialist Research Decision",
+          "Product Creation Plan",
+          "Product Experience Gate",
+          "Product Implementation Readiness",
+          "Factory v1 Completion Gate",
+          "Mapa != Prova"
+        ],
+        "required_stage_nodes": [
+          { "node_id": "intake", "title": "Universal Signal Intake", "required_output_terms": ["Tipo de sinal"] },
+          { "node_id": "ledger", "title": "Source Ledger" },
+          { "node_id": "resolution", "title": "Source Resolution", "required_output_terms": ["Specialist Research Decision"] },
+          { "node_id": "outcome", "title": "Resultado e Descoberta" },
+          { "node_id": "sot", "title": "Product SOT", "required_output_terms": ["full Product SOT scope coverage"] },
+          { "node_id": "router", "title": "Roteador de Método" },
+          { "node_id": "contract", "title": "Contrato de Método" },
+          { "node_id": "packs", "title": "Product e Surface Packs" },
+          { "node_id": "securityplan", "title": "Arquitetura de Segurança" },
+          { "node_id": "devplan", "title": "Product Creation Plan", "required_output_terms": ["Product Creation Plan", "Work units"] },
+          { "node_id": "experience", "title": "Product Experience Gate", "required_output_terms": ["professional_design_process", "surface_evidence_profile", "product_delivery_quality_profile"] },
+          { "node_id": "dataeval", "title": "Dados e Evals" },
+          { "node_id": "specgraph", "title": "Grafo de Especificação" },
+          { "node_id": "riskgates", "title": "Gates de Risco" },
+          { "node_id": "loop", "title": "Plano de Loops" },
+          { "node_id": "autonomy", "title": "Prontidão de Autonomia" },
+          { "node_id": "ready", "title": "Product Implementation Readiness" },
+          { "node_id": "controltower", "title": "Projeção da Control Tower" },
+          { "node_id": "humangate", "title": "Gate Humano" },
+          { "node_id": "runtime", "title": "Runtime Hermes" },
+          { "node_id": "workerresult", "title": "Resultado do Agente" },
+          { "node_id": "verification", "title": "Verificação" },
+          { "node_id": "review", "title": "Revisão Independente" },
+          { "node_id": "closure", "title": "Resumo de Fechamento" },
+          { "node_id": "receipt", "title": "Receipt Five" },
+          { "node_id": "completion", "title": "Factory v1 Completion Gate", "required_output_terms": ["v1 blocker", "vNext ou not planned"] },
+          { "node_id": "prodops", "title": "Operação de Produção" },
+          { "node_id": "release", "title": "Release ou Bloqueio" },
+          { "node_id": "monitoring", "title": "Monitoramento e Suporte" },
+          { "node_id": "learnback", "title": "Learnback" },
+          { "node_id": "maturity", "title": "Auditoria de Maturidade" },
+          { "node_id": "readiness", "title": "Mapa != Prova" },
+          { "node_id": "r4", "title": "Rigor R4" }
+        ]
+      }
     },
     {
       "surface_id": "visual-map-v1.0.1-svg",
@@ -91,6 +151,7 @@
       "claim_checks": [
         "metadata",
         "source_refs_exist",
+        "map_fidelity",
         "risk_tiers",
         "source_of_truth_disclaimer",
         "no_runtime_proof_claim"
@@ -102,7 +163,25 @@
         "Factory v1 Completion Gate",
         "not runtime evidence",
         "not a source of truth"
-      ]
+      ],
+      "fidelity_contract": {
+        "workflow_catalog_ref": "docs/factory-workflow.catalog.json",
+        "stage_agent_map_ref": "docs/agents/factory-stage-agent-map.md",
+        "required_workflow_phase_ids": [],
+        "required_template_refs": [
+          "templates/universal-signal-intake.json",
+          "templates/product-creation-plan.json",
+          "templates/product-implementation-readiness.json"
+        ],
+        "required_terms": [
+          "Universal Signal Intake",
+          "Product Creation Plan",
+          "Product Implementation Readiness",
+          "Factory v1 Completion Gate",
+          "not runtime evidence",
+          "not a source of truth"
+        ]
+      }
     },
     {
       "surface_id": "visuals-index",

--- a/schemas/public-surface-manifest.schema.json
+++ b/schemas/public-surface-manifest.schema.json
@@ -85,6 +85,7 @@
                 "source_refs_exist",
                 "worker_count",
                 "stage_count",
+                "map_fidelity",
                 "risk_tiers",
                 "source_of_truth_disclaimer",
                 "no_runtime_proof_claim",
@@ -102,6 +103,42 @@
           "required_phrases": {
             "type": "array",
             "items": { "type": "string", "minLength": 3 }
+          },
+          "fidelity_contract": {
+            "type": "object",
+            "properties": {
+              "workflow_catalog_ref": { "type": "string", "minLength": 3 },
+              "stage_agent_map_ref": { "type": "string", "minLength": 3 },
+              "required_workflow_phase_ids": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 2 }
+              },
+              "required_template_refs": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "required_terms": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "required_stage_nodes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["node_id", "title"],
+                  "properties": {
+                    "node_id": { "type": "string", "minLength": 2 },
+                    "title": { "type": "string", "minLength": 3 },
+                    "required_output_terms": {
+                      "type": "array",
+                      "items": { "type": "string", "minLength": 3 }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
           },
           "expected_links": {
             "type": "array",

--- a/scripts/validate_public_surface_sync.py
+++ b/scripts/validate_public_surface_sync.py
@@ -43,6 +43,27 @@ def normalized(text: str) -> str:
     return " ".join(text.lower().split())
 
 
+def normalized_loose(text: str) -> str:
+    text = re.sub(r"[_\-/]+", " ", text.lower())
+    return " ".join(text.split())
+
+
+def contains_loose(text: str, term: str) -> bool:
+    return normalized_loose(term) in normalized_loose(text)
+
+
+def term_variants(value: str) -> list[str]:
+    raw = str(value).strip()
+    words = [part for part in re.split(r"[_\-/\s]+", raw) if part]
+    variants = {raw}
+    if words:
+        variants.add(" ".join(words))
+        variants.add(" ".join(part[:1].upper() + part[1:] for part in words))
+        variants.add("_".join(words))
+        variants.add("-".join(words))
+    return [item for item in variants if item]
+
+
 def repo_path(root: Path, rel: str) -> Path:
     path = root / rel
     if not path.resolve().is_relative_to(root.resolve()):
@@ -74,6 +95,23 @@ def html_stage_count(text: str) -> int | None:
     return len(re.findall(r"\\{ id: \"[^\"]+\", n:", text)) or None
 
 
+def html_stage_nodes(text: str) -> dict[str, dict[str, Any]]:
+    nodes: dict[str, dict[str, Any]] = {}
+    stage_pattern = re.compile(
+        r'\{ id: "([^"]+)", n: "([^"]+)",.*?title: "([^"]+)".*?output: \[(.*?)\]',
+        flags=re.DOTALL,
+    )
+    for match in stage_pattern.finditer(text):
+        node_id, number, title, output_blob = match.groups()
+        outputs = re.findall(r'"([^"]+)"', output_blob)
+        nodes[node_id] = {
+            "number": number,
+            "title": title,
+            "outputs": outputs,
+        }
+    return nodes
+
+
 def missing_risk_tiers(text: str) -> set[str]:
     if "R0-R4" in text:
         return set()
@@ -102,6 +140,108 @@ def source_ref_exists(root: Path, ref: str) -> bool:
     if ref.startswith(("http://", "https://", "external:", "factoryctl:")):
         return True
     return repo_path(root, ref).exists()
+
+
+def load_workflow_phases(root: Path, workflow_catalog_ref: str) -> dict[str, dict[str, Any]]:
+    catalog = load_json(repo_path(root, workflow_catalog_ref))
+    phases = catalog.get("phases", [])
+    if not isinstance(phases, list):
+        raise ValueError(f"{workflow_catalog_ref}: phases must be an array")
+    indexed: dict[str, dict[str, Any]] = {}
+    for phase in phases:
+        if isinstance(phase, dict) and phase.get("phase_id"):
+            indexed[str(phase["phase_id"])] = phase
+    return indexed
+
+
+def workflow_phase_terms(phase: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("phase_name",):
+        value = phase.get(key)
+        if isinstance(value, str):
+            values.extend(term_variants(value))
+    for key in ("required_artifacts", "optional_artifacts", "required_gates", "required_workers"):
+        for value in phase.get(key, []):
+            if isinstance(value, str):
+                values.extend(term_variants(value))
+    return values
+
+
+def validate_map_fidelity(surface: dict[str, Any], text: str, *, root: Path) -> list[str]:
+    rel = str(surface.get("path") or "")
+    contract = surface.get("fidelity_contract")
+    if not isinstance(contract, dict):
+        return [f"{rel}: map_fidelity check requires fidelity_contract"]
+
+    findings: list[str] = []
+    workflow_catalog_ref = str(contract.get("workflow_catalog_ref") or "")
+    stage_agent_map_ref = str(contract.get("stage_agent_map_ref") or "")
+
+    for ref_name, ref in (
+        ("workflow_catalog_ref", workflow_catalog_ref),
+        ("stage_agent_map_ref", stage_agent_map_ref),
+    ):
+        if ref and not source_ref_exists(root, ref):
+            findings.append(f"{rel}: fidelity {ref_name} does not exist: {ref}")
+
+    if workflow_catalog_ref and source_ref_exists(root, workflow_catalog_ref):
+        try:
+            phases = load_workflow_phases(root, workflow_catalog_ref)
+        except ValueError as exc:
+            findings.append(f"{rel}: {exc}")
+            phases = {}
+        requested_phase_ids = [str(item) for item in contract.get("required_workflow_phase_ids", [])]
+        phase_ids = list(phases) if "__all__" in requested_phase_ids else requested_phase_ids
+        for phase_id in phase_ids:
+            phase = phases.get(str(phase_id))
+            if not phase:
+                findings.append(f"{rel}: fidelity workflow phase is missing from catalog: {phase_id}")
+                continue
+            terms = workflow_phase_terms(phase)
+            if terms and not any(contains_loose(text, term) for term in terms):
+                findings.append(
+                    f"{rel}: fidelity workflow phase {phase_id} has no derived map coverage"
+                )
+
+    for ref in contract.get("required_template_refs", []):
+        ref = str(ref)
+        if not source_ref_exists(root, ref):
+            findings.append(f"{rel}: fidelity template_ref does not exist: {ref}")
+            continue
+        stem = repo_path(root, ref).stem
+        if not any(contains_loose(text, term) for term in term_variants(stem)):
+            findings.append(f"{rel}: fidelity template_ref has no map coverage: {ref}")
+
+    for term in contract.get("required_terms", []):
+        if not contains_loose(text, str(term)):
+            findings.append(f"{rel}: missing fidelity term {term!r}")
+
+    required_nodes = contract.get("required_stage_nodes", [])
+    if required_nodes:
+        nodes = html_stage_nodes(text)
+        for required_node in required_nodes:
+            if not isinstance(required_node, dict):
+                findings.append(f"{rel}: fidelity required_stage_nodes entries must be objects")
+                continue
+            node_id = str(required_node.get("node_id") or "")
+            expected_title = str(required_node.get("title") or "")
+            actual = nodes.get(node_id)
+            if not actual:
+                findings.append(f"{rel}: fidelity stage node is missing: {node_id}")
+                continue
+            if expected_title and actual.get("title") != expected_title:
+                findings.append(
+                    f"{rel}: fidelity stage node {node_id} title {actual.get('title')!r} "
+                    f"does not match {expected_title!r}"
+                )
+            output_text = " ".join(str(item) for item in actual.get("outputs", []))
+            for term in required_node.get("required_output_terms", []):
+                if not contains_loose(output_text, str(term)):
+                    findings.append(
+                        f"{rel}: fidelity stage node {node_id} missing output term {term!r}"
+                    )
+
+    return findings
 
 
 def validate_surface(
@@ -148,6 +288,9 @@ def validate_surface(
             findings.append(f"{rel}: visual stage count {visual} does not match manifest expected_stage_count {expected_stage_count}")
         if visual is not None and visual != canonical and not surface.get("conceptual_exceptions"):
             findings.append(f"{rel}: visual stage count differs from canonical stage map without conceptual_exceptions")
+
+    if "map_fidelity" in checks:
+        findings.extend(validate_map_fidelity(surface, text, root=root))
 
     if "risk_tiers" in checks:
         missing = missing_risk_tiers(text)

--- a/tests/test_public_surface_sync.py
+++ b/tests/test_public_surface_sync.py
@@ -89,6 +89,68 @@ class PublicSurfaceSyncTest(unittest.TestCase):
             ],
         )
 
+    def test_map_fidelity_missing_workflow_phase_coverage_is_detected(self) -> None:
+        manifest = self.manifest()
+        surface = copy.deepcopy(manifest["surfaces"][0])
+
+        findings = surface_sync.validate_map_fidelity(
+            surface,
+            "this public map intentionally omits every canonical phase term",
+            root=ROOT,
+        )
+
+        self.assertTrue(
+            any("fidelity workflow phase F1 has no derived map coverage" in finding for finding in findings),
+            findings,
+        )
+
+    def test_map_fidelity_stage_node_title_drift_is_detected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["surfaces"][0]["fidelity_contract"]["required_stage_nodes"] = [
+            {"node_id": "intake", "title": "Old Intake Name"}
+        ]
+
+        findings = surface_sync.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "docs/visuals/overkill-factory-map-v1.0.1.html: fidelity stage node intake title "
+            "'Universal Signal Intake' does not match 'Old Intake Name'",
+            findings,
+        )
+
+    def test_map_fidelity_missing_stage_output_term_is_detected(self) -> None:
+        manifest = self.manifest()
+        mutated = copy.deepcopy(manifest)
+        mutated["surfaces"][0]["fidelity_contract"]["required_stage_nodes"] = [
+            {"node_id": "completion", "title": "Factory v1 Completion Gate", "required_output_terms": ["missing closure class"]}
+        ]
+
+        findings = surface_sync.validate_manifest_data(mutated)
+
+        self.assertIn(
+            "docs/visuals/overkill-factory-map-v1.0.1.html: fidelity stage node completion "
+            "missing output term 'missing closure class'",
+            findings,
+        )
+
+    def test_map_fidelity_missing_template_term_is_detected(self) -> None:
+        manifest = self.manifest()
+        surface = copy.deepcopy(manifest["surfaces"][0])
+        surface["fidelity_contract"]["required_template_refs"] = ["templates/universal-signal-intake.json"]
+
+        findings = surface_sync.validate_map_fidelity(
+            surface,
+            "this public map intentionally omits the template-backed intake name",
+            root=ROOT,
+        )
+
+        self.assertIn(
+            "docs/visuals/overkill-factory-map-v1.0.1.html: fidelity template_ref has no map coverage: "
+            "templates/universal-signal-intake.json",
+            findings,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- adds a map_fidelity claim check to the public surface manifest schema
- adds a idelity_contract for the interactive public map and SVG preview
- teaches alidate_public_surface_sync.py to validate canonical workflow coverage, required template coverage, required map terms and required HTML stage node ids/titles/output labels
- uses __all__ for the interactive map workflow coverage so future catalog phases force map review instead of silently drifting
- adds negative tests for missing workflow coverage, stale node titles, missing output terms and missing template-backed terms

Closes #291.

## Validation
- python scripts/validate_public_surface_sync.py --check-published
- python scripts/validate_public_json_artifacts.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- python scripts/validate_document_governance.py
- python -m unittest tests.test_public_surface_sync tests.test_open_source_docs -q

## Notes
- No private evidence, screenshots, local paths or historical audit artifacts were added.
- The map remains a conceptual supporting public surface; the gate prevents semantic drift but does not claim runtime/prod proof.