### PR TITLE
Add ready work-unit context boundary

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -188,6 +188,15 @@ the task is still blocked and has no pre-dispatch `promoted`, `claimed`,
 evidence exists. Complete-product claims remain forbidden until all Product SOT
 scope is reconciled through worker results, review and Receipt Five.
 
+Ready work-unit packets and the resulting Hermes task contracts also carry a
+`context_boundary`. Workers may inspect only named allowed refs plus artifacts
+created for the current `work_unit_id`; broad repository archaeology is not a
+valid recovery path. When context is missing, stale, forbidden or ambiguous, the
+task must block with owner instead of continuing through unrelated history.
+Use repeated `--forbidden-context-ref <public-safe-ref>` values when a live run
+has known off-limits public refs, such as a separate issue or parallel product
+thread.
+
 When the runtime is reachable, the live adapter can consume that plan:
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,7 +58,7 @@ factoryctl product-creation-plan --method-contract templates/method-contract.jso
 factoryctl validate-product-creation-plan templates/product-creation-plan.json
 factoryctl product-implementation-readiness --product-creation-plan templates/product-creation-plan.json --out .tmp/product-implementation-readiness.json
 factoryctl validate-product-implementation-readiness templates/product-implementation-readiness.json
-factoryctl ready-work-unit-packets --product-creation-plan templates/product-creation-plan.json --product-implementation-readiness templates/product-implementation-readiness.json --out .tmp/ready-work-unit-packets
+factoryctl ready-work-unit-packets --product-creation-plan templates/product-creation-plan.json --product-implementation-readiness templates/product-implementation-readiness.json --forbidden-context-ref external:sanitized-off-limits-parallel-thread --out .tmp/ready-work-unit-packets
 factoryctl validate-ready-work-unit-packets templates/ready-work-unit-packets.json
 factoryctl validate-signal-corpus templates/universal-signal-golden-corpus.json
 factoryctl signal-coverage --out .tmp/factory-runs/signal-coverage/factory-signal-coverage-scorecard.json
@@ -105,12 +105,21 @@ named owners and human decisions.
 `ready-work-unit-packets` turns those explicit `ready_work_units` into
 deterministic execution requests without mutating live Hermes, without exposing
 private refs and without allowing any complete-product claim from a bounded
-slice.
+slice. Each packet carries a `context_boundary`: workers may inspect only the
+named allowed refs and artifacts produced for that `work_unit_id`; broad repo
+history search is forbidden. If required context is missing, stale, forbidden
+or ambiguous, the worker must BLOCK with owner instead of asking the operator to
+coordinate or searching unrelated project history. `--forbidden-context-ref` is
+repeatable and is intended for public-safe refs that must stay outside the
+worker's search space during a run.
 `ready-work-unit-hermes-plan` prepares the blocked-first Hermes materialization
 contract for those packets. The live Hermes adapter then has a strict sequence:
 collect route readiness, materialize blocked tasks, release exactly the verified
 blocked tasks to `ready`, and only then run the native dispatch wrapper. Release
-does not dispatch workers and dispatch does not complete the product.
+does not dispatch workers and dispatch does not complete the product. The
+materialization plan copies the same `context_boundary` into each Hermes task
+contract so runtime workers receive the same bounded-search rule as the packet
+validator.
 `validate-signal-corpus` and `signal-coverage` prove that the public
 Golden Corpus covers every known route without treating contract coverage as
 production readiness.

--- a/schemas/ready-work-unit-hermes-materialization-plan.schema.json
+++ b/schemas/ready-work-unit-hermes-materialization-plan.schema.json
@@ -171,6 +171,7 @@
         "dependency_refs",
         "proof_ids_required",
         "receipt_five_contract",
+        "context_boundary",
         "runtime_refs",
         "idempotency_key",
         "create_policy",
@@ -199,6 +200,39 @@
           "items": { "type": "string", "minLength": 3 }
         },
         "receipt_five_contract": { "type": "object" },
