### PR TITLE
Add ready work-unit release gate

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -200,6 +200,12 @@ python adapters/hermes/live_kanban_adapter.py materialize-ready-work-units \
   --route-readiness path/to/route-readiness.json \
   --workspace dir:<path-visible-to-hermes-dispatcher> \
   --out path/to/live-ready-work-unit-materialization-result.json
+
+python adapters/hermes/live_kanban_adapter.py release-ready-work-units \
+  --plan path/to/ready-work-unit-hermes-plan.json \
+  --materialization-result path/to/live-ready-work-unit-materialization-result.json \
+  --route-readiness path/to/route-readiness.json \
+  --out path/to/released-ready-work-units.json
 ```
 
 The collector is read-only: it derives required workers from the plan, checks
@@ -207,7 +213,12 @@ Hermes profiles and auth/provider readiness, and emits the official
 `hermes-worker-route-readiness` manifest without embedding raw status dumps or
 private paths. Materialization then creates blocked Hermes tasks only. It does
 not dispatch workers, complete tasks, approve Receipt Five, or claim product
-completion.
+completion. Release verifies the materialization result, finds exactly one
+blocked Hermes task per planned `packet_id`/`work_unit_id`, proves the real
+`blocked` event, assignee, JSON body, dispatcher-visible workspace and absence
+of pre-dispatch activity, then unblocks those tasks to `ready`. Release does not
+dispatch workers; native Hermes dispatch remains a separate command and the
+complete-product claim remains forbidden.
 
 Use `--workspace` when the adapter runs outside the Hermes host. The workspace
 must be meaningful to the Hermes dispatcher, not merely to the machine that runs

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -501,6 +501,11 @@ def task_readback_task(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def task_readback_id(payload: dict[str, Any]) -> str:
+    task = task_readback_task(payload)
+    return str(task.get("id") or task.get("task_id") or payload.get("id") or payload.get("task_id") or "").strip()
+
+
 def task_readback_events(payload: dict[str, Any]) -> list[Any]:
     events = payload.get("events") or payload.get("history") or payload.get("timeline") or []
     if isinstance(events, list):
@@ -519,6 +524,26 @@ def task_readback_assignee(payload: dict[str, Any]) -> str:
 
 def task_readback_body(payload: dict[str, Any]) -> str:
     return str(task_readback_task(payload).get("body") or "")
+
+
+def task_dispatcher_workspace_ref(payload: dict[str, Any]) -> str:
+    task = task_readback_task(payload)
+    kind = str(task.get("workspace_kind") or task.get("workspace") or "").strip()
+    path = str(task.get("workspace_path") or "").strip()
+    if kind == "dir" and path:
+        return f"dir:{path}"
+    if kind:
+        return kind
+    return path
+
+
+def ensure_dispatcher_visible_workspace(payload: dict[str, Any], *, task_id: str) -> None:
+    workspace_ref = task_dispatcher_workspace_ref(payload)
+    if not workspace_ref:
+        raise RuntimeError(f"Hermes task {task_id} has no dispatcher workspace ref before release")
+    normalized = workspace_ref.replace("\\", "/")
+    if re.search(r"\b[A-Za-z]:/", normalized):
+        raise RuntimeError(f"Hermes task {task_id} workspace is local to the adapter, not dispatcher-visible")
 
 
 def pre_dispatch_activity_markers(payload: dict[str, Any]) -> list[str]:
@@ -563,6 +588,16 @@ def ensure_ready_work_unit_readback_contract(
     if str(body.get("packet_id") or "").strip() != expected_packet_id:
         raise RuntimeError(f"Hermes task {task_id} body readback does not match ready work-unit packet")
     ensure_no_pre_dispatch_activity(payload, task_id=task_id)
+
+
+def ready_work_unit_body(payload: dict[str, Any], *, task_id: str) -> dict[str, Any]:
+    try:
+        body = json.loads(task_readback_body(payload))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Hermes task {task_id} body readback is not valid JSON") from exc
+    if not isinstance(body, dict):
+        raise RuntimeError(f"Hermes task {task_id} body readback is not a JSON object")
+    return body
 
 
 def task_has_blocked_event(payload: dict[str, Any]) -> bool:
@@ -1056,6 +1091,223 @@ def materialize_ready_work_units(args: argparse.Namespace, runner: Runner = defa
             "local_state_authority": False,
         },
         "hook": {"plan": plan},
+    }
+    public_envelope = sanitize_public_refs(envelope)
+    if args.out:
+        write_json(args.out, public_envelope)
+    return public_envelope
+
+
+def load_ready_work_unit_materialization_result(path: Path, *, plan: dict[str, Any], board: str) -> dict[str, Any]:
+    result = load_json(path)
+    if result.get("mode") != "materialize-ready-work-units":
+        raise RuntimeError("ready work-unit release requires a materialize-ready-work-units result")
+    if result.get("dry_run") is True:
+        raise RuntimeError("ready work-unit release requires a real materialization result, not dry-run output")
+    result_board = str(result.get("board") or "").strip()
+    if result_board and result_board != board:
+        raise RuntimeError("materialization result board does not match ready work-unit release board")
+    plan_id = str(plan.get("plan_id") or "").strip()
+    if plan_id and str(result.get("materialization_plan_id") or "").strip() != plan_id:
+        raise RuntimeError("materialization result does not match the ready work-unit materialization plan")
+    runtime_gate = result.get("runtime_gate")
+    if not isinstance(runtime_gate, dict) or runtime_gate.get("live_hermes_mutated") is not True:
+        raise RuntimeError("materialization result does not prove live Hermes materialization")
+    if runtime_gate.get("dispatch_allowed_by_this_step") is not False:
+        raise RuntimeError("materialization result must keep dispatch separated from materialization")
+    work_unit_ids = {
+        str(task.get("work_unit_id") or "").strip()
+        for task in plan.get("tasks", [])
+        if isinstance(task, dict) and str(task.get("work_unit_id") or "").strip()
+    }
+    packet_ids = {
+        str(task.get("packet_id") or "").strip()
+        for task in plan.get("tasks", [])
+        if isinstance(task, dict) and str(task.get("packet_id") or "").strip()
+    }
+    result_work_units = set((result.get("ready_work_unit_task_ids") or {}).keys())
+    result_packets = set((result.get("packet_task_ids") or {}).keys())
+    missing_work_units = sorted(work_unit_ids - result_work_units)
+    missing_packets = sorted(packet_ids - result_packets)
+    if missing_work_units:
+        raise RuntimeError("materialization result is missing work unit ids: " + ", ".join(missing_work_units))
+    if missing_packets:
+        raise RuntimeError("materialization result is missing packet ids: " + ", ".join(missing_packets))
+    return result
+
+
+def expected_ready_work_unit_tasks(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    tasks = [task for task in plan.get("tasks", []) if isinstance(task, dict)]
+    if not tasks:
+        raise RuntimeError("ready work-unit release requires at least one task in the plan")
+    return tasks
+
+
+def expected_ready_work_unit_key(task: dict[str, Any]) -> tuple[str, str]:
+    packet_id = str(task.get("packet_id") or "").strip()
+    work_unit_id = str(task.get("work_unit_id") or "").strip()
+    if not packet_id or not work_unit_id:
+        raise RuntimeError("ready work-unit release requires packet_id and work_unit_id for every plan task")
+    return packet_id, work_unit_id
+
+
+def ready_work_unit_release_assignee(task: dict[str, Any], worker_assignee_prefix: str) -> str:
+    create_policy = task.get("create_policy") if isinstance(task.get("create_policy"), dict) else {}
+    assignee = str(create_policy.get("target_assignee_profile") or task.get("owner_worker") or "").strip()
+    if not assignee:
+        raise RuntimeError("ready work-unit release requires target_assignee_profile")
+    return worker_assignee_prefix + assignee
+
+
+def verify_ready_work_unit_release_candidate(
+    *,
+    payload: dict[str, Any],
+    plan_task: dict[str, Any],
+    worker_assignee_prefix: str,
+) -> tuple[str, str, str]:
+    task_id = task_readback_id(payload)
+    if not task_id:
+        raise RuntimeError("Hermes task readback has no task id")
+    packet_id, work_unit_id = expected_ready_work_unit_key(plan_task)
+    expected_assignee = ready_work_unit_release_assignee(plan_task, worker_assignee_prefix)
+    if task_readback_status(payload) != "blocked":
+        raise RuntimeError(f"Hermes task {task_id} is not blocked before ready work-unit release")
+    if task_readback_assignee(payload) != expected_assignee:
+        raise RuntimeError(f"Hermes task {task_id} assignee readback does not match target profile")
+    body = ready_work_unit_body(payload, task_id=task_id)
+    if str(body.get("packet_id") or "").strip() != packet_id:
+        raise RuntimeError(f"Hermes task {task_id} body readback does not match ready work-unit packet")
+    if str(body.get("work_unit_id") or "").strip() != work_unit_id:
+        raise RuntimeError(f"Hermes task {task_id} body readback does not match ready work-unit id")
+    if str(body.get("packet_type") or "").strip() != "ready_work_unit_execution_request":
+        raise RuntimeError(f"Hermes task {task_id} body readback is not a ready work-unit execution request")
+    if not task_has_blocked_event(payload):
+        raise RuntimeError(f"Hermes task {task_id} lacks verified blocked event before release")
+    ensure_no_pre_dispatch_activity(payload, task_id=task_id)
+    ensure_dispatcher_visible_workspace(payload, task_id=task_id)
+    return task_id, packet_id, work_unit_id
+
+
+def blocked_ready_work_unit_readbacks(
+    *,
+    hermes_bin: str,
+    board: str,
+    runner: Runner = default_runner,
+) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    candidates: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    seen_task_ids: set[str] = set()
+    for record in list_tasks_by_status(hermes_bin=hermes_bin, board=board, status="blocked", runner=runner):
+        task_id = str(record.get("task_id") or record.get("id") or "").strip()
+        if not task_id or task_id in seen_task_ids:
+            continue
+        seen_task_ids.add(task_id)
+        payload = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+        try:
+            body = ready_work_unit_body(payload, task_id=task_id)
+        except RuntimeError:
+            continue
+        if str(body.get("packet_type") or "").strip() != "ready_work_unit_execution_request":
+            continue
+        packet_id = str(body.get("packet_id") or "").strip()
+        work_unit_id = str(body.get("work_unit_id") or "").strip()
+        if packet_id and work_unit_id:
+            candidates.setdefault((packet_id, work_unit_id), []).append(payload)
+    return candidates
+
+
+def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
+    plan = load_ready_work_unit_materialization_plan(args.plan.resolve())
+    board = str(args.board or plan.get("board") or "").strip()
+    if not board:
+        raise RuntimeError("ready work-unit release requires a board")
+    if str(plan.get("board") or "").strip() and board != str(plan.get("board") or "").strip():
+        raise RuntimeError("provided board does not match the ready work-unit materialization plan")
+    materialization_result = load_ready_work_unit_materialization_result(
+        args.materialization_result.resolve(),
+        plan=plan,
+        board=board,
+    )
+    tasks = expected_ready_work_unit_tasks(plan)
+    required_workers = [
+        ready_work_unit_release_assignee(task, args.worker_assignee_prefix)
+        for task in tasks
+    ]
+    readiness_blockers = route_readiness_blockers(args.route_readiness, required_workers)
+    if readiness_blockers:
+        raise RuntimeError("pre-dispatch route readiness blocked ready work-unit release: " + "; ".join(readiness_blockers))
+
+    candidates = blocked_ready_work_unit_readbacks(hermes_bin=args.hermes_bin, board=board, runner=runner)
+    verified: list[tuple[dict[str, Any], str, str, str]] = []
+    for task in tasks:
+        key = expected_ready_work_unit_key(task)
+        matches = candidates.get(key) or []
+        if len(matches) != 1:
+            raise RuntimeError(
+                f"ready work-unit release expected exactly one blocked Hermes task for packet {key[0]} / work unit {key[1]}, found {len(matches)}"
+            )
+        task_id, packet_id, work_unit_id = verify_ready_work_unit_release_candidate(
+            payload=matches[0],
+            plan_task=task,
+            worker_assignee_prefix=args.worker_assignee_prefix,
+        )
+        verified.append((task, task_id, packet_id, work_unit_id))
+
+    released_ready_work_unit_task_ids: dict[str, str] = {}
+    released_packet_task_ids: dict[str, str] = {}
+    release_reason = str(
+        args.reason
+        or "runtime_gate=blocked_event_verified_for_each_task; release_scope=ready_work_units_only; dispatch_separate=true"
+    )
+    required_markers = [
+        "runtime_gate=blocked_event_verified_for_each_task",
+        "release_scope=ready_work_units_only",
+        "dispatch_separate=true",
+    ]
+    if not args.dry_run:
+        for _task, task_id, packet_id, work_unit_id in verified:
+            unblock_task(
+                hermes_bin=args.hermes_bin,
+                board=board,
+                task_id=task_id,
+                reason=release_reason,
+                required_readback_markers=required_markers,
+                runner=runner,
+            )
+            released_ready_work_unit_task_ids[work_unit_id] = task_id
+            released_packet_task_ids[packet_id] = task_id
+
+    envelope = {
+        "$schema": LIVE_ADAPTER_SCHEMA,
+        "mode": "release-ready-work-units",
+        "dry_run": bool(args.dry_run),
+        "board": board,
+        "materialization_plan_id": plan.get("plan_id"),
+        "ready_work_unit_task_ids": {
+            work_unit_id: task_id
+            for _task, task_id, _packet_id, work_unit_id in verified
+        },
+        "packet_task_ids": {
+            packet_id: task_id
+            for _task, task_id, packet_id, _work_unit_id in verified
+        },
+        "released_ready_work_unit_task_ids": released_ready_work_unit_task_ids,
+        "released_packet_task_ids": released_packet_task_ids,
+        "runtime_gate": {
+            **(plan.get("runtime_gate") if isinstance(plan.get("runtime_gate"), dict) else {}),
+            "release_verified_task_count": len(verified),
+            "dispatch_allowed_by_this_step": False,
+            "native_dispatch_required_next": not args.dry_run,
+            "complete_product_claim_allowed": False,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        },
+        "hook": {
+            "plan": plan,
+            "materialization_result": materialization_result,
+            "release_reason": release_reason,
+            "no_shadow_dispatcher": True,
+            "local_state_authority": False,
+        },
     }
     public_envelope = sanitize_public_refs(envelope)
     if args.out:
@@ -1574,6 +1826,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_ready.add_argument("--route-readiness", type=Path)
     p_ready.add_argument("--out", type=Path)
 
+    p_release = sub.add_parser(
+        "release-ready-work-units",
+        help="Release verified blocked ready work-unit tasks to ready without dispatching workers.",
+    )
+    p_release.add_argument("--plan", type=Path, required=True)
+    p_release.add_argument("--materialization-result", type=Path, required=True)
+    p_release.add_argument("--board")
+    p_release.add_argument("--hermes-bin", default="hermes")
+    p_release.add_argument("--worker-assignee-prefix", default="")
+    p_release.add_argument("--route-readiness", type=Path, required=True)
+    p_release.add_argument("--reason")
+    p_release.add_argument("--dry-run", action="store_true")
+    p_release.add_argument("--out", type=Path)
+
     p_route = sub.add_parser(
         "collect-route-readiness",
         help="Collect the public-safe Hermes worker route readiness manifest from read-only Hermes state.",
@@ -1619,6 +1885,8 @@ def main() -> int:
             envelope = materialize(args)
         elif args.command == "materialize-ready-work-units":
             envelope = materialize_ready_work_units(args)
+        elif args.command == "release-ready-work-units":
+            envelope = release_ready_work_units(args)
         elif args.command == "collect-route-readiness":
             envelope = collect_route_readiness(args)
         elif args.command == "enforce-done":

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -106,6 +106,11 @@ named owners and human decisions.
 deterministic execution requests without mutating live Hermes, without exposing
 private refs and without allowing any complete-product claim from a bounded
 slice.
+`ready-work-unit-hermes-plan` prepares the blocked-first Hermes materialization
+contract for those packets. The live Hermes adapter then has a strict sequence:
+collect route readiness, materialize blocked tasks, release exactly the verified
+blocked tasks to `ready`, and only then run the native dispatch wrapper. Release
+does not dispatch workers and dispatch does not complete the product.
 `validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.

