### PR TITLE
Honor legal ready work-unit release during recovery

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -56,6 +56,11 @@ READY_WORK_UNIT_CONTEXT_CHUNK_AUTHOR = "overkill-factory-context"
 READY_WORK_UNIT_CONTEXT_CHUNK_SIZE = 5000
 READY_WORK_UNIT_SUPERSESSION_MARKER = "ready_work_unit_superseded"
 READY_WORK_UNIT_RECOVERY_AUTHOR = "overkill-factory-recovery"
+READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS = [
+    "runtime_gate=blocked_event_verified_for_each_task",
+    "release_scope=ready_work_units_only",
+    "dispatch_separate=true",
+]
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 WORKER_MATERIALIZATION_CONTRACT_FIELDS = (
     "task_type",
@@ -1584,11 +1589,7 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
         args.reason
         or "runtime_gate=blocked_event_verified_for_each_task; release_scope=ready_work_units_only; dispatch_separate=true"
     )
-    required_markers = [
-        "runtime_gate=blocked_event_verified_for_each_task",
-        "release_scope=ready_work_units_only",
-        "dispatch_separate=true",
-    ]
+    required_markers = READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS
     if not args.dry_run:
         for _task, task_id, packet_id, work_unit_id, _status in eligible:
             unblock_task(
@@ -1778,6 +1779,16 @@ def recover_ready_work_units(args: argparse.Namespace, runner: Runner = default_
         include_superseded=True,
         runner=runner,
     )
+    dependencies = ready_work_unit_dependencies(tasks)
+    active_status_by_work_unit: dict[str, str] = {}
+    for task in tasks:
+        key = expected_ready_work_unit_key(task)
+        matches = candidates.get(key) or []
+        active_matches = [
+            payload for payload in matches if not task_has_ready_work_unit_supersession(payload)
+        ]
+        if active_matches:
+            active_status_by_work_unit[key[1]] = task_readback_status(active_matches[0])
     recovery_plan: dict[str, Any] = {}
     replacement_ready_work_unit_task_ids: dict[str, str] = {}
     superseded_ready_work_unit_task_ids: dict[str, list[str]] = {}
@@ -1803,9 +1814,21 @@ def recover_ready_work_units(args: argparse.Namespace, runner: Runner = default_
 
         contaminated: list[tuple[dict[str, Any], list[str]]] = []
         clean_blocked: list[dict[str, Any]] = []
+        dependency_blockers = [
+            dep
+            for dep in dependencies.get(work_unit_id, [])
+            if active_status_by_work_unit.get(dep) not in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES
+        ]
         for payload in active_matches:
             markers = ready_work_unit_contamination_markers(payload)
-            if markers:
+            legal_release_seen = history_contains_markers(
+                payload,
+                READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS,
+            ) or task_has_unblocked_event(
+                payload,
+                required_markers=READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS,
+            )
+            if markers and (dependency_blockers or not legal_release_seen):
                 contaminated.append((payload, markers))
             elif task_readback_status(payload) == "blocked":
                 clean_blocked.append(payload)
@@ -1816,6 +1839,7 @@ def recover_ready_work_units(args: argparse.Namespace, runner: Runner = default_
                 "packet_id": packet_id,
                 "status": "clean_no_recovery_needed",
                 "active_task_count": len(active_matches),
+                "dependency_blockers": dependency_blockers,
             }
             continue
 

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -792,6 +792,52 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertEqual(len(unblock_calls), 1)
 
+    def test_recover_ready_work_units_does_not_supersede_legally_released_blocked_first_wave(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            task_id = next(iter(fake.tasks))
+            fake.tasks[task_id]["status"] = "blocked"
+            fake.tasks[task_id].setdefault("events", []).append({"kind": "claimed"})
+            fake.tasks[task_id].setdefault("runs", []).append({"status": "blocked", "outcome": "blocked"})
+            recover_args = adapter.build_parser().parse_args(
+                [
+                    "recover-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                ]
+            )
+            recovery = adapter.recover_ready_work_units(recover_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, recovery)
+        self.assertEqual(recovery["runtime_gate"]["superseded_task_count"], 0)
+        self.assertEqual(recovery["runtime_gate"]["clean_task_count"], 1)
+        self.assertEqual(recovery["recovery_plan"]["work-unit-001"]["status"], "clean_no_recovery_needed")
+        self.assertFalse(
+            any(
+                adapter.READY_WORK_UNIT_SUPERSESSION_MARKER in str(comment.get("body") or "")
+                for comment in fake.tasks[task_id].get("comments", [])
+            )
+        )
+
     def test_release_ready_work_units_releases_only_first_dependency_wave(self) -> None:
         fake = FakeHermes()
         plan = two_step_ready_work_unit_plan()


### PR DESCRIPTION
## Summary
- refine ready work-unit recovery so legally released first-wave work that later blocks for repair/review is not superseded
- keep supersession for runtime activity without legal release markers or with unsatisfied dependency-wave blockers
- add regression coverage for a legally released blocked first-wave task

Closes #325

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `git diff --check`

## Public Safety
No private runtime evidence, screenshots, local paths, raw logs, or issue #84 artifacts were added.