### PR TITLE
Add Product SOT runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ factoryctl intake --route-class product_creation --request-type product_new --si
 factoryctl source-resolution --intake .tmp/product-intake.json --intake-ref external:sanitized-product-intake --out .tmp/source-resolution-packet.json
 factoryctl source-ledger --source-resolution .tmp/source-resolution-packet.json --source-ref external:source-card-product-brief --out .tmp/product-source-ledger.json
 factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --out .tmp/outcome-contract.json
+factoryctl product-sot --outcome-contract .tmp/outcome-contract.json --out .tmp/product-sot.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -103,6 +103,7 @@ factoryctl intake --route-class product_creation --request-type product_new --si
 factoryctl source-resolution --intake .tmp/product-intake.json --intake-ref external:sanitized-product-intake --out .tmp/source-resolution-packet.json
 factoryctl source-ledger --source-resolution .tmp/source-resolution-packet.json --source-ref external:source-card-product-brief --out .tmp/product-source-ledger.json
 factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --out .tmp/outcome-contract.json
+factoryctl product-sot --outcome-contract .tmp/outcome-contract.json --out .tmp/product-sot.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/docs/factory-workflow.catalog.json
+++ b/docs/factory-workflow.catalog.json
@@ -84,14 +84,14 @@
       "optional_artifacts": ["user_facing_autonomy_contract"],
       "required_gates": ["Product SOT Gate"],
       "required_workers": ["product-sot-planner"],
-      "allowed_next_actions": ["create or update Product SOT", "request bounded scope approval"],
+      "allowed_next_actions": ["create or update Product SOT", "create full Product SOT scope coverage", "request bounded scope approval"],
       "blocked_actions": ["execute from paper instead of Product SOT"],
       "output_locations": ["card.product_sot"],
-      "completion_detection": ["product_sot exists and scope is explicit"],
+      "completion_detection": ["product_sot exists and scope is explicit", "product_sot.handoff.next_artifact points to full_product_sot_scope_coverage"],
       "operator_visible_summary": "Factory has a candidate source of truth for the product.",
       "maintainer_visible_details": "SOT can evolve beyond the input paper; paper is source, not final authority.",
       "related_schema_refs": ["schemas/product-sot.schema.json", "schemas/user-facing-autonomy-contract.schema.json"],
