### PR TITLE
Tighten ready work-unit supersession detection

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -615,11 +615,20 @@ def pre_dispatch_activity_markers(payload: dict[str, Any]) -> list[str]:
 
 def task_has_ready_work_unit_supersession(payload: dict[str, Any]) -> bool:
     for comment in task_readback_comments(payload):
+        if str(comment.get("author") or "").strip() != READY_WORK_UNIT_RECOVERY_AUTHOR:
+            continue
         raw_body = str(comment.get("body") or comment.get("text") or comment.get("content") or "")
-        if READY_WORK_UNIT_SUPERSESSION_MARKER in raw_body:
+        try:
+            body = json.loads(raw_body)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(body, dict) and body.get("marker") == READY_WORK_UNIT_SUPERSESSION_MARKER:
             return True
     for event in task_readback_events(payload):
-        if READY_WORK_UNIT_SUPERSESSION_MARKER in str(event):
+        if not isinstance(event, dict):
+            continue
+        event_body = event.get("payload")
+        if isinstance(event_body, dict) and event_body.get("marker") == READY_WORK_UNIT_SUPERSESSION_MARKER:
             return True
     return False
 

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -792,6 +792,37 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertEqual(len(unblock_calls), 1)
 
+    def test_ready_work_unit_supersession_ignores_replacement_lineage_context(self) -> None:
+        payload = {
+            "comments": [
+                {
+                    "author": adapter.READY_WORK_UNIT_CONTEXT_CHUNK_AUTHOR,
+                    "body": json.dumps(
+                        {
+                            "context_transport": adapter.READY_WORK_UNIT_CONTEXT_TRANSPORT_MODE,
+                            "data": json.dumps(
+                                {
+                                    "runtime_lineage": {
+                                        "lineage_type": "ready_work_unit_supersession",
+                                        "supersession_marker": adapter.READY_WORK_UNIT_SUPERSESSION_MARKER,
+                                    }
+                                }
+                            ),
+                        }
+                    ),
+                }
+            ]
+        }
+        self.assertFalse(adapter.task_has_ready_work_unit_supersession(payload))
+
+        payload["comments"].append(
+            {
+                "author": adapter.READY_WORK_UNIT_RECOVERY_AUTHOR,
+                "body": json.dumps({"marker": adapter.READY_WORK_UNIT_SUPERSESSION_MARKER}),
+            }
+        )
+        self.assertTrue(adapter.task_has_ready_work_unit_supersession(payload))
+
     def test_recover_ready_work_units_repairs_incomplete_existing_replacement(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Closes #338.

Ready work-unit supersession detection now requires an explicit recovery-owned JSON marker instead of scanning for the marker string anywhere in task comments/events.

This prevents clean replacement tasks from becoming invisible merely because their context payload includes `runtime_lineage.supersession_marker` to describe what they replace.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q` (815 tests)

## Public/private boundary

No private Cockpit input, raw runtime dumps, screenshots, local paths, or dogfooding artifacts are committed.