### PR TITLE
Allow remote workspace for ready work-unit materialization

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -198,6 +198,7 @@ python adapters/hermes/live_kanban_adapter.py collect-route-readiness \
 python adapters/hermes/live_kanban_adapter.py materialize-ready-work-units \
   --plan path/to/ready-work-unit-hermes-plan.json \
   --route-readiness path/to/route-readiness.json \
+  --workspace dir:<path-visible-to-hermes-dispatcher> \
   --out path/to/live-ready-work-unit-materialization-result.json
 ```
 
@@ -207,6 +208,12 @@ Hermes profiles and auth/provider readiness, and emits the official
 private paths. Materialization then creates blocked Hermes tasks only. It does
 not dispatch workers, complete tasks, approve Receipt Five, or claim product
 completion.
+
+Use `--workspace` when the adapter runs outside the Hermes host. The workspace
+must be meaningful to the Hermes dispatcher, not merely to the machine that runs
+the adapter. Local operators can omit it and use the repo directory default;
+remote operators should pass a dispatcher-visible `dir:<path>`, `worktree`, or
+`scratch` reference intentionally.
 
 ## Dispatch Reporting
 

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -885,6 +885,7 @@ def create_ready_work_unit_task(
     board: str,
     task: dict[str, Any],
     worker_assignee_prefix: str,
+    workspace_ref: str,
     runner: Runner = default_runner,
 ) -> str:
     create_policy = task.get("create_policy") if isinstance(task.get("create_policy"), dict) else {}
@@ -919,7 +920,7 @@ def create_ready_work_unit_task(
                 "--created-by",
                 "overkill-factory",
                 "--workspace",
-                f"dir:{ROOT}",
+                workspace_ref,
                 "--json",
             ),
             runner,
@@ -1027,6 +1028,7 @@ def materialize_ready_work_units(args: argparse.Namespace, runner: Runner = defa
             board=board,
             task=task,
             worker_assignee_prefix=args.worker_assignee_prefix,
+            workspace_ref=str(args.workspace or f"dir:{ROOT}"),
             runner=runner,
         )
         work_unit_id = str(task.get("work_unit_id") or "").strip()
@@ -1566,6 +1568,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ready.add_argument("--board")
     p_ready.add_argument("--hermes-bin", default="hermes")
     p_ready.add_argument("--worker-assignee-prefix", default="")
+    p_ready.add_argument("--workspace")
     p_ready.add_argument("--ensure-board", action="store_true")
     p_ready.add_argument("--dry-run", action="store_true")
     p_ready.add_argument("--route-readiness", type=Path)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -373,6 +373,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     str(plan_path),
                     "--route-readiness",
                     str(readiness),
+                    "--workspace",
+                    "scratch",
                 ]
             )
             result = adapter.materialize_ready_work_units(args, runner=fake)
@@ -388,6 +390,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(len(create_calls), 1)
         self.assertNotIn("--assignee", create_calls[0])
         self.assertNotIn("--initial-status", create_calls[0])
+        self.assertEqual(create_calls[0][create_calls[0].index("--workspace") + 1], "scratch")
         self.assertEqual(len(block_calls), 1)
         self.assertEqual(len(assign_calls), 1)
         self.assertEqual(assign_calls[0][-1], "implementation-worker")


### PR DESCRIPTION
## Summary

Adds a workspace override for ready work-unit Hermes materialization.

Cockpit dogfooding proved that no-spawn materialization can be correct while still not dispatch-ready if the created Hermes task points at the adapter machine's local workspace instead of a workspace visible to the Hermes dispatcher. This PR lets remote operators pass the dispatcher-visible workspace explicitly.

## Changes

- Add `--workspace` to `materialize-ready-work-units`.
- Pass the workspace ref through to Hermes `create` for ready work-unit tasks.
- Test that workspace override reaches the create command.
- Document when remote operators should pass a dispatcher-visible `dir:<path>`, `worktree`, or `scratch` ref.

## Dogfooding validation summary

After this patch, the Cockpit ready work units were recreated as 4 active Hermes tasks with final state `blocked`, expected assignees, non-truncated JSON body contracts, real blocked events, dispatcher-visible workspace, and no claim/spawn/spawn_failed/running markers. Dispatch remains not allowed by the materialization step.

No private source material, local paths, screenshots, or raw runtime dumps are committed.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/validate_public_json_artifacts.py`
- `git diff --check`

Closes #319