### PR TITLE
Route post-repair review tasks for ready work units

### DIFF
--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -286,6 +286,25 @@ history also carries `ready_work_unit_done_authorized` and
 `ready_work_unit_done_definition_satisfied`. It still does not dispatch workers
 or claim product completion.
 
+If repair evidence exists but post-repair review markers are missing, the same
+route can create the missing independent-reviewer task explicitly:
+
+```bash
+python adapters/hermes/live_kanban_adapter.py reconcile-ready-work-units \
+  --plan path/to/ready-work-unit-hermes-plan.json \
+  --materialization-result path/to/live-ready-work-unit-materialization-result.json \
+  --route-readiness path/to/route-readiness.json \
+  --create-post-repair-review-tasks \
+  --out path/to/reconciled-ready-work-units.json
+```
+
+That task is scoped only to the repair result. It must emit
+`ready_work_unit_repair_review_passed` plus either
+`ready_work_unit_retry_authorized`, or `ready_work_unit_done_authorized` with
+`ready_work_unit_done_definition_satisfied`, or `human_gate_required`, or a
+structured BLOCK with owner and next repair action. Creating the review task
+does not unblock or complete the parent.
+
 Use `--workspace` when the adapter runs outside the Hermes host. The workspace
 must be meaningful to the Hermes dispatcher, not merely to the machine that runs
 the adapter. Local operators can omit it and use the repo directory default;

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -77,6 +77,8 @@ READY_WORK_UNIT_RECONCILIATION_DONE_READBACK_MARKERS = [
     "ready_work_unit_done_authorized",
     "post_release_ready_work_unit",
 ]
