### PR TITLE
Add Product Creation Plan runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --ou
 factoryctl product-sot --outcome-contract .tmp/outcome-contract.json --out .tmp/product-sot.json
 factoryctl full-scope-coverage --product-sot .tmp/product-sot.json --out .tmp/full-product-sot-scope-coverage.json
 factoryctl method-contract --full-scope-coverage .tmp/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
+factoryctl product-creation-plan --method-contract .tmp/method-contract.json --out .tmp/product-creation-plan.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -106,6 +106,7 @@ factoryctl outcome-contract --source-ledger .tmp/product-source-ledger.json --ou
 factoryctl product-sot --outcome-contract .tmp/outcome-contract.json --out .tmp/product-sot.json
 factoryctl full-scope-coverage --product-sot .tmp/product-sot.json --out .tmp/full-product-sot-scope-coverage.json
 factoryctl method-contract --full-scope-coverage .tmp/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
+factoryctl product-creation-plan --method-contract .tmp/method-contract.json --out .tmp/product-creation-plan.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,6 +54,8 @@ factoryctl full-scope-coverage --product-sot templates/product-sot.json --out .t
 factoryctl validate-full-scope-coverage templates/full-product-sot-scope-coverage.json
 factoryctl method-contract --full-scope-coverage templates/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
 factoryctl validate-method-contract templates/method-contract.json
+factoryctl product-creation-plan --method-contract templates/method-contract.json --out .tmp/product-creation-plan.json
+factoryctl validate-product-creation-plan templates/product-creation-plan.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
@@ -90,7 +92,10 @@ pass. `full-scope-coverage` accounts for every Product SOT requirement before
 method routing, so execution slices cannot silently become scope cuts.
 `method-contract` turns that coverage into factory-owned method, artifact,
 worker, gate and evidence requirements without handing DDD/BDD/spec choices to