+        "context_boundary": {
+          "type": "object",
+          "required": [
+            "allowed_context_refs",
+            "forbidden_context_refs",
+            "workspace_search_policy",
+            "broad_repo_search_allowed",
+            "missing_context_action",
+            "context_drift_action",
+            "block_owner",
+            "operator_action_required_for_missing_context",
+            "worker_instruction"
+          ],
+          "properties": {
+            "allowed_context_refs": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "forbidden_context_refs": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "workspace_search_policy": { "const": "bounded_refs_only" },
+            "broad_repo_search_allowed": { "const": false },
+            "missing_context_action": { "const": "BLOCK_WITH_OWNER" },
+            "context_drift_action": { "const": "BLOCK_AND_REPORT" },
+            "block_owner": { "type": "string", "minLength": 3 },
+            "operator_action_required_for_missing_context": { "const": false },
+            "worker_instruction": { "type": "string", "minLength": 30 }
+          },
+          "additionalProperties": false
+        },
         "runtime_refs": {
           "type": "object",
           "required": ["hermes_board_ref", "hermes_task_ref", "hermes_run_ref"],

--- a/schemas/ready-work-unit-packets.schema.json
+++ b/schemas/ready-work-unit-packets.schema.json
@@ -168,6 +168,7 @@
         "stop_conditions",
         "forbidden_actions",
         "receipt_five_contract",
+        "context_boundary",
         "hermes_materialization",
         "public_private_boundary"
       ],
@@ -210,6 +211,39 @@
             "complete_product_claim_allowed": { "const": false }
           },
           "additionalProperties": true
