### PR TITLE
[codex] Add ready work-unit packet runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ factoryctl full-scope-coverage --product-sot .tmp/product-sot.json --out .tmp/fu
 factoryctl method-contract --full-scope-coverage .tmp/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
 factoryctl product-creation-plan --method-contract .tmp/method-contract.json --out .tmp/product-creation-plan.json
 factoryctl product-implementation-readiness --product-creation-plan .tmp/product-creation-plan.json --out .tmp/product-implementation-readiness.json
+factoryctl ready-work-unit-packets --product-creation-plan .tmp/product-creation-plan.json --product-implementation-readiness .tmp/product-implementation-readiness.json --out .tmp/ready-work-unit-packets
+factoryctl validate-ready-work-unit-packets .tmp/ready-work-unit-packets/manifest.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -108,6 +108,8 @@ factoryctl full-scope-coverage --product-sot .tmp/product-sot.json --out .tmp/fu
 factoryctl method-contract --full-scope-coverage .tmp/full-product-sot-scope-coverage.json --out .tmp/method-contract.json
 factoryctl product-creation-plan --method-contract .tmp/method-contract.json --out .tmp/product-creation-plan.json
 factoryctl product-implementation-readiness --product-creation-plan .tmp/product-creation-plan.json --out .tmp/product-implementation-readiness.json
+factoryctl ready-work-unit-packets --product-creation-plan .tmp/product-creation-plan.json --product-implementation-readiness .tmp/product-implementation-readiness.json --out .tmp/ready-work-unit-packets
+factoryctl validate-ready-work-unit-packets .tmp/ready-work-unit-packets/manifest.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets

--- a/docs/concepts/factory-flow.md
+++ b/docs/concepts/factory-flow.md
@@ -32,6 +32,7 @@ source intake
 -> method contract
 -> Product Creation Plan
 -> Product Implementation Readiness
+-> ready work-unit packets
 -> Product Face or surface-specific plan
 -> security, access and budget gates
 -> decomposition into Hermes cards

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,6 +58,8 @@ factoryctl product-creation-plan --method-contract templates/method-contract.jso
 factoryctl validate-product-creation-plan templates/product-creation-plan.json
 factoryctl product-implementation-readiness --product-creation-plan templates/product-creation-plan.json --out .tmp/product-implementation-readiness.json
 factoryctl validate-product-implementation-readiness templates/product-implementation-readiness.json
+factoryctl ready-work-unit-packets --product-creation-plan templates/product-creation-plan.json --product-implementation-readiness templates/product-implementation-readiness.json --out .tmp/ready-work-unit-packets
+factoryctl validate-ready-work-unit-packets templates/ready-work-unit-packets.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
 factoryctl v1-completion-gate --release-preflight .tmp/factory-runs/release/release-integration-preflight.json --github-actions-result PASS --open-v1-blockers 0 --open-prs 0
@@ -100,6 +102,10 @@ reconciliation and the next readiness gate, while keeping execution blocked.
 `product-implementation-readiness` checks that Product Creation Plan work units
 are aligned enough to materialize only explicit ready units, or blocks with
 named owners and human decisions.
