### PR TITLE
Add Method Contract runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ factoryctl source-ledger --source-resolution .tmp/source-resolution-packet.json 
 factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --out .tmp/outcome-contract.json
 factoryctl product-sot --outcome-contract .tmp/outcome-contract.json --out .tmp/product-sot.json
 factoryctl full-scope-coverage --product-sot .tmp/product-sot.json --out .tmp/full-product-sot-scope-coverage.json
+factoryctl method-contract --full-scope-coverage .tmp/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -105,6 +105,7 @@ factoryctl source-ledger --source-resolution .tmp/source-resolution-packet.json 
 factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --out .tmp/outcome-contract.json
 factoryctl product-sot --outcome-contract .tmp/outcome-contract.json --out .tmp/product-sot.json
 factoryctl full-scope-coverage --product-sot .tmp/product-sot.json --out .tmp/full-product-sot-scope-coverage.json
+factoryctl method-contract --full-scope-coverage .tmp/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/docs/factory-workflow.catalog.json
+++ b/docs/factory-workflow.catalog.json
@@ -109,7 +109,7 @@
       "operator_visible_summary": "Factory is choosing the safest production path.",
       "maintainer_visible_details": "The router records decisions; it does not hand method selection to the user.",
       "related_schema_refs": ["schemas/method-contract.schema.json"],
