### PR TITLE
Add outcome contract runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ factoryctl route-registry --route-class product_creation
 factoryctl intake --route-class product_creation --request-type product_new --signal-type product_paper --summary "Public product brief enters the complete product-creation route." --source-ref external:source-card-product-brief --out .tmp/product-intake.json
 factoryctl source-resolution --intake .tmp/product-intake.json --intake-ref external:sanitized-product-intake --out .tmp/source-resolution-packet.json
 factoryctl source-ledger --source-resolution .tmp/source-resolution-packet.json --source-ref external:source-card-product-brief --out .tmp/product-source-ledger.json
+factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --out .tmp/outcome-contract.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -102,6 +102,7 @@ factoryctl route-registry --route-class product_creation
 factoryctl intake --route-class product_creation --request-type product_new --signal-type product_paper --summary "Brief publico do produto entra pela rota completa de criacao." --source-ref external:source-card-product-brief --out .tmp/product-intake.json
 factoryctl source-resolution --intake .tmp/product-intake.json --intake-ref external:sanitized-product-intake --out .tmp/source-resolution-packet.json
 factoryctl source-ledger --source-resolution .tmp/source-resolution-packet.json --source-ref external:source-card-product-brief --out .tmp/product-source-ledger.json
+factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --out .tmp/outcome-contract.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/docs/factory-workflow.catalog.json
+++ b/docs/factory-workflow.catalog.json
@@ -73,7 +73,7 @@
       "operator_visible_summary": "Factory is turning the material into a product outcome.",
       "maintainer_visible_details": "Outcome is still candidate until Product SOT approval or bounded acceptance.",
       "related_schema_refs": ["schemas/outcome-contract.schema.json"],