--- a/schemas/hermes-live-adapter-result.schema.json
+++ b/schemas/hermes-live-adapter-result.schema.json
@@ -8,7 +8,7 @@
       "const": "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json"
     },
     "mode": {
-      "enum": ["materialize", "materialize-ready-work-units", "enforce-done", "dispatch"]
+      "enum": ["materialize", "materialize-ready-work-units", "release-ready-work-units", "enforce-done", "dispatch"]
     },
     "dry_run": {
       "type": "boolean"
@@ -38,6 +38,14 @@
       "additionalProperties": { "type": "string", "minLength": 3 }
     },
     "packet_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
+    "released_ready_work_unit_task_ids": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 3 }
+    },
+    "released_packet_task_ids": {
       "type": "object",
       "additionalProperties": { "type": "string", "minLength": 3 }
     },
@@ -277,6 +285,25 @@
           "materialization_plan_id",
           "ready_work_unit_task_ids",
           "packet_task_ids",
+          "runtime_gate"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "mode": { "const": "release-ready-work-units" },
+          "dry_run": { "const": false }
+        },
+        "required": ["mode", "dry_run"]
+      },
+      "then": {
+        "required": [
+          "materialization_plan_id",
+          "ready_work_unit_task_ids",
+          "packet_task_ids",
+          "released_ready_work_unit_task_ids",
+          "released_packet_task_ids",
           "runtime_gate"
         ]
       }

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -51,6 +51,14 @@ class FakeHermes:
             return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
         if argv[:4] == ["hermes", "kanban", "boards", "create"]:
             return subprocess.CompletedProcess(argv, 0, stdout="created", stderr="")
