### PR TITLE
[codex] Wire ready work unit live materializer

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -178,11 +178,23 @@ python scripts/factoryctl.py ready-work-unit-hermes-plan \
 ```
 
 The plan is not runtime execution proof and does not mutate Hermes. It defines
-the exact runtime gate for each ready work unit: create the task without
-dispatch, block it, verify a real `blocked` event through Hermes readback, then
-assign and dispatch only after that gate evidence exists. Complete-product
-claims remain forbidden until all Product SOT scope is reconciled through
-worker results, review and Receipt Five.
+the exact runtime gate for each ready work unit: create the task with the
+documented Hermes `--assignee` and `--initial-status blocked` shape, block it,
+verify a real `blocked` event through Hermes readback, and dispatch only after
+that gate evidence exists. Complete-product claims remain forbidden until all
+Product SOT scope is reconciled through worker results, review and Receipt Five.
+
+When the runtime is reachable, the live adapter can consume that plan:
+
+```bash
+python adapters/hermes/live_kanban_adapter.py materialize-ready-work-units \
+  --plan path/to/ready-work-unit-hermes-plan.json \
+  --route-readiness path/to/route-readiness.json \
+  --out path/to/live-ready-work-unit-materialization-result.json
+```
+
+This command creates blocked Hermes tasks only. It does not dispatch workers,
+complete tasks, approve Receipt Five, or claim product completion.
 
 ## Dispatch Reporting
 

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
 import re
@@ -18,6 +19,7 @@ from transition_hook import ACTION_BLOCK_TRANSITION, build_hook_result, write_js
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = ROOT / "scripts"
+FACTORYCTL_PATH = SCRIPTS_DIR / "factoryctl.py"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
@@ -92,6 +94,16 @@ def parse_json_output(output: str, *, command: str) -> Any:
 
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_factoryctl() -> Any:
+    spec = importlib.util.spec_from_file_location("overkill_factoryctl_live_adapter", FACTORYCTL_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load factoryctl from {FACTORYCTL_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["overkill_factoryctl_live_adapter"] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def stable_contract_value(value: Any) -> Any:
@@ -623,6 +635,166 @@ def create_task(
     return task_id
 
 
+def load_ready_work_unit_materialization_plan(path: Path) -> dict[str, Any]:
+    plan = load_json(path)
+    factoryctl = load_factoryctl()
+    errors = factoryctl.validate_ready_work_unit_hermes_materialization_plan(plan)
+    if errors:
+        raise RuntimeError("invalid ready work-unit Hermes materialization plan: " + "; ".join(errors))
+    return plan
+
+
+def create_ready_work_unit_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    task: dict[str, Any],
+    worker_assignee_prefix: str,
+    runner: Runner = default_runner,
+) -> str:
+    create_policy = task.get("create_policy") if isinstance(task.get("create_policy"), dict) else {}
+    block_policy = task.get("block_policy") if isinstance(task.get("block_policy"), dict) else {}
+    if create_policy.get("create_with_assignee") is not True:
+        raise RuntimeError("ready work-unit task create_policy must use the documented assignee create path")
+    if block_policy.get("block_event_required_before_dispatch") is not True:
+        raise RuntimeError("ready work-unit task must require a blocked event before dispatch")
+
+    body_contract = task.get("body_contract") if isinstance(task.get("body_contract"), dict) else {}
+    ensure_non_empty_body(json.dumps(body_contract, ensure_ascii=True))
+    target_assignee = str(create_policy.get("target_assignee_profile") or task.get("owner_worker") or "").strip()
+    if not target_assignee:
+        raise RuntimeError("ready work-unit task requires target_assignee_profile")
+    task_id = parse_task_id(
+        run_checked(
+            hermes_kanban(
+                hermes_bin,
+                board,
+                "create",
+                str(task.get("title") or f"OF ready work unit {task.get('work_unit_id') or 'work-unit'}"),
+                "--body",
+                json.dumps(body_contract, indent=2, ensure_ascii=True),
+                "--assignee",
+                worker_assignee_prefix + target_assignee,
+                "--idempotency-key",
+                str(task.get("idempotency_key") or ""),
+                "--created-by",
+                "overkill-factory",
+                "--workspace",
+                f"dir:{ROOT}",
+                "--json",
+                "--initial-status",
+                "blocked",
+            ),
+            runner,
+        ).stdout
+    )
+    shown_task = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+    if not task_has_blocked_event(shown_task):
+        ensure_blocked_event(
+            hermes_bin=hermes_bin,
+            board=board,
+            task_id=task_id,
+            reason=str(
+                block_policy.get("blocked_reason")
+                or "Overkill Factory ready work-unit runtime gate starts blocked until evidence passes."
+            ),
+            runner=runner,
+        )
+    final_task = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+    if not task_has_blocked_event(final_task):
+        raise RuntimeError(f"Hermes task {task_id} lacks verified blocked event after materialization")
+    return task_id
+
+
+def materialize_ready_work_units(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
+    plan = load_ready_work_unit_materialization_plan(args.plan.resolve())
+    board = str(args.board or plan.get("board") or "").strip()
+    if not board:
+        raise RuntimeError("ready work-unit materialization requires a board")
+    if str(plan.get("board") or "").strip() and board != str(plan.get("board") or "").strip():
+        raise RuntimeError("provided board does not match the ready work-unit materialization plan")
+
+    if args.dry_run:
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "materialize-ready-work-units",
+            "dry_run": True,
+            "board": board,
+            "board_created": False,
+            "board_create_requested": bool(args.ensure_board),
+            "board_create_checked": False,
+            "materialization_plan_id": plan.get("plan_id"),
+            "ready_work_unit_task_ids": {},
+            "packet_task_ids": {},
+            "runtime_gate": plan.get("runtime_gate", {}),
+            "hook": {"plan": plan},
+        }
+        if args.out:
+            write_json(args.out, envelope)
+        return envelope
+
+    required_workers = [
+        str(task.get("owner_worker") or "").strip()
+        for task in plan.get("tasks", [])
+        if isinstance(task, dict) and str(task.get("owner_worker") or "").strip()
+    ]
+    readiness_blockers = route_readiness_blockers(args.route_readiness, required_workers)
+    if readiness_blockers:
+        raise RuntimeError("pre-dispatch route readiness blocked ready work-unit materialization: " + "; ".join(readiness_blockers))
+
+    board_created = False
+    if args.ensure_board:
+        board_created = ensure_board(
+            hermes_bin=args.hermes_bin,
+            board=board,
+            default_workdir=str(ROOT),
+            runner=runner,
+        )
+
+    ready_work_unit_task_ids: dict[str, str] = {}
+    packet_task_ids: dict[str, str] = {}
+    for task in plan.get("tasks", []):
+        if not isinstance(task, dict):
+            continue
+        task_id = create_ready_work_unit_task(
+            hermes_bin=args.hermes_bin,
+            board=board,
+            task=task,
+            worker_assignee_prefix=args.worker_assignee_prefix,
+            runner=runner,
+        )
+        work_unit_id = str(task.get("work_unit_id") or "").strip()
+        packet_id = str(task.get("packet_id") or "").strip()
+        if work_unit_id:
+            ready_work_unit_task_ids[work_unit_id] = task_id
+        if packet_id:
+            packet_task_ids[packet_id] = task_id
+
+    envelope = {
+        "$schema": LIVE_ADAPTER_SCHEMA,
+        "mode": "materialize-ready-work-units",
+        "dry_run": False,
+        "board": board,
+        "board_created": board_created,
+        "materialization_plan_id": plan.get("plan_id"),
+        "ready_work_unit_task_ids": ready_work_unit_task_ids,
+        "packet_task_ids": packet_task_ids,
+        "runtime_gate": {
+            **(plan.get("runtime_gate") if isinstance(plan.get("runtime_gate"), dict) else {}),
+            "blocked_event_verified_task_ids": ready_work_unit_task_ids,
+            "dispatch_allowed_by_this_step": False,
+            "live_hermes_mutated": True,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        },
+        "hook": {"plan": plan},
+    }
+    public_envelope = sanitize_public_refs(envelope)
+    if args.out:
+        write_json(args.out, public_envelope)
+    return public_envelope
+
+
 def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
     card_path = args.card.resolve()
     ledger_path = args.ledger.resolve()
@@ -1120,6 +1292,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_mat.add_argument("--route-readiness", type=Path)
     p_mat.add_argument("--out", type=Path)
 
+    p_ready = sub.add_parser(
+        "materialize-ready-work-units",
+        help="Create blocked Hermes tasks from a ready work-unit materialization plan.",
+    )
+    p_ready.add_argument("--plan", type=Path, required=True)
+    p_ready.add_argument("--board")
+    p_ready.add_argument("--hermes-bin", default="hermes")
+    p_ready.add_argument("--worker-assignee-prefix", default="")
+    p_ready.add_argument("--ensure-board", action="store_true")
+    p_ready.add_argument("--dry-run", action="store_true")
+    p_ready.add_argument("--route-readiness", type=Path)
+    p_ready.add_argument("--out", type=Path)
+
     p_done = sub.add_parser("enforce-done", help="Validate worker results before completing the main card.")
     p_done.add_argument("--card", type=Path, required=True)
     p_done.add_argument("--board", required=True)
@@ -1151,10 +1336,14 @@ def main() -> int:
     try:
         if args.command == "materialize":
             envelope = materialize(args)
+        elif args.command == "materialize-ready-work-units":
+            envelope = materialize_ready_work_units(args)
         elif args.command == "enforce-done":
             envelope = enforce_done(args)
-        else:
+        elif args.command == "dispatch":
             envelope = dispatch(args)
+        else:
+            raise RuntimeError(f"unsupported command: {args.command}")
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -8,7 +8,7 @@
       "const": "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json"
     },
     "mode": {
-      "enum": ["materialize", "enforce-done", "dispatch"]
+      "enum": ["materialize", "materialize-ready-work-units", "enforce-done", "dispatch"]
     },
     "dry_run": {
       "type": "boolean"
@@ -27,6 +27,21 @@
       "type": ["string", "null"]
     },
     "worker_task_ids": {
+      "type": "object"
+    },
+    "materialization_plan_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "ready_work_unit_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
+    "packet_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
+    "runtime_gate": {
       "type": "object"
     },
     "spawned": {
@@ -246,6 +261,23 @@
           "recovery_retry_blocked_worker_task_ids",
           "recovery_attempts",
           "idempotency_contract"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "mode": { "const": "materialize-ready-work-units" },
+          "dry_run": { "const": false }
+        },
+        "required": ["mode", "dry_run"]
+      },
+      "then": {
+        "required": [
+          "materialization_plan_id",
+          "ready_work_unit_task_ids",
+          "packet_task_ids",
+          "runtime_gate"
         ]
       }
     }

--- a/schemas/ready-work-unit-hermes-materialization-plan.schema.json
+++ b/schemas/ready-work-unit-hermes-materialization-plan.schema.json
@@ -212,14 +212,14 @@
           "type": "object",
           "required": [
             "create_without_dispatch",
-            "create_unassigned_first",
-            "assign_after_block_event_verified",
+            "create_with_assignee",
+            "documented_hermes_cli_shape",
             "target_assignee_profile"
           ],
           "properties": {
             "create_without_dispatch": { "const": true },
-            "create_unassigned_first": { "const": true },
-            "assign_after_block_event_verified": { "const": true },
+            "create_with_assignee": { "const": true },
+            "documented_hermes_cli_shape": { "const": "hermes kanban create --assignee --initial-status blocked --json" },
             "target_assignee_profile": { "type": "string", "minLength": 3 }
           },
           "additionalProperties": false

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -8699,8 +8699,8 @@ def build_ready_work_unit_hermes_materialization_plan(
             ),
             "create_policy": {
                 "create_without_dispatch": True,
-                "create_unassigned_first": True,
-                "assign_after_block_event_verified": True,
+                "create_with_assignee": True,
+                "documented_hermes_cli_shape": "hermes kanban create --assignee --initial-status blocked --json",
                 "target_assignee_profile": owner_worker,
             },
             "block_policy": {
@@ -8752,7 +8752,6 @@ def build_ready_work_unit_hermes_materialization_plan(
                 "create each Hermes task without dispatch",
                 "block each materialized task",
                 "verify hermes kanban show --json contains a blocked event for each task",
-                "assign the target worker only after blocked-event readback",
                 "dispatch only after the runtime gate records the verified blocked event evidence",
             ],
             "evidence_required": [

--- a/templates/ready-work-unit-hermes-materialization-plan.json
+++ b/templates/ready-work-unit-hermes-materialization-plan.json
@@ -86,8 +86,8 @@
       "idempotency_key": "overkill:ready-work-unit-template:work-unit-001:0123456789abcdef",
       "create_policy": {
         "create_without_dispatch": true,
-        "create_unassigned_first": true,
-        "assign_after_block_event_verified": true,
+        "create_with_assignee": true,
+        "documented_hermes_cli_shape": "hermes kanban create --assignee --initial-status blocked --json",
         "target_assignee_profile": "implementation-worker"
       },
       "block_policy": {
@@ -116,7 +116,6 @@
       "create each Hermes task without dispatch",
       "block each materialized task",
       "verify hermes kanban show --json contains a blocked event for each task",
-      "assign the target worker only after blocked-event readback",
       "dispatch only after the runtime gate records the verified blocked event evidence"
     ],
     "evidence_required": [

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -178,7 +178,7 @@ class FakeDispatchHermes:
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected command")
 
 
-def write_route_readiness(path: Path) -> None:
+def write_route_readiness(path: Path, extra_workers: list[str] | None = None) -> None:
     workers = [
         "codex-security",
         "solana-quasar-auditor",
@@ -193,6 +193,9 @@ def write_route_readiness(path: Path) -> None:
         "handoff-packer",
         "supply-chain-gate",
     ]
+    for worker in extra_workers or []:
+        if worker not in workers:
+            workers.append(worker)
     path.write_text(
         json.dumps(
             {
@@ -234,6 +237,87 @@ def assert_live_adapter_result_schema(testcase: unittest.TestCase, result: dict[
 
 
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
+    def test_materialize_ready_work_units_creates_blocked_tasks_without_dispatch(self) -> None:
+        fake = FakeHermes()
+        plan = factoryctl.load_json_like(ROOT / "templates" / "ready-work-unit-hermes-materialization-plan.json")
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness = tmp_path / "route-readiness.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness, extra_workers=["implementation-worker"])
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness),
+                ]
+            )
+            result = adapter.materialize_ready_work_units(args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        self.assertEqual(result["mode"], "materialize-ready-work-units")
+        self.assertFalse(result["dry_run"])
+        self.assertEqual(result["ready_work_unit_task_ids"], {"work-unit-001": adapter.PUBLIC_SAFE_KANBAN_REF})
+        create_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "create"]
+        block_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "block"]
+        dispatch_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "dispatch"]
+        self.assertEqual(len(create_calls), 1)
+        self.assertIn("--assignee", create_calls[0])
+        self.assertIn("implementation-worker", create_calls[0])
+        self.assertIn("--initial-status", create_calls[0])
+        self.assertIn("blocked", create_calls[0])
+        self.assertEqual(len(block_calls), 1)
+        self.assertEqual(dispatch_calls, [])
+        materialized_task_id = next(iter(fake.tasks))
+        self.assertEqual(fake.tasks[materialized_task_id]["status"], "blocked")
+        self.assertTrue(fake.tasks[materialized_task_id]["events"])
+
+    def test_materialize_ready_work_units_dry_run_does_not_touch_hermes(self) -> None:
+        fake = FakeHermes()
+        plan = factoryctl.load_json_like(ROOT / "templates" / "ready-work-unit-hermes-materialization-plan.json")
+        with tempfile.TemporaryDirectory() as tmp:
+            plan_path = Path(tmp) / "plan.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--dry-run",
+                    "--ensure-board",
+                ]
+            )
+            result = adapter.materialize_ready_work_units(args, runner=fake)
+
+        self.assertTrue(result["dry_run"])
+        self.assertTrue(result["board_create_requested"])
+        self.assertFalse(result["board_create_checked"])
+        self.assertEqual(fake.calls, [])
+
+    def test_materialize_ready_work_units_rejects_unsafe_plan(self) -> None:
+        fake = FakeHermes()
+        plan = factoryctl.load_json_like(ROOT / "templates" / "ready-work-unit-hermes-materialization-plan.json")
+        plan["tasks"][0]["dispatch_policy"]["dispatch_allowed_without_runtime_gate"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            plan_path = Path(tmp) / "plan.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--dry-run",
+                ]
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "invalid ready work-unit Hermes materialization plan"):
+                adapter.materialize_ready_work_units(args, runner=fake)
+
+        self.assertEqual(fake.calls, [])
+
     def test_materialize_schema_requires_recovery_and_idempotency_fields_for_real_run(self) -> None:
         schema = json.loads((ROOT / "schemas" / "hermes-live-adapter-result.schema.json").read_text(encoding="utf-8"))
         result = {


### PR DESCRIPTION
## What changed

Adds `materialize-ready-work-units` to the Hermes live adapter so a validated `ready_work_unit_hermes_materialization_plan` can be consumed by the runtime path.

The command validates the plan, checks route readiness, creates one blocked Hermes task per ready work unit using the documented Hermes `create --assignee --initial-status blocked --json` shape, verifies a real blocked event with `show --json`, and returns only public-safe runtime refs.

It also aligns the materialization plan contract with the documented Hermes CLI surface instead of promising an unsupported assign-after-create primitive.

## Why

Dogfooding exposed the next gear after #311: the factory could plan blocked Hermes materialization but the live adapter could not consume that plan. Without this, the operator would still need to manually turn ready work units into Hermes tasks.

Closes #313.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` (787 tests)
- Private dogfooding regenerated the Cockpit ready work-unit Hermes plan and validated adapter dry-run consumption of 4 planned tasks outside the public repo.

## Runtime note

This still does not claim live Cockpit implementation. Real worker execution requires reachable Hermes runtime, route readiness evidence, blocked-event readback, worker results, review and Receipt Five.