-      "related_command_refs": ["factoryctl validate-card"],
+      "related_command_refs": ["factoryctl outcome-contract", "factoryctl validate-outcome-contract", "factoryctl validate-card"],
       "related_issue_refs": ["#108", "#112"]
     },
     {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,6 +46,8 @@ factoryctl source-resolution --intake templates/universal-signal-intake.json --i
 factoryctl validate-source-resolution templates/source-resolution-packet.json
 factoryctl source-ledger --source-resolution templates/source-resolution-packet.json --source-ref external:source-card-product-brief --out .tmp/product-source-ledger.json
 factoryctl validate-source-ledger templates/product-source-ledger.json
+factoryctl outcome-contract --source-ledger templates/product-source-ledger.json --out .tmp/outcome-contract.json
+factoryctl validate-outcome-contract templates/outcome-contract.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
@@ -74,6 +76,8 @@ Product SOT ungenerated and execution blocked until the source ledger, route
 artifacts, gates and workers pass. `source-ledger` materializes that handoff as
 a product source ledger with public-safe refs, claim table, unresolved gaps and
 the next factory-owned artifact. It still does not generate Product SOT or allow
+execution. `outcome-contract` turns the source ledger into a bounded product or
+route outcome without treating the input as Product SOT and without allowing
 execution. `validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.

--- a/schemas/outcome-contract.schema.json
+++ b/schemas/outcome-contract.schema.json
@@ -4,28 +4,79 @@
   "title": "Overkill Factory Outcome Contract",
   "type": "object",
   "required": [
+    "$schema",
+    "record_type",
+    "contract_id",
+    "created_at",
+    "factory_method_version",
+    "source_ledger_ref",
+    "source_signal",
     "outcome",
     "users_or_actors",
     "problem",
     "success_signals",
     "non_goals",
     "open_questions",
+    "evidence_refs",
     "behavior_change",
     "risk_signals",
     "assumptions",
     "human_questions",
-    "discovery_depth"
+    "discovery_depth",
+    "blocking_rules",
+    "handoff",
+    "public_private_boundary",
+    "acceptance"
   ],
   "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/outcome-contract.schema.json"
+    },
+    "record_type": {
+      "const": "outcome_contract"
+    },
+    "contract_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "source_ledger_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "source_signal": {
+      "type": "object",
+      "required": [
+        "intake_id",
+        "signal_type",
+        "request_type",
+        "route_class",
+        "target_surface",
+        "summary_public_safe",
+        "signal_ref_public_safe",
+        "source_class",
+        "sensitivity_class",
+        "freshness",
+        "risk_initial",
+        "materiality",
+        "needs_product_sot"
+      ],
+      "additionalProperties": true
+    },
     "outcome": {
       "type": "string",
       "minLength": 3
     },
     "users_or_actors": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 2 }
     },
     "problem": {
       "type": "string",
@@ -33,27 +84,21 @@
     },
     "success_signals": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
     },
     "non_goals": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string", "minLength": 3 }
     },
     "open_questions": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string", "minLength": 3 }
     },
     "evidence_refs": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
     },
     "behavior_change": {
       "type": "string",
@@ -61,31 +106,94 @@
     },
     "risk_signals": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
     },
     "assumptions": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string", "minLength": 3 }
     },
     "human_questions": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string", "minLength": 3 }
     },
     "discovery_depth": {
-      "enum": [
-        "none",
-        "light",
-        "standard",
-        "deep",
-        "research_required"
-      ]
+      "enum": ["none", "light", "standard", "deep", "research_required"]
+    },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "source_ledger_required",
+        "product_sot_blocked_until_outcome_reviewed",
+        "execution_blocked_until_required_artifacts_pass",
+        "raw_private_evidence_must_stay_external",
+        "human_gate_only_for_authority_access_risk_or_preference"
+      ],
+      "properties": {
+        "source_ledger_required": { "const": true },
+        "product_sot_blocked_until_outcome_reviewed": { "type": "boolean" },
+        "execution_blocked_until_required_artifacts_pass": { "const": true },
+        "raw_private_evidence_must_stay_external": { "const": true },
+        "human_gate_only_for_authority_access_risk_or_preference": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "next_artifact",
+        "next_worker",
+        "next_safe_action",
+        "user_decision_required",
+        "factory_owned_next_step"
+      ],
+      "properties": {
+        "next_artifact": { "type": "string", "minLength": 3 },
+        "next_worker": { "type": "string", "minLength": 3 },
+        "next_safe_action": { "type": "string", "minLength": 6 },
+        "user_decision_required": { "type": "boolean" },
+        "factory_owned_next_step": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo",
+        "operator_instance_may_hold_private_source"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true },
+        "operator_instance_may_hold_private_source": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "outcome_contract_created",
+        "product_sot_generated",
+        "execution_allowed",
+        "blocked_reason",
+        "evidence_refs"
+      ],
+      "properties": {
+        "outcome_contract_created": { "const": true },
+        "product_sot_generated": { "const": false },
+        "execution_allowed": { "const": false },
+        "blocked_reason": { "type": "string", "minLength": 6 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -5700,7 +5700,7 @@ def validate_universal_signal_intake(intake: dict[str, Any]) -> list[str]:
 
 DEFAULT_ARTIFACT_REFS = {
     "source_ledger": "templates/reference-source-registry.json",
-    "outcome_contract": "templates/vfinal-factory-card.json#outcome_contract",
+    "outcome_contract": "templates/outcome-contract.json",
     "product_sot": "templates/product-sot.json",
     "full_product_sot_scope_coverage": "templates/full-product-sot-scope-coverage.json",
     "method_contract": "templates/method-contract.json",
@@ -6455,6 +6455,200 @@ def validate_product_source_ledger(ledger: dict[str, Any]) -> list[str]:
     _validate_lifecycle_refs(
         _list_items(acceptance.get("evidence_refs")),
         "product_source_ledger.acceptance.evidence_refs",
+        errors,
+    )
+
+    return errors
+
+
+def _outcome_next_artifact(ledger: dict[str, Any]) -> tuple[str, str]:
+    source_signal = ledger.get("source_signal") if isinstance(ledger.get("source_signal"), dict) else {}
+    if source_signal.get("needs_product_sot") is True:
+        return "product_sot", "product-sot-planner"
+    handoff = ledger.get("handoff") if isinstance(ledger.get("handoff"), dict) else {}
+    artifact = str(handoff.get("next_artifact") or "method_contract").strip()
+    if artifact == "outcome_contract":
+        artifact = "method_contract"
+    worker = str(handoff.get("next_worker") or DEFAULT_ARTIFACT_OWNERS.get(artifact) or "factory-orchestrator").strip()
+    if worker not in WORKERS:
+        worker = DEFAULT_ARTIFACT_OWNERS.get(artifact, "factory-orchestrator")
+    return artifact, worker
+
+
+def build_outcome_contract(
+    source_ledger: dict[str, Any],
+    *,
+    created_at: str | None = None,
+    contract_id: str | None = None,
+) -> dict[str, Any]:
+    ledger_errors = validate_product_source_ledger(source_ledger)
+    if ledger_errors:
+        raise ValueError("; ".join(ledger_errors))
+
+    source_signal = copy.deepcopy(source_ledger.get("source_signal") or {})
+    ledger_id = str(source_ledger.get("ledger_id") or "product-source-ledger")
+    summary = str(source_signal.get("summary_public_safe") or "Factory source signal must become a bounded outcome.")
+    target = str(source_signal.get("target_surface") or "target surface")
+    needs_product_sot = source_signal.get("needs_product_sot") is True
+    next_artifact, next_worker = _outcome_next_artifact(source_ledger)
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    discovery_depth = "deep" if str(source_signal.get("risk_initial") or "").upper() in {"R3", "R4"} else "standard"
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/outcome-contract.schema.json",
+        "record_type": "outcome_contract",
+        "contract_id": contract_id or f"outcome-contract-{slug_for_ref(str(source_signal.get('intake_id') or ledger_id))}",
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "source_ledger_ref": ledger_id,
+        "source_signal": source_signal,
+        "outcome": f"Produce a complete, production-ready outcome for {target}: {summary}",
+        "users_or_actors": ["target product user", "factory operator"],
+        "problem": (
+            "The factory must convert source material into a bounded outcome before Product SOT, "
+            "method routing, planning or execution can start."
+        ),
+        "success_signals": [
+            "Outcome, target user, problem, success signals and risks are explicit before downstream planning.",
+            "No execution starts until the required downstream artifacts, gates and workers pass.",
+        ],
+        "non_goals": [
+            "Do not treat the raw input or chat summary as Product SOT.",
+            "Do not start implementation from the source ledger or outcome contract alone.",
+        ],
+        "open_questions": [
+            "Worker-owned claim review must decide which source claims become Product SOT scope.",
+            "Any authority, access, risk or preference decision must become an explicit human gate if needed.",
+        ],
+        "evidence_refs": [
+            ledger_id,
+            "schemas/product-source-ledger.schema.json",
+            "schemas/outcome-contract.schema.json",
+        ],
+        "behavior_change": (
+            "The factory moves from source bookkeeping to a bounded outcome that the assigned worker can use "
+            "for the next artifact without asking the operator to coordinate internal machinery."
+        ),
+        "risk_signals": [
+            "Outcome is too vague to derive the next artifact.",
+            "A downstream artifact claims readiness without Product SOT, method, readiness or gate evidence.",
+        ],
+        "assumptions": [
+            "The product source ledger is valid and contains public-safe refs only.",
+            "The next artifact will be produced by the assigned factory worker, not inferred from chat memory.",
+        ],
+        "human_questions": [],
+        "discovery_depth": discovery_depth,
+        "blocking_rules": {
+            "source_ledger_required": True,
+            "product_sot_blocked_until_outcome_reviewed": needs_product_sot,
+            "execution_blocked_until_required_artifacts_pass": True,
+            "raw_private_evidence_must_stay_external": True,
+            "human_gate_only_for_authority_access_risk_or_preference": True,
+        },
+        "handoff": {
+            "next_artifact": next_artifact,
+            "next_worker": next_worker,
+            "next_safe_action": (
+                "Produce Product SOT from the outcome contract and source ledger before planning or execution."
+                if next_artifact == "product_sot"
+                else f"Produce {next_artifact} from the outcome contract before execution."
+            ),
+            "user_decision_required": False,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+            "operator_instance_may_hold_private_source": True,
+        },
+        "acceptance": {
+            "outcome_contract_created": True,
+            "product_sot_generated": False,
+            "execution_allowed": False,
+            "blocked_reason": (
+                "Outcome contract exists, but execution remains blocked until Product SOT when required, "
+                "method contract, readiness and gates pass."
+            ),
+            "evidence_refs": [
+                "schemas/outcome-contract.schema.json",
+                "schemas/product-source-ledger.schema.json",
+            ],
+        },
+    }
+
+
+def validate_outcome_contract(contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("outcome-contract.schema.json")
+    if not schema:
+        return ["outcome_contract schema is not bundled"]
+    errors.extend(
+        validate_node(
+            schema,
+            contract,
+            "outcome_contract",
+            schemas=schemas,
+            root_schema=schema,
+        )
+    )
+
+    for field in ("source_ledger_ref",):
+        value = str(contract.get(field) or "").strip()
+        if value:
+            _validate_public_ref(value, f"outcome_contract.{field}", errors)
+
+    source_signal = contract.get("source_signal") if isinstance(contract.get("source_signal"), dict) else {}
+    signal_ref = str(source_signal.get("signal_ref_public_safe") or "").strip()
+    if signal_ref:
+        _validate_public_ref(signal_ref, "outcome_contract.source_signal.signal_ref_public_safe", errors)
+
+    for field in ("evidence_refs", "open_questions", "assumptions", "human_questions"):
+        for index, item in enumerate(_list_items(contract.get(field))):
+            if field == "evidence_refs":
+                _validate_public_ref(item, f"outcome_contract.{field}[{index}]", errors)
+            elif not public_safe_text(item):
+                errors.append(f"outcome_contract.{field}[{index}] must be public-safe")
+
+    blocking_rules = contract.get("blocking_rules") if isinstance(contract.get("blocking_rules"), dict) else {}
+    for field in (
+        "source_ledger_required",
+        "execution_blocked_until_required_artifacts_pass",
+        "raw_private_evidence_must_stay_external",
+        "human_gate_only_for_authority_access_risk_or_preference",
+    ):
+        if blocking_rules.get(field) is not True:
+            errors.append(f"outcome_contract.blocking_rules.{field} must be true")
+    if not isinstance(blocking_rules.get("product_sot_blocked_until_outcome_reviewed"), bool):
+        errors.append("outcome_contract.blocking_rules.product_sot_blocked_until_outcome_reviewed must be boolean")
+
+    handoff = contract.get("handoff") if isinstance(contract.get("handoff"), dict) else {}
+    if handoff.get("factory_owned_next_step") is not True:
+        errors.append("outcome_contract.handoff.factory_owned_next_step must be true")
+    next_worker = str(handoff.get("next_worker") or "").strip()
+    if next_worker and next_worker not in WORKERS:
+        errors.append(f"outcome_contract.handoff.next_worker must be a registered worker: {next_worker}")
+
+    boundary = contract.get("public_private_boundary") if isinstance(contract.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("outcome_contract requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("outcome_contract must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("outcome_contract private context must stay outside the public repo")
+
+    acceptance = contract.get("acceptance") if isinstance(contract.get("acceptance"), dict) else {}
+    if acceptance.get("outcome_contract_created") is not True:
+        errors.append("outcome_contract acceptance.outcome_contract_created must be true")
+    if acceptance.get("product_sot_generated") is not False:
+        errors.append("outcome_contract must not claim Product SOT was generated")
+    if acceptance.get("execution_allowed") is not False:
+        errors.append("outcome_contract acceptance.execution_allowed must be false")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "outcome_contract.acceptance.evidence_refs",
         errors,
     )
 
@@ -12010,6 +12204,16 @@ def command_validate_source_ledger(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_outcome_contract(args: argparse.Namespace) -> int:
+    errors = validate_outcome_contract(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_route_registry(args: argparse.Namespace) -> int:
     registry = load_route_registry(args.registry)
     if args.route_class:
@@ -12087,6 +12291,25 @@ def command_source_ledger(args: argparse.Namespace) -> int:
             print(error, file=sys.stderr)
         return 1
     write_json(args.out, ledger)
+    return 0
+
+
+def command_outcome_contract(args: argparse.Namespace) -> int:
+    try:
+        contract = build_outcome_contract(
+            load_json_like(args.source_ledger),
+            created_at=args.created_at,
+            contract_id=args.contract_id,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_outcome_contract(contract)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, contract)
     return 0
 
 
@@ -12524,6 +12747,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_source_ledger_parser.add_argument("path", type=Path)
     validate_source_ledger_parser.set_defaults(func=command_validate_source_ledger)
 
+    validate_outcome_contract_parser = sub.add_parser("validate-outcome-contract")
+    validate_outcome_contract_parser.add_argument("path", type=Path)
+    validate_outcome_contract_parser.set_defaults(func=command_validate_outcome_contract)
+
     route_registry_parser = sub.add_parser("route-registry", help="Show the canonical Universal Signal route registry.")
     route_registry_parser.add_argument("--registry", type=Path, default=DEFAULT_ROUTE_REGISTRY_PATH)
     route_registry_parser.add_argument("--route-class")
@@ -12569,6 +12796,16 @@ def build_parser() -> argparse.ArgumentParser:
     source_ledger_parser.add_argument("--ledger-id")
     source_ledger_parser.add_argument("--out", type=Path)
     source_ledger_parser.set_defaults(func=command_source_ledger)
+
+    outcome_contract_parser = sub.add_parser(
+        "outcome-contract",
+        help="Build an outcome contract from a validated product source ledger without generating Product SOT.",
+    )
+    outcome_contract_parser.add_argument("--source-ledger", type=Path, required=True)
+    outcome_contract_parser.add_argument("--created-at")
+    outcome_contract_parser.add_argument("--contract-id")
+    outcome_contract_parser.add_argument("--out", type=Path)
+    outcome_contract_parser.set_defaults(func=command_outcome_contract)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1249,6 +1249,74 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             reason = public_artifact_ref_error(ref)
             if reason:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
+    if data.get("record_type") == "outcome_contract":
+        reason = public_artifact_ref_error(data.get("source_ledger_ref"))
+        if reason:
+            errors.append(f"{at}.source_ledger_ref: {reason}")
+        source_signal = data.get("source_signal") if isinstance(data.get("source_signal"), dict) else {}
+        signal_ref = str(source_signal.get("signal_ref_public_safe") or "").strip()
+        reason = public_artifact_ref_error(signal_ref)
+        if reason:
+            errors.append(f"{at}.source_signal.signal_ref_public_safe: {reason}")
+        route_class = str(source_signal.get("route_class") or "").strip()
+        request_type = str(source_signal.get("request_type") or "").strip()
+        signal_type = str(source_signal.get("signal_type") or "").strip()
+        allowed_request_types = UNIVERSAL_SIGNAL_ROUTE_REQUEST_TYPES.get(route_class)
+        if allowed_request_types and request_type and request_type not in allowed_request_types:
+            errors.append(
+                f"{at}: outcome_contract.source_signal.request_type is not valid "
+                f"for route_class {route_class}: {request_type}"
+            )
+        allowed_signal_types = UNIVERSAL_SIGNAL_ROUTE_SIGNAL_TYPES.get(route_class)
+        if allowed_signal_types and signal_type and signal_type not in allowed_signal_types:
+            errors.append(
+                f"{at}: outcome_contract.source_signal.signal_type is not valid "
+                f"for route_class {route_class}: {signal_type}"
+            )
+        for field in ("evidence_refs", "open_questions", "assumptions", "human_questions"):
+            values = data.get(field) if isinstance(data.get(field), list) else []
+            for index, value in enumerate(values):
+                if field == "evidence_refs":
+                    reason = public_artifact_ref_error(value)
+                    if reason:
+                        errors.append(f"{at}.{field}[{index}]: {reason}")
+                elif PRIVATE_MARKERS.search(str(value or "")):
+                    errors.append(f"{at}.{field}[{index}]: private local or runtime marker")
+        blocking_rules = data.get("blocking_rules") if isinstance(data.get("blocking_rules"), dict) else {}
+        for field in (
+            "source_ledger_required",
+            "execution_blocked_until_required_artifacts_pass",
+            "raw_private_evidence_must_stay_external",
+            "human_gate_only_for_authority_access_risk_or_preference",
+        ):
+            if blocking_rules.get(field) is not True:
+                errors.append(f"{at}.blocking_rules.{field} must be true")
+        if not isinstance(blocking_rules.get("product_sot_blocked_until_outcome_reviewed"), bool):
+            errors.append(f"{at}.blocking_rules.product_sot_blocked_until_outcome_reviewed must be boolean")
+        handoff = data.get("handoff") if isinstance(data.get("handoff"), dict) else {}
+        next_worker = str(handoff.get("next_worker") or "").strip()
+        if handoff.get("factory_owned_next_step") is not True:
+            errors.append(f"{at}: outcome_contract.handoff.factory_owned_next_step must be true")
+        if next_worker and next_worker not in public_worker_ids():
+            errors.append(f"{at}.handoff.next_worker must be a registered worker: {next_worker}")
+        boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: outcome_contract requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: outcome_contract must not embed raw private evidence")
+        if boundary.get("private_context_retained_outside_public_repo") is not True:
+            errors.append(f"{at}: outcome_contract private context must stay outside the public repo")
+        acceptance = data.get("acceptance") if isinstance(data.get("acceptance"), dict) else {}
+        if acceptance.get("outcome_contract_created") is not True:
+            errors.append(f"{at}: outcome_contract acceptance.outcome_contract_created must be true")
+        if acceptance.get("product_sot_generated") is not False:
+            errors.append(f"{at}: outcome_contract must not claim Product SOT was generated")
+        if acceptance.get("execution_allowed") is not False:
+            errors.append(f"{at}: outcome_contract acceptance.execution_allowed must be false")
+        for index, ref in enumerate(acceptance.get("evidence_refs", []) if isinstance(acceptance.get("evidence_refs"), list) else []):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_v1_completion_gate":

--- a/templates/outcome-contract.json
+++ b/templates/outcome-contract.json
@@ -1,31 +1,84 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/outcome-contract.schema.json",
-  "outcome": "What concrete result should exist after this work?",
+  "record_type": "outcome_contract",
+  "contract_id": "outcome-contract-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "source_ledger_ref": "product-source-ledger-public-template",
+  "source_signal": {
+    "intake_id": "universal-signal-intake-public-template",
+    "signal_type": "product_paper",
+    "request_type": "product_new",
+    "route_class": "product_creation",
+    "target_surface": "complete-product-production",
+    "summary_public_safe": "Operator supplied product material must become a bounded outcome before Product SOT or execution starts.",
+    "signal_ref_public_safe": "external:source-card-product-brief",
+    "source_class": "operator_supplied",
+    "sensitivity_class": "public_safe",
+    "freshness": "bounded",
+    "risk_initial": "R2",
+    "materiality": "material",
+    "needs_product_sot": true
+  },
+  "outcome": "Create the complete requested product outcome from the source material after source claims are reviewed.",
   "users_or_actors": [
-    "target user or actor"
+    "target operator or product user"
   ],
-  "problem": "What problem is being solved?",
+  "problem": "The factory must define the desired result before Product SOT, planning or implementation.",
   "success_signals": [
-    "observable signal that the outcome worked"
+    "Outcome, user, problem, success and risk signals are explicit before Product SOT.",
+    "Execution remains blocked until Product SOT, method, readiness and gates pass."
   ],
   "non_goals": [
-    "what this work must not solve"
+    "Do not treat the input material as Product SOT.",
+    "Do not start implementation from a static template."
   ],
   "open_questions": [
-    "unknown that must be resolved or accepted"
+    "Worker-owned claim review must decide which source claims become scope."
   ],
   "evidence_refs": [
-    "source-ledger.md"
+    "templates/product-source-ledger.json",
+    "schemas/outcome-contract.schema.json"
   ],
-  "behavior_change": "What user, system or business behavior should change?",
+  "behavior_change": "The factory moves from source bookkeeping to a bounded product outcome without asking the operator to coordinate internal artifacts.",
   "risk_signals": [
-    "observable sign that the product may be unsafe, confusing or failing"
+    "Outcome is too vague to derive Product SOT.",
+    "Outcome asks for execution before required downstream gates pass."
   ],
   "assumptions": [
-    "assumption that must be proven, accepted or tracked"
+    "The source ledger contains public-safe refs and no raw private source.",
+    "Product SOT will be produced by the assigned factory worker, not by chat memory."
   ],
-  "human_questions": [
-    "question only a human/product owner can answer"
-  ],
-  "discovery_depth": "standard"
+  "human_questions": [],
+  "discovery_depth": "standard",
+  "blocking_rules": {
+    "source_ledger_required": true,
+    "product_sot_blocked_until_outcome_reviewed": true,
+    "execution_blocked_until_required_artifacts_pass": true,
+    "raw_private_evidence_must_stay_external": true,
+    "human_gate_only_for_authority_access_risk_or_preference": true
+  },
+  "handoff": {
+    "next_artifact": "product_sot",
+    "next_worker": "product-sot-planner",
+    "next_safe_action": "Produce Product SOT from the outcome contract and source ledger before planning or execution.",
+    "user_decision_required": false,
+    "factory_owned_next_step": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true,
+    "operator_instance_may_hold_private_source": true
+  },
+  "acceptance": {
+    "outcome_contract_created": true,
+    "product_sot_generated": false,
+    "execution_allowed": false,
+    "blocked_reason": "Outcome contract exists, but execution remains blocked until Product SOT, method contract, readiness and gates pass.",
+    "evidence_refs": [
+      "schemas/outcome-contract.schema.json",
+      "templates/product-source-ledger.json"
+    ]
+  }
 }

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -344,6 +344,104 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertEqual(ledger["handoff"]["next_artifact"], "bug_reproduction")
         self.assertNotEqual(ledger["handoff"]["next_worker"], "product-sot-planner")
 
+    def test_outcome_contract_from_product_source_ledger_is_valid(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+
+        outcome = factoryctl.build_outcome_contract(ledger)
+
+        self.assertEqual(factoryctl.validate_outcome_contract(outcome), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(outcome, "$"), [])
+        self.assertEqual(outcome["record_type"], "outcome_contract")
+        self.assertEqual(outcome["source_ledger_ref"], ledger["ledger_id"])
+        self.assertEqual(outcome["handoff"]["next_artifact"], "product_sot")
+        self.assertEqual(outcome["handoff"]["next_worker"], "product-sot-planner")
+        self.assertFalse(outcome["acceptance"]["product_sot_generated"])
+        self.assertFalse(outcome["acceptance"]["execution_allowed"])
+
+    def test_outcome_contract_requires_valid_source_ledger(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        ledger["acceptance"]["execution_allowed"] = True
+
+        with self.assertRaisesRegex(ValueError, "execution_allowed"):
+            factoryctl.build_outcome_contract(ledger)
+
+    def test_outcome_contract_cli_generates_public_safe_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger_path = Path(tmpdir) / "product-source-ledger.json"
+            out_path = Path(tmpdir) / "outcome-contract.json"
+            source_resolution = factoryctl.build_source_resolution_packet(
+                signal_intake(),
+                intake_ref_public_safe="external:sanitized-universal-signal-intake",
+            )
+            ledger = factoryctl.build_product_source_ledger(
+                source_resolution,
+                source_ref_public_safe="external:sanitized-product-brief",
+            )
+            ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "outcome-contract",
+                    "--source-ledger",
+                    str(ledger_path),
+                    "--out",
+                    str(out_path),
+                ]
+            )
+
+            outcome = json.loads(out_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(outcome["record_type"], "outcome_contract")
+        self.assertEqual(factoryctl.validate_outcome_contract(outcome), [])
+
+    def test_outcome_contract_for_bug_route_does_not_generate_product_sot(self) -> None:
+        intake = factoryctl.build_universal_signal_intake(
+            route_class="bug_repair",
+            request_type="bug",
+            signal_type="bug_report",
+            summary_public_safe="Representative bug signal should produce an outcome before reproduction.",
+            signal_ref_public_safe="external:sanitized-bug-signal",
+            target_surface="bug-target",
+            owner="factory-orchestrator",
+            source_class="operator_supplied",
+            sensitivity_class="public_safe",
+            freshness="fresh",
+            risk_initial="R2",
+            materiality="material",
+            created_at="2026-06-17T00:00:00+00:00",
+            intake_id="intake-bug-repair",
+        )
+        source_resolution = factoryctl.build_source_resolution_packet(
+            intake,
+            intake_ref_public_safe="external:sanitized-bug-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-bug-report",
+        )
+
+        outcome = factoryctl.build_outcome_contract(ledger)
+
+        self.assertFalse(outcome["source_signal"]["needs_product_sot"])
+        self.assertEqual(outcome["handoff"]["next_artifact"], "bug_reproduction")
+        self.assertFalse(outcome["acceptance"]["product_sot_generated"])
+        self.assertFalse(outcome["acceptance"]["execution_allowed"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds `factoryctl outcome-contract` and `factoryctl validate-outcome-contract` for the next dogfooding handoff after `product_source_ledger`.
- Strengthens `schemas/outcome-contract.schema.json` and `templates/outcome-contract.json` into a machine-checkable factory artifact with blocking rules, handoff, boundary and acceptance fields.
- Extends public JSON domain checks, docs, workflow catalog, README examples and Universal Signal tests.

## Dogfooding Finding
After #295, Cockpit dogfooding could materialize `product_source_ledger`, but the ledger pointed to `outcome_contract` without an executable public runner. That made the next factory step depend on manual template editing instead of factory-owned materialization.

## Validation
- `python -m py_compile scripts/factoryctl.py scripts/validate_public_json_artifacts.py`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/factoryctl.py validate-outcome-contract templates/outcome-contract.json`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/factoryctl.py validate-outcome-contract .tmp/factory-runs/dogfood-outcome-contract-doc-command.json`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_surface_sync.py`
- `git diff --check`

Closes #297