-      "related_command_refs": ["factoryctl help-next"],
+      "related_command_refs": ["factoryctl product-sot", "factoryctl validate-product-sot", "factoryctl help-next"],
       "related_issue_refs": ["#108", "#112"]
     },
     {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,6 +48,8 @@ factoryctl source-ledger --source-resolution templates/source-resolution-packet.
 factoryctl validate-source-ledger templates/product-source-ledger.json
 factoryctl outcome-contract --source-ledger templates/product-source-ledger.json --out .tmp/outcome-contract.json
 factoryctl validate-outcome-contract templates/outcome-contract.json
+factoryctl product-sot --outcome-contract templates/outcome-contract.json --out .tmp/product-sot.json
+factoryctl validate-product-sot templates/product-sot.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
@@ -78,7 +80,9 @@ a product source ledger with public-safe refs, claim table, unresolved gaps and
 the next factory-owned artifact. It still does not generate Product SOT or allow
 execution. `outcome-contract` turns the source ledger into a bounded product or
 route outcome without treating the input as Product SOT and without allowing
-execution. `validate-signal-corpus` and `signal-coverage` prove that the public
+execution. `product-sot` turns that outcome into the first Product SOT and keeps
+execution blocked until full scope coverage, method contract, readiness and gates
+pass. `validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.
 

--- a/schemas/product-sot.schema.json
+++ b/schemas/product-sot.schema.json
@@ -25,6 +25,16 @@
   ],
   "properties": {
     "$schema": { "const": "https://overkill-factory.dev/schemas/product-sot.schema.json" },
+    "record_type": { "const": "product_sot" },
+    "sot_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "factory_method_version": { "const": "OVERKILL_VFINAL" },
+    "outcome_contract_ref": { "type": "string", "minLength": 3 },
+    "source_ledger_ref": { "type": "string", "minLength": 3 },
+    "source_signal": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "what_it_is": { "type": "string", "minLength": 3 },
     "target_users": { "type": "array", "items": { "type": "string" } },
     "why_it_matters": { "type": "string", "minLength": 3 },
@@ -80,7 +90,81 @@
     "research_decision_refs": { "type": "array", "items": { "type": "string" } },
     "research_confirmations": { "type": "array", "items": { "type": "string" } },
     "open_decisions": { "type": "array", "items": { "type": "string" } },
-    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "outcome_contract_required",
+        "full_scope_coverage_required",
+        "method_contract_required",
+        "execution_blocked_until_required_artifacts_pass",
+        "raw_private_evidence_must_stay_external",
+        "human_gate_only_for_authority_access_risk_or_preference"
+      ],
+      "properties": {
+        "outcome_contract_required": { "const": true },
+        "full_scope_coverage_required": { "const": true },
+        "method_contract_required": { "const": true },
+        "execution_blocked_until_required_artifacts_pass": { "const": true },
+        "raw_private_evidence_must_stay_external": { "const": true },
+        "human_gate_only_for_authority_access_risk_or_preference": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "next_artifact",
+        "next_worker",
+        "next_safe_action",
+        "user_decision_required",
+        "factory_owned_next_step"
+      ],
+      "properties": {
+        "next_artifact": { "type": "string", "minLength": 3 },
+        "next_worker": { "type": "string", "minLength": 3 },
+        "next_safe_action": { "type": "string", "minLength": 6 },
+        "user_decision_required": { "type": "boolean" },
+        "factory_owned_next_step": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo",
+        "operator_instance_may_hold_private_source"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true },
+        "operator_instance_may_hold_private_source": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "product_sot_created",
+        "execution_allowed",
+        "blocked_reason",
+        "evidence_refs"
+      ],
+      "properties": {
+        "product_sot_created": { "const": true },
+        "execution_allowed": { "const": false },
+        "blocked_reason": { "type": "string", "minLength": 6 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": true
 }

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -6655,6 +6655,367 @@ def validate_outcome_contract(contract: dict[str, Any]) -> list[str]:
     return errors
 
 
+PRODUCT_SOT_SCOPE_SECTIONS = {
+    "produto desejado",
+    "idiomas",
+    "modelo esperado: projeto, frente, run e release",
+    "promessa central do produto",
+    "regras nao negociaveis",
+    "telas esperadas",
+    "portfolio",
+    "sala do projeto",
+    "frentes do projeto",
+    "gates humanos",
+    "execucao",
+    "evidencias",
+    "release e operacoes",
+    "saude da fabrica",
+    "direcao de design",
+    "capacidades obrigatorias",
+}
+
+PRODUCT_SOT_DEPENDENCY_SECTIONS = {"fontes de dados esperadas"}
+PRODUCT_SOT_SUCCESS_SECTIONS = {"criterios de sucesso"}
+PRODUCT_SOT_DECISION_SECTIONS = {"perguntas que a fabrica deve resolver"}
+PRODUCT_SOT_OPERATOR_BOUNDARY_SECTIONS = {"restricoes do operador", "fronteira publica e privada"}
+
+
+def _product_sot_public_text(value: Any) -> str:
+    text = redact_private_text(value)
+    text = re.sub(
+        r"public\s*/\s*\[redacted-private-marker\]\s+safety scans",
+        "public and credential safety scans",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"\[redacted-private-marker\]\s+safety scans",
+        "credential safety scans",
+        text,
+        flags=re.IGNORECASE,
+    )
+    return text
+
+
+def _normalize_heading(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().strip("#").strip()).lower()
+
+
+def _markdown_material_bullets(markdown_text: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {
+        "scope_in": [],
+        "scope_out": [],
+        "dependencies": [],
+        "success_criteria": [],
+        "open_decisions": [],
+        "operations_expected": [],
+        "risks": [],
+    }
+    current = ""
+    for raw_line in markdown_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            current = _normalize_heading(line)
+            continue
+        if line.startswith("!["):
+            continue
+        text = ""
+        if line.startswith("- "):
+            text = line[2:].strip()
+        elif re.match(r"^\d+\.\s+", line):
+            text = re.sub(r"^\d+\.\s+", "", line).strip()
+        if not text:
+            continue
+        text = _product_sot_public_text(text)
+        if not public_safe_text(text):
+            continue
+        if current in PRODUCT_SOT_SCOPE_SECTIONS:
+            sections["scope_in"].append(text)
+            if current == "release e operacoes":
+                sections["operations_expected"].append(text)
+        elif current in PRODUCT_SOT_DEPENDENCY_SECTIONS:
+            sections["dependencies"].append(text)
+        elif current in PRODUCT_SOT_SUCCESS_SECTIONS:
+            sections["success_criteria"].append(text)
+        elif current in PRODUCT_SOT_DECISION_SECTIONS:
+            sections["open_decisions"].append(text)
+        elif current in PRODUCT_SOT_OPERATOR_BOUNDARY_SECTIONS:
+            sections["scope_out"].append(text)
+        if "risco" in text.lower() or "bloqueio" in text.lower() or "privad" in text.lower():
+            sections["risks"].append(text)
+    return {key: _dedupe_preserve_order(values) for key, values in sections.items()}
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = re.sub(r"\s+", " ", _product_sot_public_text(value).strip())
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _product_sot_next_action_ref(sot_id: str) -> str:
+    slug = slug_for_ref(sot_id)
+    return f"pending/{slug}-full-product-sot-scope-coverage.json"
+
+
+def build_product_sot(
+    outcome_contract: dict[str, Any],
+    *,
+    source_material_text: str | None = None,
+    created_at: str | None = None,
+    sot_id: str | None = None,
+) -> dict[str, Any]:
+    outcome_errors = validate_outcome_contract(outcome_contract)
+    if outcome_errors:
+        raise ValueError("; ".join(outcome_errors))
+
+    source_signal = copy.deepcopy(outcome_contract.get("source_signal") or {})
+    if source_signal.get("needs_product_sot") is not True:
+        raise ValueError("outcome_contract route does not require Product SOT")
+    handoff = outcome_contract.get("handoff") if isinstance(outcome_contract.get("handoff"), dict) else {}
+    if str(handoff.get("next_artifact") or "").strip() != "product_sot":
+        raise ValueError("outcome_contract does not hand off to Product SOT")
+
+    contract_id = str(outcome_contract.get("contract_id") or "outcome-contract")
+    ledger_ref = str(outcome_contract.get("source_ledger_ref") or "product-source-ledger")
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    final_sot_id = sot_id or f"product-sot-{slug_for_ref(str(source_signal.get('intake_id') or contract_id))}"
+    material = _markdown_material_bullets(source_material_text or "")
+    outcome_text = str(outcome_contract.get("outcome") or "Complete product outcome")
+    target_surface = str(source_signal.get("target_surface") or "target product")
+    summary = str(source_signal.get("summary_public_safe") or outcome_text)
+
+    scope_in = _dedupe_preserve_order(
+        [
+            f"Complete production-ready product target for {target_surface}.",
+            summary,
+            *material["scope_in"],
+        ]
+    )
+    scope_out = _dedupe_preserve_order(
+        [
+            *outcome_contract.get("non_goals", []),
+            *material["scope_out"],
+            "Implementation, release and production promotion are out of scope until downstream gates pass.",
+        ]
+    )
+    risks = _dedupe_preserve_order([*outcome_contract.get("risk_signals", []), *material["risks"]])
+    success_criteria = _dedupe_preserve_order(
+        [*outcome_contract.get("success_signals", []), *material["success_criteria"]]
+    )
+    dependencies = _dedupe_preserve_order(
+        [
+            contract_id,
+            ledger_ref,
+            *material["dependencies"],
+            "Hermes or configured runtime remains source of truth for live state.",
+        ]
+    )
+    open_decisions = _dedupe_preserve_order(
+        [*outcome_contract.get("open_questions", []), *material["open_decisions"]]
+    )
+    operations_expected = _dedupe_preserve_order(
+        [
+            "Product must include release readiness and operational visibility before production claim.",
+            *material["operations_expected"],
+        ]
+    )
+    requirement_refs = [contract_id, ledger_ref]
+    full_scope_ref = _product_sot_next_action_ref(final_sot_id)
+
+    requirement_graph = [
+        {
+            "requirement_id": "product-sot#scope-in-001",
+            "source_refs": requirement_refs,
+            "decision_state": "approved",
+            "owner": "product-sot-planner",
+            "next_action": "create full Product SOT scope coverage before method routing or execution",
+            "evidence_refs": [contract_id, "schemas/product-sot.schema.json"],
+        },
+        {
+            "requirement_id": "product-sot#coverage-001",
+            "source_refs": [contract_id],
+            "decision_state": "approved",
+            "owner": "product-sot-planner",
+            "next_action": "account for every Product SOT requirement in full scope coverage",
+            "evidence_refs": [full_scope_ref],
+        },
+    ]
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/product-sot.schema.json",
+        "record_type": "product_sot",
+        "sot_id": final_sot_id,
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "outcome_contract_ref": contract_id,
+        "source_ledger_ref": ledger_ref,
+        "source_signal": source_signal,
+        "what_it_is": f"Complete Product SOT for {target_surface}.",
+        "target_users": _dedupe_preserve_order(outcome_contract.get("users_or_actors", [])),
+        "why_it_matters": str(outcome_contract.get("behavior_change") or "The product needs a stable source of truth before execution."),
+        "outcome": outcome_text,
+        "scope_in": scope_in,
+        "scope_out": scope_out,
+        "risks": risks,
+        "authority": "Factory owns Product SOT creation; humans decide only explicit authority, access, risk or preference gates.",
+        "data_and_metrics": success_criteria,
+        "dependencies": dependencies,
+        "access_and_capabilities": [
+            "Runtime read access is needed for live state projection.",
+            "Material execution access remains blocked until downstream readiness gates pass.",
+        ],
+        "compliance_privacy": [
+            "Public artifacts must not contain raw private source, screenshots, local paths or private runtime evidence.",
+            "Private/operator runtime data may be used locally only inside the operator-owned environment.",
+        ],
+        "cost_relevance": "No material spend or deployment is allowed before method, readiness and release gates pass.",
+        "operations_expected": operations_expected,
+        "success_criteria": success_criteria,
+        "requirement_graph": requirement_graph,
+        "full_product_sot_scope_coverage_ref": full_scope_ref,
+        "research_decision_refs": [],
+        "research_confirmations": [],
+        "open_decisions": open_decisions,
+        "evidence_refs": [
+            contract_id,
+            ledger_ref,
+            "schemas/product-sot.schema.json",
+            "schemas/outcome-contract.schema.json",
+        ],
+        "blocking_rules": {
+            "outcome_contract_required": True,
+            "full_scope_coverage_required": True,
+            "method_contract_required": True,
+            "execution_blocked_until_required_artifacts_pass": True,
+            "raw_private_evidence_must_stay_external": True,
+            "human_gate_only_for_authority_access_risk_or_preference": True,
+        },
+        "handoff": {
+            "next_artifact": "full_product_sot_scope_coverage",
+            "next_worker": "product-sot-planner",
+            "next_safe_action": "Create full Product SOT scope coverage before method contract, planning or execution.",
+            "user_decision_required": False,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+            "operator_instance_may_hold_private_source": True,
+        },
+        "acceptance": {
+            "product_sot_created": True,
+            "execution_allowed": False,
+            "blocked_reason": (
+                "Product SOT exists, but execution remains blocked until full scope coverage, "
+                "method contract, readiness and gates pass."
+            ),
+            "evidence_refs": ["schemas/product-sot.schema.json", contract_id],
+        },
+    }
+
+
+def validate_product_sot(product_sot: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("product-sot.schema.json")
+    if not schema:
+        return ["product_sot schema is not bundled"]
+    errors.extend(validate_node(schema, product_sot, "product_sot", schemas=schemas, root_schema=schema))
+    if product_sot.get("record_type") != "product_sot":
+        errors.append("product_sot.record_type must be product_sot")
+    errors.extend(validate_product_sot_requirement_graph(product_sot))
+
+    for field in ("outcome_contract_ref", "source_ledger_ref", "full_product_sot_scope_coverage_ref"):
+        value = str(product_sot.get(field) or "").strip()
+        if value:
+            _validate_public_ref(value, f"product_sot.{field}", errors)
+
+    source_signal = product_sot.get("source_signal") if isinstance(product_sot.get("source_signal"), dict) else {}
+    signal_ref = str(source_signal.get("signal_ref_public_safe") or "").strip()
+    if signal_ref:
+        _validate_public_ref(signal_ref, "product_sot.source_signal.signal_ref_public_safe", errors)
+
+    for field in (
+        "scope_in",
+        "scope_out",
+        "risks",
+        "data_and_metrics",
+        "dependencies",
+        "access_and_capabilities",
+        "compliance_privacy",
+        "operations_expected",
+        "success_criteria",
+        "open_decisions",
+        "evidence_refs",
+        "research_decision_refs",
+        "research_confirmations",
+    ):
+        for index, item in enumerate(_list_items(product_sot.get(field))):
+            if field.endswith("refs") or field == "evidence_refs":
+                _validate_public_ref(item, f"product_sot.{field}[{index}]", errors)
+            elif not public_safe_text(item):
+                errors.append(f"product_sot.{field}[{index}] must be public-safe")
+
+    for index, requirement in enumerate(product_sot.get("requirement_graph", []) if isinstance(product_sot.get("requirement_graph"), list) else []):
+        if not isinstance(requirement, dict):
+            continue
+        for ref_index, ref in enumerate(_list_items(requirement.get("source_refs"))):
+            _validate_public_ref(ref, f"product_sot.requirement_graph[{index}].source_refs[{ref_index}]", errors)
+        for ref_index, ref in enumerate(_list_items(requirement.get("evidence_refs"))):
+            _validate_public_ref(ref, f"product_sot.requirement_graph[{index}].evidence_refs[{ref_index}]", errors)
+
+    blocking_rules = product_sot.get("blocking_rules") if isinstance(product_sot.get("blocking_rules"), dict) else {}
+    for field in (
+        "outcome_contract_required",
+        "full_scope_coverage_required",
+        "method_contract_required",
+        "execution_blocked_until_required_artifacts_pass",
+        "raw_private_evidence_must_stay_external",
+        "human_gate_only_for_authority_access_risk_or_preference",
+    ):
+        if blocking_rules.get(field) is not True:
+            errors.append(f"product_sot.blocking_rules.{field} must be true")
+
+    handoff = product_sot.get("handoff") if isinstance(product_sot.get("handoff"), dict) else {}
+    if handoff.get("factory_owned_next_step") is not True:
+        errors.append("product_sot.handoff.factory_owned_next_step must be true")
+    if handoff.get("next_artifact") != "full_product_sot_scope_coverage":
+        errors.append("product_sot.handoff.next_artifact must be full_product_sot_scope_coverage")
+    next_worker = str(handoff.get("next_worker") or "").strip()
+    if next_worker and next_worker not in WORKERS:
+        errors.append(f"product_sot.handoff.next_worker must be a registered worker: {next_worker}")
+
+    boundary = product_sot.get("public_private_boundary") if isinstance(product_sot.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("product_sot requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("product_sot must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("product_sot private context must stay outside the public repo")
+
+    acceptance = product_sot.get("acceptance") if isinstance(product_sot.get("acceptance"), dict) else {}
+    if acceptance.get("product_sot_created") is not True:
+        errors.append("product_sot acceptance.product_sot_created must be true")
+    if acceptance.get("execution_allowed") is not False:
+        errors.append("product_sot acceptance.execution_allowed must be false")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "product_sot.acceptance.evidence_refs",
+        errors,
+    )
+
+    return errors
+
+
 def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -12214,6 +12575,16 @@ def command_validate_outcome_contract(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_product_sot(args: argparse.Namespace) -> int:
+    errors = validate_product_sot(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_route_registry(args: argparse.Namespace) -> int:
     registry = load_route_registry(args.registry)
     if args.route_class:
@@ -12310,6 +12681,29 @@ def command_outcome_contract(args: argparse.Namespace) -> int:
             print(error, file=sys.stderr)
         return 1
     write_json(args.out, contract)
+    return 0
+
+
+def command_product_sot(args: argparse.Namespace) -> int:
+    source_material_text = None
+    if args.source_material:
+        source_material_text = args.source_material.read_text(encoding="utf-8")
+    try:
+        product_sot = build_product_sot(
+            load_json_like(args.outcome_contract),
+            source_material_text=source_material_text,
+            created_at=args.created_at,
+            sot_id=args.sot_id,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_product_sot(product_sot)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, product_sot)
     return 0
 
 
@@ -12751,6 +13145,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_outcome_contract_parser.add_argument("path", type=Path)
     validate_outcome_contract_parser.set_defaults(func=command_validate_outcome_contract)
 
+    validate_product_sot_parser = sub.add_parser("validate-product-sot")
+    validate_product_sot_parser.add_argument("path", type=Path)
+    validate_product_sot_parser.set_defaults(func=command_validate_product_sot)
+
     route_registry_parser = sub.add_parser("route-registry", help="Show the canonical Universal Signal route registry.")
     route_registry_parser.add_argument("--registry", type=Path, default=DEFAULT_ROUTE_REGISTRY_PATH)
     route_registry_parser.add_argument("--route-class")
@@ -12806,6 +13204,17 @@ def build_parser() -> argparse.ArgumentParser:
     outcome_contract_parser.add_argument("--contract-id")
     outcome_contract_parser.add_argument("--out", type=Path)
     outcome_contract_parser.set_defaults(func=command_outcome_contract)
+
+    product_sot_parser = sub.add_parser(
+        "product-sot",
+        help="Build Product SOT from a validated outcome contract without allowing execution.",
+    )
+    product_sot_parser.add_argument("--outcome-contract", type=Path, required=True)
+    product_sot_parser.add_argument("--source-material", type=Path)
+    product_sot_parser.add_argument("--created-at")
+    product_sot_parser.add_argument("--sot-id")
+    product_sot_parser.add_argument("--out", type=Path)
+    product_sot_parser.set_defaults(func=command_product_sot)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1317,6 +1317,88 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             reason = public_artifact_ref_error(ref)
             if reason:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
+    if data.get("record_type") == "product_sot":
+        for field in ("outcome_contract_ref", "source_ledger_ref", "full_product_sot_scope_coverage_ref"):
+            reason = public_artifact_ref_error(data.get(field))
+            if reason:
+                errors.append(f"{at}.{field}: {reason}")
+        source_signal = data.get("source_signal") if isinstance(data.get("source_signal"), dict) else {}
+        signal_ref = str(source_signal.get("signal_ref_public_safe") or "").strip()
+        reason = public_artifact_ref_error(signal_ref)
+        if reason:
+            errors.append(f"{at}.source_signal.signal_ref_public_safe: {reason}")
+        for field in (
+            "scope_in",
+            "scope_out",
+            "risks",
+            "data_and_metrics",
+            "dependencies",
+            "access_and_capabilities",
+            "compliance_privacy",
+            "operations_expected",
+            "success_criteria",
+            "open_decisions",
+            "research_confirmations",
+        ):
+            values = data.get(field) if isinstance(data.get(field), list) else []
+            for index, value in enumerate(values):
+                if PRIVATE_MARKERS.search(str(value or "")):
+                    errors.append(f"{at}.{field}[{index}]: private local or runtime marker")
+        for field in ("evidence_refs", "research_decision_refs"):
+            values = data.get(field) if isinstance(data.get(field), list) else []
+            for index, value in enumerate(values):
+                reason = public_artifact_ref_error(value)
+                if reason:
+                    errors.append(f"{at}.{field}[{index}]: {reason}")
+        requirements = data.get("requirement_graph") if isinstance(data.get("requirement_graph"), list) else []
+        if not requirements:
+            errors.append(f"{at}: product_sot requires typed requirement_graph")
+        for req_index, requirement in enumerate(requirements):
+            if not isinstance(requirement, dict):
+                continue
+            for field in ("source_refs", "evidence_refs"):
+                refs = requirement.get(field) if isinstance(requirement.get(field), list) else []
+                for ref_index, ref in enumerate(refs):
+                    reason = public_artifact_ref_error(ref)
+                    if reason:
+                        errors.append(f"{at}.requirement_graph[{req_index}].{field}[{ref_index}]: {reason}")
+            if requirement.get("decision_state") in {"blocked", "open_decision"} and not str(requirement.get("blocker_id") or "").strip():
+                errors.append(f"{at}.requirement_graph[{req_index}]: blocked/open decision requires blocker_id")
+        blocking_rules = data.get("blocking_rules") if isinstance(data.get("blocking_rules"), dict) else {}
+        for field in (
+            "outcome_contract_required",
+            "full_scope_coverage_required",
+            "method_contract_required",
+            "execution_blocked_until_required_artifacts_pass",
+            "raw_private_evidence_must_stay_external",
+            "human_gate_only_for_authority_access_risk_or_preference",
+        ):
+            if blocking_rules.get(field) is not True:
+                errors.append(f"{at}.blocking_rules.{field} must be true")
+        handoff = data.get("handoff") if isinstance(data.get("handoff"), dict) else {}
+        if handoff.get("next_artifact") != "full_product_sot_scope_coverage":
+            errors.append(f"{at}.handoff.next_artifact must be full_product_sot_scope_coverage")
+        if handoff.get("factory_owned_next_step") is not True:
+            errors.append(f"{at}: product_sot.handoff.factory_owned_next_step must be true")
+        next_worker = str(handoff.get("next_worker") or "").strip()
+        if next_worker and next_worker not in public_worker_ids():
+            errors.append(f"{at}.handoff.next_worker must be a registered worker: {next_worker}")
+        boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: product_sot requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: product_sot must not embed raw private evidence")
+        if boundary.get("private_context_retained_outside_public_repo") is not True:
+            errors.append(f"{at}: product_sot private context must stay outside the public repo")
+        acceptance = data.get("acceptance") if isinstance(data.get("acceptance"), dict) else {}
+        if acceptance.get("product_sot_created") is not True:
+            errors.append(f"{at}: product_sot acceptance.product_sot_created must be true")
+        if acceptance.get("execution_allowed") is not False:
+            errors.append(f"{at}: product_sot acceptance.execution_allowed must be false")
+        for index, ref in enumerate(acceptance.get("evidence_refs", []) if isinstance(acceptance.get("evidence_refs"), list) else []):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_v1_completion_gate":

--- a/templates/product-sot.json
+++ b/templates/product-sot.json
@@ -1,5 +1,26 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/product-sot.schema.json",
+  "record_type": "product_sot",
+  "sot_id": "product-sot-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "outcome_contract_ref": "templates/outcome-contract.json",
+  "source_ledger_ref": "templates/product-source-ledger.json",
+  "source_signal": {
+    "intake_id": "universal-signal-intake-public-template",
+    "signal_type": "product_paper",
+    "request_type": "product_new",
+    "route_class": "product_creation",
+    "target_surface": "complete-product-production",
+    "summary_public_safe": "Operator supplied product material must become Product SOT before planning or execution starts.",
+    "signal_ref_public_safe": "external:source-card-product-brief",
+    "source_class": "operator_supplied",
+    "sensitivity_class": "public_safe",
+    "freshness": "bounded",
+    "risk_initial": "R2",
+    "materiality": "material",
+    "needs_product_sot": true
+  },
   "what_it_is": "A short, concrete description of the complete product defined by the approved Product SOT.",
   "target_users": ["primary user or actor"],
   "why_it_matters": "Why this outcome is worth building now.",
@@ -29,5 +50,39 @@
   "research_decision_refs": ["templates/specialist-decision-packet.json"],
   "research_confirmations": ["research decisions that confirm or change Product SOT requirements"],
   "open_decisions": ["decision that is not closed yet"],
-  "evidence_refs": ["source-ledger.md"]
+  "evidence_refs": [
+    "templates/outcome-contract.json",
+    "templates/product-source-ledger.json",
+    "schemas/product-sot.schema.json"
+  ],
+  "blocking_rules": {
+    "outcome_contract_required": true,
+    "full_scope_coverage_required": true,
+    "method_contract_required": true,
+    "execution_blocked_until_required_artifacts_pass": true,
+    "raw_private_evidence_must_stay_external": true,
+    "human_gate_only_for_authority_access_risk_or_preference": true
+  },
+  "handoff": {
+    "next_artifact": "full_product_sot_scope_coverage",
+    "next_worker": "product-sot-planner",
+    "next_safe_action": "Create full Product SOT scope coverage before method contract, planning or execution.",
+    "user_decision_required": false,
+    "factory_owned_next_step": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true,
+    "operator_instance_may_hold_private_source": true
+  },
+  "acceptance": {
+    "product_sot_created": true,
+    "execution_allowed": false,
+    "blocked_reason": "Product SOT exists, but execution remains blocked until full scope coverage, method contract, readiness and gates pass.",
+    "evidence_refs": [
+      "schemas/product-sot.schema.json",
+      "templates/outcome-contract.json"
+    ]
+  }
 }

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -442,6 +442,118 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertFalse(outcome["acceptance"]["product_sot_generated"])
         self.assertFalse(outcome["acceptance"]["execution_allowed"])
 
+    def test_product_sot_from_outcome_contract_is_valid(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+
+        product_sot = factoryctl.build_product_sot(outcome)
+
+        self.assertEqual(factoryctl.validate_product_sot(product_sot), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(product_sot, "$"), [])
+        self.assertEqual(product_sot["record_type"], "product_sot")
+        self.assertEqual(product_sot["outcome_contract_ref"], outcome["contract_id"])
+        self.assertEqual(product_sot["handoff"]["next_artifact"], "full_product_sot_scope_coverage")
+        self.assertEqual(product_sot["handoff"]["next_worker"], "product-sot-planner")
+        self.assertFalse(product_sot["acceptance"]["execution_allowed"])
+        self.assertTrue(product_sot["blocking_rules"]["full_scope_coverage_required"])
+
+    def test_product_sot_requires_valid_outcome_contract(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+        outcome["acceptance"]["execution_allowed"] = True
+
+        with self.assertRaisesRegex(ValueError, "execution_allowed"):
+            factoryctl.build_product_sot(outcome)
+
+    def test_product_sot_cli_generates_public_safe_sot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outcome_path = Path(tmpdir) / "outcome-contract.json"
+            material_path = Path(tmpdir) / "source-material.md"
+            out_path = Path(tmpdir) / "product-sot.json"
+            source_resolution = factoryctl.build_source_resolution_packet(
+                signal_intake(),
+                intake_ref_public_safe="external:sanitized-universal-signal-intake",
+            )
+            ledger = factoryctl.build_product_source_ledger(
+                source_resolution,
+                source_ref_public_safe="external:sanitized-product-brief",
+            )
+            outcome = factoryctl.build_outcome_contract(ledger)
+            outcome_path.write_text(json.dumps(outcome), encoding="utf-8")
+            material_path.write_text(
+                "\n".join(
+                    [
+                        "# Saude da fabrica",
+                        "- status de public/secret safety scans;",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "product-sot",
+                    "--outcome-contract",
+                    str(outcome_path),
+                    "--source-material",
+                    str(material_path),
+                    "--out",
+                    str(out_path),
+                ]
+            )
+
+            product_sot = json.loads(out_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(product_sot["record_type"], "product_sot")
+        self.assertEqual(factoryctl.validate_product_sot(product_sot), [])
+        self.assertIn("status de public and credential safety scans;", product_sot["scope_in"])
+        self.assertNotIn("[redacted-private-marker]", json.dumps(product_sot))
+
+    def test_product_sot_for_bug_route_is_rejected(self) -> None:
+        intake = factoryctl.build_universal_signal_intake(
+            route_class="bug_repair",
+            request_type="bug",
+            signal_type="bug_report",
+            summary_public_safe="Representative bug signal should not produce Product SOT.",
+            signal_ref_public_safe="external:sanitized-bug-signal",
+            target_surface="bug-target",
+            owner="factory-orchestrator",
+            source_class="operator_supplied",
+            sensitivity_class="public_safe",
+            freshness="fresh",
+            risk_initial="R2",
+            materiality="material",
+            created_at="2026-06-17T00:00:00+00:00",
+            intake_id="intake-bug-repair",
+        )
+        source_resolution = factoryctl.build_source_resolution_packet(
+            intake,
+            intake_ref_public_safe="external:sanitized-bug-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-bug-report",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+
+        with self.assertRaisesRegex(ValueError, "does not require Product SOT"):
+            factoryctl.build_product_sot(outcome)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `factoryctl product-sot` and `factoryctl validate-product-sot` for the `outcome_contract -> product_sot` gear
- extend Product SOT schema/template/public JSON domain rules so execution remains blocked until full scope coverage, method, readiness and gates pass
- document the new command in README, PT-BR README, CLI reference and workflow catalog

## Dogfooding
- generated and validated the private Cockpit Product SOT from the private outcome contract and PT-BR input without the operator writing the SOT manually
- verified the private output did not retain local paths, image refs, clipboard/screenshot files, file URIs or redaction markers

## Validation
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts\factoryctl.py product-sot --outcome-contract templates\outcome-contract.json --out .tmp\factory-runs\dogfood-product-sot\product-sot.json`
- `python scripts\factoryctl.py validate-product-sot .tmp\factory-runs\dogfood-product-sot\product-sot.json`
- `python scripts\validate_public_json_artifacts.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_public_surface_sync.py`
- `git diff --check`

Closes #299