+READY_WORK_UNIT_POST_REPAIR_REVIEW_REQUIRED_MARKER = "ready_work_unit_post_repair_review_required"
+READY_WORK_UNIT_POST_REPAIR_REVIEW_CREATED_MARKER = "ready_work_unit_post_repair_review_task_created"
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 WORKER_MATERIALIZATION_CONTRACT_FIELDS = (
     "task_type",
@@ -1847,6 +1849,155 @@ def classify_ready_work_unit_post_release_reconciliation(payload: dict[str, Any]
     }
 
 
+def ready_work_unit_post_repair_review_idempotency_key(*, plan_task: dict[str, Any], parent_task_id: str) -> str:
+    base = str(plan_task.get("idempotency_key") or "").strip()
+    if not base:
+        _packet_id, work_unit_id = expected_ready_work_unit_key(plan_task)
+        base = f"overkill:ready-work-unit:{work_unit_id}"
+    digest = idempotency_digest_fragment(
+        contract_digest(
+            {
+                "base_idempotency_key": base,
+                "parent_task_id": parent_task_id,
+                "route": "post_repair_review",
+                "version": "v1",
+            }
+        )
+    )
+    return f"{base}:post-repair-review:{digest}"
+
+
+def ready_work_unit_post_repair_review_body(
+    *,
+    plan_task: dict[str, Any],
+    parent_task_id: str,
+    packet_id: str,
+    work_unit_id: str,
+) -> dict[str, Any]:
+    done_definition = {}
+    body_contract = plan_task.get("body_contract") if isinstance(plan_task.get("body_contract"), dict) else {}
+    if isinstance(body_contract.get("done_definition"), dict):
+        done_definition = body_contract["done_definition"]
+    elif isinstance(body_contract.get("work_unit_context_packet"), dict):
+        embedded_payloads = body_contract["work_unit_context_packet"].get("embedded_payloads", {})
+        embedded_payloads = embedded_payloads if isinstance(embedded_payloads, dict) else {}
+        current = embedded_payloads.get("current_work_unit", {})
+        if isinstance(current, dict) and isinstance(current.get("done_definition"), dict):
+            done_definition = current["done_definition"]
+    return {
+        "packet_type": "ready_work_unit_post_repair_review_request",
+        "marker": READY_WORK_UNIT_POST_REPAIR_REVIEW_REQUIRED_MARKER,
+        "parent_packet_id": packet_id,
+        "parent_work_unit_id": work_unit_id,
+        "parent_task_ref": parent_task_id,
+        "reviewer_role": "independent-reviewer",
+        "review_scope": "post_repair_result_only",
+        "review_must_not_approve": [
+            "complete_product",
+            "release",
+            "deployment",
+            "customer_ready",
+            "security_gate",
+            "human_gate",
+        ],
+        "required_positive_outcomes": [
+            {
+                "markers": [
+                    "ready_work_unit_repair_review_passed",
+                    "ready_work_unit_retry_authorized",
+                ],
+                "meaning": "repair is accepted and parent may be retried by Hermes reconciliation",
+            },
+            {
+                "markers": [
+                    "ready_work_unit_repair_review_passed",
+                    "ready_work_unit_done_authorized",
+                    "ready_work_unit_done_definition_satisfied",
+                ],
+                "meaning": "parent ready work unit may be completed, not the whole product",
+            },
+            {
+                "markers": ["human_gate_required"],
+                "meaning": "stop automatic mutation until explicit human authority exists",
+            },
+        ],
+        "blocked_outcome_required_fields": [
+            "owner",
+            "reason",
+            "next_repair_action",
+        ],
+        "done_definition": done_definition,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+        "complete_product_claim_allowed": False,
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+        },
+    }
+
+
+def create_post_repair_review_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    plan_task: dict[str, Any],
+    parent_payload: dict[str, Any],
+    parent_task_id: str,
+    packet_id: str,
+    work_unit_id: str,
+    worker_assignee_prefix: str,
+    workspace_ref: str,
+    runner: Runner = default_runner,
+) -> str:
+    body = ready_work_unit_post_repair_review_body(
+        plan_task=plan_task,
+        parent_task_id=parent_task_id,
+        packet_id=packet_id,
+        work_unit_id=work_unit_id,
+    )
+    task_id = create_task(
+        hermes_bin=hermes_bin,
+        board=board,
+        title=f"OF post-repair review for ready work unit {work_unit_id}",
+        body=compact_json_argument(body),
+        assignee=worker_assignee_prefix + "independent-reviewer",
+        idempotency_key=ready_work_unit_post_repair_review_idempotency_key(
+            plan_task=plan_task,
+            parent_task_id=parent_task_id,
+        ),
+        created_by="overkill-factory",
+        workspace=workspace_ref or task_dispatcher_workspace_ref(parent_payload) or "scratch",
+        blocked=False,
+        runner=runner,
+    )
+    run_checked(hermes_kanban(hermes_bin, board, "link", task_id, parent_task_id), runner)
+    run_checked(
+        hermes_kanban(
+            hermes_bin,
+            board,
+            "comment",
+            "--author",
+            READY_WORK_UNIT_RECONCILIATION_AUTHOR,
+            parent_task_id,
+            compact_json_argument(
+                {
+                    "marker": READY_WORK_UNIT_POST_REPAIR_REVIEW_CREATED_MARKER,
+                    "work_unit_id": work_unit_id,
+                    "review_task_ref": task_id,
+                    "reviewer_role": "independent-reviewer",
+                    "reconciliation_scope": "post_release_ready_work_unit",
+                    "runtime_authority": "hermes_kanban",
+                    "local_state_authority": False,
+                    "complete_product_claim_allowed": False,
+                }
+            ),
+        ),
+        runner,
+    )
+    return task_id
+
+
 def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = default_runner) -> dict[str, Any]:
     plan = load_ready_work_unit_materialization_plan(args.plan.resolve())
     board = str(args.board or plan.get("board") or "").strip()
@@ -1899,6 +2050,7 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
     reconciliation: dict[str, dict[str, Any]] = {}
     retry_candidates: list[tuple[dict[str, Any], str, str, str]] = []
     complete_candidates: list[tuple[dict[str, Any], str, str, str]] = []
+    post_repair_review_candidates: list[tuple[dict[str, Any], dict[str, Any], str, str, str]] = []
     post_release_blocked_count = 0
     human_gate_count = 0
     incomplete_count = 0
@@ -1907,6 +2059,7 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
         row["task_ref"] = task_id
         row["packet_id"] = packet_id
         row["dependency_blockers"] = dependency_blockers.get(work_unit_id, [])
