### PR TITLE
[codex] Add ready work unit Hermes materialization plan

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -164,6 +164,26 @@ exists, and the main card remains blocked until the normal completion gate
 passes. Without `downstream_task_authorizations`, no downstream worker is
 unblocked.
 
+## Ready Work Unit Materialization Plan
+
+Product dogfooding can reach a validated `ready_work_unit_packet_manifest`
+before a legacy/card transition exists. In that case, build the Hermes
+materialization plan first:
+
+```bash
+python scripts/factoryctl.py ready-work-unit-hermes-plan \
+  --ready-work-unit-packets path/to/ready-work-unit-packets \
+  --board overkill-factory-live \
+  --out path/to/ready-work-unit-hermes-plan.json
+```
+
+The plan is not runtime execution proof and does not mutate Hermes. It defines
+the exact runtime gate for each ready work unit: create the task without
+dispatch, block it, verify a real `blocked` event through Hermes readback, then
+assign and dispatch only after that gate evidence exists. Complete-product
+claims remain forbidden until all Product SOT scope is reconciled through
+worker results, review and Receipt Five.
+
 ## Dispatch Reporting
 
 Hermes owns dispatch. The adapter does not schedule workers itself, but it can

--- a/schemas/ready-work-unit-hermes-materialization-plan.schema.json
+++ b/schemas/ready-work-unit-hermes-materialization-plan.schema.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+  "title": "Overkill Factory Ready Work Unit Hermes Materialization Plan",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "plan_id",
+    "created_at",
+    "factory_method_version",
+    "ready_work_unit_packet_manifest_ref",
+    "ready_work_unit_packet_manifest_id",
+    "board",
+    "runtime_boundary",
+    "materialization_scope",
+    "complete_product_claim_allowed",
+    "tasks",
+    "runtime_gate",
+    "blocking_rules",
+    "public_private_boundary",
+    "acceptance",
+    "evidence_refs"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/ready-work-unit-hermes-materialization-plan.schema.json"
+    },
+    "record_type": { "const": "ready_work_unit_hermes_materialization_plan" },
+    "plan_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "factory_method_version": { "const": "OVERKILL_VFINAL" },
+    "ready_work_unit_packet_manifest_ref": { "type": "string", "minLength": 3 },
+    "ready_work_unit_packet_manifest_id": { "type": "string", "minLength": 3 },
+    "board": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{3,120}$" },
+    "runtime_boundary": {
+      "type": "object",
+      "required": [
+        "state_role",
+        "runtime_authority",
+        "local_state_authority",
+        "live_hermes_mutated",
+        "hermes_materialization_requires_gate"
+      ],
+      "properties": {
+        "state_role": { "const": "runtime_materialization_plan_only" },
+        "runtime_authority": { "const": "hermes_kanban" },
+        "local_state_authority": { "const": false },
+        "live_hermes_mutated": { "const": false },
+        "hermes_materialization_requires_gate": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "materialization_scope": { "enum": ["ready_work_units_only", "all_ready_work_units"] },
+    "complete_product_claim_allowed": { "const": false },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/materializationTask" }
+    },
+    "runtime_gate": {
+      "type": "object",
+      "required": [
+        "gate_id",
+        "human_gate_required",
+        "user_decision_required",
+        "dispatch_precondition",
+        "required_sequence",
+        "evidence_required"
+      ],
+      "properties": {
+        "gate_id": { "type": "string", "minLength": 3 },
+        "human_gate_required": { "const": false },
+        "user_decision_required": { "const": false },
+        "dispatch_precondition": { "const": "blocked_event_verified_for_each_task" },
+        "required_sequence": {
+          "type": "array",
+          "minItems": 4,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "evidence_required": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "blocking_rules": {
+      "type": "object",
+      "required": [
+        "validated_ready_work_unit_packet_manifest_required",
+        "only_ready_work_units_materialized",
+        "block_event_required_before_dispatch",
+        "dispatch_forbidden_without_runtime_gate",
+        "complete_product_claim_forbidden_until_all_scope_reconciled",
+        "raw_private_evidence_must_stay_external"
+      ],
+      "properties": {
+        "validated_ready_work_unit_packet_manifest_required": { "const": true },
+        "only_ready_work_units_materialized": { "const": true },
+        "block_event_required_before_dispatch": { "const": true },
+        "dispatch_forbidden_without_runtime_gate": { "const": true },
+        "complete_product_claim_forbidden_until_all_scope_reconciled": { "const": true },
+        "raw_private_evidence_must_stay_external": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "public_private_boundary": {
+      "type": "object",
+      "required": [
+        "public_safe_refs_only",
+        "raw_private_evidence_embedded",
+        "private_context_retained_outside_public_repo"
+      ],
+      "properties": {
+        "public_safe_refs_only": { "const": true },
+        "raw_private_evidence_embedded": { "const": false },
+        "private_context_retained_outside_public_repo": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "acceptance": {
+      "type": "object",
+      "required": [
+        "task_count",
+        "all_tasks_start_blocked",
+        "block_event_required_before_dispatch",
+        "dispatch_allowed_without_runtime_gate",
+        "live_hermes_mutated",
+        "complete_product_claim_allowed",
+        "evidence_refs"
+      ],
+      "properties": {
+        "task_count": { "type": "integer", "minimum": 1 },
+        "all_tasks_start_blocked": { "const": true },
+        "block_event_required_before_dispatch": { "const": true },
+        "dispatch_allowed_without_runtime_gate": { "const": false },
+        "live_hermes_mutated": { "const": false },
+        "complete_product_claim_allowed": { "const": false },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "$defs": {
+    "materializationTask": {
+      "type": "object",
+      "required": [
+        "task_plan_id",
+        "packet_id",
+        "work_unit_id",
+        "owner_worker",
+        "reviewer_role",
+        "title",
+        "materialization_state",
+        "initial_status",
+        "body_format",
+        "body_contract",
+        "dependency_refs",
+        "proof_ids_required",
+        "receipt_five_contract",
+        "runtime_refs",
+        "idempotency_key",
+        "create_policy",
+        "block_policy",
+        "dispatch_policy",
+        "public_private_boundary"
+      ],
+      "properties": {
+        "task_plan_id": { "type": "string", "minLength": 3 },
+        "packet_id": { "type": "string", "minLength": 3 },
+        "work_unit_id": { "type": "string", "minLength": 3 },
+        "owner_worker": { "type": "string", "minLength": 3 },
+        "reviewer_role": { "type": "string", "minLength": 3 },
+        "title": { "type": "string", "minLength": 8 },
+        "materialization_state": { "const": "planned_pending_hermes_runtime_gate" },
+        "initial_status": { "const": "blocked" },
+        "body_format": { "const": "ready_work_unit_execution_request_json" },
+        "body_contract": { "type": "object" },
+        "dependency_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "proof_ids_required": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "receipt_five_contract": { "type": "object" },
+        "runtime_refs": {
+          "type": "object",
+          "required": ["hermes_board_ref", "hermes_task_ref", "hermes_run_ref"],
+          "properties": {
+            "hermes_board_ref": { "type": "string", "minLength": 3 },
+            "hermes_task_ref": { "const": "external:pending-hermes-task" },
+            "hermes_run_ref": { "const": "external:pending-hermes-run" }
+          },
+          "additionalProperties": false
+        },
+        "idempotency_key": { "type": "string", "minLength": 16 },
+        "create_policy": {
+          "type": "object",
+          "required": [
+            "create_without_dispatch",
+            "create_unassigned_first",
+            "assign_after_block_event_verified",
+            "target_assignee_profile"
+          ],
+          "properties": {
+            "create_without_dispatch": { "const": true },
+            "create_unassigned_first": { "const": true },
+            "assign_after_block_event_verified": { "const": true },
+            "target_assignee_profile": { "type": "string", "minLength": 3 }
+          },
+          "additionalProperties": false
+        },
+        "block_policy": {
+          "type": "object",
+          "required": [
+            "initial_block_required",
+            "block_event_required_before_dispatch",
+            "verify_command",
+            "blocked_reason"
+          ],
+          "properties": {
+            "initial_block_required": { "const": true },
+            "block_event_required_before_dispatch": { "const": true },
+            "verify_command": { "const": "hermes kanban show --json" },
+            "blocked_reason": { "type": "string", "minLength": 8 }
+          },
+          "additionalProperties": false
+        },
+        "dispatch_policy": {
+          "type": "object",
+          "required": [
+            "dispatch_allowed_without_runtime_gate",
+            "complete_product_claim_allowed",
+            "dispatch_precondition"
+          ],
+          "properties": {
+            "dispatch_allowed_without_runtime_gate": { "const": false },
+            "complete_product_claim_allowed": { "const": false },
+            "dispatch_precondition": { "const": "blocked_event_verified" }
+          },
+          "additionalProperties": false
+        },
+        "public_private_boundary": {
+          "type": "object",
+          "required": ["public_safe_refs_only", "raw_private_evidence_embedded"],
+          "properties": {
+            "public_safe_refs_only": { "const": true },
+            "raw_private_evidence_embedded": { "const": false }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -8615,6 +8615,289 @@ def validate_ready_work_unit_packet_manifest(manifest: dict[str, Any]) -> list[s
     return errors
 
 
+def _ready_work_unit_hermes_plan_id(manifest_id: str, board: str) -> str:
+    return f"ready-work-unit-hermes-plan-{slug_for_ref(manifest_id)}-{slug_for_ref(board)}"[:120]
+
+
+def _ready_work_unit_hermes_idempotency_key(
+    *,
+    manifest_id: str,
+    packet: dict[str, Any],
+) -> str:
+    work_unit_id = str(packet.get("work_unit_id") or "work-unit").strip()
+    contract = {
+        "manifest_id": manifest_id,
+        "packet_id": str(packet.get("packet_id") or "").strip(),
+        "work_unit_id": work_unit_id,
+        "body_contract": packet,
+    }
+    digest = hashlib.sha256(json.dumps(contract, sort_keys=True, ensure_ascii=True).encode("utf-8")).hexdigest()
+    return f"overkill:{slug_for_ref(manifest_id)}:{slug_for_ref(work_unit_id)}:{digest[:16]}"
+
+
+def _ready_work_unit_hermes_title(packet: dict[str, Any]) -> str:
+    work_unit_id = str(packet.get("work_unit_id") or "work-unit").strip()
+    objective = str(packet.get("objective") or "").strip()
+    title = f"OF ready work unit {work_unit_id}"
+    if objective:
+        title = f"{title}: {objective}"
+    return title[:160]
+
+
+def build_ready_work_unit_hermes_materialization_plan(
+    ready_work_unit_packet_manifest: dict[str, Any],
+    *,
+    board: str,
+    created_at: str | None = None,
+    plan_id: str | None = None,
+    ready_work_unit_packet_manifest_ref: str | None = None,
+) -> dict[str, Any]:
+    manifest_errors = validate_ready_work_unit_packet_manifest(ready_work_unit_packet_manifest)
+    if manifest_errors:
+        raise ValueError("; ".join(manifest_errors))
+
+    board_slug = str(board or "").strip()
+    if not re.fullmatch(r"[A-Za-z0-9_.-]{3,120}", board_slug):
+        raise ValueError("Hermes board must be a public-safe slug with 3-120 letters, numbers, dots, underscores or hyphens")
+
+    manifest_id = str(ready_work_unit_packet_manifest.get("manifest_id") or "").strip()
+    manifest_ref = ready_work_unit_packet_manifest_ref or manifest_id or "external:sanitized-ready-work-unit-packet-manifest"
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    final_plan_id = plan_id or _ready_work_unit_hermes_plan_id(manifest_id, board_slug)
+    gate_id = f"runtime-gate-{slug_for_ref(final_plan_id)}"
+    tasks: list[dict[str, Any]] = []
+
+    for packet in ready_work_unit_packet_manifest.get("packets", []):
+        if not isinstance(packet, dict):
+            continue
+        owner_worker = str(packet.get("owner_worker") or "").strip()
+        work_unit_id = str(packet.get("work_unit_id") or "").strip()
+        packet_id = str(packet.get("packet_id") or "").strip()
+        safe_packet = sanitize_public_refs(copy.deepcopy(packet))
+        task = {
+            "task_plan_id": f"hermes-ready-work-unit-{slug_for_ref(work_unit_id)}",
+            "packet_id": packet_id,
+            "work_unit_id": work_unit_id,
+            "owner_worker": owner_worker,
+            "reviewer_role": str(packet.get("reviewer_role") or "").strip(),
+            "title": _ready_work_unit_hermes_title(packet),
+            "materialization_state": "planned_pending_hermes_runtime_gate",
+            "initial_status": "blocked",
+            "body_format": "ready_work_unit_execution_request_json",
+            "body_contract": safe_packet,
+            "dependency_refs": _list_items(packet.get("dependency_refs")),
+            "proof_ids_required": _list_items(packet.get("proof_ids_required")),
+            "receipt_five_contract": copy.deepcopy(packet.get("receipt_five_contract") or {}),
+            "runtime_refs": {
+                "hermes_board_ref": f"hermes:{board_slug}",
+                "hermes_task_ref": "external:pending-hermes-task",
+                "hermes_run_ref": "external:pending-hermes-run",
+            },
+            "idempotency_key": _ready_work_unit_hermes_idempotency_key(
+                manifest_id=manifest_id,
+                packet=safe_packet,
+            ),
+            "create_policy": {
+                "create_without_dispatch": True,
+                "create_unassigned_first": True,
+                "assign_after_block_event_verified": True,
+                "target_assignee_profile": owner_worker,
+            },
+            "block_policy": {
+                "initial_block_required": True,
+                "block_event_required_before_dispatch": True,
+                "verify_command": "hermes kanban show --json",
+                "blocked_reason": (
+                    "Ready work unit starts blocked until Hermes readback proves a blocked event "
+                    "for this exact materialized task."
+                ),
+            },
+            "dispatch_policy": {
+                "dispatch_allowed_without_runtime_gate": False,
+                "complete_product_claim_allowed": False,
+                "dispatch_precondition": "blocked_event_verified",
+            },
+            "public_private_boundary": {
+                "public_safe_refs_only": True,
+                "raw_private_evidence_embedded": False,
+            },
+        }
+        tasks.append(task)
+
+    plan: dict[str, Any] = {
+        "$schema": "https://overkill-factory.dev/schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+        "record_type": "ready_work_unit_hermes_materialization_plan",
+        "plan_id": final_plan_id,
+        "created_at": created,
+        "factory_method_version": "OVERKILL_VFINAL",
+        "ready_work_unit_packet_manifest_ref": manifest_ref,
+        "ready_work_unit_packet_manifest_id": manifest_id,
+        "board": board_slug,
+        "runtime_boundary": {
+            "state_role": "runtime_materialization_plan_only",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "live_hermes_mutated": False,
+            "hermes_materialization_requires_gate": True,
+        },
+        "materialization_scope": str(ready_work_unit_packet_manifest.get("allowed_execution_scope") or "").strip(),
+        "complete_product_claim_allowed": False,
+        "tasks": tasks,
+        "runtime_gate": {
+            "gate_id": gate_id,
+            "human_gate_required": False,
+            "user_decision_required": False,
+            "dispatch_precondition": "blocked_event_verified_for_each_task",
+            "required_sequence": [
+                "create each Hermes task without dispatch",
+                "block each materialized task",
+                "verify hermes kanban show --json contains a blocked event for each task",
+                "assign the target worker only after blocked-event readback",
+                "dispatch only after the runtime gate records the verified blocked event evidence",
+            ],
+            "evidence_required": [
+                "Hermes show --json readback contains a blocked event for every materialized ready work-unit task"
+            ],
+        },
+        "blocking_rules": {
+            "validated_ready_work_unit_packet_manifest_required": True,
+            "only_ready_work_units_materialized": True,
+            "block_event_required_before_dispatch": True,
+            "dispatch_forbidden_without_runtime_gate": True,
+            "complete_product_claim_forbidden_until_all_scope_reconciled": True,
+            "raw_private_evidence_must_stay_external": True,
+        },
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_context_retained_outside_public_repo": True,
+        },
+        "acceptance": {
+            "task_count": len(tasks),
+            "all_tasks_start_blocked": True,
+            "block_event_required_before_dispatch": True,
+            "dispatch_allowed_without_runtime_gate": False,
+            "live_hermes_mutated": False,
+            "complete_product_claim_allowed": False,
+            "evidence_refs": [
+                "schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+                "schemas/ready-work-unit-packets.schema.json",
+                manifest_ref,
+            ],
+        },
+        "evidence_refs": [
+            "schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+            "schemas/ready-work-unit-packets.schema.json",
+            manifest_ref,
+        ],
+    }
+    return sanitize_public_refs(plan)
+
+
+def validate_ready_work_unit_hermes_materialization_plan(plan: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("ready-work-unit-hermes-materialization-plan.schema.json")
+    if not schema:
+        return ["ready_work_unit_hermes_materialization_plan schema is not bundled"]
+    errors.extend(validate_node(schema, plan, "ready_work_unit_hermes_materialization_plan", schemas=schemas, root_schema=schema))
+    if plan.get("record_type") != "ready_work_unit_hermes_materialization_plan":
+        errors.append("ready_work_unit_hermes_materialization_plan.record_type must be ready_work_unit_hermes_materialization_plan")
+
+    for field in ("ready_work_unit_packet_manifest_ref",):
+        value = str(plan.get(field) or "").strip()
+        if value:
+            _validate_public_ref(value, f"ready_work_unit_hermes_materialization_plan.{field}", errors)
+    _validate_lifecycle_refs(_list_items(plan.get("evidence_refs")), "ready_work_unit_hermes_materialization_plan.evidence_refs", errors)
+
+    runtime_boundary = plan.get("runtime_boundary") if isinstance(plan.get("runtime_boundary"), dict) else {}
+    if runtime_boundary.get("live_hermes_mutated") is not False:
+        errors.append("ready_work_unit_hermes_materialization_plan.runtime_boundary.live_hermes_mutated must be false")
+    if runtime_boundary.get("hermes_materialization_requires_gate") is not True:
+        errors.append("ready_work_unit_hermes_materialization_plan.runtime_boundary.hermes_materialization_requires_gate must be true")
+    if plan.get("complete_product_claim_allowed") is not False:
+        errors.append("ready_work_unit_hermes_materialization_plan.complete_product_claim_allowed must be false")
+
+    tasks = plan.get("tasks") if isinstance(plan.get("tasks"), list) else []
+    packet_ids: list[str] = []
+    work_unit_ids: list[str] = []
+    for index, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            errors.append(f"ready_work_unit_hermes_materialization_plan.tasks[{index}] must be an object")
+            continue
+        serialized = json.dumps(task, ensure_ascii=True, sort_keys=True)
+        if not public_safe_text(serialized):
+            errors.append(f"ready_work_unit_hermes_materialization_plan.tasks[{index}] must be public-safe")
+        packet_id = str(task.get("packet_id") or "").strip()
+        work_unit_id = str(task.get("work_unit_id") or "").strip()
+        if packet_id:
+            packet_ids.append(packet_id)
+        if work_unit_id:
+            work_unit_ids.append(work_unit_id)
+        owner = str(task.get("owner_worker") or "").strip()
+        if owner and owner not in WORKERS:
+            errors.append(f"ready_work_unit_hermes_materialization_plan.tasks[{index}].owner_worker must be registered: {owner}")
+        if task.get("initial_status") != "blocked":
+            errors.append(f"ready_work_unit_hermes_materialization_plan.tasks[{index}].initial_status must be blocked")
+        receipt = task.get("receipt_five_contract") if isinstance(task.get("receipt_five_contract"), dict) else {}
+        if receipt.get("complete_product_claim_allowed") is not False:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].receipt_five_contract.complete_product_claim_allowed must be false"
+            )
+        body_contract = task.get("body_contract") if isinstance(task.get("body_contract"), dict) else {}
+        if body_contract.get("packet_type") != "ready_work_unit_execution_request":
+            errors.append(f"ready_work_unit_hermes_materialization_plan.tasks[{index}].body_contract must be a ready work-unit packet")
+        block_policy = task.get("block_policy") if isinstance(task.get("block_policy"), dict) else {}
+        if block_policy.get("block_event_required_before_dispatch") is not True:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].block_policy.block_event_required_before_dispatch must be true"
+            )
+        dispatch_policy = task.get("dispatch_policy") if isinstance(task.get("dispatch_policy"), dict) else {}
+        if dispatch_policy.get("dispatch_allowed_without_runtime_gate") is not False:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].dispatch_policy.dispatch_allowed_without_runtime_gate must be false"
+            )
+        if dispatch_policy.get("complete_product_claim_allowed") is not False:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].dispatch_policy.complete_product_claim_allowed must be false"
+            )
+
+    duplicate_packet_ids = sorted({item for item in packet_ids if packet_ids.count(item) > 1})
+    if duplicate_packet_ids:
+        errors.append("ready_work_unit_hermes_materialization_plan duplicate packet ids: " + ", ".join(duplicate_packet_ids))
+    duplicate_work_units = sorted({item for item in work_unit_ids if work_unit_ids.count(item) > 1})
+    if duplicate_work_units:
+        errors.append("ready_work_unit_hermes_materialization_plan duplicate work unit ids: " + ", ".join(duplicate_work_units))
+
+    acceptance = plan.get("acceptance") if isinstance(plan.get("acceptance"), dict) else {}
+    if acceptance.get("task_count") != len(tasks):
+        errors.append("ready_work_unit_hermes_materialization_plan.acceptance.task_count must match tasks length")
+    if acceptance.get("all_tasks_start_blocked") is not True:
+        errors.append("ready_work_unit_hermes_materialization_plan.acceptance.all_tasks_start_blocked must be true")
+    if acceptance.get("block_event_required_before_dispatch") is not True:
+        errors.append("ready_work_unit_hermes_materialization_plan.acceptance.block_event_required_before_dispatch must be true")
+    if acceptance.get("dispatch_allowed_without_runtime_gate") is not False:
+        errors.append("ready_work_unit_hermes_materialization_plan.acceptance.dispatch_allowed_without_runtime_gate must be false")
+    if acceptance.get("live_hermes_mutated") is not False:
+        errors.append("ready_work_unit_hermes_materialization_plan.acceptance.live_hermes_mutated must be false")
+    if acceptance.get("complete_product_claim_allowed") is not False:
+        errors.append("ready_work_unit_hermes_materialization_plan.acceptance.complete_product_claim_allowed must be false")
+    _validate_lifecycle_refs(
+        _list_items(acceptance.get("evidence_refs")),
+        "ready_work_unit_hermes_materialization_plan.acceptance.evidence_refs",
+        errors,
+    )
+
+    boundary = plan.get("public_private_boundary") if isinstance(plan.get("public_private_boundary"), dict) else {}
+    if boundary.get("public_safe_refs_only") is not True:
+        errors.append("ready_work_unit_hermes_materialization_plan requires public_safe_refs_only=true")
+    if boundary.get("raw_private_evidence_embedded") is not False:
+        errors.append("ready_work_unit_hermes_materialization_plan must not embed raw private evidence")
+    if boundary.get("private_context_retained_outside_public_repo") is not True:
+        errors.append("ready_work_unit_hermes_materialization_plan private context must stay outside the public repo")
+    return errors
+
+
 def validate_universal_signal_golden_corpus(corpus: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -14471,6 +14754,43 @@ def command_validate_ready_work_unit_packets(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_ready_work_unit_hermes_plan(args: argparse.Namespace) -> int:
+    manifest_path = args.ready_work_unit_packets
+    if manifest_path.is_dir():
+        manifest_path = manifest_path / "manifest.json"
+    try:
+        plan = build_ready_work_unit_hermes_materialization_plan(
+            load_json_like(manifest_path),
+            board=args.board,
+            created_at=args.created_at,
+            plan_id=args.plan_id,
+            ready_work_unit_packet_manifest_ref=_sanitized_cli_artifact_ref(
+                manifest_path,
+                "ready-work-unit-packets",
+            ),
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    errors = validate_ready_work_unit_hermes_materialization_plan(plan)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    write_json(args.out, plan)
+    return 0
+
+
+def command_validate_ready_work_unit_hermes_plan(args: argparse.Namespace) -> int:
+    errors = validate_ready_work_unit_hermes_materialization_plan(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_signal_corpus(args: argparse.Namespace) -> int:
     errors = validate_universal_signal_golden_corpus(load_json_like(args.path))
     if errors:
@@ -15050,6 +15370,21 @@ def build_parser() -> argparse.ArgumentParser:
     validate_ready_work_unit_packets_parser = sub.add_parser("validate-ready-work-unit-packets")
     validate_ready_work_unit_packets_parser.add_argument("path", type=Path)
     validate_ready_work_unit_packets_parser.set_defaults(func=command_validate_ready_work_unit_packets)
+
+    ready_work_unit_hermes_plan_parser = sub.add_parser(
+        "ready-work-unit-hermes-plan",
+        help="Build the blocked Hermes runtime materialization plan for ready work-unit packets without mutating Hermes.",
+    )
+    ready_work_unit_hermes_plan_parser.add_argument("--ready-work-unit-packets", type=Path, required=True)
+    ready_work_unit_hermes_plan_parser.add_argument("--board", required=True)
+    ready_work_unit_hermes_plan_parser.add_argument("--created-at")
+    ready_work_unit_hermes_plan_parser.add_argument("--plan-id")
+    ready_work_unit_hermes_plan_parser.add_argument("--out", type=Path, required=True)
+    ready_work_unit_hermes_plan_parser.set_defaults(func=command_ready_work_unit_hermes_plan)
+
+    validate_ready_work_unit_hermes_plan_parser = sub.add_parser("validate-ready-work-unit-hermes-plan")
+    validate_ready_work_unit_hermes_plan_parser.add_argument("path", type=Path)
+    validate_ready_work_unit_hermes_plan_parser.set_defaults(func=command_validate_ready_work_unit_hermes_plan)
 
     validate_signal_corpus_parser = sub.add_parser("validate-signal-corpus")
     validate_signal_corpus_parser.add_argument("path", type=Path)

--- a/templates/ready-work-unit-hermes-materialization-plan.json
+++ b/templates/ready-work-unit-hermes-materialization-plan.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+  "record_type": "ready_work_unit_hermes_materialization_plan",
+  "plan_id": "ready-work-unit-hermes-plan-public-template",
+  "created_at": "2026-06-17T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "ready_work_unit_packet_manifest_ref": "templates/ready-work-unit-packets.json",
+  "ready_work_unit_packet_manifest_id": "ready-work-unit-packets-public-template",
+  "board": "overkill-factory-live",
+  "runtime_boundary": {
+    "state_role": "runtime_materialization_plan_only",
+    "runtime_authority": "hermes_kanban",
+    "local_state_authority": false,
+    "live_hermes_mutated": false,
+    "hermes_materialization_requires_gate": true
+  },
+  "materialization_scope": "ready_work_units_only",
+  "complete_product_claim_allowed": false,
+  "tasks": [
+    {
+      "task_plan_id": "hermes-ready-work-unit-work-unit-001",
+      "packet_id": "ready-work-unit-packet-work-unit-001",
+      "work_unit_id": "work-unit-001",
+      "owner_worker": "implementation-worker",
+      "reviewer_role": "independent-reviewer",
+      "title": "OF ready work unit work-unit-001: Deliver one safe execution slice without reducing the Product SOT scope.",
+      "materialization_state": "planned_pending_hermes_runtime_gate",
+      "initial_status": "blocked",
+      "body_format": "ready_work_unit_execution_request_json",
+      "body_contract": {
+        "packet_id": "ready-work-unit-packet-work-unit-001",
+        "packet_type": "ready_work_unit_execution_request",
+        "work_unit_id": "work-unit-001",
+        "status": "ready_for_worker_execution",
+        "owner_worker": "implementation-worker",
+        "reviewer_role": "independent-reviewer",
+        "objective": "Deliver one safe execution slice without reducing the Product SOT scope.",
+        "scope_in": ["the named Product SOT requirement refs"],
+        "scope_out": ["unrelated Product SOT requirements"],
+        "verification": ["run the checks named by the work unit"],
+        "expected_result": "PASS or explicit BLOCK with owner",
+        "proof_ids_required": ["generic.scope-fit"],
+        "product_sot_requirement_refs": ["product-sot#scope-in-001"],
+        "dependency_refs": ["product-sot#scope-in-001"],
+        "capability_profile_refs": ["agents/hermes-profile-bindings.public.json#implementation-worker"],
+        "ready_rules": ["Product SOT requirement refs resolve to the approved Product SOT"],
+        "done_rules": ["all proof_ids_required have PASS or valid waiver evidence"],
+        "stop_conditions": ["Product SOT drifted"],
+        "forbidden_actions": ["claim complete product done from ready work-unit execution"],
+        "receipt_five_contract": {
+          "must_attach_artifact_refs": true,
+          "must_state_blocking_findings": true,
+          "must_record_tool_or_profile": true,
+          "must_record_review": true,
+          "complete_product_claim_allowed": false,
+          "required_proof_ids": ["generic.scope-fit"],
+          "reviewer_role": "independent-reviewer"
+        },
+        "hermes_materialization": {
+          "recommended_initial_status": "blocked",
+          "block_event_required_before_dispatch": true,
+          "dispatch_allowed_without_runtime_gate": false,
+          "live_hermes_mutated": false
+        },
+        "public_private_boundary": {
+          "public_safe_refs_only": true,
+          "raw_private_evidence_embedded": false
+        }
+      },
+      "dependency_refs": ["product-sot#scope-in-001"],
+      "proof_ids_required": ["generic.scope-fit"],
+      "receipt_five_contract": {
+        "must_attach_artifact_refs": true,
+        "must_state_blocking_findings": true,
+        "must_record_tool_or_profile": true,
+        "must_record_review": true,
+        "complete_product_claim_allowed": false,
+        "required_proof_ids": ["generic.scope-fit"],
+        "reviewer_role": "independent-reviewer"
+      },
+      "runtime_refs": {
+        "hermes_board_ref": "external:pending-hermes-board",
+        "hermes_task_ref": "external:pending-hermes-task",
+        "hermes_run_ref": "external:pending-hermes-run"
+      },
+      "idempotency_key": "overkill:ready-work-unit-template:work-unit-001:0123456789abcdef",
+      "create_policy": {
+        "create_without_dispatch": true,
+        "create_unassigned_first": true,
+        "assign_after_block_event_verified": true,
+        "target_assignee_profile": "implementation-worker"
+      },
+      "block_policy": {
+        "initial_block_required": true,
+        "block_event_required_before_dispatch": true,
+        "verify_command": "hermes kanban show --json",
+        "blocked_reason": "Ready work unit starts blocked until Hermes readback proves a blocked event for this exact materialized task."
+      },
+      "dispatch_policy": {
+        "dispatch_allowed_without_runtime_gate": false,
+        "complete_product_claim_allowed": false,
+        "dispatch_precondition": "blocked_event_verified"
+      },
+      "public_private_boundary": {
+        "public_safe_refs_only": true,
+        "raw_private_evidence_embedded": false
+      }
+    }
+  ],
+  "runtime_gate": {
+    "gate_id": "runtime-gate-ready-work-unit-hermes-plan-public-template",
+    "human_gate_required": false,
+    "user_decision_required": false,
+    "dispatch_precondition": "blocked_event_verified_for_each_task",
+    "required_sequence": [
+      "create each Hermes task without dispatch",
+      "block each materialized task",
+      "verify hermes kanban show --json contains a blocked event for each task",
+      "assign the target worker only after blocked-event readback",
+      "dispatch only after the runtime gate records the verified blocked event evidence"
+    ],
+    "evidence_required": [
+      "Hermes show --json readback contains a blocked event for every materialized ready work-unit task"
+    ]
+  },
+  "blocking_rules": {
+    "validated_ready_work_unit_packet_manifest_required": true,
+    "only_ready_work_units_materialized": true,
+    "block_event_required_before_dispatch": true,
+    "dispatch_forbidden_without_runtime_gate": true,
+    "complete_product_claim_forbidden_until_all_scope_reconciled": true,
+    "raw_private_evidence_must_stay_external": true
+  },
+  "public_private_boundary": {
+    "public_safe_refs_only": true,
+    "raw_private_evidence_embedded": false,
+    "private_context_retained_outside_public_repo": true
+  },
+  "acceptance": {
+    "task_count": 1,
+    "all_tasks_start_blocked": true,
+    "block_event_required_before_dispatch": true,
+    "dispatch_allowed_without_runtime_gate": false,
+    "live_hermes_mutated": false,
+    "complete_product_claim_allowed": false,
+    "evidence_refs": [
+      "schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+      "schemas/ready-work-unit-packets.schema.json",
+      "templates/ready-work-unit-packets.json"
+    ]
+  },
+  "evidence_refs": [
+    "schemas/ready-work-unit-hermes-materialization-plan.schema.json",
+    "schemas/ready-work-unit-packets.schema.json",
+    "templates/ready-work-unit-packets.json"
+  ]
+}

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -989,6 +989,116 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertEqual(manifest["record_type"], "ready_work_unit_packet_manifest")
         self.assertEqual(len(manifest["packets"]), len(readiness["ready_work_units"]))
 
+    def test_ready_work_unit_hermes_plan_from_packets_is_valid_and_blocked_first(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+
+        materialization = factoryctl.build_ready_work_unit_hermes_materialization_plan(
+            manifest,
+            board="overkill-factory-live",
+            ready_work_unit_packet_manifest_ref="external:sanitized-ready-work-unit-packets",
+        )
+
+        self.assertEqual(factoryctl.validate_ready_work_unit_hermes_materialization_plan(materialization), [])
+        self.assertEqual(public_json_validator.validate_domain_rules(materialization, "$"), [])
+        self.assertEqual(materialization["record_type"], "ready_work_unit_hermes_materialization_plan")
+        self.assertFalse(materialization["runtime_boundary"]["live_hermes_mutated"])
+        self.assertFalse(materialization["complete_product_claim_allowed"])
+        self.assertEqual(len(materialization["tasks"]), len(manifest["packets"]))
+        self.assertTrue(all(task["initial_status"] == "blocked" for task in materialization["tasks"]))
+        self.assertTrue(
+            all(task["block_policy"]["block_event_required_before_dispatch"] for task in materialization["tasks"])
+        )
+        self.assertTrue(
+            all(
+                task["dispatch_policy"]["dispatch_allowed_without_runtime_gate"] is False
+                for task in materialization["tasks"]
+            )
+        )
+        self.assertTrue(
+            all(
+                task["dispatch_policy"]["complete_product_claim_allowed"] is False
+                for task in materialization["tasks"]
+            )
+        )
+        self.assertEqual(
+            [task["work_unit_id"] for task in materialization["tasks"]],
+            [packet["work_unit_id"] for packet in manifest["packets"]],
+        )
+
+    def test_ready_work_unit_hermes_plan_rejects_dispatch_without_runtime_gate(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+        materialization = factoryctl.build_ready_work_unit_hermes_materialization_plan(
+            manifest,
+            board="overkill-factory-live",
+            ready_work_unit_packet_manifest_ref="external:sanitized-ready-work-unit-packets",
+        )
+
+        materialization["tasks"][0]["dispatch_policy"]["dispatch_allowed_without_runtime_gate"] = True
+        materialization["acceptance"]["dispatch_allowed_without_runtime_gate"] = True
+
+        errors = factoryctl.validate_ready_work_unit_hermes_materialization_plan(materialization)
+
+        self.assertTrue(any("dispatch_allowed_without_runtime_gate must be false" in error for error in errors), errors)
+
+    def test_ready_work_unit_hermes_plan_cli_generates_and_validates_plan(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plan_path = Path(tmpdir) / "product-creation-plan.json"
+            readiness_path = Path(tmpdir) / "product-implementation-readiness.json"
+            packets_dir = Path(tmpdir) / "ready-work-unit-packets"
+            materialization_path = Path(tmpdir) / "ready-work-unit-hermes-plan.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            readiness_path.write_text(json.dumps(readiness), encoding="utf-8")
+
+            packet_result = factoryctl.main_with_args_for_test(
+                [
+                    "ready-work-unit-packets",
+                    "--product-creation-plan",
+                    str(plan_path),
+                    "--product-implementation-readiness",
+                    str(readiness_path),
+                    "--out",
+                    str(packets_dir),
+                ]
+            )
+            materialization_result = factoryctl.main_with_args_for_test(
+                [
+                    "ready-work-unit-hermes-plan",
+                    "--ready-work-unit-packets",
+                    str(packets_dir),
+                    "--board",
+                    "overkill-factory-live",
+                    "--out",
+                    str(materialization_path),
+                ]
+            )
+            validate_result = factoryctl.main_with_args_for_test(
+                ["validate-ready-work-unit-hermes-plan", str(materialization_path)]
+            )
+            materialization = json.loads(materialization_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(packet_result, 0)
+        self.assertEqual(materialization_result, 0)
+        self.assertEqual(validate_result, 0)
+        self.assertEqual(materialization["record_type"], "ready_work_unit_hermes_materialization_plan")
+        self.assertEqual(materialization["acceptance"]["task_count"], len(readiness["ready_work_units"]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Adds a public-safe factory gear after `ready_work_unit_packet_manifest`: `factoryctl ready-work-unit-hermes-plan`.

The new contract turns validated ready work-unit packets into a deterministic Hermes materialization plan without mutating live Hermes. Each planned task is blocked-first, requires a verified Hermes `blocked` event before dispatch, keeps dispatch forbidden without the runtime gate, and preserves `complete_product_claim_allowed=false`.

## Why

Dogfooding exposed a gap after #309: the factory could produce ready work-unit execution requests, but did not have a public-safe bridge into the blocked-first Hermes runtime materialization sequence. Existing live adapter materialization starts from card transition plans, not product-level ready work-unit packet manifests.

Closes #311.

## Validation

- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` (784 tests)
- Private dogfooding generated and validated a 4-task ready work-unit Hermes materialization plan outside the public repo.

## Runtime note

This is not live Hermes execution proof. Hermes remains authoritative for actual task creation, blocked-event readback, assignment, dispatch and worker results.