+        },
+        "context_boundary": {
+          "type": "object",
+          "required": [
+            "allowed_context_refs",
+            "forbidden_context_refs",
+            "workspace_search_policy",
+            "broad_repo_search_allowed",
+            "missing_context_action",
+            "context_drift_action",
+            "block_owner",
+            "operator_action_required_for_missing_context",
+            "worker_instruction"
+          ],
+          "properties": {
+            "allowed_context_refs": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "forbidden_context_refs": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 3 }
+            },
+            "workspace_search_policy": { "const": "bounded_refs_only" },
+            "broad_repo_search_allowed": { "const": false },
+            "missing_context_action": { "const": "BLOCK_WITH_OWNER" },
+            "context_drift_action": { "const": "BLOCK_AND_REPORT" },
+            "block_owner": { "type": "string", "minLength": 3 },
+            "operator_action_required_for_missing_context": { "const": false },
+            "worker_instruction": { "type": "string", "minLength": 30 }
+          },
+          "additionalProperties": false
         },
         "hermes_materialization": {
           "type": "object",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -8321,6 +8321,40 @@ def _ready_work_unit_dependency_refs(plan: dict[str, Any], work_unit_id: str) ->
     return _dedupe_preserve_order(refs)
 
 
+def _ready_work_unit_context_boundary(
+    *,
+    plan_ref: str,
+    readiness_ref: str,
+    unit: dict[str, Any],
+    dependency_refs: list[str],
+    forbidden_context_refs: list[str] | None,
+) -> dict[str, Any]:
+    allowed_context_refs = _dedupe_preserve_order(
+        [
+            plan_ref,
+            readiness_ref,
+            *_list_items(unit.get("product_sot_requirement_refs")),
+            *dependency_refs,
+            *_list_items(unit.get("capability_profile_refs")),
+        ]
+    )
+    return {
+        "allowed_context_refs": allowed_context_refs,
+        "forbidden_context_refs": _dedupe_preserve_order(forbidden_context_refs or []),
+        "workspace_search_policy": "bounded_refs_only",
+        "broad_repo_search_allowed": False,
+        "missing_context_action": "BLOCK_WITH_OWNER",
+        "context_drift_action": "BLOCK_AND_REPORT",
+        "block_owner": str(unit.get("owner_worker") or "").strip(),
+        "operator_action_required_for_missing_context": False,
+        "worker_instruction": (
+            "Use only the named allowed_context_refs and artifacts produced for this work_unit_id. "
+            "If required context is missing, stale, forbidden or ambiguous, block with owner instead "
+            "of searching unrelated repository history."
+        ),
+    }
+
+
 def build_ready_work_unit_packet_manifest(
     product_creation_plan: dict[str, Any],
     product_implementation_readiness: dict[str, Any],
@@ -8329,6 +8363,7 @@ def build_ready_work_unit_packet_manifest(
     manifest_id: str | None = None,
     product_creation_plan_ref: str | None = None,
     product_implementation_readiness_ref: str | None = None,
+    forbidden_context_refs: list[str] | None = None,
 ) -> dict[str, Any]:
     plan_errors = validate_product_creation_plan(product_creation_plan)
     if plan_errors:
@@ -8408,6 +8443,7 @@ def build_ready_work_unit_packet_manifest(
     for work_unit_id in ready_unit_ids:
         unit = work_units[work_unit_id]
         packet_id = f"ready-work-unit-packet-{slug_for_ref(work_unit_id)}"
+        dependency_refs = _ready_work_unit_dependency_refs(product_creation_plan, work_unit_id)
         packet = {
             "packet_id": packet_id,
             "packet_type": "ready_work_unit_execution_request",
@@ -8423,7 +8459,7 @@ def build_ready_work_unit_packet_manifest(
             "expected_result": str(unit.get("expected_result") or "").strip(),
             "proof_ids_required": _list_items(unit.get("proof_ids_required")),
             "product_sot_requirement_refs": _list_items(unit.get("product_sot_requirement_refs")),
-            "dependency_refs": _ready_work_unit_dependency_refs(product_creation_plan, work_unit_id),
+            "dependency_refs": dependency_refs,
             "capability_profile_refs": _list_items(unit.get("capability_profile_refs")),
             "ready_rules": _list_items(unit.get("ready_rules")),
             "blocked_when": _list_items(unit.get("blocked_when")),
@@ -8439,6 +8475,13 @@ def build_ready_work_unit_packet_manifest(
                 "required_proof_ids": _list_items(unit.get("proof_ids_required")),
                 "reviewer_role": str(unit.get("reviewer_role") or "").strip(),
             },
+            "context_boundary": _ready_work_unit_context_boundary(
+                plan_ref=plan_ref,
+                readiness_ref=readiness_ref,
+                unit=unit,
+                dependency_refs=dependency_refs,
+                forbidden_context_refs=forbidden_context_refs,
+            ),
             "hermes_materialization": {
                 "recommended_initial_status": "blocked",
                 "block_event_required_before_dispatch": True,
@@ -8559,6 +8602,41 @@ def validate_ready_work_unit_packet_manifest(manifest: dict[str, Any]) -> list[s
         if receipt.get("complete_product_claim_allowed") is not False:
             errors.append(
                 f"ready_work_unit_packet_manifest.packets[{index}].receipt_five_contract.complete_product_claim_allowed must be false"
+            )
+        context_boundary = packet.get("context_boundary") if isinstance(packet.get("context_boundary"), dict) else {}
+        allowed_context_refs = _list_items(context_boundary.get("allowed_context_refs"))
+        forbidden_context_refs = _list_items(context_boundary.get("forbidden_context_refs"))
+        if not allowed_context_refs:
+            errors.append(f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.allowed_context_refs must not be empty")
+        _validate_lifecycle_refs(
+            allowed_context_refs,
+            f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.allowed_context_refs",
+            errors,
+        )
+        _validate_lifecycle_refs(
+            forbidden_context_refs,
+            f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.forbidden_context_refs",
+            errors,
+        )
+        if context_boundary.get("workspace_search_policy") != "bounded_refs_only":
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.workspace_search_policy must be bounded_refs_only"
+            )
+        if context_boundary.get("broad_repo_search_allowed") is not False:
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.broad_repo_search_allowed must be false"
+            )
+        if context_boundary.get("missing_context_action") != "BLOCK_WITH_OWNER":
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.missing_context_action must be BLOCK_WITH_OWNER"
+            )
+        if context_boundary.get("context_drift_action") != "BLOCK_AND_REPORT":
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.context_drift_action must be BLOCK_AND_REPORT"
+            )
+        if context_boundary.get("operator_action_required_for_missing_context") is not False:
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.operator_action_required_for_missing_context must be false"
             )
         materialization = (
             packet.get("hermes_materialization")
@@ -8689,6 +8767,7 @@ def build_ready_work_unit_hermes_materialization_plan(
             "dependency_refs": _list_items(packet.get("dependency_refs")),
             "proof_ids_required": _list_items(packet.get("proof_ids_required")),
             "receipt_five_contract": copy.deepcopy(packet.get("receipt_five_contract") or {}),
+            "context_boundary": copy.deepcopy(packet.get("context_boundary") or {}),
             "runtime_refs": {
                 "hermes_board_ref": f"hermes:{board_slug}",
                 "hermes_task_ref": "external:pending-hermes-task",
@@ -8856,6 +8935,40 @@ def validate_ready_work_unit_hermes_materialization_plan(plan: dict[str, Any]) -
         body_contract = task.get("body_contract") if isinstance(task.get("body_contract"), dict) else {}
         if body_contract.get("packet_type") != "ready_work_unit_execution_request":
             errors.append(f"ready_work_unit_hermes_materialization_plan.tasks[{index}].body_contract must be a ready work-unit packet")
+        task_context_boundary = task.get("context_boundary") if isinstance(task.get("context_boundary"), dict) else {}
+        body_context_boundary = body_contract.get("context_boundary") if isinstance(body_contract.get("context_boundary"), dict) else {}
+        if task_context_boundary != body_context_boundary:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary must match body_contract.context_boundary"
+            )
+        task_allowed_context_refs = _list_items(task_context_boundary.get("allowed_context_refs"))
+        task_forbidden_context_refs = _list_items(task_context_boundary.get("forbidden_context_refs"))
+        _validate_lifecycle_refs(
+            task_allowed_context_refs,
+            f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.allowed_context_refs",
+            errors,
+        )
+        _validate_lifecycle_refs(
+            task_forbidden_context_refs,
+            f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.forbidden_context_refs",
+            errors,
+        )
+        if task_context_boundary.get("workspace_search_policy") != "bounded_refs_only":
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.workspace_search_policy must be bounded_refs_only"
+            )
+        if task_context_boundary.get("broad_repo_search_allowed") is not False:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.broad_repo_search_allowed must be false"
+            )
+        if task_context_boundary.get("missing_context_action") != "BLOCK_WITH_OWNER":
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.missing_context_action must be BLOCK_WITH_OWNER"
+            )
+        if not task_allowed_context_refs:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.allowed_context_refs must not be empty"
+            )
         create_policy = task.get("create_policy") if isinstance(task.get("create_policy"), dict) else {}
         if create_policy.get("create_without_dispatch") is not True:
             errors.append(
@@ -14758,6 +14871,7 @@ def command_ready_work_unit_packets(args: argparse.Namespace) -> int:
                 args.product_implementation_readiness,
                 "product-implementation-readiness",
             ),
+            forbidden_context_refs=args.forbidden_context_ref,
         )
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
@@ -15398,6 +15512,12 @@ def build_parser() -> argparse.ArgumentParser:
     ready_work_unit_packets_parser.add_argument("--product-implementation-readiness", type=Path, required=True)
     ready_work_unit_packets_parser.add_argument("--created-at")
     ready_work_unit_packets_parser.add_argument("--manifest-id")
