### PR TITLE
Fix Hermes adapter UTF-8 command decoding

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -100,7 +100,14 @@ WORKER_MATERIALIZATION_CONTRACT_FIELDS = (
 def default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.setdefault("HOME", str(Path.home()))
-    return subprocess.run(argv, text=True, capture_output=True, env=env)  # nosec B603
+    return subprocess.run(  # nosec B603
+        argv,
+        text=True,
+        capture_output=True,
+        env=env,
+        encoding="utf-8",
+        errors="replace",
+    )
 
 
 def safe_command_for_error(argv: list[str]) -> str:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -396,6 +396,17 @@ def assert_route_readiness_schema(testcase: unittest.TestCase, result: dict[str,
 
 
 class HermesLiveKanbanAdapterTest(unittest.TestCase):
+    def test_default_runner_decodes_utf8_terminal_output(self) -> None:
+        script = (
+            "import sys; "
+            "sys.stdout.buffer.write('OpenAI Codex  \u2713 logged in\\n'.encode('utf-8'))"
+        )
+        result = adapter.default_runner([sys.executable, "-c", script])
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("OpenAI Codex", result.stdout)
+        self.assertIn("\u2713 logged in", result.stdout)
+
     def test_safe_command_for_error_redacts_body_and_large_args(self) -> None:
         unsafe_body = '{"private":"secret"}'
         unsafe_comment = "x" * 600


### PR DESCRIPTION
## Summary

- Decode Hermes adapter command stdout/stderr as UTF-8 with replacement instead of relying on the Windows platform default.
- Add a regression test for UTF-8 terminal output containing Hermes-style auth glyphs.

## Why

Route readiness must be based on trustworthy Hermes readback. On Windows, platform-default decoding can fail on UTF-8 terminal glyphs and make readiness evidence unreliable.

Closes #348.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q`