### PR TITLE
Add source resolution handoff runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Useful next commands:
 ```bash
 factoryctl init --out ../my-product-factory --project-name my-product
 factoryctl route-registry --route-class product_creation
+factoryctl intake --route-class product_creation --request-type product_new --signal-type product_paper --summary "Public product brief enters the complete product-creation route." --source-ref external:source-card-product-brief --out .tmp/product-intake.json
+factoryctl source-resolution --intake .tmp/product-intake.json --intake-ref external:sanitized-product-intake --out .tmp/source-resolution-packet.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -99,6 +99,8 @@ Comandos uteis na sequencia:
 ```bash
 factoryctl init --out ../my-product-factory --project-name my-product
 factoryctl route-registry --route-class product_creation
+factoryctl intake --route-class product_creation --request-type product_new --signal-type product_paper --summary "Brief publico do produto entra pela rota completa de criacao." --source-ref external:source-card-product-brief --out .tmp/product-intake.json
+factoryctl source-resolution --intake .tmp/product-intake.json --intake-ref external:sanitized-product-intake --out .tmp/source-resolution-packet.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,6 +42,8 @@ factoryctl validate-card examples/minimal-hermes-project/card.md
 factoryctl route-registry --route-class product_creation
 factoryctl intake --route-class bug_repair --request-type bug --signal-type bug_report --summary "Public-safe bug report enters reproduction and regression gates." --source-ref external:source-card-bug-001 --out .tmp/bug-intake.json
 factoryctl validate-signal-intake templates/universal-signal-intake.json
+factoryctl source-resolution --intake templates/universal-signal-intake.json --intake-ref templates/universal-signal-intake.json --out .tmp/source-resolution-packet.json
+factoryctl validate-source-resolution templates/source-resolution-packet.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
@@ -64,7 +66,10 @@ and execution blocked until the factory has enough source and scope.
 `route-registry` exposes the canonical route matrix used by the validators:
 route class, request types, signal types, required artifacts, workers, recovery
 policy and Hermes boundary. `intake` builds a valid Universal Signal Intake
-from that registry without executing work. `validate-signal-corpus` and
+from that registry without executing work. `source-resolution` turns a valid
+intake into the next factory-owned source-resolution handoff packet, keeping
+Product SOT ungenerated and execution blocked until the source ledger, route
+artifacts, gates and workers pass. `validate-signal-corpus` and
 `signal-coverage` prove that the public Golden Corpus covers every known route
 without treating contract coverage as production readiness.
 