+        if len(argv) >= 8 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "list":
+            status = argv[argv.index("--status") + 1] if "--status" in argv else ""
+            rows = [
+                {"id": task_id, **task}
+                for task_id, task in self.tasks.items()
+                if not status or str(task.get("status") or "") == status
+            ]
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(rows), stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "create":
             idempotency_key = argv[argv.index("--idempotency-key") + 1] if "--idempotency-key" in argv else ""
             if idempotency_key and idempotency_key in self.idempotent_task_ids:
@@ -62,7 +70,14 @@ class FakeHermes:
             initial_status = "blocked" if "--initial-status" in argv and "blocked" in argv else "ready"
             body = argv[argv.index("--body") + 1] if "--body" in argv else "{}"
             assignee = argv[argv.index("--assignee") + 1] if "--assignee" in argv else None
-            self.tasks[task_id] = {"status": initial_status, "events": [], "body": body, "assignee": assignee}
+            workspace_ref = argv[argv.index("--workspace") + 1] if "--workspace" in argv else "scratch"
+            task = {"id": task_id, "status": initial_status, "events": [], "body": body, "assignee": assignee}
+            if workspace_ref.startswith("dir:"):
+                task["workspace_kind"] = "dir"
+                task["workspace_path"] = workspace_ref[4:]
+            else:
+                task["workspace_kind"] = workspace_ref
+            self.tasks[task_id] = task
             if idempotency_key:
                 self.idempotent_task_ids[idempotency_key] = task_id
             return subprocess.CompletedProcess(argv, 0, stdout=f'{{"id":"{task_id}"}}', stderr="")
