### PR TITLE
Query supported Hermes statuses for ready work release

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -37,6 +37,7 @@ Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 RECOVERY_ATTEMPT_MARKER = "factory_recovery_attempt"
 ACTIVE_OR_TERMINAL_STATUSES = {"ready", "running", "done", "complete", "completed"}
 READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES = {"done", "complete", "completed"}
+READY_WORK_UNIT_RELEASE_QUERY_STATUSES = ["blocked", "done"]
 HISTORY_SOURCE_KEYS = ("events", "history", "timeline", "comments", "runs")
 CONTRACT_DIGEST_ALGORITHM = "sha256"
 IDEMPOTENCY_DIGEST_LENGTH = 16
@@ -1560,7 +1561,7 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
     candidates = ready_work_unit_readbacks_by_status(
         hermes_bin=args.hermes_bin,
         board=board,
-        statuses=["blocked", *sorted(READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES)],
+        statuses=READY_WORK_UNIT_RELEASE_QUERY_STATUSES,
         runner=runner,
     )
     verified: list[tuple[dict[str, Any], str, str, str, str]] = []

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1024,6 +1024,12 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(result["release_wave"]["eligible_work_unit_ids"], ["work-unit-002"])
         self.assertEqual(result["release_wave"]["satisfied_work_unit_ids"], ["work-unit-001"])
         self.assertEqual(result["release_wave"]["held_work_unit_ids"], [])
+        queried_statuses = [
+            call[call.index("--status") + 1]
+            for call in fake.calls
+            if len(call) >= 5 and call[4] == "list" and "--status" in call
+        ]
+        self.assertEqual(sorted(set(queried_statuses)), ["blocked", "done"])
         unblock_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertEqual(len(unblock_calls), 1)
         released_task = next(task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-002")


### PR DESCRIPTION
## Summary

Closes #340.

`release-ready-work-units` now queries only Hermes-supported Kanban statuses (`blocked`, `done`) instead of passing terminal synonym values (`complete`, `completed`) to the live CLI.

The adapter still keeps terminal synonym handling for readback/compatibility logic, but live `hermes kanban list --status ...` calls stay inside the real Hermes enum.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q` (815 tests)

## Public/private boundary

No private Cockpit input, raw runtime dumps, screenshots, local paths, or dogfooding artifacts are committed.