+        row["post_repair_review_required"] = row["decision"] == "awaiting_repair_review"
         reconciliation[work_unit_id] = row
         if status == "blocked" and row["release_record_seen"]:
             post_release_blocked_count += 1
@@ -1923,6 +2076,8 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
             retry_candidates.append((task, task_id, packet_id, work_unit_id))
         elif row["decision"] == "complete_parent":
             complete_candidates.append((task, task_id, packet_id, work_unit_id))
+        elif row["decision"] == "awaiting_repair_review":
+            post_repair_review_candidates.append((task, payload, task_id, packet_id, work_unit_id))
 
     if not args.dry_run and retry_candidates:
         required_workers = [
@@ -1932,14 +2087,38 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
         readiness_blockers = route_readiness_blockers(args.route_readiness, required_workers)
         if readiness_blockers:
             raise RuntimeError("pre-retry route readiness blocked ready work-unit reconciliation: " + "; ".join(readiness_blockers))
+    if not args.dry_run and args.create_post_repair_review_tasks and post_repair_review_candidates:
+        readiness_blockers = route_readiness_blockers(
+            args.route_readiness,
+            [args.worker_assignee_prefix + "independent-reviewer"],
+        )
+        if readiness_blockers:
+            raise RuntimeError("post-repair review route readiness blocked ready work-unit reconciliation: " + "; ".join(readiness_blockers))
 
     retry_ready_work_unit_task_ids: dict[str, str] = {}
     completed_ready_work_unit_task_ids: dict[str, str] = {}
+    post_repair_review_task_ids: dict[str, str] = {}
     retry_reason = str(
         args.reason
         or "ready_work_unit_retry_authorized; ready_work_unit_repair_review_passed; reconciliation_scope=post_release_ready_work_unit; dispatch_separate=true"
     )
     if not args.dry_run:
+        if args.create_post_repair_review_tasks:
+            workspace_ref = str(args.post_repair_review_workspace or "").strip()
+            for task, payload, task_id, packet_id, work_unit_id in post_repair_review_candidates:
+                review_task_id = create_post_repair_review_task(
+                    hermes_bin=args.hermes_bin,
+                    board=board,
+                    plan_task=task,
+                    parent_payload=payload,
+                    parent_task_id=task_id,
+                    packet_id=packet_id,
+                    work_unit_id=work_unit_id,
+                    worker_assignee_prefix=args.worker_assignee_prefix,
+                    workspace_ref=workspace_ref,
+                    runner=runner,
+                )
+                post_repair_review_task_ids[work_unit_id] = review_task_id
         for _task, task_id, _packet_id, work_unit_id in retry_candidates:
             unblock_task(
                 hermes_bin=args.hermes_bin,
@@ -1991,6 +2170,10 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
         },
         "retry_ready_work_unit_task_ids": retry_ready_work_unit_task_ids,
         "completed_ready_work_unit_task_ids": completed_ready_work_unit_task_ids,
+        "post_repair_review_task_ids": post_repair_review_task_ids,
+        "post_repair_review_required_work_unit_ids": sorted(
+            work_unit_id for _task, _payload, _task_id, _packet_id, work_unit_id in post_repair_review_candidates
+        ),
         "post_release_reconciliation": reconciliation,
         "release_wave": {
             "held_work_unit_ids": sorted(dependency_blockers.keys()),
@@ -2006,6 +2189,8 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
             "post_release_blocked_task_count": post_release_blocked_count,
             "retry_candidate_count": len(retry_candidates),
             "complete_candidate_count": len(complete_candidates),
+            "post_repair_review_required_count": len(post_repair_review_candidates),
+            "post_repair_review_task_created_count": len(post_repair_review_task_ids),
             "retry_unblocked_task_count": len(retry_ready_work_unit_task_ids),
             "completed_task_count": len(completed_ready_work_unit_task_ids),
             "human_gate_required_count": human_gate_count,
@@ -2870,6 +3055,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_reconcile_ready.add_argument("--worker-assignee-prefix", default="")
     p_reconcile_ready.add_argument("--route-readiness", type=Path)
     p_reconcile_ready.add_argument("--reason")
+    p_reconcile_ready.add_argument("--create-post-repair-review-tasks", action="store_true")
+    p_reconcile_ready.add_argument("--post-repair-review-workspace")
     p_reconcile_ready.add_argument("--completion-result", default="Ready work-unit reconciliation satisfied.")
     p_reconcile_ready.add_argument(
         "--completion-summary",

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1182,8 +1182,162 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(result["release_wave"]["held_work_unit_ids"], ["work-unit-002"])
         self.assertEqual(result["release_wave"]["dependency_blockers"], {"work-unit-002": ["work-unit-001"]})
         self.assertEqual(result["runtime_gate"]["incomplete_repair_or_review_count"], 1)
+        self.assertEqual(result["post_repair_review_required_work_unit_ids"], ["work-unit-001"])
+        self.assertEqual(result["post_repair_review_task_ids"], {})
+        self.assertTrue(result["post_release_reconciliation"]["work-unit-001"]["post_repair_review_required"])
+        self.assertEqual(result["runtime_gate"]["post_repair_review_required_count"], 1)
+        self.assertEqual(result["runtime_gate"]["post_repair_review_task_created_count"], 0)
         unblock_calls_after = [call for call in fake.calls if len(call) >= 5 and call[4] == "unblock"]
         self.assertEqual(unblock_calls_after, unblock_calls_before)
+
+    def test_reconcile_ready_work_units_creates_post_repair_review_task(self) -> None:
+        fake = FakeHermes()
+        plan = two_step_ready_work_unit_plan()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            materialization_result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["decomposition-planner", "implementation-worker"])
+            materialize_args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                ]
+            )
+            materialization_result = adapter.materialize_ready_work_units(materialize_args, runner=fake)
+            materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            upstream_task = next(
+                task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-001"
+            )
+            upstream_task["status"] = "blocked"
+            upstream_task.setdefault("events", []).append({"kind": "claimed"})
+            upstream_task.setdefault("events", []).append({"kind": "blocked", "reason": "repair required"})
+            upstream_task.setdefault("comments", []).append(
+                {
+                    "author": "factory-orchestrator",
+                    "body": json.dumps({"marker": "ready_work_unit_repair_completed"}),
+                }
+            )
+            reconcile_args = adapter.build_parser().parse_args(
+                [
+                    "reconcile-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--create-post-repair-review-tasks",
+                ]
+            )
+            result = adapter.reconcile_ready_work_units(reconcile_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        self.assertEqual(result["post_repair_review_required_work_unit_ids"], ["work-unit-001"])
+        self.assertEqual(result["post_repair_review_task_ids"], {"work-unit-001": adapter.PUBLIC_SAFE_KANBAN_REF})
+        self.assertEqual(result["runtime_gate"]["post_repair_review_task_created_count"], 1)
+        review_tasks = [
+            task
+            for task in fake.tasks.values()
+            if json.loads(str(task.get("body") or "{}")).get("packet_type")
+            == "ready_work_unit_post_repair_review_request"
+        ]
+        self.assertEqual(len(review_tasks), 1)
+        self.assertEqual(review_tasks[0]["assignee"], "independent-reviewer")
+        self.assertEqual(review_tasks[0]["status"], "ready")
+        review_body = json.loads(str(review_tasks[0]["body"]))
+        self.assertEqual(review_body["marker"], "ready_work_unit_post_repair_review_required")
+        self.assertEqual(review_body["review_scope"], "post_repair_result_only")
+        link_calls = [call for call in fake.calls if len(call) >= 7 and call[4] == "link"]
+        self.assertTrue(link_calls)
+        parent_comments = upstream_task.get("comments") or []
+        self.assertTrue(
+            any("ready_work_unit_post_repair_review_task_created" in str(comment.get("body")) for comment in parent_comments)
+        )
+
+    def test_reconcile_ready_work_units_requires_route_readiness_before_post_repair_review_task(self) -> None:
+        fake = FakeHermes()
+        plan = two_step_ready_work_unit_plan()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            materialization_result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["decomposition-planner", "implementation-worker"])
+            materialize_args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                ]
+            )
+            materialization_result = adapter.materialize_ready_work_units(materialize_args, runner=fake)
+            materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            upstream_task = next(
+                task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-001"
+            )
+            upstream_task["status"] = "blocked"
+            upstream_task.setdefault("events", []).append({"kind": "claimed"})
+            upstream_task.setdefault("events", []).append({"kind": "blocked", "reason": "repair required"})
+            upstream_task.setdefault("comments", []).append(
+                {
+                    "author": "factory-orchestrator",
+                    "body": json.dumps({"marker": "ready_work_unit_repair_completed"}),
+                }
+            )
+            create_calls_before = [call for call in fake.calls if len(call) >= 5 and call[4] == "create"]
+            reconcile_args = adapter.build_parser().parse_args(
+                [
+                    "reconcile-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--create-post-repair-review-tasks",
+                ]
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "post-repair review route readiness blocked"):
+                adapter.reconcile_ready_work_units(reconcile_args, runner=fake)
+
+        create_calls_after = [call for call in fake.calls if len(call) >= 5 and call[4] == "create"]
+        self.assertEqual(create_calls_after, create_calls_before)
 
     def test_reconcile_ready_work_units_unblocks_retry_when_review_authorizes(self) -> None:
         fake = FakeHermes()