@@ -277,6 +292,34 @@ def write_route_readiness(path: Path, extra_workers: list[str] | None = None) ->
     )
 
 
+def materialize_template_ready_work_unit(
+    *,
+    fake: FakeHermes,
+    tmp_path: Path,
+    workspace: str = "scratch",
+) -> tuple[dict[str, object], Path, Path, Path]:
+    plan = factoryctl.load_json_like(ROOT / "templates" / "ready-work-unit-hermes-materialization-plan.json")
+    plan_path = tmp_path / "plan.json"
+    readiness_path = tmp_path / "route-readiness.json"
+    materialization_result_path = tmp_path / "materialization-result.json"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    write_route_readiness(readiness_path, extra_workers=["implementation-worker"])
+    materialize_args = adapter.build_parser().parse_args(
+        [
+            "materialize-ready-work-units",
+            "--plan",
+            str(plan_path),
+            "--route-readiness",
+            str(readiness_path),
+            "--workspace",
+            workspace,
+        ]
+    )
+    materialization_result = adapter.materialize_ready_work_units(materialize_args, runner=fake)
+    materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+    return plan, plan_path, readiness_path, materialization_result_path
+
+
 def assert_live_adapter_result_schema(testcase: unittest.TestCase, result: dict[str, object]) -> None:
     schema = json.loads((ROOT / "schemas" / "hermes-live-adapter-result.schema.json").read_text(encoding="utf-8"))
     errors = validator.validate_node(schema, result, "$", schemas={"hermes-live-adapter-result.schema.json": schema}, root_schema=schema)