+    ready_work_unit_packets_parser.add_argument(
+        "--forbidden-context-ref",
+        action="append",
+        default=[],
+        help="Public-safe context ref that worker packets must not inspect; repeatable.",
+    )
     ready_work_unit_packets_parser.add_argument("--out", type=Path, required=True)
     ready_work_unit_packets_parser.set_defaults(func=command_ready_work_unit_packets)
 

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -8606,8 +8606,19 @@ def validate_ready_work_unit_packet_manifest(manifest: dict[str, Any]) -> list[s
         context_boundary = packet.get("context_boundary") if isinstance(packet.get("context_boundary"), dict) else {}
         allowed_context_refs = _list_items(context_boundary.get("allowed_context_refs"))
         forbidden_context_refs = _list_items(context_boundary.get("forbidden_context_refs"))
+        context_ref_conflicts = sorted(set(allowed_context_refs).intersection(forbidden_context_refs))
+        block_owner = str(context_boundary.get("block_owner") or "").strip()
         if not allowed_context_refs:
             errors.append(f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.allowed_context_refs must not be empty")
+        if context_ref_conflicts:
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary refs cannot be both allowed and forbidden: "
+                + ", ".join(context_ref_conflicts)
+            )
+        if block_owner != owner:
+            errors.append(
+                f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.block_owner must match owner_worker"
+            )
         _validate_lifecycle_refs(
             allowed_context_refs,
             f"ready_work_unit_packet_manifest.packets[{index}].context_boundary.allowed_context_refs",
@@ -8943,6 +8954,17 @@ def validate_ready_work_unit_hermes_materialization_plan(plan: dict[str, Any]) -
             )
         task_allowed_context_refs = _list_items(task_context_boundary.get("allowed_context_refs"))
         task_forbidden_context_refs = _list_items(task_context_boundary.get("forbidden_context_refs"))
+        task_context_ref_conflicts = sorted(set(task_allowed_context_refs).intersection(task_forbidden_context_refs))
+        task_block_owner = str(task_context_boundary.get("block_owner") or "").strip()
+        if task_context_ref_conflicts:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary refs cannot be both allowed and forbidden: "
+                + ", ".join(task_context_ref_conflicts)
+            )
+        if task_block_owner != owner:
+            errors.append(
+                f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.block_owner must match owner_worker"
+            )
         _validate_lifecycle_refs(
             task_allowed_context_refs,
             f"ready_work_unit_hermes_materialization_plan.tasks[{index}].context_boundary.allowed_context_refs",

--- a/templates/ready-work-unit-hermes-materialization-plan.json
+++ b/templates/ready-work-unit-hermes-materialization-plan.json
@@ -56,6 +56,22 @@
           "required_proof_ids": ["generic.scope-fit"],
           "reviewer_role": "independent-reviewer"
         },
