### PR TITLE
Validate ready work-unit recovery replacements

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -656,6 +656,25 @@ def ensure_ready_work_unit_readback_contract(
     ensure_no_pre_dispatch_activity(payload, task_id=task_id)
 
 
+def ready_work_unit_readback_contract_error(
+    *,
+    payload: dict[str, Any],
+    task_id: str,
+    expected_assignee: str,
+    expected_packet_id: str,
+) -> str | None:
+    try:
+        ensure_ready_work_unit_readback_contract(
+            payload=payload,
+            task_id=task_id,
+            expected_assignee=expected_assignee,
+            expected_packet_id=expected_packet_id,
+        )
+    except RuntimeError as exc:
+        return str(exc)
+    return None
+
+
 def ready_work_unit_body_transport_comments(*, payload: dict[str, Any], task_id: str, manifest: dict[str, Any]) -> list[str]:
     transport = manifest.get("context_transport")
     if not isinstance(transport, dict):
@@ -1828,10 +1847,21 @@ def recover_ready_work_units(args: argparse.Namespace, runner: Runner = default_
                 payload,
                 required_markers=READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS,
             )
-            if markers and (dependency_blockers or not legal_release_seen):
-                contaminated.append((payload, markers))
-            elif task_readback_status(payload) == "blocked":
-                clean_blocked.append(payload)
+            if markers:
+                if dependency_blockers or not legal_release_seen:
+                    contaminated.append((payload, markers))
+                continue
+            if task_readback_status(payload) == "blocked":
+                contract_error = ready_work_unit_readback_contract_error(
+                    payload=payload,
+                    task_id=task_readback_id(payload),
+                    expected_assignee=ready_work_unit_release_assignee(task, args.worker_assignee_prefix),
+                    expected_packet_id=packet_id,
+                )
+                if contract_error:
+                    contaminated.append((payload, ["invalid_blocked_replacement_contract"]))
+                else:
+                    clean_blocked.append(payload)
 
         if not contaminated:
             clean_work_unit_ids.append(work_unit_id)
@@ -1866,8 +1896,15 @@ def recover_ready_work_units(args: argparse.Namespace, runner: Runner = default_
             )
             replacement_ready_work_unit_task_ids[work_unit_id] = replacement_task_id
 
+        superseded_task_ids_for_plan = [
+            task_id
+            for task_id in contaminated_task_ids
+            if not replacement_task_id or task_id != replacement_task_id
+        ]
         if args.create_replacements or clean_blocked:
             for payload, markers in contaminated:
+                if task_readback_id(payload) == replacement_task_id:
+                    continue
                 mark_ready_work_unit_superseded(
                     hermes_bin=args.hermes_bin,
                     board=board,
@@ -1877,11 +1914,11 @@ def recover_ready_work_units(args: argparse.Namespace, runner: Runner = default_
                     contamination_markers=markers,
                     runner=runner,
                 )
-        superseded_ready_work_unit_task_ids[work_unit_id] = contaminated_task_ids
+        superseded_ready_work_unit_task_ids[work_unit_id] = superseded_task_ids_for_plan
         recovery_plan[work_unit_id] = {
             "packet_id": packet_id,
             "status": "replacement_created" if replacement_task_id and args.create_replacements else "replacement_planned",
-            "contaminated_task_refs": contaminated_task_ids,
+            "contaminated_task_refs": superseded_task_ids_for_plan,
             "contamination_markers": contamination_markers,
             "replacement_task_ref": replacement_task_id,
             "replacement_idempotency_key": replacement_task["idempotency_key"],

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -792,6 +792,70 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertEqual(len(unblock_calls), 1)
 
+    def test_recover_ready_work_units_repairs_incomplete_existing_replacement(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            contaminated_task_id = next(iter(fake.tasks))
+            fake.tasks[contaminated_task_id].setdefault("runs", []).append({"status": "reclaimed"})
+            replacement_task = adapter.replacement_ready_work_unit_task(
+                plan_task=plan["tasks"][0],
+                contaminated_task_ids=[contaminated_task_id],
+                contamination_markers=["run:reclaimed"],
+            )
+            partial_replacement_task_id = adapter.create_ready_work_unit_task(
+                hermes_bin="hermes",
+                board=TEST_BOARD,
+                task=replacement_task,
+                worker_assignee_prefix="",
+                workspace_ref="scratch",
+                runner=fake,
+            )
+            fake.tasks[partial_replacement_task_id]["assignee"] = None
+            recover_args = adapter.build_parser().parse_args(
+                [
+                    "recover-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                    "--create-replacements",
+                ]
+            )
+            recovery = adapter.recover_ready_work_units(recover_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, recovery)
+        self.assertEqual(recovery["runtime_gate"]["replacement_created_count"], 1)
+        self.assertIn(
+            adapter.READY_WORK_UNIT_SUPERSESSION_MARKER,
+            fake.tasks[contaminated_task_id]["comments"][0]["body"],
+        )
+        partial_comments = fake.tasks[partial_replacement_task_id].get("comments", [])
+        partial_repaired_or_superseded = (
+            fake.tasks[partial_replacement_task_id]["assignee"] == "implementation-worker"
+            or any(adapter.READY_WORK_UNIT_SUPERSESSION_MARKER in str(comment.get("body") or "") for comment in partial_comments)
+        )
+        self.assertTrue(partial_repaired_or_superseded)
+        self.assertTrue(
+            any(
+                task_id != contaminated_task_id
+                and str(task.get("assignee") or "") == "implementation-worker"
+                and not any(
+                    adapter.READY_WORK_UNIT_SUPERSESSION_MARKER in str(comment.get("body") or "")
+                    for comment in task.get("comments", [])
+                )
+                for task_id, task in fake.tasks.items()
+            )
+        )
+
     def test_recover_ready_work_units_does_not_supersede_legally_released_blocked_first_wave(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Closes #336.

This fixes a ready work-unit recovery edge found during Cockpit dogfooding: a blocked replacement task is no longer considered clean merely because its status is `blocked`.

Recovery now reuses an existing blocked replacement only when it passes the same readback contract required after creation:

- blocked status
- expected assignee
- expected packet id
- reconstructable ready work-unit body/context transport
- digest-valid context chunks when chunk transport is used
- no pre-dispatch activity before legal release

If a replacement is incomplete, recovery treats it as unsafe and either completes a safe idempotent replacement path or supersedes the incomplete attempt with a clean replacement. Legally released first-wave work that later blocks for repair/review remains protected and is not misclassified as contaminated.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m unittest tests.test_universal_signal_intake -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q` (814 tests)

## Public/private boundary

No private Cockpit input, local runtime evidence, screenshots, local paths, raw logs, or dogfooding artifacts are committed.