-the operator. `validate-signal-corpus` and `signal-coverage` prove that the public
+the operator. `product-creation-plan` turns the Method Contract into a complete
+product decomposition with work units, proof ids, blockers, stop rules,
+reconciliation and the next readiness gate, while keeping execution blocked.
+`validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.
 

--- a/schemas/product-creation-plan.schema.json
+++ b/schemas/product-creation-plan.schema.json
@@ -5,6 +5,9 @@
   "type": "object",
   "required": [
     "record_type",
+    "plan_id",
+    "created_at",
+    "factory_method_version",
     "product_sot_ref",
     "method_contract_ref",
     "product_delivery_quality_profile_ref",
@@ -23,11 +26,18 @@
     "stop_conditions",
     "reconciliation_policy",
     "runtime_boundary",
+    "blocking_rules",
+    "handoff",
+    "public_private_boundary",
+    "acceptance",
     "evidence_refs"
   ],
   "properties": {
     "$schema": { "const": "https://overkill-factory.dev/schemas/product-creation-plan.schema.json" },
     "record_type": { "const": "product_creation_plan" },
+    "plan_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "factory_method_version": { "const": "OVERKILL_VFINAL" },
     "product_sot_ref": { "type": "string", "minLength": 3 },
     "method_contract_ref": { "type": "string", "minLength": 3 },
     "product_delivery_quality_profile_ref": { "type": "string", "minLength": 3 },
@@ -143,6 +153,80 @@
         }
       },
       "additionalProperties": true
+    },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "product_sot_required",
+        "method_contract_required",
+        "product_implementation_readiness_required",
+        "execution_blocked_until_ready_gate",
+        "raw_private_evidence_must_stay_external"
+      ],
+      "properties": {
+        "product_sot_required": { "const": true },
+        "method_contract_required": { "const": true },
+        "product_implementation_readiness_required": { "const": true },
+        "execution_blocked_until_ready_gate": { "const": true },
+        "raw_private_evidence_must_stay_external": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "next_artifact",
+        "next_worker",
+        "next_safe_action",
+        "user_decision_required",
+        "factory_owned_next_step"
+      ],
+      "properties": {
+        "next_artifact": { "type": "string", "minLength": 3 },
+        "next_worker": { "type": "string", "minLength": 3 },
+        "next_safe_action": { "type": "string", "minLength": 6 },
+        "user_decision_required": { "type": "boolean" },
+        "factory_owned_next_step": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "product_creation_plan_created",
+        "execution_allowed",
+        "scope_reduction_detected",
+        "work_units_accounted",
+        "blocked_reason",
+        "evidence_refs"
+      ],
+      "properties": {
+        "product_creation_plan_created": { "const": true },
+        "execution_allowed": { "const": false },
+        "scope_reduction_detected": { "const": false },
+        "work_units_accounted": { "type": "integer", "minimum": 1 },
+        "blocked_reason": { "type": "string", "minLength": 6 },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
     },
     "evidence_refs": {
       "type": "array",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -7549,6 +7549,449 @@ def validate_method_contract(method_contract: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _product_creation_plan_id(method_contract_ref: str) -> str:
+    return f"product-creation-plan-{slug_for_ref(method_contract_ref)}"
+
+
+def _product_creation_unit(
+    *,
+    unit_id: str,
+    requirement_refs: list[str],
+    objective: str,
+    scope_in: list[str],
+    scope_out: list[str],
+    verification: list[str],
+    expected_result: str,
+    owner_worker: str,
+    proof_ids: list[str],
+    ready_rules: list[str],
+    blocked_when: list[str],
+    done_rules: list[str],
+    stop_conditions: list[str],
+    status: str,
+    blocker_id: str | None = None,
+    blocker_owner: str | None = None,
+    next_action: str | None = None,
+) -> dict[str, Any]:
+    unit: dict[str, Any] = {
+        "unit_id": unit_id,
+        "product_sot_requirement_refs": _dedupe_preserve_order(requirement_refs),
+        "objective": objective,
+        "scope_in": _dedupe_preserve_order(scope_in),
+        "scope_out": _dedupe_preserve_order(scope_out),
+        "verification": _dedupe_preserve_order(verification),
+        "expected_result": expected_result,
+        "proof_ids_required": _dedupe_preserve_order(proof_ids),
+        "owner_worker": owner_worker,
+        "reviewer_role": "independent-reviewer",
+        "capability_profile_refs": _dedupe_preserve_order(
+            [
+                f"agents/hermes-profile-bindings.public.json#{owner_worker}",
+                "agents/hermes-profile-bindings.public.json#independent-reviewer",
+            ]
+        ),
+        "ready_rules": _dedupe_preserve_order(ready_rules),
+        "blocked_when": _dedupe_preserve_order(blocked_when),
+        "done_rules": _dedupe_preserve_order(done_rules),
+        "stop_conditions": _dedupe_preserve_order(stop_conditions),
+        "status": status,
+        "product_context_packet_ref": "templates/product-context-packet.json",
+    }
+    if status == "blocked":
+        unit["blocker_id"] = blocker_id or f"{unit_id}-blocker"
+        unit["blocker_owner"] = blocker_owner or "factory-orchestrator"
+        unit["next_action"] = next_action or "Resolve the blocker before this work unit can move to readiness."
+    return unit
+
+
+def build_product_creation_plan(
+    method_contract: dict[str, Any],
+    *,
+    created_at: str | None = None,
+    plan_id: str | None = None,
+) -> dict[str, Any]:
+    method_errors = validate_method_contract(method_contract)
+    if method_errors:
+        raise ValueError("; ".join(method_errors))
+
+    handoff = method_contract.get("handoff") if isinstance(method_contract.get("handoff"), dict) else {}
+    if str(handoff.get("next_artifact") or "").strip() != "product_creation_plan":
+        raise ValueError("method_contract does not hand off to Product Creation Plan")
+
+    method_contract_ref = str(method_contract.get("contract_id") or "method-contract")
+    coverage_ref = str(method_contract.get("full_product_sot_scope_coverage_ref") or "full-product-sot-scope-coverage")
+    product_sot_ref = f"{coverage_ref}#approved-product-sot"
+    final_plan_id = plan_id or _product_creation_plan_id(method_contract_ref)
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    user_decision_required = bool(handoff.get("user_decision_required"))
+    matrix = method_contract.get("engineering_method_matrix") if isinstance(method_contract.get("engineering_method_matrix"), list) else []
+    selected_methods = _list_items(method_contract.get("selected_methods"))
+    required_artifacts = _dedupe_preserve_order(
+        [
+            *[item for item in _list_items(method_contract.get("required_artifacts")) if item != "product_creation_plan"],
+            *[item for item in _list_items(method_contract.get("required_plans")) if item != "product_creation_plan"],
+            "product_implementation_readiness",
+        ]
+    )
+    blocker_refs = _dedupe_preserve_order(
+        [
+            value
+            for value in _list_items(method_contract.get("evidence_requirements"))
+            if "human-gate" in value or "blocker" in value.lower()
+        ]
+    )
+    base_requirement_refs = [f"{coverage_ref}#all-active-product-sot-requirements"]
+    common_ready_rules = [
+        "Product Creation Plan validates against schema and domain rules",
+        "Product Implementation Readiness allows this work unit before material execution",
+        "required capability profile and reviewer are available",
+    ]
+    common_blocked_when = [
+        "Product Implementation Readiness is FAIL or BLOCKED",
+        "required capability pack, access, worker or reviewer is unavailable",
+        "Product SOT, Method Contract or full scope coverage has drifted",
+    ]
+    common_done_rules = [
+        "all proof_ids_required have PASS, BLOCK with owner, or valid human-gated waiver evidence",
+        "independent-reviewer reviewed the work-unit evidence",
+        "Receipt Five can reference the produced evidence without private refs",
+    ]
+    common_stop_conditions = [
+        "Product SOT scope changes without a refreshed plan",
+        "worker would need to infer private source material or hidden operator context",
+        "execution tries to treat one slice as complete-product completion",
+    ]
+
+    work_units: list[dict[str, Any]] = []
+    work_units.append(
+        _product_creation_unit(
+            unit_id="work-unit-001-scope-reconciliation",
+            requirement_refs=base_requirement_refs,
+            objective="Reconcile the complete Product SOT scope into executable work without reducing the product promise.",
+            scope_in=[
+                "all active Product SOT requirements represented by full scope coverage",
+                "method, gates, workers, reviewers and evidence requirements from Method Contract",
+            ],
+            scope_out=["raw private source material", "implementation or release state"],
+            verification=[
+                "validate-product-creation-plan passes",
+                "every planned slice links back to Method Contract and full scope coverage",
+            ],
+            expected_result="PASS or explicit BLOCK with owner before any work unit can execute",
+            owner_worker="decomposition-planner",
+            proof_ids=["product_creation.scope_reconciliation", "product_creation.no_scope_reduction"],
+            ready_rules=common_ready_rules,
+            blocked_when=common_blocked_when,
+            done_rules=common_done_rules,
+            stop_conditions=common_stop_conditions,
+            status="blocked" if user_decision_required else "todo",
+            blocker_id=blocker_refs[0] if blocker_refs else "human-gate-product-scope",
+            blocker_owner="human-gate-clerk",
+            next_action="Resolve the named human scope decision before planning moves to readiness.",
+        )
+    )
+
+    for index, row in enumerate(matrix, start=2):
+        row = row if isinstance(row, dict) else {}
+        surface = str(row.get("surface_or_component") or f"method-surface-{index - 1}").strip()
+        unit_id = f"work-unit-{index:03d}-{slug_for_ref(surface)}"
+        row_methods = _list_items(row.get("methods")) or selected_methods or ["spec-first"]
+        required_row_artifacts = _list_items(row.get("required_artifacts")) or required_artifacts
+        evidence_required = _list_items(row.get("evidence_required")) or ["tests pass", "worker result evidence"]
+        work_units.append(
+            _product_creation_unit(
+                unit_id=unit_id,
+                requirement_refs=[*base_requirement_refs, f"{method_contract_ref}#engineering-method-matrix-{index - 1:03d}"],
+                objective=f"Plan and execute the {surface} slice using {', '.join(row_methods)} while preserving full product scope.",
+                scope_in=[
+                    f"{surface} requirements from approved Product SOT coverage",
+                    *[f"required artifact: {artifact}" for artifact in required_row_artifacts],
+                ],
+                scope_out=[
+                    "requirements not represented by the approved Product SOT",
+                    "release or production promotion without later readiness gates",
+                ],
+                verification=[
+                    *evidence_required,
+                    "Product Implementation Readiness confirms this slice is allowed",
+                ],
+                expected_result="Slice evidence is PASS, or BLOCKED with owner and recovery route.",
+                owner_worker="implementation-worker",
+                proof_ids=[f"product_creation.{slug_for_ref(surface)}.scope_fit", f"product_creation.{slug_for_ref(surface)}.verification"],
+                ready_rules=[
+                    *common_ready_rules,
+                    f"methods selected for this slice are fixed: {', '.join(row_methods)}",
+                ],
+                blocked_when=common_blocked_when,
+                done_rules=common_done_rules,
+                stop_conditions=common_stop_conditions,
+                status="todo",
+            )
+        )
+
+    readiness_unit_id = f"work-unit-{len(work_units) + 1:03d}-implementation-readiness"
+    work_units.append(
+        _product_creation_unit(
+            unit_id=readiness_unit_id,
+            requirement_refs=[*base_requirement_refs, f"{method_contract_ref}#product-implementation-readiness"],
+            objective="Prove artifact alignment before material implementation starts.",
+            scope_in=[
+                "Product SOT, full scope coverage, Method Contract and Product Creation Plan",
+                "work-unit proof, reviewer, blocker and stop-rule coverage",
+            ],
+            scope_out=["executing workers", "approving production readiness without evidence"],
+            verification=["validate product_implementation_readiness artifact", "gate report blocks or allows explicit slices"],
+            expected_result="Product Implementation Readiness returns PASS, CONCERNS, FAIL or BLOCKED with allowed next actions.",
+            owner_worker="factory-orchestrator",
+            proof_ids=["product_creation.implementation_readiness", "product_creation.gate_alignment"],
+            ready_rules=common_ready_rules,
+            blocked_when=common_blocked_when,
+            done_rules=common_done_rules,
+            stop_conditions=common_stop_conditions,
+            status="todo",
+        )
+    )
+
+    promotion_unit_id = f"work-unit-{len(work_units) + 1:03d}-release-operations-readiness"
+    work_units.append(
+        _product_creation_unit(
+            unit_id=promotion_unit_id,
+            requirement_refs=[*base_requirement_refs, f"{method_contract_ref}#production-route"],
+            objective="Plan production, release, rollback, monitoring and support proof before customer-ready claims.",
+            scope_in=["production promotion ladder", "rollback", "monitoring", "support", "customer readiness"],
+            scope_out=["mainnet, customer, irreversible or production release without explicit promotion gates"],
+            verification=["production promotion ladder is referenced", "release readiness evidence is attached before promotion"],
+            expected_result="Release path is ready, blocked with owner, or explicitly out of scope by human-gated SOT rebaseline.",
+            owner_worker="release-ops-worker",
+            proof_ids=["product_creation.release_path", "product_creation.operations_readiness"],
+            ready_rules=common_ready_rules,
+            blocked_when=common_blocked_when,
+            done_rules=common_done_rules,
+            stop_conditions=common_stop_conditions,
+            status="todo",
+        )
+    )
+
+    execution_order = [str(unit["unit_id"]) for unit in work_units]
+    dependency_graph = [{"from": method_contract_ref, "to": "work-unit-001-scope-reconciliation"}]
+    dependency_graph.extend({"from": "work-unit-001-scope-reconciliation", "to": unit_id} for unit_id in execution_order[1:])
+    dependency_graph.append({"from": readiness_unit_id, "to": "product_implementation_readiness"})
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/product-creation-plan.schema.json",
+        "record_type": "product_creation_plan",
+        "plan_id": final_plan_id,
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "product_sot_ref": product_sot_ref,
+        "method_contract_ref": method_contract_ref,
+        "product_delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
+        "research_decision_refs": _list_items(method_contract.get("research_decision_refs")),
+        "architecture_decision_refs": [],
+        "complete_product_required": True,
+        "complete_product_scope": [
+            f"all active Product SOT requirements accounted by {coverage_ref}",
+            "all Method Contract required artifacts, gates, workers, reviewers and evidence requirements",
+            "production, operations, release and support requirements when product intent reaches real users",
+        ],
+        "complete_product_non_goals": ["anything explicitly marked out of scope by the approved Product SOT or human-gated rebaseline"],
+        "production_readiness_scope": ["release path", "rollback", "monitoring", "support", "customer readiness"],
+        "surface_matrix": [
+            {
+                "surface": str(row.get("surface_or_component") or "complete product scope"),
+                "methods": _list_items(row.get("methods")) or selected_methods or ["spec-first"],
+                "proof": _list_items(row.get("evidence_required")) or ["tests pass", "worker result evidence"],
+            }
+            for row in matrix
+            if isinstance(row, dict)
+        ],
+        "capability_pack_requirements": ["templates/capability-pack-contract.json"],
+        "work_units": work_units,
+        "execution_order": execution_order,
+        "slice_boundaries": [
+            "slices are execution order units, not product scope reductions",
+            "each slice must remain reversible or explicitly gated before irreversible change",
+            "no slice may claim whole-product completion without full Product SOT reconciliation",
+        ],
+        "dependency_graph": dependency_graph,
+        "risk_map": [
+            f"method risk tier: {method_contract.get('risk_tier')}",
+            "scope shrinkage is blocked by full Product SOT coverage",
+            "execution is blocked until Product Implementation Readiness and Ready Gate pass",
+        ],
+        "access_and_secret_requirements": ["declare required access in Product Implementation Readiness before material execution"],
+        "release_promotion_ladder_refs": ["templates/production-promotion-ladder.json"],
+        "complete_product_done_criteria": [
+            "every active Product SOT requirement is done, blocked with owner, or explicitly rebaselined by human gate",
+            "all required work units carry PASS/BLOCK/waiver evidence and independent review",
+            "production/customer-ready claims have release, rollback, monitoring and support evidence",
+        ],
+        "slice_done_criteria": [
+            "slice verification passes and evidence refs are attached",
+            "reviewer_role has reviewed the slice evidence",
+            "slice result updates Product Creation Plan reconciliation state",
+        ],
+        "drift_check": "Refresh this plan when Product SOT, full scope coverage, Method Contract, capability packs, landed slices or repo state change.",
+        "stop_conditions": [
+            "missing Product SOT coverage",
+            "Method Contract changed after this plan was created",
+            "required proof cannot be produced",
+            "execution attempts to bypass Product Implementation Readiness",
+        ],
+        "reconciliation_policy": (
+            "Mark work units todo, ready, blocked, in_progress, done, rejected, superseded or needs_refresh; "
+            "never treat a done slice as whole-product completion."
+        ),
+        "runtime_boundary": {
+            "state_role": "planning_only",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "materialized_hermes_task_refs": [],
+        },
+        "blocking_rules": {
+            "product_sot_required": True,
+            "method_contract_required": True,
+            "product_implementation_readiness_required": True,
+            "execution_blocked_until_ready_gate": True,
+            "raw_private_evidence_must_stay_external": True,
+        },
+        "handoff": {
+            "next_artifact": "product_implementation_readiness",
+            "next_worker": "factory-orchestrator",
+            "next_safe_action": "Create Product Implementation Readiness before material work units or execution.",
+            "user_decision_required": user_decision_required,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+        },
+        "acceptance": {
+            "product_creation_plan_created": True,
+            "execution_allowed": False,
+            "scope_reduction_detected": False,
+            "work_units_accounted": len(work_units),
+            "blocked_reason": (
+                "Product Creation Plan exists, but execution remains blocked until implementation "
+                "readiness, Ready Gate, required workers and proof pass."
+            ),
+            "evidence_refs": ["schemas/product-creation-plan.schema.json", method_contract_ref, coverage_ref],
+        },
+        "evidence_refs": ["schemas/product-creation-plan.schema.json", method_contract_ref, coverage_ref],
+    }
+
+
+def validate_product_creation_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("product-creation-plan.schema.json")
+    if not schema:
+        return ["product_creation_plan schema is not bundled"]
+    errors.extend(validate_node(schema, plan, "product_creation_plan", schemas=schemas, root_schema=schema))
+    if plan.get("record_type") != "product_creation_plan":
+        errors.append("product_creation_plan.record_type must be product_creation_plan")
+    if plan.get("complete_product_required") is not True:
+        errors.append("product_creation_plan.complete_product_required must be true")
+
+    for field in ("product_sot_ref", "method_contract_ref", "product_delivery_quality_profile_ref"):
+        value = str(plan.get(field) or "").strip()
+        if value:
+            _validate_public_ref(value, f"product_creation_plan.{field}", errors)
+
+    errors.extend(validate_product_creation_plan_work_unit_graph(plan))
+
+    for field in (
+        "complete_product_scope",
+        "production_readiness_scope",
+        "release_promotion_ladder_refs",
+        "complete_product_done_criteria",
+        "slice_done_criteria",
+        "stop_conditions",
+        "evidence_refs",
+    ):
+        if not _non_empty_string_list(plan.get(field)):
+            errors.append(f"product_creation_plan.{field} must be non-empty")
+    for field in ("drift_check", "reconciliation_policy"):
+        if not public_safe_text(plan.get(field)):
+            errors.append(f"product_creation_plan.{field} must be public-safe")
+
+    for index, ref in enumerate(_list_items(plan.get("release_promotion_ladder_refs"))):
+        _validate_public_ref(ref, f"product_creation_plan.release_promotion_ladder_refs[{index}]", errors)
+    for index, ref in enumerate(_list_items(plan.get("evidence_refs"))):
+        _validate_public_ref(ref, f"product_creation_plan.evidence_refs[{index}]", errors)
+
+    for index, unit in enumerate(plan.get("work_units", []) if isinstance(plan.get("work_units"), list) else []):
+        if not isinstance(unit, dict):
+            continue
+        owner = str(unit.get("owner_worker") or "").strip()
+        reviewer = str(unit.get("reviewer_role") or "").strip()
+        blocker_owner = str(unit.get("blocker_owner") or "").strip()
+        if owner and owner not in WORKERS:
+            errors.append(f"product_creation_plan.work_units[{index}].owner_worker must be a registered worker: {owner}")
+        if reviewer and reviewer not in WORKERS:
+            errors.append(f"product_creation_plan.work_units[{index}].reviewer_role must be a registered worker: {reviewer}")
+        if blocker_owner and blocker_owner not in WORKERS:
+            errors.append(f"product_creation_plan.work_units[{index}].blocker_owner must be a registered worker: {blocker_owner}")
+        for ref_field in ("product_sot_requirement_refs", "capability_profile_refs"):
+            for ref_index, ref in enumerate(_list_items(unit.get(ref_field))):
+                _validate_public_ref(ref, f"product_creation_plan.work_units[{index}].{ref_field}[{ref_index}]", errors)
+
+    runtime_boundary = plan.get("runtime_boundary") if isinstance(plan.get("runtime_boundary"), dict) else {}
+    if runtime_boundary.get("state_role") != "planning_only":
+        errors.append("product_creation_plan.runtime_boundary.state_role must be planning_only")
+    if runtime_boundary.get("runtime_authority") != "hermes_kanban":
+        errors.append("product_creation_plan.runtime_boundary.runtime_authority must be hermes_kanban")
+    if runtime_boundary.get("local_state_authority") is not False:
+        errors.append("product_creation_plan.runtime_boundary.local_state_authority must be false")
+
+    blocking_rules = plan.get("blocking_rules") if isinstance(plan.get("blocking_rules"), dict) else {}
+    for field in (
+        "product_sot_required",
+        "method_contract_required",
+        "product_implementation_readiness_required",
+        "execution_blocked_until_ready_gate",
+        "raw_private_evidence_must_stay_external",
+    ):
+        if blocking_rules.get(field) is not True:
+            errors.append(f"product_creation_plan.blocking_rules.{field} must be true")
+
+    handoff = plan.get("handoff") if isinstance(plan.get("handoff"), dict) else {}
+    if handoff.get("factory_owned_next_step") is not True:
+        errors.append("product_creation_plan.handoff.factory_owned_next_step must be true")
+    if handoff.get("next_artifact") != "product_implementation_readiness":
+        errors.append("product_creation_plan.handoff.next_artifact must be product_implementation_readiness")
+    next_worker = str(handoff.get("next_worker") or "").strip()
+    if next_worker and next_worker not in WORKERS:
+        errors.append(f"product_creation_plan.handoff.next_worker must be a registered worker: {next_worker}")
+
+    boundary = plan.get("public_private_boundary") if isinstance(plan.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("product_creation_plan requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("product_creation_plan must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("product_creation_plan private context must stay outside the public repo")
+
+    acceptance = plan.get("acceptance") if isinstance(plan.get("acceptance"), dict) else {}
+    if acceptance.get("product_creation_plan_created") is not True:
+        errors.append("product_creation_plan acceptance.product_creation_plan_created must be true")
+    if acceptance.get("execution_allowed") is not False:
+        errors.append("product_creation_plan acceptance.execution_allowed must be false")
+    if acceptance.get("scope_reduction_detected") is not False:
+        errors.append("product_creation_plan acceptance.scope_reduction_detected must be false")
+    work_units = plan.get("work_units") if isinstance(plan.get("work_units"), list) else []
+    if acceptance.get("work_units_accounted") != len(work_units):
+        errors.append("product_creation_plan acceptance.work_units_accounted must match work_units length")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "product_creation_plan.acceptance.evidence_refs",
+        errors,
+    )
+
+    return errors
+
+
 def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -13138,6 +13581,16 @@ def command_validate_method_contract(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_product_creation_plan(args: argparse.Namespace) -> int:
+    errors = validate_product_creation_plan(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_route_registry(args: argparse.Namespace) -> int:
     registry = load_route_registry(args.registry)
     if args.route_class:
@@ -13295,6 +13748,25 @@ def command_method_contract(args: argparse.Namespace) -> int:
             print(error, file=sys.stderr)
         return 1
     write_json(args.out, method_contract)
+    return 0
+
+
+def command_product_creation_plan(args: argparse.Namespace) -> int:
+    try:
+        plan = build_product_creation_plan(
+            load_json_like(args.method_contract),
+            created_at=args.created_at,
+            plan_id=args.plan_id,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_product_creation_plan(plan)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, plan)
     return 0
 
 
@@ -13748,6 +14220,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_method_contract_parser.add_argument("path", type=Path)
     validate_method_contract_parser.set_defaults(func=command_validate_method_contract)
 
+    validate_product_creation_plan_parser = sub.add_parser("validate-product-creation-plan")
+    validate_product_creation_plan_parser.add_argument("path", type=Path)
+    validate_product_creation_plan_parser.set_defaults(func=command_validate_product_creation_plan)
+
     route_registry_parser = sub.add_parser("route-registry", help="Show the canonical Universal Signal route registry.")
     route_registry_parser.add_argument("--registry", type=Path, default=DEFAULT_ROUTE_REGISTRY_PATH)
     route_registry_parser.add_argument("--route-class")
@@ -13834,6 +14310,16 @@ def build_parser() -> argparse.ArgumentParser:
     method_contract_parser.add_argument("--contract-id")
     method_contract_parser.add_argument("--out", type=Path)
     method_contract_parser.set_defaults(func=command_method_contract)
+
+    product_creation_plan_parser = sub.add_parser(
+        "product-creation-plan",
+        help="Build Product Creation Plan from a validated Method Contract without allowing execution.",
+    )
+    product_creation_plan_parser.add_argument("--method-contract", type=Path, required=True)
+    product_creation_plan_parser.add_argument("--created-at")
+    product_creation_plan_parser.add_argument("--plan-id")
+    product_creation_plan_parser.add_argument("--out", type=Path)
+    product_creation_plan_parser.set_defaults(func=command_product_creation_plan)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1580,6 +1580,123 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             reason = public_artifact_ref_error(ref)
             if reason:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
+    if data.get("record_type") == "product_creation_plan":
+        for field in ("product_sot_ref", "method_contract_ref", "product_delivery_quality_profile_ref"):
+            reason = public_artifact_ref_error(data.get(field))
+            if reason:
+                errors.append(f"{at}.{field}: {reason}")
+        if data.get("complete_product_required") is not True:
+            errors.append(f"{at}.complete_product_required must be true")
+        for field in (
+            "complete_product_scope",
+            "production_readiness_scope",
+            "release_promotion_ladder_refs",
+            "complete_product_done_criteria",
+            "slice_done_criteria",
+            "stop_conditions",
+            "evidence_refs",
+        ):
+            if not (data.get(field) if isinstance(data.get(field), list) else []):
+                errors.append(f"{at}.{field} must be non-empty")
+        work_units = data.get("work_units") if isinstance(data.get("work_units"), list) else []
+        if not work_units:
+            errors.append(f"{at}.work_units must be non-empty")
+        unit_ids: set[str] = set()
+        for index, unit in enumerate(work_units):
+            if not isinstance(unit, dict):
+                continue
+            unit_id = str(unit.get("unit_id") or "").strip()
+            if not unit_id:
+                errors.append(f"{at}.work_units[{index}].unit_id is required")
+            elif unit_id in unit_ids:
+                errors.append(f"{at}.work_units[{index}].unit_id must be unique: {unit_id}")
+            else:
+                unit_ids.add(unit_id)
+            for field in (
+                "product_sot_requirement_refs",
+                "scope_in",
+                "scope_out",
+                "verification",
+                "proof_ids_required",
+                "capability_profile_refs",
+                "ready_rules",
+                "blocked_when",
+                "done_rules",
+                "stop_conditions",
+            ):
+                if not (unit.get(field) if isinstance(unit.get(field), list) else []):
+                    errors.append(f"{at}.work_units[{index}].{field} must be non-empty")
+            for field in ("owner_worker", "reviewer_role", "expected_result"):
+                if not str(unit.get(field) or "").strip():
+                    errors.append(f"{at}.work_units[{index}].{field} is required")
+            owner = str(unit.get("owner_worker") or "").strip()
+            reviewer = str(unit.get("reviewer_role") or "").strip()
+            blocker_owner = str(unit.get("blocker_owner") or "").strip()
+            if owner and owner not in public_worker_ids():
+                errors.append(f"{at}.work_units[{index}].owner_worker must be a registered worker: {owner}")
+            if reviewer and reviewer not in public_worker_ids():
+                errors.append(f"{at}.work_units[{index}].reviewer_role must be a registered worker: {reviewer}")
+            if blocker_owner and blocker_owner not in public_worker_ids():
+                errors.append(f"{at}.work_units[{index}].blocker_owner must be a registered worker: {blocker_owner}")
+            if str(unit.get("status") or "").strip() == "blocked":
+                for field in ("blocker_id", "blocker_owner", "next_action"):
+                    if not str(unit.get(field) or "").strip():
+                        errors.append(f"{at}.work_units[{index}].{field} is required when status is blocked")
+            for ref_field in ("product_sot_requirement_refs", "capability_profile_refs"):
+                refs = unit.get(ref_field) if isinstance(unit.get(ref_field), list) else []
+                for ref_index, ref in enumerate(refs):
+                    reason = public_artifact_ref_error(ref)
+                    if reason:
+                        errors.append(f"{at}.work_units[{index}].{ref_field}[{ref_index}]: {reason}")
+        execution_order = data.get("execution_order") if isinstance(data.get("execution_order"), list) else []
+        missing_order_refs = [unit_id for unit_id in execution_order if unit_id not in unit_ids]
+        if missing_order_refs:
+            errors.append(f"{at}.execution_order references unknown work_units: {', '.join(missing_order_refs)}")
+        runtime_boundary = data.get("runtime_boundary") if isinstance(data.get("runtime_boundary"), dict) else {}
+        if runtime_boundary.get("state_role") != "planning_only":
+            errors.append(f"{at}.runtime_boundary.state_role must be planning_only")
+        if runtime_boundary.get("runtime_authority") != "hermes_kanban":
+            errors.append(f"{at}.runtime_boundary.runtime_authority must be hermes_kanban")
+        if runtime_boundary.get("local_state_authority") is not False:
+            errors.append(f"{at}.runtime_boundary.local_state_authority must be false")
+        blocking_rules = data.get("blocking_rules") if isinstance(data.get("blocking_rules"), dict) else {}
+        for field in (
+            "product_sot_required",
+            "method_contract_required",
+            "product_implementation_readiness_required",
+            "execution_blocked_until_ready_gate",
+            "raw_private_evidence_must_stay_external",
+        ):
+            if blocking_rules.get(field) is not True:
+                errors.append(f"{at}.blocking_rules.{field} must be true")
+        handoff = data.get("handoff") if isinstance(data.get("handoff"), dict) else {}
+        if handoff.get("next_artifact") != "product_implementation_readiness":
+            errors.append(f"{at}.handoff.next_artifact must be product_implementation_readiness")
+        if handoff.get("factory_owned_next_step") is not True:
+            errors.append(f"{at}: product_creation_plan.handoff.factory_owned_next_step must be true")
+        next_worker = str(handoff.get("next_worker") or "").strip()
+        if next_worker and next_worker not in public_worker_ids():
+            errors.append(f"{at}.handoff.next_worker must be a registered worker: {next_worker}")
+        boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: product_creation_plan requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: product_creation_plan must not embed raw private evidence")
+        if boundary.get("private_context_retained_outside_public_repo") is not True:
+            errors.append(f"{at}: product_creation_plan private context must stay outside the public repo")
+        acceptance = data.get("acceptance") if isinstance(data.get("acceptance"), dict) else {}
+        if acceptance.get("product_creation_plan_created") is not True:
+            errors.append(f"{at}: product_creation_plan acceptance.product_creation_plan_created must be true")
+        if acceptance.get("execution_allowed") is not False:
+            errors.append(f"{at}: product_creation_plan acceptance.execution_allowed must be false")
+        if acceptance.get("scope_reduction_detected") is not False:
+            errors.append(f"{at}: product_creation_plan acceptance.scope_reduction_detected must be false")
+        if acceptance.get("work_units_accounted") != len(work_units):
+            errors.append(f"{at}: product_creation_plan acceptance.work_units_accounted must match work_units length")
+        for index, ref in enumerate(acceptance.get("evidence_refs", []) if isinstance(acceptance.get("evidence_refs"), list) else []):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_v1_completion_gate":

--- a/templates/product-creation-plan.json
+++ b/templates/product-creation-plan.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/product-creation-plan.schema.json",
   "record_type": "product_creation_plan",
+  "plan_id": "product-creation-plan-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
   "product_sot_ref": "templates/product-sot.json",
   "method_contract_ref": "templates/method-contract.json",
   "product_delivery_quality_profile_ref": "templates/product-delivery-quality-profile.json",
@@ -73,6 +76,36 @@
     "runtime_authority": "hermes_kanban",
     "local_state_authority": false,
     "materialized_hermes_task_refs": []
+  },
+  "blocking_rules": {
+    "product_sot_required": true,
+    "method_contract_required": true,
+    "product_implementation_readiness_required": true,
+    "execution_blocked_until_ready_gate": true,
+    "raw_private_evidence_must_stay_external": true
+  },
+  "handoff": {
+    "next_artifact": "product_implementation_readiness",
+    "next_worker": "factory-orchestrator",
+    "next_safe_action": "Create Product Implementation Readiness before material work units or execution.",
+    "user_decision_required": false,
+    "factory_owned_next_step": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  },
+  "acceptance": {
+    "product_creation_plan_created": true,
+    "execution_allowed": false,
+    "scope_reduction_detected": false,
+    "work_units_accounted": 1,
+    "blocked_reason": "Product Creation Plan exists, but execution remains blocked until implementation readiness, Ready Gate, required workers and proof pass.",
+    "evidence_refs": [
+      "templates/product-creation-plan.json",
+      "templates/method-contract.json"
+    ]
   },
   "evidence_refs": ["templates/full-product-sot-scope-coverage.json"]
 }

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -31,6 +31,21 @@ def signal_intake() -> dict:
     return json.loads((ROOT / "templates" / "universal-signal-intake.json").read_text(encoding="utf-8"))
 
 
+def build_valid_method_contract() -> dict:
+    source_resolution = factoryctl.build_source_resolution_packet(
+        signal_intake(),
+        intake_ref_public_safe="external:sanitized-universal-signal-intake",
+    )
+    ledger = factoryctl.build_product_source_ledger(
+        source_resolution,
+        source_ref_public_safe="external:sanitized-product-brief",
+    )
+    outcome = factoryctl.build_outcome_contract(ledger)
+    product_sot = factoryctl.build_product_sot(outcome)
+    coverage = factoryctl.build_full_scope_coverage(product_sot)
+    return factoryctl.build_method_contract(coverage)
+
+
 class UniversalSignalIntakeTest(unittest.TestCase):
     def test_public_template_validates(self) -> None:
         errors = factoryctl.validate_universal_signal_intake(signal_intake())
@@ -743,6 +758,76 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertIn("Human Scope Gate", method_contract["required_gates"])
         self.assertTrue(method_contract["handoff"]["user_decision_required"])
         self.assertIn("human-gate-method-scope-001", method_contract["evidence_requirements"])
+
+    def test_product_creation_plan_from_method_contract_is_valid(self) -> None:
+        method_contract = build_valid_method_contract()
+
+        plan = factoryctl.build_product_creation_plan(method_contract)
+
+        self.assertEqual(factoryctl.validate_product_creation_plan(plan), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(plan, "$"), [])
+        self.assertEqual(plan["record_type"], "product_creation_plan")
+        self.assertEqual(plan["method_contract_ref"], method_contract["contract_id"])
+        self.assertTrue(plan["complete_product_required"])
+        self.assertIn("work-unit-001-scope-reconciliation", plan["execution_order"])
+        self.assertEqual(plan["handoff"]["next_artifact"], "product_implementation_readiness")
+        self.assertEqual(plan["handoff"]["next_worker"], "factory-orchestrator")
+        self.assertFalse(plan["acceptance"]["execution_allowed"])
+
+    def test_product_creation_plan_requires_valid_method_contract(self) -> None:
+        method_contract = build_valid_method_contract()
+        method_contract["acceptance"]["execution_allowed"] = True
+
+        with self.assertRaisesRegex(ValueError, "execution_allowed"):
+            factoryctl.build_product_creation_plan(method_contract)
+
+    def test_product_creation_plan_cli_generates_public_safe_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            method_contract_path = Path(tmpdir) / "method-contract.json"
+            out_path = Path(tmpdir) / "product-creation-plan.json"
+            method_contract = build_valid_method_contract()
+            method_contract_path.write_text(json.dumps(method_contract), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "product-creation-plan",
+                    "--method-contract",
+                    str(method_contract_path),
+                    "--out",
+                    str(out_path),
+                ]
+            )
+
+            plan = json.loads(out_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(plan["record_type"], "product_creation_plan")
+        self.assertEqual(factoryctl.validate_product_creation_plan(plan), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(plan, "$"), [])
+
+    def test_product_creation_plan_preserves_human_scope_gate(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+        product_sot = factoryctl.build_product_sot(outcome)
+        coverage = factoryctl.build_full_scope_coverage(product_sot)
+        coverage["requirement_coverage"][0]["status"] = "human_decision_required"
+        coverage["requirement_coverage"][0]["blocker_id"] = "human-gate-method-scope-001"
+        method_contract = factoryctl.build_method_contract(coverage)
+
+        plan = factoryctl.build_product_creation_plan(method_contract)
+
+        scope_unit = plan["work_units"][0]
+        self.assertTrue(plan["handoff"]["user_decision_required"])
+        self.assertEqual(scope_unit["status"], "blocked")
+        self.assertEqual(scope_unit["blocker_id"], "human-gate-method-scope-001")
+        self.assertEqual(scope_unit["blocker_owner"], "human-gate-clerk")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `factoryctl product-creation-plan` and `validate-product-creation-plan`
- generate Product Creation Plan from validated Method Contract while preserving full-product scope and keeping execution blocked
- harden schema/template/public JSON validation for Product Creation Plan handoff, blockers, work units, acceptance and public/private boundary
- document the new public CLI step in README and CLI reference

Closes #305

## Validation
- `python -m py_compile scripts\factoryctl.py scripts\validate_public_json_artifacts.py`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts\factoryctl.py validate-product-creation-plan templates\product-creation-plan.json`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\factoryctl.py product-creation-plan --method-contract templates\method-contract.json --out .tmp\factory-runs\dogfood-product-creation-plan\product-creation-plan.json`
- `python scripts\factoryctl.py validate-product-creation-plan .tmp\factory-runs\dogfood-product-creation-plan\product-creation-plan.json`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\quickstart_smoke.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_public_surface_sync.py`
- `git diff --check`

## Public/private boundary
No private cockpit input, screenshots, local paths, raw research dumps, or process evidence are committed. Private dogfooding output stayed outside the public repo and was scanned for local path/image/clipboard markers.