+        "context_boundary": {
+          "allowed_context_refs": [
+            "templates/product-creation-plan.json",
+            "templates/product-implementation-readiness.json",
+            "product-sot#scope-in-001",
+            "agents/hermes-profile-bindings.public.json#implementation-worker"
+          ],
+          "forbidden_context_refs": [],
+          "workspace_search_policy": "bounded_refs_only",
+          "broad_repo_search_allowed": false,
+          "missing_context_action": "BLOCK_WITH_OWNER",
+          "context_drift_action": "BLOCK_AND_REPORT",
+          "block_owner": "implementation-worker",
+          "operator_action_required_for_missing_context": false,
+          "worker_instruction": "Use only the named allowed_context_refs and artifacts produced for this work_unit_id. If required context is missing, stale, forbidden or ambiguous, block with owner instead of searching unrelated repository history."
+        },
         "hermes_materialization": {
           "recommended_initial_status": "blocked",
           "block_event_required_before_dispatch": true,
@@ -77,6 +93,22 @@
         "complete_product_claim_allowed": false,
         "required_proof_ids": ["generic.scope-fit"],
         "reviewer_role": "independent-reviewer"
+      },
+      "context_boundary": {
+        "allowed_context_refs": [
+          "templates/product-creation-plan.json",
+          "templates/product-implementation-readiness.json",
+          "product-sot#scope-in-001",
+          "agents/hermes-profile-bindings.public.json#implementation-worker"
+        ],
+        "forbidden_context_refs": [],
+        "workspace_search_policy": "bounded_refs_only",
+        "broad_repo_search_allowed": false,
+        "missing_context_action": "BLOCK_WITH_OWNER",
+        "context_drift_action": "BLOCK_AND_REPORT",
+        "block_owner": "implementation-worker",
+        "operator_action_required_for_missing_context": false,
+        "worker_instruction": "Use only the named allowed_context_refs and artifacts produced for this work_unit_id. If required context is missing, stale, forbidden or ambiguous, block with owner instead of searching unrelated repository history."
       },
       "runtime_refs": {
         "hermes_board_ref": "external:pending-hermes-board",

--- a/templates/ready-work-unit-packets.json
+++ b/templates/ready-work-unit-packets.json
@@ -62,6 +62,22 @@
         "required_proof_ids": ["generic.scope-fit"],
         "reviewer_role": "independent-reviewer"
       },
+      "context_boundary": {
+        "allowed_context_refs": [
+          "templates/product-creation-plan.json",
+          "templates/product-implementation-readiness.json",
+          "product-sot#scope-in-001",
+          "agents/hermes-profile-bindings.public.json#implementation-worker"
+        ],
+        "forbidden_context_refs": [],
+        "workspace_search_policy": "bounded_refs_only",
+        "broad_repo_search_allowed": false,
+        "missing_context_action": "BLOCK_WITH_OWNER",
+        "context_drift_action": "BLOCK_AND_REPORT",
+        "block_owner": "implementation-worker",
+        "operator_action_required_for_missing_context": false,
+        "worker_instruction": "Use only the named allowed_context_refs and artifacts produced for this work_unit_id. If required context is missing, stale, forbidden or ambiguous, block with owner instead of searching unrelated repository history."
+      },
       "hermes_materialization": {
         "recommended_initial_status": "blocked",
         "block_event_required_before_dispatch": true,

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -926,6 +926,32 @@ class UniversalSignalIntakeTest(unittest.TestCase):
             readiness["ready_work_units"],
         )
         self.assertTrue(all(packet["receipt_five_contract"]["must_attach_artifact_refs"] for packet in manifest["packets"]))
