### PR TITLE
Report post-release blocked ready work units

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -808,6 +808,16 @@ def history_contains_markers(payload: dict[str, Any], markers: list[str]) -> boo
     return False
 
 
+def task_has_ready_work_unit_release_record(payload: dict[str, Any]) -> bool:
+    return history_contains_markers(
+        payload,
+        READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS,
+    ) or task_has_unblocked_event(
+        payload,
+        required_markers=READY_WORK_UNIT_RELEASE_REQUIRED_MARKERS,
+    )
+
+
 def worker_satisfied_by_reconciliation(plan: dict[str, Any], worker_id: str) -> bool:
     reconciliation = plan.get("completion_reconciliation")
     if not isinstance(reconciliation, dict):
@@ -1565,6 +1575,7 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
         runner=runner,
     )
     verified: list[tuple[dict[str, Any], str, str, str, str]] = []
+    post_release_blocked: dict[str, str] = {}
     for task in tasks:
         key = expected_ready_work_unit_key(task)
         matches = candidates.get(key) or []
@@ -1574,11 +1585,22 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
             )
         status = task_readback_status(matches[0])
         if status == "blocked":
-            task_id, packet_id, work_unit_id = verify_ready_work_unit_release_candidate(
-                payload=matches[0],
-                plan_task=task,
-                worker_assignee_prefix=args.worker_assignee_prefix,
-            )
+            if task_has_ready_work_unit_release_record(matches[0]):
+                task_id, packet_id, work_unit_id = verify_ready_work_unit_identity(
+                    payload=matches[0],
+                    plan_task=task,
+                    worker_assignee_prefix=args.worker_assignee_prefix,
+                )
+                if not task_has_blocked_event(matches[0]):
+                    raise RuntimeError(f"Hermes task {task_id} is post-release blocked but lacks a blocked event")
+                status = "blocked_after_release"
+                post_release_blocked[work_unit_id] = task_id
+            else:
+                task_id, packet_id, work_unit_id = verify_ready_work_unit_release_candidate(
+                    payload=matches[0],
+                    plan_task=task,
+                    worker_assignee_prefix=args.worker_assignee_prefix,
+                )
         elif status in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES:
             task_id, packet_id, work_unit_id = verify_ready_work_unit_identity(
                 payload=matches[0],
@@ -1652,14 +1674,16 @@ def release_ready_work_units(args: argparse.Namespace, runner: Runner = default_
             "eligible_work_unit_ids": sorted(work_unit_id for _task, _task_id, _packet_id, work_unit_id, _status in eligible),
             "held_work_unit_ids": sorted(dependency_blockers.keys()),
             "satisfied_work_unit_ids": satisfied_work_unit_ids,
+            "post_release_blocked_work_unit_ids": sorted(post_release_blocked.keys()),
             "dependency_blockers": {key: dependency_blockers[key] for key in sorted(dependency_blockers)},
         },
         "runtime_gate": {
             **(plan.get("runtime_gate") if isinstance(plan.get("runtime_gate"), dict) else {}),
             "release_verified_task_count": len(verified),
             "release_eligible_task_count": len(eligible),
-            "release_held_task_count": len(dependency_blockers),
+            "release_held_task_count": len(dependency_blockers) + len(post_release_blocked),
             "release_satisfied_task_count": len(satisfied_work_unit_ids),
+            "post_release_blocked_task_count": len(post_release_blocked),
             "dispatch_allowed_by_this_step": False,
             "native_dispatch_required_next": bool(released_ready_work_unit_task_ids),
             "complete_product_claim_allowed": False,

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1035,6 +1035,69 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         released_task = next(task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-002")
         self.assertEqual(released_task["status"], "ready")
 
+    def test_release_ready_work_units_reports_post_release_blocked_dependency(self) -> None:
+        fake = FakeHermes()
+        plan = two_step_ready_work_unit_plan()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            materialization_result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["decomposition-planner", "implementation-worker"])
+            args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                ]
+            )
+            materialization_result = adapter.materialize_ready_work_units(args, runner=fake)
+            materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+            release_first_wave_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_first_wave_args, runner=fake)
+            upstream_task = next(
+                task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-001"
+            )
+            upstream_task["status"] = "blocked"
+            upstream_task.setdefault("events", []).append({"kind": "claimed"})
+            upstream_task.setdefault("events", []).append({"kind": "spawned"})
+            upstream_task.setdefault("events", []).append({"kind": "blocked", "reason": "repair required"})
+            dry_run_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--dry-run",
+                ]
+            )
+            result = adapter.release_ready_work_units(dry_run_args, runner=fake)
+
+        self.assertEqual(result["released_ready_work_unit_task_ids"], {})
+        self.assertEqual(result["release_wave"]["eligible_work_unit_ids"], [])
+        self.assertEqual(result["release_wave"]["post_release_blocked_work_unit_ids"], ["work-unit-001"])
+        self.assertEqual(result["release_wave"]["held_work_unit_ids"], ["work-unit-002"])
+        self.assertEqual(result["release_wave"]["dependency_blockers"], {"work-unit-002": ["work-unit-001"]})
+        self.assertEqual(result["runtime_gate"]["post_release_blocked_task_count"], 1)
+
     def test_release_ready_work_units_rejects_ambiguous_matching_tasks(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Closes #342.

`release-ready-work-units` now distinguishes two blocked states:

- never-released blocked tasks, which still require the strict pre-dispatch release candidate contract;
- legally released tasks that later returned to `blocked`, which are reported as `post_release_blocked_work_unit_ids` and keep downstream waves held instead of crashing the release dry-run.

This keeps the factory gear-like invariant intact: post-release non-human blocks remain known blockers, do not become satisfied dependencies, do not get re-released, and do not permit complete-product claims.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q` (816 tests)

## Public/private boundary

No private Cockpit input, raw runtime dumps, screenshots, local paths, or dogfooding artifacts are committed.