-      "related_command_refs": ["factoryctl gate-report"],
+      "related_command_refs": ["factoryctl method-contract", "factoryctl validate-method-contract", "factoryctl gate-report"],
       "related_issue_refs": ["#110", "#117"]
     },
     {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,6 +52,8 @@ factoryctl product-sot --outcome-contract templates/outcome-contract.json --out 
 factoryctl validate-product-sot templates/product-sot.json
 factoryctl full-scope-coverage --product-sot templates/product-sot.json --out .tmp/full-product-sot-scope-coverage.json
 factoryctl validate-full-scope-coverage templates/full-product-sot-scope-coverage.json
+factoryctl method-contract --full-scope-coverage templates/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
+factoryctl validate-method-contract templates/method-contract.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
@@ -86,7 +88,9 @@ execution. `product-sot` turns that outcome into the first Product SOT and keeps
 execution blocked until full scope coverage, method contract, readiness and gates
 pass. `full-scope-coverage` accounts for every Product SOT requirement before
 method routing, so execution slices cannot silently become scope cuts.
-`validate-signal-corpus` and `signal-coverage` prove that the public
+`method-contract` turns that coverage into factory-owned method, artifact,
+worker, gate and evidence requirements without handing DDD/BDD/spec choices to
+the operator. `validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.
 

--- a/schemas/method-contract.schema.json
+++ b/schemas/method-contract.schema.json
@@ -4,6 +4,11 @@
   "title": "Overkill Factory Method Contract",
   "type": "object",
   "required": [
+    "record_type",
+    "contract_id",
+    "created_at",
+    "factory_method_version",
+    "full_product_sot_scope_coverage_ref",
     "selected_method",
     "why_this_method",
     "risk_tier",
@@ -25,9 +30,19 @@
     "reviewers",
     "evidence_requirements",
     "authority_limit",
-    "done_criteria"
+    "done_criteria",
+    "blocking_rules",
+    "handoff",
+    "public_private_boundary",
+    "acceptance"
   ],
   "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/method-contract.schema.json" },
+    "record_type": { "const": "method_contract" },
+    "contract_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "factory_method_version": { "const": "OVERKILL_VFINAL" },
+    "full_product_sot_scope_coverage_ref": { "type": "string", "minLength": 3 },
     "selected_method": {
       "type": "string",
       "minLength": 3
@@ -209,6 +224,80 @@
         "type": "string",
         "minLength": 3
       }
+    },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "full_scope_coverage_required",
+        "product_creation_plan_required",
+        "execution_blocked_until_ready_gate",
+        "raw_private_evidence_must_stay_external",
+        "operator_must_not_choose_internal_method"
+      ],
+      "properties": {
+        "full_scope_coverage_required": { "const": true },
+        "product_creation_plan_required": { "const": true },
+        "execution_blocked_until_ready_gate": { "const": true },
+        "raw_private_evidence_must_stay_external": { "const": true },
+        "operator_must_not_choose_internal_method": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "next_artifact",
+        "next_worker",
+        "next_safe_action",
+        "user_decision_required",
+        "factory_owned_next_step"
+      ],
+      "properties": {
+        "next_artifact": { "type": "string", "minLength": 3 },
+        "next_worker": { "type": "string", "minLength": 3 },
+        "next_safe_action": { "type": "string", "minLength": 6 },
+        "user_decision_required": { "type": "boolean" },
+        "factory_owned_next_step": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "method_contract_created",
+        "execution_allowed",
+        "selected_method_is_factory_owned",
+        "scope_reduction_detected",
+        "blocked_reason",
+        "evidence_refs"
+      ],
+      "properties": {
+        "method_contract_created": { "const": true },
+        "execution_allowed": { "const": false },
+        "selected_method_is_factory_owned": { "const": true },
+        "scope_reduction_detected": { "const": false },
+        "blocked_reason": { "type": "string", "minLength": 6 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -7285,6 +7285,270 @@ def validate_full_scope_coverage(coverage: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _method_contract_id(coverage_ref: str) -> str:
+    return f"method-contract-{slug_for_ref(coverage_ref)}"
+
+
+def _method_selected_methods(coverage: dict[str, Any]) -> list[str]:
+    requirements = coverage.get("requirement_coverage") if isinstance(coverage.get("requirement_coverage"), list) else []
+    statuses = {str(item.get("status") or "").strip() for item in requirements if isinstance(item, dict)}
+    methods = ["spec-first", "test-first"]
+    if statuses.intersection({"blocked", "human_decision_required", "deferred_with_owner"}):
+        methods.append("discovery-first")
+    return _dedupe_preserve_order(methods)
+
+
+def build_method_contract(
+    full_scope_coverage: dict[str, Any],
+    *,
+    created_at: str | None = None,
+    contract_id: str | None = None,
+) -> dict[str, Any]:
+    coverage_errors = validate_full_scope_coverage(full_scope_coverage)
+    if coverage_errors:
+        raise ValueError("; ".join(coverage_errors))
+
+    handoff = full_scope_coverage.get("handoff") if isinstance(full_scope_coverage.get("handoff"), dict) else {}
+    if str(handoff.get("next_artifact") or "").strip() != "method_contract":
+        raise ValueError("full_product_sot_scope_coverage does not hand off to method contract")
+
+    coverage_ref = str(full_scope_coverage.get("coverage_id") or full_scope_coverage.get("product_sot_ref") or "full-product-sot-scope-coverage")
+    final_contract_id = contract_id or _method_contract_id(coverage_ref)
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    selected_methods = _method_selected_methods(full_scope_coverage)
+    user_decision_required = any(
+        isinstance(item, dict) and item.get("status") in {"human_decision_required", "blocked"}
+        for item in full_scope_coverage.get("requirement_coverage", [])
+        if isinstance(full_scope_coverage.get("requirement_coverage"), list)
+    )
+    blocker_refs = _dedupe_preserve_order(
+        [
+            str(item.get("blocker_id") or "")
+            for item in full_scope_coverage.get("requirement_coverage", [])
+            if isinstance(item, dict) and str(item.get("blocker_id") or "").strip()
+        ]
+    )
+    required_gates = ["Ready Gate", "Review Gate", "Done Gate"]
+    if user_decision_required:
+        required_gates.insert(0, "Human Scope Gate")
+    required_workers = ["factory-orchestrator", "decomposition-planner", "qa-verification-worker", "independent-reviewer"]
+    if user_decision_required:
+        required_workers.insert(0, "human-gate-clerk")
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/method-contract.schema.json",
+        "record_type": "method_contract",
+        "contract_id": final_contract_id,
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "full_product_sot_scope_coverage_ref": coverage_ref,
+        "selected_method": selected_methods[0],
+        "why_this_method": (
+            "Full Product SOT scope coverage is accounted, so the factory can route through "
+            "spec-first and test-first planning without asking the operator to choose internal methods."
+        ),
+        "risk_tier": "R3" if user_decision_required else "R2",
+        "required_plans": [
+            "product_creation_plan",
+            "software_development_plan",
+            "loop_plan",
+        ],
+        "required_gates": required_gates,
+        "waivers": [],
+        "canonical_scope_source": "approved Product SOT",
+        "scope_intent": "full_product",
+        "factory_route": "complete-product-production",
+        "required_factory_artifacts": [
+            "full_product_sot_scope_coverage",
+            "product_creation_plan",
+            "product_implementation_readiness",
+        ],
+        "engineering_method_matrix": [
+            {
+                "surface_or_component": "complete product scope",
+                "methods": selected_methods,
+                "reason": "Coverage requires every Product SOT requirement to be planned before implementation starts.",
+                "required_artifacts": ["product_creation_plan", "spec_graph", "work_unit_contract"],
+                "evidence_required": ["full scope coverage", "worker result evidence", "tests pass"],
+            }
+        ],
+        "slice_execution_policy": {
+            "slices_are_execution_units_only": True,
+            "canonical_scope_must_not_shrink": True,
+            "first_slice_completion_is_not_product_completion": True,
+        },
+        "production_route_decision": (
+            "Use the production promotion ladder only after product creation plan, readiness, "
+            "required gates and Receipt Five evidence pass."
+        ),
+        "research_decision_refs": [],
+        "research_route_impacts": [],
+        "work_type": "complex-product",
+        "selected_methods": selected_methods,
+        "skipped_methods": [
+            {
+                "method": "prototype-first",
+                "reason": "Prototype work is not selected before method, scope and readiness gates require it.",
+            }
+        ],
+        "required_artifacts": [
+            "product_creation_plan",
+            "software_development_plan",
+            "loop_plan",
+            "product_implementation_readiness",
+        ],
+        "required_workers": _dedupe_preserve_order(required_workers),
+        "reviewers": ["independent-reviewer"],
+        "evidence_requirements": _dedupe_preserve_order(
+            [
+                coverage_ref,
+                "product_creation_plan",
+                "product_implementation_readiness",
+                "Receipt Five",
+                *blocker_refs,
+            ]
+        ),
+        "authority_limit": "bounded_planning_only; no implementation or release without ready gates",
+        "done_criteria": [
+            "method contract validates",
+            "Product Creation Plan exists",
+            "implementation readiness gate is blocked or passed with explicit evidence",
+            "execution remains blocked until Ready Gate",
+        ],
+        "blocking_rules": {
+            "full_scope_coverage_required": True,
+            "product_creation_plan_required": True,
+            "execution_blocked_until_ready_gate": True,
+            "raw_private_evidence_must_stay_external": True,
+            "operator_must_not_choose_internal_method": True,
+        },
+        "handoff": {
+            "next_artifact": "product_creation_plan",
+            "next_worker": "decomposition-planner",
+            "next_safe_action": "Create Product Creation Plan before work units or execution.",
+            "user_decision_required": user_decision_required,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+        },
+        "acceptance": {
+            "method_contract_created": True,
+            "execution_allowed": False,
+            "selected_method_is_factory_owned": True,
+            "scope_reduction_detected": False,
+            "blocked_reason": (
+                "Method contract exists, but execution remains blocked until product creation plan, "
+                "readiness, required gates and workers pass."
+            ),
+            "evidence_refs": ["schemas/method-contract.schema.json", coverage_ref],
+        },
+    }
+
+
+def validate_method_contract(method_contract: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("method-contract.schema.json")
+    if not schema:
+        return ["method_contract schema is not bundled"]
+    errors.extend(validate_node(schema, method_contract, "method_contract", schemas=schemas, root_schema=schema))
+    if method_contract.get("record_type") != "method_contract":
+        errors.append("method_contract.record_type must be method_contract")
+
+    coverage_ref = str(method_contract.get("full_product_sot_scope_coverage_ref") or "").strip()
+    if coverage_ref:
+        _validate_public_ref(coverage_ref, "method_contract.full_product_sot_scope_coverage_ref", errors)
+    if str(method_contract.get("canonical_scope_source") or "").strip().lower() not in {"approved product sot", "product_sot", "product sot"}:
+        errors.append("method_contract.canonical_scope_source must be approved Product SOT")
+    if str(method_contract.get("scope_intent") or "").strip() not in {"full_product", "child_slice", "bug", "release", "incident", "doc", "migration", "integration"}:
+        errors.append("method_contract.scope_intent is not valid")
+
+    required_factory_artifacts = set(_list_items(method_contract.get("required_factory_artifacts")))
+    for artifact in ("full_product_sot_scope_coverage", "product_creation_plan", "product_implementation_readiness"):
+        if artifact not in required_factory_artifacts:
+            errors.append(f"method_contract.required_factory_artifacts must include {artifact}")
+
+    matrix = method_contract.get("engineering_method_matrix") if isinstance(method_contract.get("engineering_method_matrix"), list) else []
+    if not matrix:
+        errors.append("method_contract.engineering_method_matrix is required")
+    for index, item in enumerate(matrix):
+        if not isinstance(item, dict):
+            continue
+        for field in ("surface_or_component", "methods", "reason", "required_artifacts", "evidence_required"):
+            if not item.get(field):
+                errors.append(f"method_contract.engineering_method_matrix[{index}].{field} is required")
+        for field in ("surface_or_component", "reason"):
+            if not public_safe_text(item.get(field)):
+                errors.append(f"method_contract.engineering_method_matrix[{index}].{field} must be public-safe")
+
+    slice_policy = method_contract.get("slice_execution_policy") if isinstance(method_contract.get("slice_execution_policy"), dict) else {}
+    if slice_policy.get("slices_are_execution_units_only") is not True:
+        errors.append("method_contract.slice_execution_policy.slices_are_execution_units_only must be true")
+    if slice_policy.get("canonical_scope_must_not_shrink") is not True:
+        errors.append("method_contract.slice_execution_policy.canonical_scope_must_not_shrink must be true")
+
+    if not _list_items(method_contract.get("selected_methods")):
+        errors.append("method_contract.selected_methods must be non-empty")
+    for field in ("required_workers", "reviewers"):
+        for index, worker in enumerate(_list_items(method_contract.get(field))):
+            if worker not in WORKERS:
+                errors.append(f"method_contract.{field}[{index}] must be a registered worker: {worker}")
+    for field in ("why_this_method", "production_route_decision", "authority_limit"):
+        if not public_safe_text(method_contract.get(field)):
+            errors.append(f"method_contract.{field} must be public-safe")
+    for index, value in enumerate(_list_items(method_contract.get("evidence_requirements"))):
+        if not public_safe_text(value):
+            errors.append(f"method_contract.evidence_requirements[{index}] must be public-safe")
+
+    blocking_rules = method_contract.get("blocking_rules") if isinstance(method_contract.get("blocking_rules"), dict) else {}
+    for field in (
+        "full_scope_coverage_required",
+        "product_creation_plan_required",
+        "execution_blocked_until_ready_gate",
+        "raw_private_evidence_must_stay_external",
+        "operator_must_not_choose_internal_method",
+    ):
+        if blocking_rules.get(field) is not True:
+            errors.append(f"method_contract.blocking_rules.{field} must be true")
+
+    handoff = method_contract.get("handoff") if isinstance(method_contract.get("handoff"), dict) else {}
+    if handoff.get("factory_owned_next_step") is not True:
+        errors.append("method_contract.handoff.factory_owned_next_step must be true")
+    if handoff.get("next_artifact") != "product_creation_plan":
+        errors.append("method_contract.handoff.next_artifact must be product_creation_plan")
+    next_worker = str(handoff.get("next_worker") or "").strip()
+    if next_worker and next_worker not in WORKERS:
+        errors.append(f"method_contract.handoff.next_worker must be a registered worker: {next_worker}")
+
+    boundary = method_contract.get("public_private_boundary") if isinstance(method_contract.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("method_contract requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("method_contract must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("method_contract private context must stay outside the public repo")
+
+    acceptance = method_contract.get("acceptance") if isinstance(method_contract.get("acceptance"), dict) else {}
+    if acceptance.get("method_contract_created") is not True:
+        errors.append("method_contract acceptance.method_contract_created must be true")
+    if acceptance.get("execution_allowed") is not False:
+        errors.append("method_contract acceptance.execution_allowed must be false")
+    if acceptance.get("selected_method_is_factory_owned") is not True:
+        errors.append("method_contract acceptance.selected_method_is_factory_owned must be true")
+    if acceptance.get("scope_reduction_detected") is not False:
+        errors.append("method_contract acceptance.scope_reduction_detected must be false")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "method_contract.acceptance.evidence_refs",
+        errors,
+    )
+
+    return errors
+
+
 def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -12864,6 +13128,16 @@ def command_validate_full_scope_coverage(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_method_contract(args: argparse.Namespace) -> int:
+    errors = validate_method_contract(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_route_registry(args: argparse.Namespace) -> int:
     registry = load_route_registry(args.registry)
     if args.route_class:
@@ -13002,6 +13276,25 @@ def command_full_scope_coverage(args: argparse.Namespace) -> int:
             print(error, file=sys.stderr)
         return 1
     write_json(args.out, coverage)
+    return 0
+
+
+def command_method_contract(args: argparse.Namespace) -> int:
+    try:
+        method_contract = build_method_contract(
+            load_json_like(args.full_scope_coverage),
+            created_at=args.created_at,
+            contract_id=args.contract_id,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_method_contract(method_contract)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, method_contract)
     return 0
 
 
@@ -13451,6 +13744,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_full_scope_coverage_parser.add_argument("path", type=Path)
     validate_full_scope_coverage_parser.set_defaults(func=command_validate_full_scope_coverage)
 
+    validate_method_contract_parser = sub.add_parser("validate-method-contract")
+    validate_method_contract_parser.add_argument("path", type=Path)
+    validate_method_contract_parser.set_defaults(func=command_validate_method_contract)
+
     route_registry_parser = sub.add_parser("route-registry", help="Show the canonical Universal Signal route registry.")
     route_registry_parser.add_argument("--registry", type=Path, default=DEFAULT_ROUTE_REGISTRY_PATH)
     route_registry_parser.add_argument("--route-class")
@@ -13527,6 +13824,16 @@ def build_parser() -> argparse.ArgumentParser:
     full_scope_coverage_parser.add_argument("--coverage-id")
     full_scope_coverage_parser.add_argument("--out", type=Path)
     full_scope_coverage_parser.set_defaults(func=command_full_scope_coverage)
+
+    method_contract_parser = sub.add_parser(
+        "method-contract",
+        help="Build Method Contract from validated full Product SOT scope coverage without allowing execution.",
+    )
+    method_contract_parser.add_argument("--full-scope-coverage", type=Path, required=True)
+    method_contract_parser.add_argument("--created-at")
+    method_contract_parser.add_argument("--contract-id")
+    method_contract_parser.add_argument("--out", type=Path)
+    method_contract_parser.set_defaults(func=command_method_contract)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1498,6 +1498,88 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             reason = public_artifact_ref_error(ref)
             if reason:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
+    if data.get("record_type") == "method_contract":
+        reason = public_artifact_ref_error(data.get("full_product_sot_scope_coverage_ref"))
+        if reason:
+            errors.append(f"{at}.full_product_sot_scope_coverage_ref: {reason}")
+        if str(data.get("canonical_scope_source") or "").strip().lower() not in {
+            "approved product sot",
+            "product_sot",
+            "product sot",
+        }:
+            errors.append(f"{at}.canonical_scope_source must be approved Product SOT")
+        required_factory_artifacts = set(data.get("required_factory_artifacts") if isinstance(data.get("required_factory_artifacts"), list) else [])
+        for artifact in ("full_product_sot_scope_coverage", "product_creation_plan", "product_implementation_readiness"):
+            if artifact not in required_factory_artifacts:
+                errors.append(f"{at}.required_factory_artifacts must include {artifact}")
+        matrix = data.get("engineering_method_matrix") if isinstance(data.get("engineering_method_matrix"), list) else []
+        if not matrix:
+            errors.append(f"{at}.engineering_method_matrix is required")
+        for index, item in enumerate(matrix):
+            if not isinstance(item, dict):
+                continue
+            for field in ("surface_or_component", "methods", "reason", "required_artifacts", "evidence_required"):
+                if not item.get(field):
+                    errors.append(f"{at}.engineering_method_matrix[{index}].{field} is required")
+            for field in ("surface_or_component", "reason"):
+                if PRIVATE_MARKERS.search(str(item.get(field) or "")):
+                    errors.append(f"{at}.engineering_method_matrix[{index}].{field}: private local or runtime marker")
+        slice_policy = data.get("slice_execution_policy") if isinstance(data.get("slice_execution_policy"), dict) else {}
+        if slice_policy.get("slices_are_execution_units_only") is not True:
+            errors.append(f"{at}.slice_execution_policy.slices_are_execution_units_only must be true")
+        if slice_policy.get("canonical_scope_must_not_shrink") is not True:
+            errors.append(f"{at}.slice_execution_policy.canonical_scope_must_not_shrink must be true")
+        if not (data.get("selected_methods") if isinstance(data.get("selected_methods"), list) else []):
+            errors.append(f"{at}.selected_methods must be non-empty")
+        for field in ("required_workers", "reviewers"):
+            workers = data.get(field) if isinstance(data.get(field), list) else []
+            for index, worker in enumerate(workers):
+                if str(worker or "").strip() not in public_worker_ids():
+                    errors.append(f"{at}.{field}[{index}] must be a registered worker: {worker}")
+        for field in ("why_this_method", "production_route_decision", "authority_limit"):
+            if PRIVATE_MARKERS.search(str(data.get(field) or "")):
+                errors.append(f"{at}.{field}: private local or runtime marker")
+        for index, value in enumerate(data.get("evidence_requirements", []) if isinstance(data.get("evidence_requirements"), list) else []):
+            if PRIVATE_MARKERS.search(str(value or "")):
+                errors.append(f"{at}.evidence_requirements[{index}]: private local or runtime marker")
+        blocking_rules = data.get("blocking_rules") if isinstance(data.get("blocking_rules"), dict) else {}
+        for field in (
+            "full_scope_coverage_required",
+            "product_creation_plan_required",
+            "execution_blocked_until_ready_gate",
+            "raw_private_evidence_must_stay_external",
+            "operator_must_not_choose_internal_method",
+        ):
+            if blocking_rules.get(field) is not True:
+                errors.append(f"{at}.blocking_rules.{field} must be true")
+        handoff = data.get("handoff") if isinstance(data.get("handoff"), dict) else {}
+        if handoff.get("next_artifact") != "product_creation_plan":
+            errors.append(f"{at}.handoff.next_artifact must be product_creation_plan")
+        if handoff.get("factory_owned_next_step") is not True:
+            errors.append(f"{at}: method_contract.handoff.factory_owned_next_step must be true")
+        next_worker = str(handoff.get("next_worker") or "").strip()
+        if next_worker and next_worker not in public_worker_ids():
+            errors.append(f"{at}.handoff.next_worker must be a registered worker: {next_worker}")
+        boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: method_contract requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: method_contract must not embed raw private evidence")
+        if boundary.get("private_context_retained_outside_public_repo") is not True:
+            errors.append(f"{at}: method_contract private context must stay outside the public repo")
+        acceptance = data.get("acceptance") if isinstance(data.get("acceptance"), dict) else {}
+        if acceptance.get("method_contract_created") is not True:
+            errors.append(f"{at}: method_contract acceptance.method_contract_created must be true")
+        if acceptance.get("execution_allowed") is not False:
+            errors.append(f"{at}: method_contract acceptance.execution_allowed must be false")
+        if acceptance.get("selected_method_is_factory_owned") is not True:
+            errors.append(f"{at}: method_contract acceptance.selected_method_is_factory_owned must be true")
+        if acceptance.get("scope_reduction_detected") is not False:
+            errors.append(f"{at}: method_contract acceptance.scope_reduction_detected must be false")
+        for index, ref in enumerate(acceptance.get("evidence_refs", []) if isinstance(acceptance.get("evidence_refs"), list) else []):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_v1_completion_gate":

--- a/templates/method-contract.json
+++ b/templates/method-contract.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/method-contract.schema.json",
+  "record_type": "method_contract",
+  "contract_id": "method-contract-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "full_product_sot_scope_coverage_ref": "templates/full-product-sot-scope-coverage.json",
   "selected_method": "spec-first | test-first | behavior-first | discovery-first | prototype-first | legacy-diagnosis | incident-first",
   "why_this_method": "Explain in plain language why this method fits this work.",
   "risk_tier": "R2",
@@ -70,5 +75,35 @@
     "required artifacts exist",
     "required workers returned evidence",
     "Receipt Five ready"
-  ]
+  ],
+  "blocking_rules": {
+    "full_scope_coverage_required": true,
+    "product_creation_plan_required": true,
+    "execution_blocked_until_ready_gate": true,
+    "raw_private_evidence_must_stay_external": true,
+    "operator_must_not_choose_internal_method": true
+  },
+  "handoff": {
+    "next_artifact": "product_creation_plan",
+    "next_worker": "decomposition-planner",
+    "next_safe_action": "Create Product Creation Plan before work units or execution.",
+    "user_decision_required": false,
+    "factory_owned_next_step": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  },
+  "acceptance": {
+    "method_contract_created": true,
+    "execution_allowed": false,
+    "selected_method_is_factory_owned": true,
+    "scope_reduction_detected": false,
+    "blocked_reason": "Method contract exists, but execution remains blocked until product creation plan, readiness, required gates and workers pass.",
+    "evidence_refs": [
+      "templates/method-contract.json",
+      "templates/full-product-sot-scope-coverage.json"
+    ]
+  }
 }

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -647,6 +647,103 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertEqual(first_requirement["blocker_id"], "human-gate-product-scope-001")
         self.assertIn("human-gate-product-scope-001", first_requirement["evidence_refs"])
 
+    def test_method_contract_from_full_scope_coverage_is_valid(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+        product_sot = factoryctl.build_product_sot(outcome)
+        coverage = factoryctl.build_full_scope_coverage(product_sot)
+
+        method_contract = factoryctl.build_method_contract(coverage)
+
+        self.assertEqual(factoryctl.validate_method_contract(method_contract), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(method_contract, "$"), [])
+        self.assertEqual(method_contract["record_type"], "method_contract")
+        self.assertEqual(method_contract["full_product_sot_scope_coverage_ref"], coverage["coverage_id"])
+        self.assertEqual(method_contract["canonical_scope_source"], "approved Product SOT")
+        self.assertIn("full_product_sot_scope_coverage", method_contract["required_factory_artifacts"])
+        self.assertIn("product_creation_plan", method_contract["required_factory_artifacts"])
+        self.assertEqual(method_contract["handoff"]["next_artifact"], "product_creation_plan")
+        self.assertEqual(method_contract["handoff"]["next_worker"], "decomposition-planner")
+        self.assertFalse(method_contract["acceptance"]["execution_allowed"])
+
+    def test_method_contract_requires_valid_full_scope_coverage(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+        product_sot = factoryctl.build_product_sot(outcome)
+        coverage = factoryctl.build_full_scope_coverage(product_sot)
+        coverage["acceptance"]["execution_allowed"] = True
+
+        with self.assertRaisesRegex(ValueError, "execution_allowed"):
+            factoryctl.build_method_contract(coverage)
+
+    def test_method_contract_cli_generates_public_safe_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            coverage_path = Path(tmpdir) / "full-scope-coverage.json"
+            out_path = Path(tmpdir) / "method-contract.json"
+            source_resolution = factoryctl.build_source_resolution_packet(
+                signal_intake(),
+                intake_ref_public_safe="external:sanitized-universal-signal-intake",
+            )
+            ledger = factoryctl.build_product_source_ledger(
+                source_resolution,
+                source_ref_public_safe="external:sanitized-product-brief",
+            )
+            outcome = factoryctl.build_outcome_contract(ledger)
+            product_sot = factoryctl.build_product_sot(outcome)
+            coverage = factoryctl.build_full_scope_coverage(product_sot)
+            coverage_path.write_text(json.dumps(coverage), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "method-contract",
+                    "--full-scope-coverage",
+                    str(coverage_path),
+                    "--out",
+                    str(out_path),
+                ]
+            )
+
+            method_contract = json.loads(out_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(method_contract["record_type"], "method_contract")
+        self.assertEqual(factoryctl.validate_method_contract(method_contract), [])
+
+    def test_method_contract_preserves_human_scope_gate(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+        product_sot = factoryctl.build_product_sot(outcome)
+        coverage = factoryctl.build_full_scope_coverage(product_sot)
+        coverage["requirement_coverage"][0]["status"] = "human_decision_required"
+        coverage["requirement_coverage"][0]["blocker_id"] = "human-gate-method-scope-001"
+
+        method_contract = factoryctl.build_method_contract(coverage)
+
+        self.assertIn("Human Scope Gate", method_contract["required_gates"])
+        self.assertTrue(method_contract["handoff"]["user_decision_required"])
+        self.assertIn("human-gate-method-scope-001", method_contract["evidence_requirements"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `factoryctl method-contract` and `factoryctl validate-method-contract`
- harden Method Contract schema/template/domain validation so method selection stays factory-owned and execution remains blocked
- document the command in README, PT-BR README, CLI reference and workflow catalog

## Dogfooding
- advanced the private Cockpit dogfooding run from validated full Product SOT scope coverage to validated Method Contract without operator-chosen method machinery
- verified the private output did not retain local paths, image refs, clipboard/screenshot files, file URIs or redaction markers
- next factory-owned artifact is now `product_creation_plan`

## Validation
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts\factoryctl.py validate-method-contract templates\method-contract.json`
- `python scripts\factoryctl.py method-contract --full-scope-coverage templates/full-product-sot-scope-coverage.json --out .tmp/factory-runs/dogfood-method-contract/method-contract.json`
- `python scripts\factoryctl.py validate-method-contract .tmp/factory-runs/dogfood-method-contract/method-contract.json`
- `python scripts\validate_public_json_artifacts.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_public_surface_sync.py`
- `git diff --check`

Closes #303