+`ready-work-unit-packets` turns those explicit `ready_work_units` into
+deterministic execution requests without mutating live Hermes, without exposing
+private refs and without allowing any complete-product claim from a bounded
+slice.
 `validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.

--- a/schemas/ready-work-unit-packets.schema.json
+++ b/schemas/ready-work-unit-packets.schema.json
@@ -1,0 +1,247 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/ready-work-unit-packets.schema.json",
+  "title": "Overkill Factory Ready Work Unit Packet Manifest",
+  "type": "object",
+  "required": [
+    "record_type",
+    "manifest_id",
+    "created_at",
+    "factory_method_version",
+    "product_creation_plan_ref",
+    "product_implementation_readiness_ref",
+    "readiness_result",
+    "allowed_execution_scope",
+    "complete_product_claim_allowed",
+    "runtime_boundary",
+    "packets",
+    "blocked_work_units_not_materialized",
+    "blocking_rules",
+    "handoff",
+    "public_private_boundary",
+    "acceptance",
+    "evidence_refs"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/ready-work-unit-packets.schema.json" },
+    "record_type": { "const": "ready_work_unit_packet_manifest" },
+    "manifest_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "factory_method_version": { "const": "OVERKILL_VFINAL" },
+    "product_creation_plan_ref": { "type": "string", "minLength": 3 },
+    "product_implementation_readiness_ref": { "type": "string", "minLength": 3 },
+    "readiness_result": { "enum": ["PASS", "CONCERNS"] },
+    "allowed_execution_scope": { "enum": ["ready_work_units_only", "all_ready_work_units"] },
+    "complete_product_claim_allowed": { "const": false },
+    "runtime_boundary": {
+      "type": "object",
+      "required": [
+        "state_role",
+        "runtime_authority",
+        "local_state_authority",
+        "live_hermes_mutated",
+        "hermes_materialization_requires_gate"
+      ],
+      "properties": {
+        "state_role": { "const": "execution_request_only" },
+        "runtime_authority": { "const": "hermes_kanban" },
+        "local_state_authority": { "const": false },
+        "live_hermes_mutated": { "const": false },
+        "hermes_materialization_requires_gate": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "packets": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/readyWorkUnitPacket" }
+    },
+    "blocked_work_units_not_materialized": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "validated_product_creation_plan_required",
+        "validated_product_implementation_readiness_required",
+        "only_ready_work_units_materialized",
+        "failed_or_blocked_readiness_blocks_packet_creation",
+        "complete_product_claim_forbidden_until_all_scope_reconciled",
+        "live_hermes_mutation_forbidden_without_runtime_gate",
+        "raw_private_evidence_must_stay_external"
+      ],
+      "properties": {
+        "validated_product_creation_plan_required": { "const": true },
+        "validated_product_implementation_readiness_required": { "const": true },
+        "only_ready_work_units_materialized": { "const": true },
+        "failed_or_blocked_readiness_blocks_packet_creation": { "const": true },
+        "complete_product_claim_forbidden_until_all_scope_reconciled": { "const": true },
+        "live_hermes_mutation_forbidden_without_runtime_gate": { "const": true },
+        "raw_private_evidence_must_stay_external": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "next_artifact",
+        "next_worker",
+        "next_safe_action",
+        "user_decision_required",
+        "factory_owned_next_step"
+      ],
+      "properties": {
+        "next_artifact": { "type": "string", "minLength": 3 },
+        "next_worker": { "type": "string", "minLength": 3 },
+        "next_safe_action": { "type": "string", "minLength": 6 },
+        "user_decision_required": { "type": "boolean" },
+        "factory_owned_next_step": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "worker_packets_created",
+        "packet_count",
+        "allowed_execution_scope",
+        "live_hermes_mutated",
+        "complete_product_claim_allowed",
+        "evidence_refs"
+      ],
+      "properties": {
+        "worker_packets_created": { "const": true },
+        "packet_count": { "type": "integer", "minimum": 1 },
+        "allowed_execution_scope": { "enum": ["ready_work_units_only", "all_ready_work_units"] },
+        "live_hermes_mutated": { "const": false },
+        "complete_product_claim_allowed": { "const": false },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "$defs": {
+    "readyWorkUnitPacket": {
+      "type": "object",
+      "required": [
+        "packet_id",
+        "packet_type",
+        "work_unit_id",
+        "status",
+        "owner_worker",
+        "reviewer_role",
+        "objective",
+        "scope_in",
+        "scope_out",
+        "verification",
+        "expected_result",
+        "proof_ids_required",
+        "product_sot_requirement_refs",
+        "dependency_refs",
+        "capability_profile_refs",
+        "ready_rules",
+        "done_rules",
+        "stop_conditions",
+        "forbidden_actions",
+        "receipt_five_contract",
+        "hermes_materialization",
+        "public_private_boundary"
+      ],
+      "properties": {
+        "packet_id": { "type": "string", "minLength": 3 },
+        "packet_type": { "const": "ready_work_unit_execution_request" },
+        "work_unit_id": { "type": "string", "minLength": 3 },
+        "packet_file_name": { "type": "string", "minLength": 8 },
+        "status": { "const": "ready_for_worker_execution" },
+        "owner_worker": { "type": "string", "minLength": 3 },
+        "reviewer_role": { "type": "string", "minLength": 3 },
+        "objective": { "type": "string", "minLength": 8 },
+        "scope_in": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "scope_out": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "verification": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "expected_result": { "type": "string", "minLength": 3 },
+        "proof_ids_required": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "product_sot_requirement_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "dependency_refs": { "type": "array", "items": { "type": "string", "minLength": 3 } },
+        "capability_profile_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "ready_rules": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "blocked_when": { "type": "array", "items": { "type": "string", "minLength": 3 } },
+        "done_rules": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "stop_conditions": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "forbidden_actions": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
+        "receipt_five_contract": {
+          "type": "object",
+          "required": [
+            "must_attach_artifact_refs",
+            "must_state_blocking_findings",
+            "must_record_tool_or_profile",
+            "must_record_review",
+            "complete_product_claim_allowed"
+          ],
+          "properties": {
+            "must_attach_artifact_refs": { "const": true },
+            "must_state_blocking_findings": { "const": true },
+            "must_record_tool_or_profile": { "const": true },
+            "must_record_review": { "const": true },
+            "complete_product_claim_allowed": { "const": false }
+          },
+          "additionalProperties": true
+        },
+        "hermes_materialization": {
+          "type": "object",
+          "required": [
+            "recommended_initial_status",
+            "block_event_required_before_dispatch",
+            "dispatch_allowed_without_runtime_gate",
+            "live_hermes_mutated"
+          ],
+          "properties": {
+            "recommended_initial_status": { "enum": ["blocked", "todo"] },
+            "block_event_required_before_dispatch": { "const": true },
+            "dispatch_allowed_without_runtime_gate": { "const": false },
+            "live_hermes_mutated": { "const": false }
+          },
+          "additionalProperties": true
+        },
+        "public_private_boundary": {
+          "type": "object",
+          "required": [
+            "public_safe_refs_only",
+            "raw_private_evidence_embedded"
+          ],
+          "properties": {
+            "public_safe_refs_only": { "const": true },
+            "raw_private_evidence_embedded": { "const": false }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -8299,6 +8299,322 @@ def validate_product_implementation_readiness(readiness: dict[str, Any]) -> list
     return errors
 
 
+def _ready_work_unit_manifest_id(product_creation_plan_ref: str, product_implementation_readiness_ref: str) -> str:
+    return (
+        "ready-work-unit-packets-"
+        f"{slug_for_ref(product_creation_plan_ref)}-"
+        f"{slug_for_ref(product_implementation_readiness_ref)}"
+    )[:120]
+
+
+def _ready_work_unit_dependency_refs(plan: dict[str, Any], work_unit_id: str) -> list[str]:
+    refs: list[str] = []
+    for edge in plan.get("dependency_graph", []) if isinstance(plan.get("dependency_graph"), list) else []:
+        if not isinstance(edge, dict):
+            continue
+        source = str(edge.get("from") or "").strip()
+        target = str(edge.get("to") or "").strip()
+        if source == work_unit_id and target:
+            refs.append(target)
+        if target == work_unit_id and source:
+            refs.append(source)
+    return _dedupe_preserve_order(refs)
+
+
+def build_ready_work_unit_packet_manifest(
+    product_creation_plan: dict[str, Any],
+    product_implementation_readiness: dict[str, Any],
+    *,
+    created_at: str | None = None,
+    manifest_id: str | None = None,
+    product_creation_plan_ref: str | None = None,
+    product_implementation_readiness_ref: str | None = None,
+) -> dict[str, Any]:
+    plan_errors = validate_product_creation_plan(product_creation_plan)
+    if plan_errors:
+        raise ValueError("; ".join(plan_errors))
+    readiness_errors = validate_product_implementation_readiness(product_implementation_readiness)
+    if readiness_errors:
+        raise ValueError("; ".join(readiness_errors))
+
+    readiness_result = str(product_implementation_readiness.get("artifact_alignment_result") or "").strip().upper()
+    readiness_acceptance = (
+        product_implementation_readiness.get("acceptance")
+        if isinstance(product_implementation_readiness.get("acceptance"), dict)
+        else {}
+    )
+    material_execution_allowed = readiness_acceptance.get("material_execution_allowed") is True
+    allowed_scope = str(readiness_acceptance.get("allowed_execution_scope") or "").strip()
+    if readiness_result not in {"PASS", "CONCERNS"} or not material_execution_allowed:
+        raise ValueError("Product Implementation Readiness does not allow ready work-unit packet materialization")
+    if allowed_scope not in {"ready_work_units_only", "all_ready_work_units"}:
+        raise ValueError("Product Implementation Readiness must limit execution to ready work units")
+    if readiness_acceptance.get("complete_product_claim_allowed") is not False:
+        raise ValueError("Product Implementation Readiness must forbid complete-product claims before packet materialization")
+
+    handoff = (
+        product_implementation_readiness.get("handoff")
+        if isinstance(product_implementation_readiness.get("handoff"), dict)
+        else {}
+    )
+    if str(handoff.get("next_artifact") or "").strip() != "worker_packets":
+        raise ValueError("Product Implementation Readiness must hand off to worker_packets")
+    if handoff.get("factory_owned_next_step") is not True:
+        raise ValueError("Product Implementation Readiness handoff must be factory-owned")
+
+    plan_id = str(product_creation_plan.get("plan_id") or "").strip()
+    readiness_plan_ref = str(product_implementation_readiness.get("product_creation_plan_ref") or "").strip()
+    if plan_id and readiness_plan_ref and readiness_plan_ref != plan_id:
+        raise ValueError("Product Implementation Readiness does not reference this Product Creation Plan")
+
+    work_units = {
+        str(unit.get("unit_id") or "").strip(): unit
+        for unit in product_creation_plan.get("work_units", [])
+        if isinstance(unit, dict) and str(unit.get("unit_id") or "").strip()
+    }
+    ready_unit_ids = _list_items(product_implementation_readiness.get("ready_work_units"))
+    if not ready_unit_ids:
+        raise ValueError("Product Implementation Readiness has no ready_work_units to materialize")
+    unknown_units = [unit_id for unit_id in ready_unit_ids if unit_id not in work_units]
+    if unknown_units:
+        raise ValueError("ready_work_units not found in Product Creation Plan: " + ", ".join(unknown_units))
+
+    invalid_status_units = [
+        unit_id
+        for unit_id in ready_unit_ids
+        if str(work_units[unit_id].get("status") or "").strip() in {"blocked", "rejected", "superseded", "needs_refresh"}
+    ]
+    if invalid_status_units:
+        raise ValueError("ready_work_units cannot include blocked or stale Product Creation Plan units: " + ", ".join(invalid_status_units))
+
+    plan_ref = product_creation_plan_ref or plan_id or "external:sanitized-product-creation-plan"
+    readiness_ref = (
+        product_implementation_readiness_ref
+        or str(product_implementation_readiness.get("readiness_id") or "").strip()
+        or "external:sanitized-product-implementation-readiness"
+    )
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    final_manifest_id = manifest_id or _ready_work_unit_manifest_id(plan_ref, readiness_ref)
+
+    forbidden_actions = _dedupe_preserve_order(
+        [
+            "claim complete product done from ready work-unit execution",
+            "execute blocked, failed, stale or unlisted work units",
+            "mutate live Hermes without an explicit runtime gate",
+            *_list_items(product_implementation_readiness.get("forbidden_next_actions")),
+        ]
+    )
+    packets: list[dict[str, Any]] = []
+    for work_unit_id in ready_unit_ids:
+        unit = work_units[work_unit_id]
+        packet_id = f"ready-work-unit-packet-{slug_for_ref(work_unit_id)}"
+        packet = {
+            "packet_id": packet_id,
+            "packet_type": "ready_work_unit_execution_request",
+            "work_unit_id": work_unit_id,
+            "packet_file_name": f"{slug_for_ref(work_unit_id)}-request.json",
+            "status": "ready_for_worker_execution",
+            "owner_worker": str(unit.get("owner_worker") or "").strip(),
+            "reviewer_role": str(unit.get("reviewer_role") or "").strip(),
+            "objective": str(unit.get("objective") or "").strip(),
+            "scope_in": _list_items(unit.get("scope_in")),
+            "scope_out": _list_items(unit.get("scope_out")),
+            "verification": _list_items(unit.get("verification")),
+            "expected_result": str(unit.get("expected_result") or "").strip(),
+            "proof_ids_required": _list_items(unit.get("proof_ids_required")),
+            "product_sot_requirement_refs": _list_items(unit.get("product_sot_requirement_refs")),
+            "dependency_refs": _ready_work_unit_dependency_refs(product_creation_plan, work_unit_id),
+            "capability_profile_refs": _list_items(unit.get("capability_profile_refs")),
+            "ready_rules": _list_items(unit.get("ready_rules")),
+            "blocked_when": _list_items(unit.get("blocked_when")),
+            "done_rules": _list_items(unit.get("done_rules")),
+            "stop_conditions": _list_items(unit.get("stop_conditions")),
+            "forbidden_actions": forbidden_actions,
+            "receipt_five_contract": {
+                "must_attach_artifact_refs": True,
+                "must_state_blocking_findings": True,
+                "must_record_tool_or_profile": True,
+                "must_record_review": True,
+                "complete_product_claim_allowed": False,
+                "required_proof_ids": _list_items(unit.get("proof_ids_required")),
+                "reviewer_role": str(unit.get("reviewer_role") or "").strip(),
+            },
+            "hermes_materialization": {
+                "recommended_initial_status": "blocked",
+                "block_event_required_before_dispatch": True,
+                "dispatch_allowed_without_runtime_gate": False,
+                "live_hermes_mutated": False,
+                "runtime_note": (
+                    "Create a durable Hermes task only through the approved runtime integration path; "
+                    "this packet is a deterministic execution request, not a board mutation."
+                ),
+            },
+            "public_private_boundary": {
+                "public_safe_refs_only": True,
+                "raw_private_evidence_embedded": False,
+            },
+        }
+        packets.append(sanitize_public_refs(packet))
+
+    manifest: dict[str, Any] = {
+        "$schema": "https://overkill-factory.dev/schemas/ready-work-unit-packets.schema.json",
+        "record_type": "ready_work_unit_packet_manifest",
+        "manifest_id": final_manifest_id,
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "product_creation_plan_ref": plan_ref,
+        "product_implementation_readiness_ref": readiness_ref,
+        "readiness_result": readiness_result,
+        "allowed_execution_scope": allowed_scope,
+        "complete_product_claim_allowed": False,
+        "runtime_boundary": {
+            "state_role": "execution_request_only",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "live_hermes_mutated": False,
+            "hermes_materialization_requires_gate": True,
+        },
+        "packets": packets,
+        "blocked_work_units_not_materialized": _list_items(product_implementation_readiness.get("blocked_work_units")),
+        "blocking_rules": {
+            "validated_product_creation_plan_required": True,
+            "validated_product_implementation_readiness_required": True,
+            "only_ready_work_units_materialized": True,
+            "failed_or_blocked_readiness_blocks_packet_creation": True,
+            "complete_product_claim_forbidden_until_all_scope_reconciled": True,
+            "live_hermes_mutation_forbidden_without_runtime_gate": True,
+            "raw_private_evidence_must_stay_external": True,
+        },
+        "handoff": {
+            "next_artifact": "worker_results",
+            "next_worker": "factory-orchestrator",
+            "next_safe_action": (
+                "Route each ready_work_unit packet to its owner worker through Hermes only after the runtime gate "
+                "creates durable blocked tasks and verifies the blocked event."
+            ),
+            "user_decision_required": False,
+            "factory_owned_next_step": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+        },
+        "acceptance": {
+            "worker_packets_created": True,
+            "packet_count": len(packets),
+            "allowed_execution_scope": allowed_scope,
+            "live_hermes_mutated": False,
+            "complete_product_claim_allowed": False,
+            "evidence_refs": [
+                "schemas/ready-work-unit-packets.schema.json",
+                plan_ref,
+                readiness_ref,
+            ],
+        },
+        "evidence_refs": [
+            "schemas/ready-work-unit-packets.schema.json",
+            plan_ref,
+            readiness_ref,
+        ],
+    }
+    return sanitize_public_refs(manifest)
+
+
+def validate_ready_work_unit_packet_manifest(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("ready-work-unit-packets.schema.json")
+    if not schema:
+        return ["ready_work_unit_packet_manifest schema is not bundled"]
+    errors.extend(validate_node(schema, manifest, "ready_work_unit_packet_manifest", schemas=schemas, root_schema=schema))
+    if manifest.get("record_type") != "ready_work_unit_packet_manifest":
+        errors.append("ready_work_unit_packet_manifest.record_type must be ready_work_unit_packet_manifest")
+
+    for field in ("product_creation_plan_ref", "product_implementation_readiness_ref"):
+        value = str(manifest.get(field) or "").strip()
+        if value:
+            _validate_public_ref(value, f"ready_work_unit_packet_manifest.{field}", errors)
+    _validate_lifecycle_refs(_list_items(manifest.get("evidence_refs")), "ready_work_unit_packet_manifest.evidence_refs", errors)
+
+    packets = manifest.get("packets") if isinstance(manifest.get("packets"), list) else []
+    packet_ids: list[str] = []
+    work_unit_ids: list[str] = []
+    for index, packet in enumerate(packets):
+        if not isinstance(packet, dict):
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}] must be an object")
+            continue
+        packet_id = str(packet.get("packet_id") or "").strip()
+        work_unit_id = str(packet.get("work_unit_id") or "").strip()
+        if packet_id:
+            packet_ids.append(packet_id)
+        if work_unit_id:
+            work_unit_ids.append(work_unit_id)
+        owner = str(packet.get("owner_worker") or "").strip()
+        if owner and owner not in WORKERS:
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}].owner_worker must be a registered worker: {owner}")
+        if packet.get("status") != "ready_for_worker_execution":
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}].status must be ready_for_worker_execution")
+        receipt = packet.get("receipt_five_contract") if isinstance(packet.get("receipt_five_contract"), dict) else {}
+        if receipt.get("complete_product_claim_allowed") is not False:
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].receipt_five_contract.complete_product_claim_allowed must be false"
+            )
+        materialization = (
+            packet.get("hermes_materialization")
+            if isinstance(packet.get("hermes_materialization"), dict)
+            else {}
+        )
+        if materialization.get("live_hermes_mutated") is not False:
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}].hermes_materialization.live_hermes_mutated must be false")
+        if materialization.get("dispatch_allowed_without_runtime_gate") is not False:
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].hermes_materialization.dispatch_allowed_without_runtime_gate must be false"
+            )
+        boundary = packet.get("public_private_boundary") if isinstance(packet.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}] requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}] must not embed raw private evidence")
+
+    duplicate_packet_ids = sorted({item for item in packet_ids if packet_ids.count(item) > 1})
+    if duplicate_packet_ids:
+        errors.append("ready_work_unit_packet_manifest duplicate packet ids: " + ", ".join(duplicate_packet_ids))
+    duplicate_work_units = sorted({item for item in work_unit_ids if work_unit_ids.count(item) > 1})
+    if duplicate_work_units:
+        errors.append("ready_work_unit_packet_manifest duplicate work unit ids: " + ", ".join(duplicate_work_units))
+
+    runtime_boundary = manifest.get("runtime_boundary") if isinstance(manifest.get("runtime_boundary"), dict) else {}
+    if runtime_boundary.get("live_hermes_mutated") is not False:
+        errors.append("ready_work_unit_packet_manifest.runtime_boundary.live_hermes_mutated must be false")
+    if runtime_boundary.get("hermes_materialization_requires_gate") is not True:
+        errors.append("ready_work_unit_packet_manifest.runtime_boundary.hermes_materialization_requires_gate must be true")
+
+    if manifest.get("complete_product_claim_allowed") is not False:
+        errors.append("ready_work_unit_packet_manifest.complete_product_claim_allowed must be false")
+    acceptance = manifest.get("acceptance") if isinstance(manifest.get("acceptance"), dict) else {}
+    if acceptance.get("packet_count") != len(packets):
+        errors.append("ready_work_unit_packet_manifest.acceptance.packet_count must match packets length")
+    if acceptance.get("live_hermes_mutated") is not False:
+        errors.append("ready_work_unit_packet_manifest.acceptance.live_hermes_mutated must be false")
+    if acceptance.get("complete_product_claim_allowed") is not False:
+        errors.append("ready_work_unit_packet_manifest.acceptance.complete_product_claim_allowed must be false")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "ready_work_unit_packet_manifest.acceptance.evidence_refs",
+        errors,
+    )
+
+    boundary = manifest.get("public_private_boundary") if isinstance(manifest.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("ready_work_unit_packet_manifest requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("ready_work_unit_packet_manifest must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("ready_work_unit_packet_manifest private context must stay outside the public repo")
+    return errors
+
+
 def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -14108,6 +14424,53 @@ def command_product_implementation_readiness(args: argparse.Namespace) -> int:
     return 0
 
 
+def _sanitized_cli_artifact_ref(path: Path, fallback: str) -> str:
+    slug = slug_for_ref(path.stem or fallback)
+    return f"external:sanitized-{slug}"
+
+
+def command_ready_work_unit_packets(args: argparse.Namespace) -> int:
+    try:
+        manifest = build_ready_work_unit_packet_manifest(
+            load_json_like(args.product_creation_plan),
+            load_json_like(args.product_implementation_readiness),
+            created_at=args.created_at,
+            manifest_id=args.manifest_id,
+            product_creation_plan_ref=_sanitized_cli_artifact_ref(args.product_creation_plan, "product-creation-plan"),
+            product_implementation_readiness_ref=_sanitized_cli_artifact_ref(
+                args.product_implementation_readiness,
+                "product-implementation-readiness",
+            ),
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_ready_work_unit_packet_manifest(manifest)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    args.out.mkdir(parents=True, exist_ok=True)
+    for packet in manifest["packets"]:
+        packet_file = args.out / str(packet["packet_file_name"])
+        write_json(packet_file, packet)
+    write_json(args.out / "manifest.json", manifest)
+    return 0
+
+
+def command_validate_ready_work_unit_packets(args: argparse.Namespace) -> int:
+    path = args.path
+    if path.is_dir():
+        path = path / "manifest.json"
+    errors = validate_ready_work_unit_packet_manifest(load_json_like(path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_signal_corpus(args: argparse.Namespace) -> int:
     errors = validate_universal_signal_golden_corpus(load_json_like(args.path))
     if errors:
@@ -14672,6 +15035,21 @@ def build_parser() -> argparse.ArgumentParser:
     product_implementation_readiness_parser.add_argument("--readiness-id")
     product_implementation_readiness_parser.add_argument("--out", type=Path, required=True)
     product_implementation_readiness_parser.set_defaults(func=command_product_implementation_readiness)
+
+    ready_work_unit_packets_parser = sub.add_parser(
+        "ready-work-unit-packets",
+        help="Materialize execution requests only for Product Implementation Readiness ready_work_units.",
+    )
+    ready_work_unit_packets_parser.add_argument("--product-creation-plan", type=Path, required=True)
+    ready_work_unit_packets_parser.add_argument("--product-implementation-readiness", type=Path, required=True)
+    ready_work_unit_packets_parser.add_argument("--created-at")
+    ready_work_unit_packets_parser.add_argument("--manifest-id")
+    ready_work_unit_packets_parser.add_argument("--out", type=Path, required=True)
+    ready_work_unit_packets_parser.set_defaults(func=command_ready_work_unit_packets)
+
+    validate_ready_work_unit_packets_parser = sub.add_parser("validate-ready-work-unit-packets")
+    validate_ready_work_unit_packets_parser.add_argument("path", type=Path)
+    validate_ready_work_unit_packets_parser.set_defaults(func=command_validate_ready_work_unit_packets)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1806,6 +1806,73 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             reason = public_artifact_ref_error(ref)
             if reason:
                 errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
+    if data.get("record_type") == "ready_work_unit_packet_manifest":
+        for field in ("product_creation_plan_ref", "product_implementation_readiness_ref"):
+            reason = public_artifact_ref_error(data.get(field))
+            if reason:
+                errors.append(f"{at}.{field}: {reason}")
+        if data.get("complete_product_claim_allowed") is not False:
+            errors.append(f"{at}: ready_work_unit_packet_manifest cannot allow complete-product claim")
+        runtime = data.get("runtime_boundary") if isinstance(data.get("runtime_boundary"), dict) else {}
+        if runtime.get("live_hermes_mutated") is not False:
+            errors.append(f"{at}: ready_work_unit_packet_manifest must not claim live Hermes mutation")
+        if runtime.get("hermes_materialization_requires_gate") is not True:
+            errors.append(f"{at}: ready_work_unit_packet_manifest requires Hermes materialization gate")
+        packets = data.get("packets") if isinstance(data.get("packets"), list) else []
+        acceptance = data.get("acceptance") if isinstance(data.get("acceptance"), dict) else {}
+        if acceptance.get("packet_count") != len(packets):
+            errors.append(f"{at}: ready_work_unit_packet_manifest acceptance.packet_count must match packets length")
+        if acceptance.get("complete_product_claim_allowed") is not False:
+            errors.append(f"{at}: ready_work_unit_packet_manifest acceptance cannot allow complete-product claim")
+        if acceptance.get("live_hermes_mutated") is not False:
+            errors.append(f"{at}: ready_work_unit_packet_manifest acceptance must not claim live Hermes mutation")
+        packet_ids: list[str] = []
+        work_unit_ids: list[str] = []
+        for index, packet in enumerate(packets):
+            if not isinstance(packet, dict):
+                errors.append(f"{at}.packets[{index}]: expected object")
+                continue
+            packet_id = str(packet.get("packet_id") or "").strip()
+            work_unit_id = str(packet.get("work_unit_id") or "").strip()
+            if packet_id:
+                packet_ids.append(packet_id)
+            if work_unit_id:
+                work_unit_ids.append(work_unit_id)
+            owner = str(packet.get("owner_worker") or "").strip()
+            if owner and owner not in public_worker_ids():
+                errors.append(f"{at}.packets[{index}].owner_worker must be a registered worker: {owner}")
+            receipt = packet.get("receipt_five_contract") if isinstance(packet.get("receipt_five_contract"), dict) else {}
+            if receipt.get("complete_product_claim_allowed") is not False:
+                errors.append(f"{at}.packets[{index}].receipt_five_contract cannot allow complete-product claim")
+            materialization = packet.get("hermes_materialization") if isinstance(packet.get("hermes_materialization"), dict) else {}
+            if materialization.get("live_hermes_mutated") is not False:
+                errors.append(f"{at}.packets[{index}].hermes_materialization must not claim live Hermes mutation")
+            if materialization.get("dispatch_allowed_without_runtime_gate") is not False:
+                errors.append(f"{at}.packets[{index}].hermes_materialization cannot dispatch without runtime gate")
+            boundary = packet.get("public_private_boundary") if isinstance(packet.get("public_private_boundary"), dict) else {}
+            if boundary.get("public_safe_refs_only") is not True:
+                errors.append(f"{at}.packets[{index}] requires public_safe_refs_only=true")
+            if boundary.get("raw_private_evidence_embedded") is not False:
+                errors.append(f"{at}.packets[{index}] must not embed raw private evidence")
+        duplicate_packets = sorted({packet_id for packet_id in packet_ids if packet_ids.count(packet_id) > 1})
+        if duplicate_packets:
+            errors.append(f"{at}: duplicate ready work-unit packet ids: {', '.join(duplicate_packets)}")
+        duplicate_units = sorted({unit_id for unit_id in work_unit_ids if work_unit_ids.count(unit_id) > 1})
+        if duplicate_units:
+            errors.append(f"{at}: duplicate ready work-unit ids: {', '.join(duplicate_units)}")
+        boundary = data.get("public_private_boundary") if isinstance(data.get("public_private_boundary"), dict) else {}
+        if boundary.get("public_safe_refs_only") is not True:
+            errors.append(f"{at}: ready_work_unit_packet_manifest requires public_safe_refs_only=true")
+        if boundary.get("raw_private_evidence_embedded") is not False:
+            errors.append(f"{at}: ready_work_unit_packet_manifest must not embed raw private evidence")
+        for index, ref in enumerate(data.get("evidence_refs", []) if isinstance(data.get("evidence_refs"), list) else []):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.evidence_refs[{index}]: {reason}")
+        for index, ref in enumerate(acceptance.get("evidence_refs", []) if isinstance(acceptance.get("evidence_refs"), list) else []):
+            reason = public_artifact_ref_error(ref)
+            if reason:
+                errors.append(f"{at}.acceptance.evidence_refs[{index}]: {reason}")
     if data.get("record_type") == "factory_readiness_scorecard":
         errors.extend(validate_factory_readiness_scorecard_domain(data, at))
     if data.get("record_type") == "factory_v1_completion_gate":

--- a/templates/ready-work-unit-packets.json
+++ b/templates/ready-work-unit-packets.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/ready-work-unit-packets.schema.json",
+  "record_type": "ready_work_unit_packet_manifest",
+  "manifest_id": "ready-work-unit-packets-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "product_creation_plan_ref": "templates/product-creation-plan.json",
+  "product_implementation_readiness_ref": "templates/product-implementation-readiness.json",
+  "readiness_result": "CONCERNS",
+  "allowed_execution_scope": "ready_work_units_only",
+  "complete_product_claim_allowed": false,
+  "runtime_boundary": {
+    "state_role": "execution_request_only",
+    "runtime_authority": "hermes_kanban",
+    "local_state_authority": false,
+    "live_hermes_mutated": false,
+    "hermes_materialization_requires_gate": true
+  },
+  "packets": [
+    {
+      "packet_id": "ready-work-unit-packet-work-unit-001",
+      "packet_type": "ready_work_unit_execution_request",
+      "work_unit_id": "work-unit-001",
+      "packet_file_name": "work-unit-001-request.json",
+      "status": "ready_for_worker_execution",
+      "owner_worker": "implementation-worker",
+      "reviewer_role": "independent-reviewer",
+      "objective": "Deliver one safe execution slice without reducing the Product SOT scope.",
+      "scope_in": ["the named Product SOT requirement refs"],
+      "scope_out": ["unrelated Product SOT requirements"],
+      "verification": ["run the checks named by the work unit"],
+      "expected_result": "PASS or explicit BLOCK with owner",
+      "proof_ids_required": ["generic.scope-fit"],
+      "product_sot_requirement_refs": ["product-sot#scope-in-001"],
+      "dependency_refs": ["product-sot#scope-in-001"],
+      "capability_profile_refs": ["agents/hermes-profile-bindings.public.json#implementation-worker"],
+      "ready_rules": [
+        "Product SOT requirement refs resolve to the approved Product SOT",
+        "required proof ids are mapped before execution starts"
+      ],
+      "blocked_when": [
+        "required proof cannot be produced",
+        "owner worker or reviewer role is unavailable"
+      ],
+      "done_rules": [
+        "all proof_ids_required have PASS or valid waiver evidence",
+        "reviewer_role has reviewed the work-unit evidence"
+      ],
+      "stop_conditions": ["Product SOT drifted", "required context packet is stale"],
+      "forbidden_actions": [
+        "claim complete product done from ready work-unit execution",
+        "execute blocked, failed, stale or unlisted work units",
+        "mutate live Hermes without an explicit runtime gate",
+        "claim complete product done from one bounded slice"
+      ],
+      "receipt_five_contract": {
+        "must_attach_artifact_refs": true,
+        "must_state_blocking_findings": true,
+        "must_record_tool_or_profile": true,
+        "must_record_review": true,
+        "complete_product_claim_allowed": false,
+        "required_proof_ids": ["generic.scope-fit"],
+        "reviewer_role": "independent-reviewer"
+      },
+      "hermes_materialization": {
+        "recommended_initial_status": "blocked",
+        "block_event_required_before_dispatch": true,
+        "dispatch_allowed_without_runtime_gate": false,
+        "live_hermes_mutated": false,
+        "runtime_note": "Create a durable Hermes task only through the approved runtime integration path; this packet is a deterministic execution request, not a board mutation."
+      },
+      "public_private_boundary": {
+        "public_safe_refs_only": true,
+        "raw_private_evidence_embedded": false
+      }
+    }
+  ],
+  "blocked_work_units_not_materialized": [],
+  "blocking_rules": {
+    "validated_product_creation_plan_required": true,
+    "validated_product_implementation_readiness_required": true,
+    "only_ready_work_units_materialized": true,
+    "failed_or_blocked_readiness_blocks_packet_creation": true,
+    "complete_product_claim_forbidden_until_all_scope_reconciled": true,
+    "live_hermes_mutation_forbidden_without_runtime_gate": true,
+    "raw_private_evidence_must_stay_external": true
+  },
+  "handoff": {
+    "next_artifact": "worker_results",
+    "next_worker": "factory-orchestrator",
+    "next_safe_action": "Route each ready_work_unit packet to its owner worker through Hermes only after the runtime gate creates durable blocked tasks and verifies the blocked event.",
+    "user_decision_required": false,
+    "factory_owned_next_step": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  },
+  "acceptance": {
+    "worker_packets_created": true,
+    "packet_count": 1,
+    "allowed_execution_scope": "ready_work_units_only",
+    "live_hermes_mutated": false,
+    "complete_product_claim_allowed": false,
+    "evidence_refs": [
+      "schemas/ready-work-unit-packets.schema.json",
+      "templates/product-creation-plan.json",
+      "templates/product-implementation-readiness.json"
+    ]
+  },
+  "evidence_refs": [
+    "schemas/ready-work-unit-packets.schema.json",
+    "templates/product-creation-plan.json",
+    "templates/product-implementation-readiness.json"
+  ]
+}

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -903,6 +903,92 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertIn("human-gate-method-scope-001", readiness["human_decisions_required"])
         self.assertFalse(readiness["acceptance"]["material_execution_allowed"])
 
+    def test_ready_work_unit_packets_from_readiness_are_valid(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+
+        self.assertEqual(factoryctl.validate_ready_work_unit_packet_manifest(manifest), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(manifest, "$"), [])
+        self.assertEqual(manifest["record_type"], "ready_work_unit_packet_manifest")
+        self.assertEqual(manifest["readiness_result"], "CONCERNS")
+        self.assertEqual(manifest["acceptance"]["allowed_execution_scope"], "ready_work_units_only")
+        self.assertFalse(manifest["acceptance"]["complete_product_claim_allowed"])
+        self.assertFalse(manifest["runtime_boundary"]["live_hermes_mutated"])
+        self.assertEqual(
+            [packet["work_unit_id"] for packet in manifest["packets"]],
+            readiness["ready_work_units"],
+        )
+        self.assertTrue(all(packet["receipt_five_contract"]["must_attach_artifact_refs"] for packet in manifest["packets"]))
+
+    def test_ready_work_unit_packets_reject_blocked_readiness(self) -> None:
+        source_resolution = factoryctl.build_source_resolution_packet(
+            signal_intake(),
+            intake_ref_public_safe="external:sanitized-universal-signal-intake",
+        )
+        ledger = factoryctl.build_product_source_ledger(
+            source_resolution,
+            source_ref_public_safe="external:sanitized-product-brief",
+        )
+        outcome = factoryctl.build_outcome_contract(ledger)
+        product_sot = factoryctl.build_product_sot(outcome)
+        coverage = factoryctl.build_full_scope_coverage(product_sot)
+        coverage["requirement_coverage"][0]["status"] = "human_decision_required"
+        coverage["requirement_coverage"][0]["blocker_id"] = "human-gate-method-scope-001"
+        method_contract = factoryctl.build_method_contract(coverage)
+        plan = factoryctl.build_product_creation_plan(method_contract)
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+
+        with self.assertRaisesRegex(ValueError, "does not allow ready work-unit packet materialization"):
+            factoryctl.build_ready_work_unit_packet_manifest(plan, readiness)
+
+    def test_ready_work_unit_packets_reject_unknown_ready_unit(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        readiness["ready_work_units"].append("missing-work-unit")
+
+        with self.assertRaisesRegex(ValueError, "ready_work_units not found in Product Creation Plan"):
+            factoryctl.build_ready_work_unit_packet_manifest(plan, readiness)
+
+    def test_ready_work_unit_packets_cli_generates_manifest_and_requests(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plan_path = Path(tmpdir) / "product-creation-plan.json"
+            readiness_path = Path(tmpdir) / "product-implementation-readiness.json"
+            out_dir = Path(tmpdir) / "ready-work-unit-packets"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            readiness_path.write_text(json.dumps(readiness), encoding="utf-8")
+
+            result = factoryctl.main_with_args_for_test(
+                [
+                    "ready-work-unit-packets",
+                    "--product-creation-plan",
+                    str(plan_path),
+                    "--product-implementation-readiness",
+                    str(readiness_path),
+                    "--out",
+                    str(out_dir),
+                ]
+            )
+            manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+
+            validate_result = factoryctl.main_with_args_for_test(
+                ["validate-ready-work-unit-packets", str(out_dir / "manifest.json")]
+            )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(validate_result, 0)
+        self.assertEqual(manifest["record_type"], "ready_work_unit_packet_manifest")
+        self.assertEqual(len(manifest["packets"]), len(readiness["ready_work_units"]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds `factoryctl ready-work-unit-packets` and `validate-ready-work-unit-packets` after Product Implementation Readiness.
- Adds a schema/template for `ready_work_unit_packet_manifest` so readiness-scoped work units become deterministic execution requests.
- Documents the new step in README and CLI reference.

## Why
Product Implementation Readiness already handed off to `worker_packets`, but the public kernel only had `worker-packet` for whole cards. That left a manual operator gap between "these work units are ready" and "here are the execution requests".

This PR closes that gear without mutating live Hermes, without exposing private refs, and without allowing a bounded ready unit to claim complete-product acceptance.

Closes #309.

## Validation
- `python scripts/factoryctl.py validate-ready-work-unit-packets templates\\ready-work-unit-packets.json`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python -m unittest tests.test_product_method_sot_planning tests.test_worker_profiles -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_worker_profiles.py`
- `python scripts/quickstart_smoke.py`
- `git diff --check`