### PR TITLE
Respect ready work-unit release waves

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -35,6 +35,7 @@ ROUTE_READINESS_SCHEMA = "https://overkill-factory.dev/schemas/hermes-worker-rou
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 RECOVERY_ATTEMPT_MARKER = "factory_recovery_attempt"
 ACTIVE_OR_TERMINAL_STATUSES = {"ready", "running", "done", "complete", "completed"}
+READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES = {"done", "complete", "completed"}
 HISTORY_SOURCE_KEYS = ("events", "history", "timeline", "comments", "runs")
 CONTRACT_DIGEST_ALGORITHM = "sha256"
 IDEMPOTENCY_DIGEST_LENGTH = 16
@@ -1385,30 +1386,89 @@ def verify_ready_work_unit_release_candidate(
     return task_id, packet_id, work_unit_id
 
 
-def blocked_ready_work_unit_readbacks(
+def verify_ready_work_unit_identity(
+    *,
+    payload: dict[str, Any],
+    plan_task: dict[str, Any],
+    worker_assignee_prefix: str,
+) -> tuple[str, str, str]:
+    task_id = task_readback_id(payload)
+    if not task_id:
+        raise RuntimeError("Hermes task readback has no task id")
+    packet_id, work_unit_id = expected_ready_work_unit_key(plan_task)
+    expected_assignee = ready_work_unit_release_assignee(plan_task, worker_assignee_prefix)
+    if task_readback_assignee(payload) != expected_assignee:
+        raise RuntimeError(f"Hermes task {task_id} assignee readback does not match target profile")
+    body = ready_work_unit_body(payload, task_id=task_id)
+    if str(body.get("packet_id") or "").strip() != packet_id:
+        raise RuntimeError(f"Hermes task {task_id} body readback does not match ready work-unit packet")
+    if str(body.get("work_unit_id") or "").strip() != work_unit_id:
+        raise RuntimeError(f"Hermes task {task_id} body readback does not match ready work-unit id")
+    if str(body.get("packet_type") or "").strip() != "ready_work_unit_execution_request":
+        raise RuntimeError(f"Hermes task {task_id} body readback is not a ready work-unit execution request")
+    return task_id, packet_id, work_unit_id
+
+
+def ready_work_unit_dependencies(tasks: list[dict[str, Any]]) -> dict[str, list[str]]:
+    work_unit_ids = {
+        str(task.get("work_unit_id") or "").strip()
+        for task in tasks
+        if str(task.get("work_unit_id") or "").strip()
+    }
+    dependencies: dict[str, set[str]] = {work_unit_id: set() for work_unit_id in work_unit_ids}
+    for task in tasks:
+        body = task.get("body_contract") if isinstance(task.get("body_contract"), dict) else {}
+        context_packet = body.get("work_unit_context_packet") if isinstance(body.get("work_unit_context_packet"), dict) else {}
+        embedded = context_packet.get("embedded_payloads") if isinstance(context_packet.get("embedded_payloads"), dict) else {}
+        product_plan = embedded.get("product_creation_plan") if isinstance(embedded.get("product_creation_plan"), dict) else {}
+        graph = product_plan.get("dependency_graph") if isinstance(product_plan.get("dependency_graph"), list) else []
+        for edge in graph:
+            if not isinstance(edge, dict):
+                continue
+            source = str(edge.get("from") or "").strip()
+            target = str(edge.get("to") or "").strip()
+            if source in work_unit_ids and target in work_unit_ids:
+                dependencies.setdefault(target, set()).add(source)
+    if any(dependencies.values()):
+        return {work_unit_id: sorted(deps) for work_unit_id, deps in sorted(dependencies.items())}
+
+    for task in tasks:
+        work_unit_id = str(task.get("work_unit_id") or "").strip()
+        body = task.get("body_contract") if isinstance(task.get("body_contract"), dict) else {}
+        refs = body.get("dependency_refs") if isinstance(body.get("dependency_refs"), list) else []
+        for ref in refs:
+            dep = str(ref or "").strip()
+            if dep in work_unit_ids and dep != work_unit_id:
+                dependencies.setdefault(work_unit_id, set()).add(dep)
+    return {work_unit_id: sorted(deps) for work_unit_id, deps in sorted(dependencies.items())}
+
+
+def ready_work_unit_readbacks_by_status(
     *,
     hermes_bin: str,
     board: str,
+    statuses: list[str],
     runner: Runner = default_runner,
 ) -> dict[tuple[str, str], list[dict[str, Any]]]:
     candidates: dict[tuple[str, str], list[dict[str, Any]]] = {}
     seen_task_ids: set[str] = set()
-    for record in list_tasks_by_status(hermes_bin=hermes_bin, board=board, status="blocked", runner=runner):
-        task_id = str(record.get("task_id") or record.get("id") or "").strip()
-        if not task_id or task_id in seen_task_ids:
-            continue
-        seen_task_ids.add(task_id)
-        payload = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
-        try:
-            body = ready_work_unit_body(payload, task_id=task_id)
-        except RuntimeError:
-            continue
-        if str(body.get("packet_type") or "").strip() != "ready_work_unit_execution_request":
-            continue
-        packet_id = str(body.get("packet_id") or "").strip()
-        work_unit_id = str(body.get("work_unit_id") or "").strip()
-        if packet_id and work_unit_id:
-            candidates.setdefault((packet_id, work_unit_id), []).append(payload)
+    for status in statuses:
+        for record in list_tasks_by_status(hermes_bin=hermes_bin, board=board, status=status, runner=runner):
+            task_id = str(record.get("task_id") or record.get("id") or "").strip()
+            if not task_id or task_id in seen_task_ids:
+                continue
+            seen_task_ids.add(task_id)
+            payload = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+            try:
+                body = ready_work_unit_body(payload, task_id=task_id)
+            except RuntimeError:
+                continue
+            if str(body.get("packet_type") or "").strip() != "ready_work_unit_execution_request":
+                continue
+            packet_id = str(body.get("packet_id") or "").strip()
+            work_unit_id = str(body.get("work_unit_id") or "").strip()
+            if packet_id and work_unit_id:
+                candidates.setdefault((packet_id, work_unit_id), []).append(payload)
     return candidates
 
 
@@ -1433,21 +1493,59 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
     if readiness_blockers:
         raise RuntimeError("pre-dispatch route readiness blocked ready work-unit release: " + "; ".join(readiness_blockers))
 
-    candidates = blocked_ready_work_unit_readbacks(hermes_bin=args.hermes_bin, board=board, runner=runner)
-    verified: list[tuple[dict[str, Any], str, str, str]] = []
+    candidates = ready_work_unit_readbacks_by_status(
+        hermes_bin=args.hermes_bin,
+        board=board,
+        statuses=["blocked", *sorted(READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES)],
+        runner=runner,
+    )
+    verified: list[tuple[dict[str, Any], str, str, str, str]] = []
     for task in tasks:
         key = expected_ready_work_unit_key(task)
         matches = candidates.get(key) or []
         if len(matches) != 1:
             raise RuntimeError(
-                f"ready work-unit release expected exactly one blocked Hermes task for packet {key[0]} / work unit {key[1]}, found {len(matches)}"
+                f"ready work-unit release expected exactly one blocked or completed Hermes task for packet {key[0]} / work unit {key[1]}, found {len(matches)}"
             )
-        task_id, packet_id, work_unit_id = verify_ready_work_unit_release_candidate(
-            payload=matches[0],
-            plan_task=task,
-            worker_assignee_prefix=args.worker_assignee_prefix,
-        )
-        verified.append((task, task_id, packet_id, work_unit_id))
+        status = task_readback_status(matches[0])
+        if status == "blocked":
+            task_id, packet_id, work_unit_id = verify_ready_work_unit_release_candidate(
+                payload=matches[0],
+                plan_task=task,
+                worker_assignee_prefix=args.worker_assignee_prefix,
+            )
+        elif status in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES:
+            task_id, packet_id, work_unit_id = verify_ready_work_unit_identity(
+                payload=matches[0],
+                plan_task=task,
+                worker_assignee_prefix=args.worker_assignee_prefix,
+            )
+        else:
+            raise RuntimeError(f"Hermes task for ready work unit {key[1]} is not releasable or satisfied: {status}")
+        verified.append((task, task_id, packet_id, work_unit_id, status))
+
+    dependencies = ready_work_unit_dependencies(tasks)
+    status_by_work_unit = {work_unit_id: status for _task, _task_id, _packet_id, work_unit_id, status in verified}
+    satisfied_work_unit_ids = sorted(
+        work_unit_id
+        for work_unit_id, status in status_by_work_unit.items()
+        if status in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES
+    )
+    dependency_blockers: dict[str, list[str]] = {}
+    eligible: list[tuple[dict[str, Any], str, str, str, str]] = []
+    for item in verified:
+        _task, _task_id, _packet_id, work_unit_id, status = item
+        if status != "blocked":
+            continue
+        blockers = [
+            dep
+            for dep in dependencies.get(work_unit_id, [])
+            if status_by_work_unit.get(dep) not in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES
+        ]
+        if blockers:
+            dependency_blockers[work_unit_id] = blockers
+            continue
+        eligible.append(item)
 
     released_ready_work_unit_task_ids: dict[str, str] = {}
     released_packet_task_ids: dict[str, str] = {}
@@ -1461,7 +1559,7 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
         "dispatch_separate=true",
     ]
     if not args.dry_run:
-        for _task, task_id, packet_id, work_unit_id in verified:
+        for _task, task_id, packet_id, work_unit_id, _status in eligible:
             unblock_task(
                 hermes_bin=args.hermes_bin,
                 board=board,
@@ -1481,19 +1579,28 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
         "materialization_plan_id": plan.get("plan_id"),
         "ready_work_unit_task_ids": {
             work_unit_id: task_id
-            for _task, task_id, _packet_id, work_unit_id in verified
+            for _task, task_id, _packet_id, work_unit_id, _status in verified
         },
         "packet_task_ids": {
             packet_id: task_id
-            for _task, task_id, packet_id, _work_unit_id in verified
+            for _task, task_id, packet_id, _work_unit_id, _status in verified
         },
         "released_ready_work_unit_task_ids": released_ready_work_unit_task_ids,
         "released_packet_task_ids": released_packet_task_ids,
+        "release_wave": {
+            "eligible_work_unit_ids": sorted(work_unit_id for _task, _task_id, _packet_id, work_unit_id, _status in eligible),
+            "held_work_unit_ids": sorted(dependency_blockers.keys()),
+            "satisfied_work_unit_ids": satisfied_work_unit_ids,
+            "dependency_blockers": {key: dependency_blockers[key] for key in sorted(dependency_blockers)},
+        },
         "runtime_gate": {
             **(plan.get("runtime_gate") if isinstance(plan.get("runtime_gate"), dict) else {}),
             "release_verified_task_count": len(verified),
+            "release_eligible_task_count": len(eligible),
+            "release_held_task_count": len(dependency_blockers),
+            "release_satisfied_task_count": len(satisfied_work_unit_ids),
             "dispatch_allowed_by_this_step": False,
-            "native_dispatch_required_next": not args.dry_run,
+            "native_dispatch_required_next": bool(released_ready_work_unit_task_ids),
             "complete_product_claim_allowed": False,
             "runtime_authority": "hermes_kanban",
             "local_state_authority": False,

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import subprocess
@@ -303,6 +304,44 @@ def write_route_readiness(path: Path, extra_workers: list[str] | None = None) ->
         ),
         encoding="utf-8",
     )
+
+
+def two_step_ready_work_unit_plan() -> dict[str, object]:
+    plan = factoryctl.load_json_like(ROOT / "templates" / "ready-work-unit-hermes-materialization-plan.json")
+    first = copy.deepcopy(plan["tasks"][0])
+    second = copy.deepcopy(plan["tasks"][0])
+
+    first["work_unit_id"] = "work-unit-001"
+    first["packet_id"] = "ready-work-unit-packet-work-unit-001"
+    first["idempotency_key"] = "overkill:test:work-unit-001"
+    first["body_contract"]["work_unit_id"] = "work-unit-001"
+    first["body_contract"]["packet_id"] = "ready-work-unit-packet-work-unit-001"
+    first["body_contract"]["dependency_refs"] = []
+    first["body_contract"]["work_unit_context_packet"]["work_unit_id"] = "work-unit-001"
+    first["body_contract"]["work_unit_context_packet"]["embedded_payloads"]["current_work_unit"]["unit_id"] = "work-unit-001"
+
+    second["work_unit_id"] = "work-unit-002"
+    second["packet_id"] = "ready-work-unit-packet-work-unit-002"
+    second["idempotency_key"] = "overkill:test:work-unit-002"
+    second["title"] = "OF ready work unit work-unit-002"
+    second["body_contract"]["work_unit_id"] = "work-unit-002"
+    second["body_contract"]["packet_id"] = "ready-work-unit-packet-work-unit-002"
+    second["body_contract"]["dependency_refs"] = ["work-unit-001"]
+    second["body_contract"]["work_unit_context_packet"]["work_unit_id"] = "work-unit-002"
+    second["body_contract"]["work_unit_context_packet"]["embedded_payloads"]["current_work_unit"]["unit_id"] = "work-unit-002"
+
+    for task in (first, second):
+        product_plan = task["body_contract"]["work_unit_context_packet"]["embedded_payloads"]["product_creation_plan"]
+        product_plan["execution_order"] = ["work-unit-001", "work-unit-002"]
+        product_plan["dependency_graph"] = [{"from": "work-unit-001", "to": "work-unit-002"}]
+        task["body_contract"]["work_unit_context_packet"]["embedded_payloads"]["current_work_unit"][
+            "dependency_refs"
+        ] = list(task["body_contract"].get("dependency_refs") or [])
+        task["work_unit_context_packet"] = task["body_contract"]["work_unit_context_packet"]
+
+    plan["tasks"] = [first, second]
+    plan["acceptance"]["task_count"] = 2
+    return plan
 
 
 def materialize_template_ready_work_unit(
@@ -667,6 +706,102 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertEqual(unblock_calls, [])
 
+    def test_release_ready_work_units_releases_only_first_dependency_wave(self) -> None:
+        fake = FakeHermes()
+        plan = two_step_ready_work_unit_plan()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            materialization_result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["decomposition-planner", "implementation-worker"])
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                ]
+            )
+            materialization_result = adapter.materialize_ready_work_units(args, runner=fake)
+            materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            result = adapter.release_ready_work_units(release_args, runner=fake)
+
+        self.assertEqual(result["released_ready_work_unit_task_ids"], {"work-unit-001": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertEqual(result["release_wave"]["eligible_work_unit_ids"], ["work-unit-001"])
+        self.assertEqual(result["release_wave"]["held_work_unit_ids"], ["work-unit-002"])
+        self.assertEqual(result["release_wave"]["dependency_blockers"], {"work-unit-002": ["work-unit-001"]})
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(len(unblock_calls), 1)
+        released_task = next(task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-001")
+        held_task = next(task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-002")
+        self.assertEqual(released_task["status"], "ready")
+        self.assertEqual(held_task["status"], "blocked")
+
+    def test_release_ready_work_units_releases_downstream_after_dependency_done(self) -> None:
+        fake = FakeHermes()
+        plan = two_step_ready_work_unit_plan()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            materialization_result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["decomposition-planner", "implementation-worker"])
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                ]
+            )
+            materialization_result = adapter.materialize_ready_work_units(args, runner=fake)
+            materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+            upstream_task = next(
+                task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-001"
+            )
+            upstream_task["status"] = "done"
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            result = adapter.release_ready_work_units(release_args, runner=fake)
+
+        self.assertEqual(result["released_ready_work_unit_task_ids"], {"work-unit-002": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertEqual(result["release_wave"]["eligible_work_unit_ids"], ["work-unit-002"])
+        self.assertEqual(result["release_wave"]["satisfied_work_unit_ids"], ["work-unit-001"])
+        self.assertEqual(result["release_wave"]["held_work_unit_ids"], [])
+        unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
+        self.assertEqual(len(unblock_calls), 1)
+        released_task = next(task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-002")
+        self.assertEqual(released_task["status"], "ready")
+
     def test_release_ready_work_units_rejects_ambiguous_matching_tasks(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:
@@ -689,7 +824,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 ]
             )
 
-            with self.assertRaisesRegex(RuntimeError, "expected exactly one blocked Hermes task"):
+            with self.assertRaisesRegex(RuntimeError, "expected exactly one blocked or completed Hermes task"):
                 adapter.release_ready_work_units(args, runner=fake)
 
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]


### PR DESCRIPTION
## Summary

Fixes #332.

This PR prevents the Hermes adapter from releasing every materialized ready work unit in one pass when the Product Creation Plan contains internal dependency edges.

## What changed

- Reads internal ready work-unit dependency edges from embedded Product Creation Plan dependency graphs.
- Classifies release candidates as satisfied, eligible, or held.
- Releases only the current eligible wave.
- Keeps downstream work units blocked until upstream dependencies are `done`, `complete`, or `completed`.
- Allows a later release pass to release downstream work once upstream evidence is terminal.
- Reports `release_wave` details in the adapter result.

## Why

Live dogfooding showed WU2/WU3/WU4 could be spawned before WU1 had produced and reviewed gate evidence. That breaks the factory's gear-like execution model: downstream work must not outrun the graph.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`