@@ -467,6 +510,192 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         dispatch_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "dispatch"]
         self.assertEqual(dispatch_calls, [])
+
+    def test_release_ready_work_units_unblocks_verified_tasks_without_dispatch(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            result = adapter.release_ready_work_units(args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        self.assertEqual(result["mode"], "release-ready-work-units")
+        self.assertFalse(result["dry_run"])
+        self.assertEqual(result["released_ready_work_unit_task_ids"], {"work-unit-001": adapter.PUBLIC_SAFE_KANBAN_REF})
+        task_id = next(iter(fake.tasks))
+        self.assertEqual(fake.tasks[task_id]["status"], "ready")
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        dispatch_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "dispatch"]
+        self.assertEqual(len(unblock_calls), 1)
+        self.assertIn("runtime_gate=blocked_event_verified_for_each_task", unblock_calls[0][-1])
+        self.assertEqual(dispatch_calls, [])
+        self.assertFalse(result["runtime_gate"]["dispatch_allowed_by_this_step"])
+        self.assertTrue(result["runtime_gate"]["native_dispatch_required_next"])
+
+    def test_release_ready_work_units_dry_run_verifies_without_unblock(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--dry-run",
+                ]
+            )
+            result = adapter.release_ready_work_units(args, runner=fake)
+
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(result["released_ready_work_unit_task_ids"], {})
+        task_id = next(iter(fake.tasks))
+        self.assertEqual(fake.tasks[task_id]["status"], "blocked")
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(unblock_calls, [])
+
+    def test_release_ready_work_units_rejects_pre_dispatch_activity(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            task_id = next(iter(fake.tasks))
+            fake.tasks[task_id].setdefault("events", []).append({"kind": "claimed"})
+            args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "pre-dispatch activity"):
+                adapter.release_ready_work_units(args, runner=fake)
+
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(unblock_calls, [])
+
+    def test_release_ready_work_units_rejects_ambiguous_matching_tasks(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            existing = next(iter(fake.tasks.values())).copy()
+            fake.tasks["t_duplicate"] = {**existing, "id": "t_duplicate"}
+            args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "expected exactly one blocked Hermes task"):
+                adapter.release_ready_work_units(args, runner=fake)
+
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(unblock_calls, [])
+
+    def test_release_ready_work_units_rejects_adapter_local_workspace(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+                workspace="dir:C:/Users/operator/repo",
+            )
+            args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "not dispatcher-visible"):
+                adapter.release_ready_work_units(args, runner=fake)
+
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(unblock_calls, [])
+
+    def test_release_ready_work_units_requires_real_materialization_result(self) -> None:
+        fake = FakeHermes()
+        plan = factoryctl.load_json_like(ROOT / "templates" / "ready-work-unit-hermes-materialization-plan.json")
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["implementation-worker"])
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://overkill-factory.dev/schemas/hermes-live-adapter-result.schema.json",
+                        "mode": "materialize-ready-work-units",
+                        "dry_run": True,
+                        "board": "overkill-factory-live",
+                        "hook": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "real materialization result"):
+                adapter.release_ready_work_units(args, runner=fake)
+
+        self.assertEqual(fake.calls, [])
 
     def test_materialize_schema_requires_recovery_and_idempotency_fields_for_real_run(self) -> None:
         schema = json.loads((ROOT / "schemas" / "hermes-live-adapter-result.schema.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Closes #321.

Adds a first-class `release-ready-work-units` Hermes adapter command for the gap between blocked ready work-unit materialization and native Hermes dispatch.

The new release gate:

- consumes the ready work-unit materialization plan and real materialization result;
- rechecks route readiness before release;
- finds exactly one blocked Hermes task per planned `packet_id` / `work_unit_id` from the live board;
- verifies blocked status, real blocked event, assignee, JSON body, dispatcher-visible workspace, and no pre-dispatch activity;
- unblocks verified tasks to `ready` without dispatching workers;
- keeps native dispatch and complete-product claims as separate later steps.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/factoryctl.py validate-ready-work-unit-hermes-plan templates/ready-work-unit-hermes-materialization-plan.json`
- `python -m unittest discover -s tests -p "test_*.py" -q` (797 tests)
- `git diff --check`