--- a/schemas/source-resolution-packet.schema.json
+++ b/schemas/source-resolution-packet.schema.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/source-resolution-packet.schema.json",
+  "title": "Overkill Factory Source Resolution Packet",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "packet_id",
+    "created_at",
+    "factory_method_version",
+    "intake_ref_public_safe",
+    "source_signal",
+    "source_claim_classes",
+    "resolution_policy",
+    "next_artifacts",
+    "required_gates",
+    "required_workers",
+    "blocking_rules",
+    "handoff",
+    "public_private_boundary",
+    "acceptance"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/source-resolution-packet.schema.json"
+    },
+    "record_type": {
+      "const": "source_resolution_packet"
+    },
+    "packet_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "intake_ref_public_safe": {
+      "type": "string",
+      "minLength": 3
+    },
+    "source_signal": {
+      "type": "object",
+      "required": [
+        "intake_id",
+        "signal_type",
+        "request_type",
+        "route_class",
+        "target_surface",
+        "summary_public_safe",
+        "signal_ref_public_safe",
+        "source_class",
+        "sensitivity_class",
+        "freshness",
+        "risk_initial",
+        "materiality",
+        "needs_product_sot"
+      ],
+      "properties": {
+        "intake_id": { "type": "string", "minLength": 3 },
+        "signal_type": { "type": "string", "minLength": 3 },
+        "request_type": { "type": "string", "minLength": 3 },
+        "route_class": { "type": "string", "minLength": 3 },
+        "target_surface": { "type": "string", "minLength": 3 },
+        "summary_public_safe": { "type": "string", "minLength": 6 },
+        "signal_ref_public_safe": { "type": "string", "minLength": 3 },
+        "source_class": { "type": "string", "minLength": 3 },
+        "sensitivity_class": { "type": "string", "minLength": 3 },
+        "freshness": { "type": "string", "minLength": 3 },
+        "risk_initial": { "type": "string", "minLength": 2 },
+        "materiality": { "type": "string", "minLength": 3 },
+        "needs_product_sot": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "source_claim_classes": {
+      "type": "array",
+      "minItems": 6,
+      "items": {
+        "type": "object",
+        "required": ["class", "routing"],
+        "properties": {
+          "class": {
+            "enum": ["fact", "inference", "decision", "conflict", "gap", "stale"]
+          },
+          "routing": {
+            "type": "string",
+            "minLength": 6
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "resolution_policy": {
+      "type": "object",
+      "required": [
+        "source_resolution_required",
+        "factory_owns_discoverable_gaps",
+        "user_only_for_authority_access_risk_or_preference",
+        "no_chat_only_state",
+        "claim_resolution_required_before_product_sot",
+        "non_human_block_recovery"
+      ],
+      "properties": {
+        "source_resolution_required": { "const": true },
+        "factory_owns_discoverable_gaps": { "const": true },
+        "user_only_for_authority_access_risk_or_preference": { "const": true },
+        "no_chat_only_state": { "const": true },
+        "claim_resolution_required_before_product_sot": { "const": true },
+        "non_human_block_recovery": {
+          "type": "object",
+          "required": ["factory_owned_repair_allowed", "retry_policy"],
+          "properties": {
+            "factory_owned_repair_allowed": { "const": true },
+            "retry_policy": {
+              "type": "object",
+              "required": ["max_attempts", "until"],
+              "properties": {
+                "max_attempts": { "type": "integer", "minimum": 1 },
+                "until": { "type": "string", "minLength": 6 }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "next_artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "artifact_type",
+          "artifact_ref",
+          "required_before",
+          "owner_worker",
+          "status",
+          "blocks_execution_when_missing"
+        ],
+        "properties": {
+          "artifact_type": { "type": "string", "minLength": 3 },
+          "artifact_ref": { "type": "string", "minLength": 3 },
+          "required_before": {
+            "enum": [
+              "source_resolution",
+              "product_sot",
+              "method_contract",
+              "ready_gate",
+              "execution",
+              "verification",
+              "release",
+              "completion"
+            ]
+          },
+          "owner_worker": { "type": "string", "minLength": 3 },
+          "status": {
+            "enum": [
+              "pending_factory_worker",
+              "blocked",
+              "not_required"
+            ]
+          },
+          "blocks_execution_when_missing": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "required_gates": { "type": "array", "minItems": 1 },
+    "required_workers": { "type": "array", "minItems": 1 },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "source_resolution_required",
+        "source_ledger_required",
+        "product_sot_worker_required",
+        "execution_blocked_until_required_artifacts_pass",
+        "human_gate_only_for_authority_access_risk_or_preference"
+      ],
+      "properties": {
+        "source_resolution_required": { "const": true },
+        "source_ledger_required": { "const": true },
+        "product_sot_worker_required": { "type": "boolean" },
+        "execution_blocked_until_required_artifacts_pass": { "const": true },
+        "human_gate_only_for_authority_access_risk_or_preference": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "next_artifact",
+        "next_worker",
+        "next_safe_action",
+        "user_decision_required",
+        "factory_owned_next_step"
+      ],
+      "properties": {
+        "next_artifact": { "type": "string", "minLength": 3 },
+        "next_worker": { "type": "string", "minLength": 3 },
+        "next_safe_action": { "type": "string", "minLength": 6 },
+        "user_decision_required": { "type": "boolean" },
+        "factory_owned_next_step": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo",
+        "operator_instance_may_hold_private_source"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true },
+        "operator_instance_may_hold_private_source": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "source_resolution_packet_ready",
+        "product_sot_generated",
+        "execution_allowed",
+        "blocked_reason",
+        "evidence_refs"
+      ],
+      "properties": {
+        "source_resolution_packet_ready": { "const": true },
+        "product_sot_generated": { "const": false },
+        "execution_allowed": { "const": false },
+        "blocked_reason": { "type": "string", "minLength": 6 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -10,6 +10,7 @@ specialist worker still has to run and attach real evidence.
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import importlib.util
 import json
@@ -5925,6 +5926,300 @@ def build_universal_signal_intake(
     }
 
 
+SOURCE_CLAIM_CLASSES = [
+    {
+        "class": "fact",
+        "routing": "Resolved facts become source-ledger claims with evidence refs before Product SOT.",
+    },
+    {
+        "class": "inference",
+        "routing": "Inferences stay marked as inference until accepted by the responsible factory worker.",
+    },
+    {
+        "class": "decision",
+        "routing": "Decisions require an owner, authority class and downstream artifact impact.",
+    },
+    {
+        "class": "conflict",
+        "routing": "Conflicts block promotion until source resolution assigns a winner, split, or human gate.",
+    },
+    {
+        "class": "gap",
+        "routing": "Discoverable gaps stay factory-owned; only authority, access, risk or preference gaps reach the user.",
+    },
+    {
+        "class": "stale",
+        "routing": "Stale material must be refreshed, marked bounded, or excluded before it can shape Product SOT.",
+    },
+]
+
+
+def _source_resolution_next_artifacts(intake: dict[str, Any]) -> list[dict[str, Any]]:
+    artifacts = intake.get("required_artifacts") if isinstance(intake.get("required_artifacts"), list) else []
+    next_artifacts: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        artifact_type = str(artifact.get("artifact_type") or "").strip()
+        if not artifact_type:
+            continue
+        seen.add(artifact_type)
+        next_artifacts.append(
+            {
+                "artifact_type": artifact_type,
+                "artifact_ref": str(artifact.get("artifact_ref") or artifact_ref_for_type(artifact_type)),
+                "required_before": str(artifact.get("required_before") or artifact_required_before(artifact_type)),
+                "owner_worker": str(artifact.get("owner_worker") or "factory-orchestrator"),
+                "status": "pending_factory_worker",
+                "blocks_execution_when_missing": bool(artifact.get("blocks_execution_when_missing") is True),
+            }
+        )
+    if "source_ledger" not in seen:
+        next_artifacts.insert(
+            0,
+            {
+                "artifact_type": "source_ledger",
+                "artifact_ref": artifact_ref_for_type("source_ledger"),
+                "required_before": artifact_required_before("source_ledger"),
+                "owner_worker": artifact_owner_for_type("source_ledger", {}),
+                "status": "pending_factory_worker",
+                "blocks_execution_when_missing": True,
+            },
+        )
+    return next_artifacts
+
+
+def _next_source_worker(packet_artifacts: list[dict[str, Any]]) -> str:
+    for artifact in packet_artifacts:
+        if artifact.get("artifact_type") == "source_ledger":
+            return str(artifact.get("owner_worker") or "source-ledger-worker")
+    return "source-ledger-worker"
+
+
+def build_source_resolution_packet(
+    intake: dict[str, Any],
+    *,
+    intake_ref_public_safe: str,
+    created_at: str | None = None,
+    packet_id: str | None = None,
+) -> dict[str, Any]:
+    intake_errors = validate_universal_signal_intake(intake)
+    if intake_errors:
+        raise ValueError("; ".join(intake_errors))
+
+    signal = intake.get("signal") if isinstance(intake.get("signal"), dict) else {}
+    classification = intake.get("classification") if isinstance(intake.get("classification"), dict) else {}
+    route = intake.get("route_decision") if isinstance(intake.get("route_decision"), dict) else {}
+    recovery = route.get("non_human_block_recovery") if isinstance(route.get("non_human_block_recovery"), dict) else {}
+    retry_policy = recovery.get("retry_policy") if isinstance(recovery.get("retry_policy"), dict) else {}
+    next_artifacts = _source_resolution_next_artifacts(intake)
+    next_worker = _next_source_worker(next_artifacts)
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    intake_id = str(intake.get("intake_id") or "intake")
+    needs_product_sot = bool(classification.get("needs_product_sot") is True)
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/source-resolution-packet.schema.json",
+        "record_type": "source_resolution_packet",
+        "packet_id": packet_id or f"source-resolution-{slug_for_ref(intake_id)}",
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "intake_ref_public_safe": intake_ref_public_safe,
+        "source_signal": {
+            "intake_id": intake_id,
+            "signal_type": str(signal.get("signal_type") or ""),
+            "request_type": str(classification.get("request_type") or ""),
+            "route_class": str(classification.get("route_class") or ""),
+            "target_surface": str(signal.get("target_surface") or ""),
+            "summary_public_safe": str(signal.get("summary_public_safe") or ""),
+            "signal_ref_public_safe": str(signal.get("signal_ref_public_safe") or ""),
+            "source_class": str(signal.get("source_class") or ""),
+            "sensitivity_class": str(signal.get("sensitivity_class") or ""),
+            "freshness": str(signal.get("freshness") or ""),
+            "risk_initial": str(classification.get("risk_initial") or ""),
+            "materiality": str(classification.get("materiality") or ""),
+            "needs_product_sot": needs_product_sot,
+        },
+        "source_claim_classes": copy.deepcopy(SOURCE_CLAIM_CLASSES),
+        "resolution_policy": {
+            "source_resolution_required": True,
+            "factory_owns_discoverable_gaps": True,
+            "user_only_for_authority_access_risk_or_preference": True,
+            "no_chat_only_state": True,
+            "claim_resolution_required_before_product_sot": True,
+            "non_human_block_recovery": {
+                "factory_owned_repair_allowed": True,
+                "retry_policy": {
+                    "max_attempts": int(retry_policy.get("max_attempts") or 1),
+                    "until": str(retry_policy.get("until") or "the blocking gate passes"),
+                },
+            },
+        },
+        "next_artifacts": next_artifacts,
+        "required_gates": copy.deepcopy(intake.get("required_gates") or []),
+        "required_workers": copy.deepcopy(intake.get("required_workers") or []),
+        "blocking_rules": {
+            "source_resolution_required": True,
+            "source_ledger_required": True,
+            "product_sot_worker_required": needs_product_sot,
+            "execution_blocked_until_required_artifacts_pass": True,
+            "human_gate_only_for_authority_access_risk_or_preference": True,
+        },
+        "handoff": {
+            "next_artifact": "source_ledger",
+            "next_worker": next_worker,
+            "next_safe_action": "Materialize the source ledger and resolve source claims before Product SOT or execution.",
+            "user_decision_required": False,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+            "operator_instance_may_hold_private_source": True,
+        },
+        "acceptance": {
+            "source_resolution_packet_ready": True,
+            "product_sot_generated": False,
+            "execution_allowed": False,
+            "blocked_reason": (
+                "Source resolution handoff is ready, but execution remains blocked until source ledger, "
+                "Product SOT when required, method contract, readiness and gates pass."
+            ),
+            "evidence_refs": [
+                "schemas/source-resolution-packet.schema.json",
+                "schemas/universal-signal-intake.schema.json",
+                "templates/factory-route-registry.json",
+            ],
+        },
+    }
+
+
+def validate_source_resolution_packet(packet: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("source-resolution-packet.schema.json")
+    if not schema:
+        return ["source_resolution_packet schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            packet,
+            "source_resolution_packet",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    intake_ref = str(packet.get("intake_ref_public_safe") or "").strip()
+    if intake_ref:
+        _validate_public_ref(intake_ref, "source_resolution_packet.intake_ref_public_safe", errors)
+
+    source_signal = packet.get("source_signal") if isinstance(packet.get("source_signal"), dict) else {}
+    signal_ref = str(source_signal.get("signal_ref_public_safe") or "").strip()
+    if signal_ref:
+        _validate_public_ref(signal_ref, "source_resolution_packet.source_signal.signal_ref_public_safe", errors)
+
+    claim_classes = {
+        str(item.get("class") or "").strip()
+        for item in packet.get("source_claim_classes", [])
+        if isinstance(item, dict)
+    }
+    missing_claim_classes = sorted({"fact", "inference", "decision", "conflict", "gap", "stale"} - claim_classes)
+    if missing_claim_classes:
+        errors.append("source_resolution_packet missing claim classes: " + ", ".join(missing_claim_classes))
+
+    resolution = packet.get("resolution_policy") if isinstance(packet.get("resolution_policy"), dict) else {}
+    if resolution.get("source_resolution_required") is not True:
+        errors.append("source_resolution_packet.source_resolution_required must be true")
+    if resolution.get("factory_owns_discoverable_gaps") is not True:
+        errors.append("source_resolution_packet discoverable gaps must be factory-owned")
+    if resolution.get("user_only_for_authority_access_risk_or_preference") is not True:
+        errors.append("source_resolution_packet user gate must be limited to authority, access, risk or preference")
+    if resolution.get("no_chat_only_state") is not True:
+        errors.append("source_resolution_packet no_chat_only_state must be true")
+    if resolution.get("claim_resolution_required_before_product_sot") is not True:
+        errors.append("source_resolution_packet claim resolution must precede Product SOT")
+    recovery = resolution.get("non_human_block_recovery") if isinstance(resolution.get("non_human_block_recovery"), dict) else {}
+    if recovery.get("factory_owned_repair_allowed") is not True:
+        errors.append("source_resolution_packet non-human block must return to factory-owned repair")
+    retry_policy = recovery.get("retry_policy") if isinstance(recovery.get("retry_policy"), dict) else {}
+    max_attempts = retry_policy.get("max_attempts")
+    if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or max_attempts < 1:
+        errors.append("source_resolution_packet retry_policy.max_attempts must be >= 1")
+
+    artifacts = packet.get("next_artifacts") if isinstance(packet.get("next_artifacts"), list) else []
+    artifact_types = {
+        str(artifact.get("artifact_type") or "").strip()
+        for artifact in artifacts
+        if isinstance(artifact, dict)
+    }
+    if "source_ledger" not in artifact_types:
+        errors.append("source_resolution_packet requires source_ledger as a next artifact")
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        artifact_ref = str(artifact.get("artifact_ref") or "").strip()
+        if artifact_ref:
+            _validate_public_ref(artifact_ref, f"source_resolution_packet.next_artifacts[{index}].artifact_ref", errors)
+        if artifact.get("status") != "pending_factory_worker":
+            errors.append(f"source_resolution_packet.next_artifacts[{index}].status must be pending_factory_worker")
+        if artifact.get("blocks_execution_when_missing") is not True:
+            errors.append(
+                f"source_resolution_packet.next_artifacts[{index}].blocks_execution_when_missing must be true"
+            )
+        owner_worker = str(artifact.get("owner_worker") or "").strip()
+        if owner_worker and owner_worker not in WORKERS:
+            errors.append(
+                f"source_resolution_packet.next_artifacts[{index}].owner_worker must be a registered worker: {owner_worker}"
+            )
+
+    blocking_rules = packet.get("blocking_rules") if isinstance(packet.get("blocking_rules"), dict) else {}
+    for field in (
+        "source_resolution_required",
+        "source_ledger_required",
+        "execution_blocked_until_required_artifacts_pass",
+        "human_gate_only_for_authority_access_risk_or_preference",
+    ):
+        if blocking_rules.get(field) is not True:
+            errors.append(f"source_resolution_packet.blocking_rules.{field} must be true")
+    needs_product_sot = source_signal.get("needs_product_sot") is True
+    if needs_product_sot and blocking_rules.get("product_sot_worker_required") is not True:
+        errors.append("source_resolution_packet.blocking_rules.product_sot_worker_required must be true when Product SOT is required")
+    if not isinstance(blocking_rules.get("product_sot_worker_required"), bool):
+        errors.append("source_resolution_packet.blocking_rules.product_sot_worker_required must be boolean")
+
+    handoff = packet.get("handoff") if isinstance(packet.get("handoff"), dict) else {}
+    if handoff.get("next_artifact") != "source_ledger":
+        errors.append("source_resolution_packet.handoff.next_artifact must be source_ledger")
+    if handoff.get("factory_owned_next_step") is not True:
+        errors.append("source_resolution_packet.handoff.factory_owned_next_step must be true")
+
+    boundary = packet.get("public_private_boundary") if isinstance(packet.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("source_resolution_packet requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("source_resolution_packet must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("source_resolution_packet private context must stay outside the public repo")
+
+    acceptance = packet.get("acceptance") if isinstance(packet.get("acceptance"), dict) else {}
+    if acceptance.get("source_resolution_packet_ready") is not True:
+        errors.append("source_resolution_packet acceptance.source_resolution_packet_ready must be true")
+    if acceptance.get("product_sot_generated") is not False:
+        errors.append("source_resolution_packet must not claim Product SOT was generated")
+    if acceptance.get("execution_allowed") is not False:
+        errors.append("source_resolution_packet acceptance.execution_allowed must be false")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "source_resolution_packet.acceptance.evidence_refs",
+        errors,
+    )
+
+    return errors
+
+
 def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -11454,6 +11749,16 @@ def command_validate_signal_intake(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_source_resolution(args: argparse.Namespace) -> int:
+    errors = validate_source_resolution_packet(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_route_registry(args: argparse.Namespace) -> int:
     registry = load_route_registry(args.registry)
     if args.route_class:
@@ -11491,6 +11796,26 @@ def command_intake(args: argparse.Namespace) -> int:
             print(error, file=sys.stderr)
         return 1
     write_json(args.out, intake)
+    return 0
+
+
+def command_source_resolution(args: argparse.Namespace) -> int:
+    try:
+        packet = build_source_resolution_packet(
+            load_json_like(args.intake),
+            intake_ref_public_safe=args.intake_ref,
+            created_at=args.created_at,
+            packet_id=args.packet_id,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_source_resolution_packet(packet)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, packet)
     return 0
 
 
@@ -11920,6 +12245,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_signal_intake_parser.add_argument("path", type=Path)
     validate_signal_intake_parser.set_defaults(func=command_validate_signal_intake)
 
+    validate_source_resolution_parser = sub.add_parser("validate-source-resolution")
+    validate_source_resolution_parser.add_argument("path", type=Path)
+    validate_source_resolution_parser.set_defaults(func=command_validate_source_resolution)
+
     route_registry_parser = sub.add_parser("route-registry", help="Show the canonical Universal Signal route registry.")
     route_registry_parser.add_argument("--registry", type=Path, default=DEFAULT_ROUTE_REGISTRY_PATH)
     route_registry_parser.add_argument("--route-class")
@@ -11943,6 +12272,17 @@ def build_parser() -> argparse.ArgumentParser:
     intake_parser.add_argument("--intake-id")
     intake_parser.add_argument("--out", type=Path)
     intake_parser.set_defaults(func=command_intake)
+
+    source_resolution_parser = sub.add_parser(
+        "source-resolution",
+        help="Build a source-resolution handoff packet from a validated Universal Signal Intake.",
+    )
+    source_resolution_parser.add_argument("--intake", type=Path, required=True)
+    source_resolution_parser.add_argument("--intake-ref", default="external:sanitized-universal-signal-intake")
+    source_resolution_parser.add_argument("--created-at")
+    source_resolution_parser.add_argument("--packet-id")
+    source_resolution_parser.add_argument("--out", type=Path)
+    source_resolution_parser.set_defaults(func=command_source_resolution)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1064,6 +1064,104 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             reason = public_artifact_ref_error(ref)
             if reason:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
+    if data.get("record_type") == "source_resolution_packet":
+        intake_ref = str(data.get("intake_ref_public_safe") or "").strip()
+        reason = public_artifact_ref_error(intake_ref)
+        if reason:
+            errors.append(f"{at}.intake_ref_public_safe: {reason}")
+        source_signal = data.get("source_signal") if isinstance(data.get("source_signal"), dict) else {}
+        signal_ref = str(source_signal.get("signal_ref_public_safe") or "").strip()
+        reason = public_artifact_ref_error(signal_ref)
+        if reason:
+            errors.append(f"{at}.source_signal.signal_ref_public_safe: {reason}")
+        claim_classes = {
+            str(item.get("class") or "").strip()
+            for item in data.get("source_claim_classes", [])
+            if isinstance(item, dict)
+        }
+        missing_claim_classes = sorted({"fact", "inference", "decision", "conflict", "gap", "stale"} - claim_classes)
+        if missing_claim_classes:
+            errors.append(f"{at}: source_resolution_packet missing claim classes: " + ", ".join(missing_claim_classes))
+        resolution = data.get("resolution_policy") if isinstance(data.get("resolution_policy"), dict) else {}
+        if resolution.get("source_resolution_required") is not True:
+            errors.append(f"{at}: source_resolution_packet source_resolution_required must be true")
+        if resolution.get("factory_owns_discoverable_gaps") is not True:
+            errors.append(f"{at}: source_resolution_packet discoverable gaps must be factory-owned")
+        if resolution.get("user_only_for_authority_access_risk_or_preference") is not True:
+            errors.append(f"{at}: source_resolution_packet user gate must be limited to authority, access, risk or preference")
+        if resolution.get("no_chat_only_state") is not True:
+            errors.append(f"{at}: source_resolution_packet no_chat_only_state must be true")
+        if resolution.get("claim_resolution_required_before_product_sot") is not True:
+            errors.append(f"{at}: source_resolution_packet claim resolution must precede Product SOT")
+        recovery = resolution.get("non_human_block_recovery") if isinstance(resolution.get("non_human_block_recovery"), dict) else {}
+        if recovery.get("factory_owned_repair_allowed") is not True:
+            errors.append(f"{at}: source_resolution_packet non-human block must return to factory-owned repair")
+        retry_policy = recovery.get("retry_policy") if isinstance(recovery.get("retry_policy"), dict) else {}
+        max_attempts = retry_policy.get("max_attempts")
+        if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or max_attempts < 1:
+            errors.append(f"{at}: source_resolution_packet retry_policy.max_attempts must be >= 1")
+        artifacts = data.get("next_artifacts") if isinstance(data.get("next_artifacts"), list) else []
+        artifact_types = {
+            str(artifact.get("artifact_type") or "").strip()
+            for artifact in artifacts
+            if isinstance(artifact, dict)
+        }
+        if "source_ledger" not in artifact_types:
+            errors.append(f"{at}: source_resolution_packet requires source_ledger as a next artifact")
+        for index, artifact in enumerate(artifacts):
+            if not isinstance(artifact, dict):
+                continue
+            artifact_ref = str(artifact.get("artifact_ref") or "").strip()
+            reason = public_artifact_ref_error(artifact_ref)
+            if reason:
+                errors.append(f"{at}.next_artifacts[{index}].artifact_ref: {reason}")
+            if artifact.get("status") != "pending_factory_worker":
+                errors.append(f"{at}.next_artifacts[{index}].status must be pending_factory_worker")
+            if artifact.get("blocks_execution_when_missing") is not True:
+                errors.append(f"{at}.next_artifacts[{index}].blocks_execution_when_missing must be true")
+            owner_worker = str(artifact.get("owner_worker") or "").strip()
+            if owner_worker and owner_worker not in public_worker_ids():
+                errors.append(f"{at}.next_artifacts[{index}].owner_worker must be a registered worker: {owner_worker}")
+        blocking_rules = data.get("blocking_rules") if isinstance(data.get("blocking_rules"), dict) else {}
+        for field in (
+            "source_resolution_required",
+            "source_ledger_required",
+            "execution_blocked_until_required_artifacts_pass",
+            "human_gate_only_for_authority_access_risk_or_preference",
+        ):
+            if blocking_rules.get(field) is not True:
+                errors.append(f"{at}.blocking_rules.{field} must be true")
+        needs_product_sot = source_signal.get("needs_product_sot") is True
+        if needs_product_sot and blocking_rules.get("product_sot_worker_required") is not True:
+            errors.append(
+                f"{at}.blocking_rules.product_sot_worker_required must be true when Product SOT is required"
+            )
+        if not isinstance(blocking_rules.get("product_sot_worker_required"), bool):
+            errors.append(f"{at}.blocking_rules.product_sot_worker_required must be boolean")
+        handoff = data.get("handoff") if isinstance(data.get("handoff"), dict) else {}
+        if handoff.get("next_artifact") != "source_ledger":
+            errors.append(f"{at}: source_resolution_packet.handoff.next_artifact must be source_ledger")
+        if handoff.get("factory_owned_next_step") is not True:
+            errors.append(f"{at}: source_resolution_packet.handoff.factory_owned_next_step must be true")
+        boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: source_resolution_packet requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: source_resolution_packet must not embed raw private evidence")
+        if boundary.get("private_context_retained_outside_public_repo") is not True:
+            errors.append(f"{at}: source_resolution_packet private context must stay outside the public repo")
+        acceptance = data.get("acceptance") if isinstance(data.get("acceptance"), dict) else {}
+        if acceptance.get("source_resolution_packet_ready") is not True:
+            errors.append(f"{at}: source_resolution_packet acceptance.source_resolution_packet_ready must be true")
+        if acceptance.get("product_sot_generated") is not False:
+            errors.append(f"{at}: source_resolution_packet must not claim Product SOT was generated")
+        if acceptance.get("execution_allowed") is not False:
+            errors.append(f"{at}: source_resolution_packet acceptance.execution_allowed must be false")
+        evidence_refs = acceptance.get("evidence_refs") if isinstance(acceptance.get("evidence_refs"), list) else []
+        for index, ref in enumerate(evidence_refs):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_v1_completion_gate":

--- a/templates/source-resolution-packet.json
+++ b/templates/source-resolution-packet.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/source-resolution-packet.schema.json",
+  "record_type": "source_resolution_packet",
+  "packet_id": "source-resolution-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "intake_ref_public_safe": "templates/universal-signal-intake.json",
+  "source_signal": {
+    "intake_id": "universal-signal-intake-public-template",
+    "signal_type": "product_paper",
+    "request_type": "product_new",
+    "route_class": "product_creation",
+    "target_surface": "complete-product-production",
+    "summary_public_safe": "Operator supplied product material must become a routed source-resolution packet before Product SOT or execution starts.",
+    "signal_ref_public_safe": "external:source-card-product-brief",
+    "source_class": "operator_supplied",
+    "sensitivity_class": "public_safe",
+    "freshness": "bounded",
+    "risk_initial": "R2",
+    "materiality": "material",
+    "needs_product_sot": true
+  },
+  "source_claim_classes": [
+    {
+      "class": "fact",
+      "routing": "Resolved facts become source-ledger claims with evidence refs before Product SOT."
+    },
+    {
+      "class": "inference",
+      "routing": "Inferences stay marked as inference until accepted by the responsible factory worker."
+    },
+    {
+      "class": "decision",
+      "routing": "Decisions require an owner, authority class and downstream artifact impact."
+    },
+    {
+      "class": "conflict",
+      "routing": "Conflicts block promotion until source resolution assigns a winner, split, or human gate."
+    },
+    {
+      "class": "gap",
+      "routing": "Discoverable gaps stay factory-owned; only authority, access, risk or preference gaps reach the user."
+    },
+    {
+      "class": "stale",
+      "routing": "Stale material must be refreshed, marked bounded, or excluded before it can shape Product SOT."
+    }
+  ],
+  "resolution_policy": {
+    "source_resolution_required": true,
+    "factory_owns_discoverable_gaps": true,
+    "user_only_for_authority_access_risk_or_preference": true,
+    "no_chat_only_state": true,
+    "claim_resolution_required_before_product_sot": true,
+    "non_human_block_recovery": {
+      "factory_owned_repair_allowed": true,
+      "retry_policy": {
+        "max_attempts": 10,
+        "until": "the blocking source or readiness gate passes or a real human authority gate is required"
+      }
+    }
+  },
+  "next_artifacts": [
+    {
+      "artifact_type": "source_ledger",
+      "artifact_ref": "templates/reference-source-registry.json",
+      "required_before": "source_resolution",
+      "owner_worker": "source-ledger-worker",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "outcome_contract",
+      "artifact_ref": "templates/vfinal-factory-card.json#outcome_contract",
+      "required_before": "product_sot",
+      "owner_worker": "product-sot-planner",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "product_sot",
+      "artifact_ref": "templates/product-sot.json",
+      "required_before": "method_contract",
+      "owner_worker": "product-sot-planner",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "full_product_sot_scope_coverage",
+      "artifact_ref": "templates/full-product-sot-scope-coverage.json",
+      "required_before": "method_contract",
+      "owner_worker": "product-sot-planner",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "method_contract",
+      "artifact_ref": "templates/method-contract.json",
+      "required_before": "ready_gate",
+      "owner_worker": "factory-orchestrator",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "product_creation_plan",
+      "artifact_ref": "templates/product-creation-plan.json",
+      "required_before": "ready_gate",
+      "owner_worker": "decomposition-planner",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "product_implementation_readiness",
+      "artifact_ref": "templates/product-implementation-readiness.json",
+      "required_before": "execution",
+      "owner_worker": "factory-orchestrator",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    },
+    {
+      "artifact_type": "sdlc_feedback_loop",
+      "artifact_ref": "templates/factory-sdlc-feedback-loop.json",
+      "required_before": "execution",
+      "owner_worker": "skill-eval-distiller",
+      "status": "pending_factory_worker",
+      "blocks_execution_when_missing": true
+    }
+  ],
+  "required_gates": [
+    {
+      "gate": "Source Gate",
+      "authority": "source-ledger-worker",
+      "evidence_required": ["source refs", "claim resolution"],
+      "blocks_execution_when_missing": true
+    },
+    {
+      "gate": "Product SOT Gate",
+      "authority": "product-sot-planner",
+      "evidence_required": ["approved Product SOT", "full Product SOT scope coverage"],
+      "blocks_execution_when_missing": true
+    },
+    {
+      "gate": "Ready Gate",
+      "authority": "factory-orchestrator",
+      "evidence_required": ["product implementation readiness", "autonomy readiness"],
+      "blocks_execution_when_missing": true
+    }
+  ],
+  "required_workers": [
+    {
+      "worker_id": "factory-orchestrator",
+      "role": "route-owner",
+      "reason": "Maintains the selected route and blocks execution until required artifacts are present.",
+      "required_before_execution": true
+    },
+    {
+      "worker_id": "source-ledger-worker",
+      "role": "source-owner",
+      "reason": "Separates facts, inference, decisions, conflicts, stale material and gaps before Product SOT.",
+      "required_before_execution": true
+    },
+    {
+      "worker_id": "product-sot-planner",
+      "role": "product-scope-owner",
+      "reason": "Turns resolved source material into complete Product SOT scope.",
+      "required_before_execution": true
+    }
+  ],
+  "blocking_rules": {
+    "source_resolution_required": true,
+    "source_ledger_required": true,
+    "product_sot_worker_required": true,
+    "execution_blocked_until_required_artifacts_pass": true,
+    "human_gate_only_for_authority_access_risk_or_preference": true
+  },
+  "handoff": {
+    "next_artifact": "source_ledger",
+    "next_worker": "source-ledger-worker",
+    "next_safe_action": "Materialize the source ledger and resolve source claims before Product SOT or execution.",
+    "user_decision_required": false,
+    "factory_owned_next_step": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true,
+    "operator_instance_may_hold_private_source": true
+  },
+  "acceptance": {
+    "source_resolution_packet_ready": true,
+    "product_sot_generated": false,
+    "execution_allowed": false,
+    "blocked_reason": "Source resolution handoff is ready, but execution remains blocked until source ledger, Product SOT, method contract, readiness and gates pass.",
+    "evidence_refs": [
+      "schemas/source-resolution-packet.schema.json",
+      "schemas/universal-signal-intake.schema.json",
+      "templates/factory-route-registry.json",
+      "templates/universal-signal-intake.json"
+    ]
+  }
+}

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -123,6 +123,135 @@ class UniversalSignalIntakeTest(unittest.TestCase):
 
         self.assertEqual(result, 0)
 
+    def test_source_resolution_packet_from_intake_is_valid(self) -> None:
+        intake = signal_intake()
+
+        packet = factoryctl.build_source_resolution_packet(
+            intake,
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+
+        self.assertEqual(factoryctl.validate_source_resolution_packet(packet), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(packet, "$"), [])
+        self.assertEqual(packet["record_type"], "source_resolution_packet")
+        self.assertEqual(packet["source_signal"]["intake_id"], intake["intake_id"])
+        self.assertEqual(packet["handoff"]["next_artifact"], "source_ledger")
+        self.assertTrue(packet["handoff"]["factory_owned_next_step"])
+
+    def test_source_resolution_packet_keeps_product_sot_uncreated(self) -> None:
+        packet = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+
+        self.assertFalse(packet["acceptance"]["product_sot_generated"])
+        self.assertFalse(packet["acceptance"]["execution_allowed"])
+        self.assertTrue(packet["blocking_rules"]["product_sot_worker_required"])
+        product_sot_artifacts = [
+            artifact for artifact in packet["next_artifacts"] if artifact["artifact_type"] == "product_sot"
+        ]
+        self.assertEqual(len(product_sot_artifacts), 1)
+        self.assertEqual(product_sot_artifacts[0]["status"], "pending_factory_worker")
+
+    def test_source_resolution_packet_does_not_require_product_sot_for_bug_route(self) -> None:
+        intake = factoryctl.build_universal_signal_intake(
+            route_class="bug_repair",
+            request_type="bug",
+            signal_type="bug_report",
+            summary_public_safe="Representative bug signal should enter source resolution without Product SOT.",
+            signal_ref_public_safe="external:sanitized-bug-signal",
+            target_surface="bug-target",
+            owner="factory-orchestrator",
+            source_class="operator_supplied",
+            sensitivity_class="public_safe",
+            freshness="fresh",
+            risk_initial="R2",
+            materiality="material",
+            created_at="2026-06-17T00:00:00+00:00",
+            intake_id="intake-bug-repair",
+        )
+
+        packet = factoryctl.build_source_resolution_packet(
+            intake,
+            intake_ref_public_safe="external:sanitized-bug-intake",
+        )
+
+        self.assertFalse(packet["source_signal"]["needs_product_sot"])
+        self.assertFalse(packet["blocking_rules"]["product_sot_worker_required"])
+        self.assertFalse(any(artifact["artifact_type"] == "product_sot" for artifact in packet["next_artifacts"]))
+
+    def test_source_resolution_packet_rejects_invalid_intake(self) -> None:
+        intake = signal_intake()
+        intake["normalization"]["source_resolution_required"] = False
+
+        with self.assertRaisesRegex(ValueError, "source_resolution_required"):
+            factoryctl.build_source_resolution_packet(
+                intake,
+                intake_ref_public_safe="external:sanitized-universal-signal-intake",
+            )
+
+    def test_source_resolution_cli_generates_packet(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            intake_path = Path(tmpdir) / "signal-intake.json"
+            out_path = Path(tmpdir) / "source-resolution-packet.json"
+            intake_path.write_text(json.dumps(signal_intake()), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "source-resolution",
+                    "--intake",
+                    str(intake_path),
+                    "--intake-ref",
+                    "external:sanitized-universal-signal-intake",
+                    "--out",
+                    str(out_path),
+                ]
+            )
+
+            packet = json.loads(out_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(packet["record_type"], "source_resolution_packet")
+        self.assertEqual(factoryctl.validate_source_resolution_packet(packet), [])
+
+    def test_source_resolution_runner_covers_representative_signal_routes(self) -> None:
+        cases = [
+            ("product_creation", "product_new", "product_paper"),
+            ("ux_product_experience", "ux_ui", "ux_ui_request"),
+            ("bug_repair", "bug", "bug_report"),
+            ("incident_response", "incident", "incident"),
+            ("feature_delivery", "feature", "feature_idea"),
+        ]
+
+        for route_class, request_type, signal_type in cases:
+            with self.subTest(route_class=route_class):
+                intake = factoryctl.build_universal_signal_intake(
+                    route_class=route_class,
+                    request_type=request_type,
+                    signal_type=signal_type,
+                    summary_public_safe=f"Representative {route_class} signal for source resolution runner coverage.",
+                    signal_ref_public_safe=f"external:sanitized-{route_class}-signal",
+                    target_surface=f"{route_class}-target",
+                    owner="factory-orchestrator",
+                    source_class="operator_supplied",
+                    sensitivity_class="public_safe",
+                    freshness="fresh",
+                    risk_initial="R2",
+                    materiality="material",
+                    created_at="2026-06-17T00:00:00+00:00",
+                    intake_id=f"intake-{route_class}",
+                )
+
+                packet = factoryctl.build_source_resolution_packet(
+                    intake,
+                    intake_ref_public_safe=f"external:sanitized-{route_class}-intake",
+                )
+
+                self.assertEqual(factoryctl.validate_source_resolution_packet(packet), [])
+                self.assertTrue(packet["handoff"]["factory_owned_next_step"])
+                self.assertFalse(packet["acceptance"]["execution_allowed"])
+                self.assertEqual(packet["blocking_rules"]["source_resolution_required"], True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #293.

Adds the public/local bridge from a validated `universal_signal_intake` into the next factory-owned source-resolution handoff packet without starting implementation or generating Product SOT manually.

## What changed

- Added `source_resolution_packet` schema and template.
- Added `factoryctl source-resolution` and `factoryctl validate-source-resolution`.
- Added public validator domain rules for the new packet.
- Documented the operator path in README PT-BR/EN and CLI reference.
- Covered product creation, UX/product-experience, bug, incident and feature signals at contract level.
- Kept Product SOT conditional: product routes require Product SOT worker handoff; bug routes do not.

## Validation

- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_surface_sync.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`

## Boundaries

- Does not implement or take over cockpit UI work.
- Does not touch issue #84.
- Does not publish private dogfooding input, screenshots, local paths, raw research or private evidence.
- Does not claim Hermes runtime E2E proof; Hermes remains the runtime authority.