+        for packet in manifest["packets"]:
+            context_boundary = packet["context_boundary"]
+            self.assertEqual(context_boundary["workspace_search_policy"], "bounded_refs_only")
+            self.assertFalse(context_boundary["broad_repo_search_allowed"])
+            self.assertEqual(context_boundary["missing_context_action"], "BLOCK_WITH_OWNER")
+            self.assertEqual(context_boundary["context_drift_action"], "BLOCK_AND_REPORT")
+            self.assertFalse(context_boundary["operator_action_required_for_missing_context"])
+            self.assertIn("external:sanitized-product-creation-plan", context_boundary["allowed_context_refs"])
+            self.assertIn("external:sanitized-product-implementation-readiness", context_boundary["allowed_context_refs"])
+
+    def test_ready_work_unit_packets_reject_unbounded_context_boundary(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+        manifest["packets"][0]["context_boundary"]["broad_repo_search_allowed"] = True
+        manifest["packets"][0]["context_boundary"]["workspace_search_policy"] = "search_entire_workspace"
+
+        errors = factoryctl.validate_ready_work_unit_packet_manifest(manifest)
+
+        self.assertTrue(any("broad_repo_search_allowed must be false" in error for error in errors), errors)
+        self.assertTrue(any("workspace_search_policy must be bounded_refs_only" in error for error in errors), errors)
 
     def test_ready_work_unit_packets_reject_blocked_readiness(self) -> None:
         source_resolution = factoryctl.build_source_resolution_packet(
@@ -974,6 +1000,8 @@ class UniversalSignalIntakeTest(unittest.TestCase):
                     str(plan_path),
                     "--product-implementation-readiness",
                     str(readiness_path),
+                    "--forbidden-context-ref",
+                    "external:sanitized-off-limits-parallel-thread",
                     "--out",
                     str(out_dir),
                 ]
@@ -988,6 +1016,12 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertEqual(validate_result, 0)
         self.assertEqual(manifest["record_type"], "ready_work_unit_packet_manifest")
         self.assertEqual(len(manifest["packets"]), len(readiness["ready_work_units"]))
+        self.assertTrue(
+            all(
+                "external:sanitized-off-limits-parallel-thread" in packet["context_boundary"]["forbidden_context_refs"]
+                for packet in manifest["packets"]
+            )
+        )
 
     def test_ready_work_unit_hermes_plan_from_packets_is_valid_and_blocked_first(self) -> None:
         plan = build_valid_product_creation_plan()
@@ -1031,10 +1065,41 @@ class UniversalSignalIntakeTest(unittest.TestCase):
                 for task in materialization["tasks"]
             )
         )
+        self.assertTrue(
+            all(task["context_boundary"] == task["body_contract"]["context_boundary"] for task in materialization["tasks"])
+        )
+        self.assertTrue(
+            all(task["context_boundary"]["workspace_search_policy"] == "bounded_refs_only" for task in materialization["tasks"])
+        )
+        self.assertTrue(
+            all(task["context_boundary"]["broad_repo_search_allowed"] is False for task in materialization["tasks"])
+        )
         self.assertEqual(
             [task["work_unit_id"] for task in materialization["tasks"]],
             [packet["work_unit_id"] for packet in manifest["packets"]],
         )
