### PR TITLE
Accept Hermes unblock audit comments

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -216,9 +216,12 @@ not dispatch workers, complete tasks, approve Receipt Five, or claim product
 completion. Release verifies the materialization result, finds exactly one
 blocked Hermes task per planned `packet_id`/`work_unit_id`, proves the real
 `blocked` event, assignee, JSON body, dispatcher-visible workspace and absence
-of pre-dispatch activity, then unblocks those tasks to `ready`. Release does not
-dispatch workers; native Hermes dispatch remains a separate command and the
-complete-product claim remains forbidden.
+of pre-dispatch activity, records a Hermes-native audit comment with the
+release markers, then unblocks those tasks to `ready`. Release accepts real
+Hermes readback where the `unblocked` event itself has no payload as long as the
+marker-bearing comment is present. Release does not dispatch workers; native
+Hermes dispatch remains a separate command and the complete-product claim
+remains forbidden.
 
 Use `--workspace` when the adapter runs outside the Hermes host. The workspace
 must be meaningful to the Hermes dispatcher, not merely to the machine that runs

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -620,17 +620,32 @@ def task_has_unblocked_event(payload: dict[str, Any], required_markers: list[str
     if task_readback_status(payload) == "blocked":
         return False
     markers = [marker.strip().lower() for marker in (required_markers or []) if marker.strip()]
+    unblocked_event_seen = False
     for event in task_readback_events(payload):
         if isinstance(event, dict):
             event_type = str(
                 event.get("type") or event.get("event") or event.get("action") or event.get("kind") or ""
             ).strip().lower()
-            if event_type in {"unblock", "unblocked"} and all(marker in str(event).lower() for marker in markers):
-                return True
+            if event_type in {"unblock", "unblocked"}:
+                unblocked_event_seen = True
+                if not markers or all(marker in str(event).lower() for marker in markers):
+                    return True
             continue
         text = str(event).lower()
         if "unblock" not in text:
             continue
+        if all(marker in text for marker in markers):
+            return True
+    return unblocked_event_seen and history_contains_markers(payload, markers)
+
+
+def history_contains_markers(payload: dict[str, Any], markers: list[str]) -> bool:
+    if not markers:
+        return True
+    for key, _index, item in history_items(payload):
+        if key == "runs":
+            continue
+        text = json.dumps(item, ensure_ascii=True, sort_keys=True).lower() if isinstance(item, dict) else str(item).lower()
         if all(marker in text for marker in markers):
             return True
     return False
@@ -753,6 +768,19 @@ def unblock_task(
     required_readback_markers: list[str] | None = None,
     runner: Runner = default_runner,
 ) -> None:
+    if required_readback_markers:
+        run_checked(
+            hermes_kanban(
+                hermes_bin,
+                board,
+                "comment",
+                "--author",
+                "overkill-factory",
+                task_id,
+                reason,
+            ),
+            runner,
+        )
     run_checked(hermes_kanban(hermes_bin, board, "unblock", task_id, reason), runner)
     shown = run_checked(hermes_kanban(hermes_bin, board, "show", task_id, "--json"), runner)
     try:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -91,10 +91,23 @@ class FakeHermes:
             task["status"] = "blocked"
             task.setdefault("events", []).append({"type": "blocked", "reason": argv[6]})
             return subprocess.CompletedProcess(argv, 0, stdout='{"status":"blocked"}', stderr="")
+        if len(argv) >= 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "comment":
+            if argv[5] == "--author":
+                author = argv[6]
+                task_id = argv[7]
+                body = " ".join(argv[8:])
+            else:
+                author = "default"
+                task_id = argv[5]
+                body = " ".join(argv[6:])
+            task = self.tasks.setdefault(task_id, {"status": "blocked", "events": [], "comments": []})
+            task.setdefault("comments", []).append({"author": author, "body": body})
+            task.setdefault("events", []).append({"type": "commented", "author": author})
+            return subprocess.CompletedProcess(argv, 0, stdout="commented", stderr="")
         if len(argv) == 7 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "unblock":
             task = self.tasks.setdefault(argv[5], {"status": "blocked", "events": []})
             task["status"] = "ready"
-            task.setdefault("events", []).append({"type": "unblocked", "reason": argv[6]})
+            task.setdefault("events", []).append({"type": "unblocked", "payload": None})
             return subprocess.CompletedProcess(argv, 0, stdout='{"status":"ready"}', stderr="")
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
             payload = self.tasks.get(argv[5], {"status": "blocked", "events": [{"type": "blocked", "reason": "gate"}]})
@@ -858,6 +871,25 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     "events": [{"kind": "unblocked", "payload": {"reason": "factory_recovery_attempt"}}],
                 },
                 required_markers=["factory_recovery_attempt"],
+            )
+        )
+        self.assertTrue(
+            adapter.task_has_unblocked_event(
+                {
+                    "task": {"status": "ready"},
+                    "events": [{"kind": "unblocked", "payload": None}],
+                    "comments": [
+                        {
+                            "author": "overkill-factory",
+                            "body": "runtime_gate=blocked_event_verified_for_each_task release_scope=ready_work_units_only dispatch_separate=true",
+                        }
+                    ],
+                },
+                required_markers=[
+                    "runtime_gate=blocked_event_verified_for_each_task",
+                    "release_scope=ready_work_units_only",
+                    "dispatch_separate=true",
+                ],
             )
         )
 


### PR DESCRIPTION
## Summary

Closes #323.

Live Hermes readback showed that `unblock` can create an `unblocked` event with `payload: null`, so marker-only event validation was too strict. This patch preserves release authority by writing a Hermes-native audit comment before unblock and accepting the readback only when a real `unblocked` event and marker-bearing comment/history item are both present.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` (797 tests)
- `git diff --check`