@@ -1345,6 +1499,74 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(completed_task["status"], "done")
         complete_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "complete"]
         self.assertEqual(len(complete_calls), 1)
+
+    def test_reconcile_ready_work_units_human_gate_marker_blocks_automatic_mutation(self) -> None:
+        fake = FakeHermes()
+        plan = two_step_ready_work_unit_plan()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plan_path = tmp_path / "plan.json"
+            readiness_path = tmp_path / "route-readiness.json"
+            materialization_result_path = tmp_path / "materialization-result.json"
+            plan_path.write_text(json.dumps(plan), encoding="utf-8")
+            write_route_readiness(readiness_path, extra_workers=["decomposition-planner", "implementation-worker"])
+            materialize_args = adapter.build_parser().parse_args(
+                [
+                    "materialize-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--workspace",
+                    "scratch",
+                ]
+            )
+            materialization_result = adapter.materialize_ready_work_units(materialize_args, runner=fake)
+            materialization_result_path.write_text(json.dumps(materialization_result), encoding="utf-8")
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            upstream_task = next(
+                task for task in fake.tasks.values() if json.loads(task["body"])["work_unit_id"] == "work-unit-001"
+            )
+            upstream_task["status"] = "blocked"
+            upstream_task.setdefault("events", []).append({"kind": "claimed"})
+            upstream_task.setdefault("events", []).append({"kind": "blocked", "reason": "repair required"})
+            upstream_task.setdefault("comments", []).append(
+                {
+                    "author": "independent-reviewer",
+                    "body": json.dumps({"marker": "human_gate_required"}),
+                }
+            )
+            reconcile_args = adapter.build_parser().parse_args(
+                [
+                    "reconcile-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--create-post-repair-review-tasks",
+                ]
+            )
+            result = adapter.reconcile_ready_work_units(reconcile_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        self.assertEqual(result["post_release_reconciliation"]["work-unit-001"]["decision"], "human_gate_required")
+        self.assertEqual(result["runtime_gate"]["human_gate_required_count"], 1)
+        self.assertEqual(result["post_repair_review_task_ids"], {})
+        self.assertEqual(result["retry_ready_work_unit_task_ids"], {})
+        self.assertEqual(result["completed_ready_work_unit_task_ids"], {})
 
     def test_release_ready_work_units_rejects_ambiguous_matching_tasks(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary
- extend `reconcile-ready-work-units` so repair-complete / review-missing parents can create a scoped independent post-repair review task
- add public-safe review request payload, idempotent task creation, Hermes link back to the parent, and parent comment marker
- keep the parent blocked: creating the review task does not retry, complete, dispatch downstream, or claim product completion
- document the explicit `--create-post-repair-review-tasks` mutation path

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m compileall -q adapters/hermes/live_kanban_adapter.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- live-safe dry-run on the dogfooding board: `reconcile-ready-work-units --dry-run` reported 1 `post_repair_review_required` work unit, 0 created review tasks, 0 retry/complete candidates, and no complete-product claim

Closes #346