+
+    def test_ready_work_unit_hermes_plan_rejects_context_boundary_mismatch(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+        materialization = factoryctl.build_ready_work_unit_hermes_materialization_plan(
+            manifest,
+            board="overkill-factory-live",
+            ready_work_unit_packet_manifest_ref="external:sanitized-ready-work-unit-packets",
+        )
+
+        materialization["tasks"][0]["context_boundary"]["broad_repo_search_allowed"] = True
+
+        errors = factoryctl.validate_ready_work_unit_hermes_materialization_plan(materialization)
+
+        self.assertTrue(any("context_boundary must match body_contract.context_boundary" in error for error in errors), errors)
+        self.assertTrue(any("broad_repo_search_allowed must be false" in error for error in errors), errors)
 
     def test_ready_work_unit_hermes_plan_rejects_dispatch_without_runtime_gate(self) -> None:
         plan = build_valid_product_creation_plan()

--- a/tests/test_universal_signal_intake.py
+++ b/tests/test_universal_signal_intake.py
@@ -953,6 +953,24 @@ class UniversalSignalIntakeTest(unittest.TestCase):
         self.assertTrue(any("broad_repo_search_allowed must be false" in error for error in errors), errors)
         self.assertTrue(any("workspace_search_policy must be bounded_refs_only" in error for error in errors), errors)
 
+    def test_ready_work_unit_packets_reject_context_boundary_conflicts_and_bad_owner(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+        conflict_ref = manifest["packets"][0]["context_boundary"]["allowed_context_refs"][0]
+        manifest["packets"][0]["context_boundary"]["forbidden_context_refs"].append(conflict_ref)
+        manifest["packets"][0]["context_boundary"]["block_owner"] = "not-a-real-worker"
+
+        errors = factoryctl.validate_ready_work_unit_packet_manifest(manifest)
+
+        self.assertTrue(any("refs cannot be both allowed and forbidden" in error for error in errors), errors)
+        self.assertTrue(any("block_owner must match owner_worker" in error for error in errors), errors)
+
     def test_ready_work_unit_packets_reject_blocked_readiness(self) -> None:
         source_resolution = factoryctl.build_source_resolution_packet(
             signal_intake(),
@@ -1100,6 +1118,31 @@ class UniversalSignalIntakeTest(unittest.TestCase):
 
         self.assertTrue(any("context_boundary must match body_contract.context_boundary" in error for error in errors), errors)
         self.assertTrue(any("broad_repo_search_allowed must be false" in error for error in errors), errors)
+
+    def test_ready_work_unit_hermes_plan_rejects_context_boundary_conflicts_and_bad_owner(self) -> None:
+        plan = build_valid_product_creation_plan()
+        readiness = factoryctl.build_product_implementation_readiness(plan)
+        manifest = factoryctl.build_ready_work_unit_packet_manifest(
+            plan,
+            readiness,
+            product_creation_plan_ref="external:sanitized-product-creation-plan",
+            product_implementation_readiness_ref="external:sanitized-product-implementation-readiness",
+        )
+        materialization = factoryctl.build_ready_work_unit_hermes_materialization_plan(
+            manifest,
+            board="overkill-factory-live",
+            ready_work_unit_packet_manifest_ref="external:sanitized-ready-work-unit-packets",
+        )
+        conflict_ref = materialization["tasks"][0]["context_boundary"]["allowed_context_refs"][0]
+        materialization["tasks"][0]["context_boundary"]["forbidden_context_refs"].append(conflict_ref)
+        materialization["tasks"][0]["body_contract"]["context_boundary"]["forbidden_context_refs"].append(conflict_ref)
+        materialization["tasks"][0]["context_boundary"]["block_owner"] = "not-a-real-worker"
+        materialization["tasks"][0]["body_contract"]["context_boundary"]["block_owner"] = "not-a-real-worker"
+
+        errors = factoryctl.validate_ready_work_unit_hermes_materialization_plan(materialization)
+
+        self.assertTrue(any("refs cannot be both allowed and forbidden" in error for error in errors), errors)
+        self.assertTrue(any("block_owner must match owner_worker" in error for error in errors), errors)
 
     def test_ready_work_unit_hermes_plan_rejects_dispatch_without_runtime_gate(self) -> None:
         plan = build_valid_product_creation_plan()


### PR DESCRIPTION
Fixes #326.

## Summary
- Add a required `context_boundary` to ready work-unit packets so workers receive explicit allowed context refs, forbidden context refs, bounded search policy, and fail-closed missing-context behavior.
- Copy the same context boundary into Hermes materialization tasks and validate that the top-level task boundary matches `body_contract.context_boundary`.
- Add CLI support for repeatable `--forbidden-context-ref` values and update public templates/docs/tests.

## Validation
- `python -m unittest tests.test_universal_signal_intake -q`
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` (799 tests)
- `git diff --check`