### PR TITLE
Fix fresh post-repair authority matching

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -2152,12 +2152,21 @@ def existing_post_repair_review_task_ref(payload: dict[str, Any], *, work_unit_i
     return ""
 
 
-def existing_post_repair_authority_task_ref(payload: dict[str, Any], *, work_unit_id: str) -> str:
+def existing_post_repair_authority_task_ref(
+    payload: dict[str, Any],
+    *,
+    work_unit_id: str,
+    review_task_ref: str | None = None,
+) -> str:
+    expected_review_task_ref = str(review_task_ref or "").strip()
     for comment in reversed(task_readback_comments(payload)):
         marker = parse_json_object(comment.get("body") or comment.get("text") or comment.get("payload"))
         if marker.get("marker") != READY_WORK_UNIT_POST_REPAIR_AUTHORITY_CREATED_MARKER:
             continue
         if str(marker.get("work_unit_id") or "").strip() != work_unit_id:
+            continue
+        marker_review_task_ref = str(marker.get("review_task_ref") or "").strip()
+        if expected_review_task_ref and marker_review_task_ref != expected_review_task_ref:
             continue
         authority_task_ref = str(marker.get("authority_task_ref") or "").strip()
         if authority_task_ref:
@@ -2346,11 +2355,20 @@ def post_repair_review_result_from_run(
     if metadata_work_unit and metadata_work_unit != work_unit_id:
         return None
 
+    nested_review = metadata.get("independent_review_result")
+    nested_review = nested_review if isinstance(nested_review, dict) else {}
+    nested_review_target = str(
+        nested_review.get("review_target")
+        or nested_review.get("reviewed_parent_card_id")
+        or nested_review.get("parent_task_ref")
+        or ""
+    ).strip()
+    nested_verdict = str(nested_review.get("verdict") or "").strip().upper()
     explicit_marker = metadata.get("marker") == READY_WORK_UNIT_POST_REPAIR_REVIEW_RESULT_MARKER
     reviewed_repair_card = str(metadata.get("reviewed_repair_card") or metadata.get("repair_task_ref") or "").strip()
     review_scope = str(metadata.get("review_scope") or "").strip().lower()
     run_profile = str(run.get("profile") or run.get("assignee") or "").strip()
-    if not explicit_marker and not reviewed_repair_card and "repair" not in review_scope:
+    if not explicit_marker and not reviewed_repair_card and "repair" not in review_scope and not nested_review_target:
         return None
     if run_profile and run_profile != "independent-reviewer":
         return None
@@ -2359,9 +2377,18 @@ def post_repair_review_result_from_run(
     outcome = str(run.get("outcome") or "").strip().lower()
     validation_result = str(metadata.get("validation_result") or metadata.get("result") or "").strip().upper()
     blocking_findings = metadata.get("blocking_findings")
-    human_gate_required = metadata.get("human_gate_required") is True
+    if blocking_findings is None:
+        blocking_findings = nested_review.get("blocking_findings")
+    human_gate_required = metadata.get("human_gate_required") is True or nested_review.get("human_gate_required") is True
 
     explicit_pass = metadata.get("ready_work_unit_repair_review_passed") is True
+    nested_pass = (
+        status in {"done", "complete", "completed"}
+        and outcome in {"", "completed", "done", "pass", "passed"}
+        and nested_verdict.startswith("PASS")
+        and blocking_findings is False
+        and nested_review_target == parent_task_id
+    )
     legacy_pass = (
         status in {"done", "complete", "completed"}
         and outcome in {"", "completed", "done", "pass", "passed"}
@@ -2377,7 +2404,7 @@ def post_repair_review_result_from_run(
         or status == "blocked"
         or outcome == "blocked"
     )
-    repair_review_passed = explicit_pass or legacy_pass
+    repair_review_passed = explicit_pass or legacy_pass or nested_pass
     if not repair_review_passed and not blocked and not human_gate_required:
         return None
 
@@ -2407,13 +2434,11 @@ def apply_post_repair_review_result(row: dict[str, Any], result: dict[str, Any] 
         return row
     merged = dict(row)
     merged["post_repair_review_result"] = result
-    merged["repair_review_passed"] = bool(merged.get("repair_review_passed")) or result.get("repair_review_passed") is True
-    merged["retry_authorized"] = bool(merged.get("retry_authorized")) or result.get("retry_authorized") is True
-    merged["done_authorized"] = bool(merged.get("done_authorized")) or result.get("done_authorized") is True
-    merged["done_definition_satisfied"] = (
-        bool(merged.get("done_definition_satisfied")) or result.get("done_definition_satisfied") is True
-    )
-    merged["human_gate_required"] = bool(merged.get("human_gate_required")) or result.get("human_gate_required") is True
+    merged["repair_review_passed"] = result.get("repair_review_passed") is True
+    merged["retry_authorized"] = result.get("retry_authorized") is True
+    merged["done_authorized"] = result.get("done_authorized") is True
+    merged["done_definition_satisfied"] = result.get("done_definition_satisfied") is True
+    merged["human_gate_required"] = result.get("human_gate_required") is True
 
     if merged["human_gate_required"]:
         merged["decision"] = "human_gate_required"
@@ -2493,15 +2518,20 @@ def post_repair_authority_result_from_run(
     authority_task_id: str,
     parent_task_id: str,
     work_unit_id: str,
+    review_task_ref: str,
 ) -> dict[str, Any] | None:
     metadata = run.get("metadata")
     if not isinstance(metadata, dict):
         return None
     review_result = metadata.get("independent_review_result")
     review_result = review_result if isinstance(review_result, dict) else {}
+    authority_decision = review_result.get("authority_decision")
+    authority_decision = authority_decision if isinstance(authority_decision, dict) else {}
     selected_markers = metadata.get("selected_markers")
     if not isinstance(selected_markers, list):
         selected_markers = review_result.get("selected_markers")
+    if not isinstance(selected_markers, list):
+        selected_markers = authority_decision.get("selected_markers")
     markers = {str(marker or "").strip() for marker in (selected_markers or []) if str(marker or "").strip()}
     if not markers:
         for marker_key in (
@@ -2522,10 +2552,14 @@ def post_repair_authority_result_from_run(
     retry_authorized = "ready_work_unit_retry_authorized" in markers
     done_authorized = "ready_work_unit_done_authorized" in markers
     done_definition_satisfied = "ready_work_unit_done_definition_satisfied" in markers
+    authority_verdict = str(review_result.get("verdict") or "").strip().upper()
+    if authority_verdict.startswith("PASS") and (retry_authorized or done_authorized or done_definition_satisfied):
+        repair_review_passed = True
     human_gate_required = "human_gate_required" in markers or metadata.get("human_gate_required") is True
     return {
         "marker": READY_WORK_UNIT_POST_REPAIR_AUTHORITY_RESULT_MARKER,
         "authority_task_ref": authority_task_id,
+        "review_task_ref": review_task_ref or None,
         "parent_task_ref": parent_task_id,
         "work_unit_id": work_unit_id,
         "source": "hermes_run_metadata",
@@ -2581,6 +2615,7 @@ def post_repair_authority_results_by_work_unit(
     hermes_bin: str,
     board: str,
     parent_task_ids_by_work_unit: dict[str, str],
+    review_task_refs_by_work_unit: dict[str, str] | None = None,
     worker_assignee_prefix: str,
     runner: Runner = default_runner,
 ) -> dict[str, dict[str, Any]]:
@@ -2608,6 +2643,10 @@ def post_repair_authority_results_by_work_unit(
             parent_task_id = str(body.get("parent_task_ref") or "").strip()
             if not work_unit_id or parent_task_ids_by_work_unit.get(work_unit_id) != parent_task_id:
                 continue
+            review_task_ref = str(body.get("review_task_ref") or "").strip()
+            expected_review_task_ref = str((review_task_refs_by_work_unit or {}).get(work_unit_id) or "").strip()
+            if expected_review_task_ref and review_task_ref != expected_review_task_ref:
+                continue
             try:
                 runs = task_run_records(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
             except RuntimeError:
@@ -2618,6 +2657,7 @@ def post_repair_authority_results_by_work_unit(
                     authority_task_id=task_id,
                     parent_task_id=parent_task_id,
                     work_unit_id=work_unit_id,
+                    review_task_ref=review_task_ref,
                 )
                 if not result:
                     continue
@@ -2723,6 +2763,11 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
             work_unit_id: task_id
             for _task, _payload, task_id, _packet_id, work_unit_id, _status in verified
         },
+        review_task_refs_by_work_unit={
+            work_unit_id: str(result.get("review_task_ref") or "").strip()
+            for work_unit_id, result in review_results.items()
+            if str(result.get("review_task_ref") or "").strip()
+        },
         worker_assignee_prefix=args.worker_assignee_prefix,
         runner=runner,
     )
@@ -2784,7 +2829,11 @@ def reconcile_ready_work_units(args: argparse.Namespace, runner: Runner = defaul
         existing_authority_task_id = ""
         if row["decision"] == "awaiting_retry_or_done_authority":
             post_repair_authority_required_work_unit_ids.add(work_unit_id)
-            existing_authority_task_id = existing_post_repair_authority_task_ref(payload, work_unit_id=work_unit_id)
+            existing_authority_task_id = existing_post_repair_authority_task_ref(
+                payload,
+                work_unit_id=work_unit_id,
+                review_task_ref=str((review_result or {}).get("review_task_ref") or "").strip(),
+            )
             if existing_authority_task_id:
                 existing_post_repair_authority_task_ids[work_unit_id] = existing_authority_task_id
         elif authority_result and authority_result.get("authority_task_ref"):

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1562,11 +1562,106 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             ]
             upstream_task["status"] = "todo"
             fifth = adapter.reconcile_ready_work_units(authority_args, runner=fake)
+            upstream_status_after_retry = str(fake.tasks[upstream_id].get("status") or "")
+            upstream_parents_after_retry = [str(parent_id) for parent_id in fake.tasks[upstream_id].get("parents", [])]
+            upstream_task["status"] = "blocked"
+            upstream_task.setdefault("events", []).append({"kind": "claimed"})
+            upstream_task.setdefault("events", []).append({"kind": "blocked", "reason": "post-retry review required"})
+            fake.tasks["review-fixture-v3"] = {
+                "id": "review-fixture-v3",
+                "status": "done",
+                "title": "OF independent review: post-retry owner result",
+                "assignee": "independent-reviewer",
+                "events": [],
+                "comments": [],
+                "runs": [
+                    {
+                        "id": 4,
+                        "profile": "independent-reviewer",
+                        "status": "done",
+                        "outcome": "completed",
+                        "ended_at": 40,
+                        "metadata": {
+                            "independent_review_result": {
+                                "verdict": "PASS_ACCEPT_WU1_POST_REPAIR_DECOMPOSITION_EVIDENCE_ONLY",
+                                "review_target": upstream_id,
+                                "blocking_findings": False,
+                                "remaining_risk": [
+                                    "review accepts owner evidence only",
+                                    "downstream execution still needs a fresh authority decision",
+                                ],
+                            },
+                        },
+                    }
+                ],
+            }
+            observe_after_new_review_args = adapter.build_parser().parse_args(
+                [
+                    "reconcile-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            sixth = adapter.reconcile_ready_work_units(observe_after_new_review_args, runner=fake)
+            seventh = adapter.reconcile_ready_work_units(authority_args, runner=fake)
+            _fresh_authority_task_id, fresh_authority_task = next(
+                (task_id, task)
+                for task_id, task in fake.tasks.items()
+                if json.loads(str(task.get("body") or "{}")).get("packet_type")
+                == "ready_work_unit_post_repair_authority_request"
+                and json.loads(str(task.get("body") or "{}")).get("review_task_ref") == "review-fixture-v3"
+            )
+            fresh_authority_task["status"] = "done"
+            fresh_authority_task["runs"] = [
+                {
+                    "id": 5,
+                    "profile": "independent-reviewer",
+                    "status": "done",
+                    "outcome": "completed",
+                    "ended_at": 50,
+                    "metadata": {
+                        "independent_review_result": {
+                            "verdict": "PASS_WU1_DONE_DEFINITION_SATISFIED_AUTHORITY_DONE_ONLY",
+                            "authority_decision": {
+                                "selected_markers": [
+                                    "ready_work_unit_done_authorized",
+                                    "ready_work_unit_done_definition_satisfied",
+                                ],
+                                "rejected_markers": [
+                                    "ready_work_unit_retry_authorized",
+                                    "human_gate_required",
+                                    "structured_block",
+                                ],
+                            },
+                        }
+                    },
+                }
+            ]
+            dry_after_fresh_authority_args = adapter.build_parser().parse_args(
+                [
+                    "reconcile-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                    "--dry-run",
+                ]
+            )
+            eighth = adapter.reconcile_ready_work_units(dry_after_fresh_authority_args, runner=fake)
 
         assert_live_adapter_result_schema(self, second)
         assert_live_adapter_result_schema(self, third)
         assert_live_adapter_result_schema(self, fourth)
         assert_live_adapter_result_schema(self, fifth)
+        assert_live_adapter_result_schema(self, sixth)
+        assert_live_adapter_result_schema(self, seventh)
+        assert_live_adapter_result_schema(self, eighth)
         self.assertEqual(first["runtime_gate"]["post_repair_review_task_created_count"], 1)
         row = second["post_release_reconciliation"]["work-unit-001"]
         self.assertEqual(row["decision"], "awaiting_retry_or_done_authority")
@@ -1610,15 +1705,33 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             fifth["unlinked_superseded_post_repair_review_parent_task_ids"],
             {"work-unit-001": [adapter.PUBLIC_SAFE_KANBAN_REF]},
         )
-        self.assertEqual(fake.tasks[upstream_id]["status"], "ready")
-        self.assertNotIn(
-            stale_review_task_id,
-            [str(parent_id) for parent_id in fake.tasks[upstream_id].get("parents", [])],
-        )
-        self.assertIn(authority_task_id, [str(parent_id) for parent_id in fake.tasks[upstream_id].get("parents", [])])
+        self.assertEqual(upstream_status_after_retry, "ready")
+        self.assertNotIn(stale_review_task_id, upstream_parents_after_retry)
+        self.assertIn(authority_task_id, upstream_parents_after_retry)
         self.assertEqual(second["retry_ready_work_unit_task_ids"], {})
         self.assertEqual(second["completed_ready_work_unit_task_ids"], {})
         self.assertEqual(fifth["completed_ready_work_unit_task_ids"], {})
+        fresh_review_row = sixth["post_release_reconciliation"]["work-unit-001"]
+        self.assertEqual(fresh_review_row["decision"], "awaiting_retry_or_done_authority")
+        self.assertEqual(fresh_review_row["post_repair_review_task_ref"], "review-fixture-v3")
+        self.assertIsNone(fresh_review_row["post_repair_authority_task_ref"])
+        self.assertFalse(fresh_review_row["retry_authorized"])
+        self.assertFalse(fresh_review_row["done_authorized"])
+        self.assertEqual(sixth["retry_ready_work_unit_task_ids"], {})
+        self.assertEqual(sixth["completed_ready_work_unit_task_ids"], {})
+        self.assertEqual(sixth["existing_post_repair_authority_task_ids"], {})
+        self.assertEqual(sixth["runtime_gate"]["post_repair_authority_required_count"], 1)
+        self.assertEqual(sixth["runtime_gate"]["post_repair_authority_missing_task_count"], 1)
+        self.assertEqual(sixth["runtime_gate"]["post_repair_authority_result_count"], 0)
+        self.assertEqual(seventh["created_post_repair_authority_task_ids"], {"work-unit-001": adapter.PUBLIC_SAFE_KANBAN_REF})
+        complete_row = eighth["post_release_reconciliation"]["work-unit-001"]
+        self.assertEqual(complete_row["decision"], "complete_parent")
+        self.assertTrue(complete_row["done_authorized"])
+        self.assertTrue(complete_row["done_definition_satisfied"])
+        self.assertEqual(complete_row["post_repair_authority_task_ref"], adapter.PUBLIC_SAFE_KANBAN_REF)
+        self.assertEqual(eighth["runtime_gate"]["post_repair_authority_result_count"], 1)
+        self.assertEqual(eighth["runtime_gate"]["complete_candidate_count"], 1)
+        self.assertEqual(eighth["completed_ready_work_unit_task_ids"], {})
         review_tasks = [
             task
             for task in fake.tasks.values()
@@ -1632,11 +1745,23 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             if json.loads(str(task.get("body") or "{}")).get("packet_type")
             == "ready_work_unit_post_repair_authority_request"
         ]
-        self.assertEqual(len(authority_tasks), 1)
-        self.assertEqual(authority_tasks[0]["assignee"], "independent-reviewer")
-        authority_body = json.loads(str(authority_tasks[0]["body"]))
+        self.assertEqual(len(authority_tasks), 2)
+        old_authority_tasks = [
+            task
+            for task in authority_tasks
+            if json.loads(str(task.get("body") or "{}")).get("review_task_ref") == "review-fixture-v2"
+        ]
+        self.assertEqual(len(old_authority_tasks), 1)
+        self.assertEqual(old_authority_tasks[0]["assignee"], "independent-reviewer")
+        authority_body = json.loads(str(old_authority_tasks[0]["body"]))
         self.assertEqual(authority_body["marker"], "ready_work_unit_post_repair_authority_required")
         self.assertEqual(authority_body["authority_scope"], "post_repair_retry_or_done_only")
+        fresh_authority_tasks = [
+            task
+            for task in authority_tasks
+            if json.loads(str(task.get("body") or "{}")).get("review_task_ref") == "review-fixture-v3"
+        ]
+        self.assertEqual(len(fresh_authority_tasks), 1)
 
     def test_reconcile_ready_work_units_requires_route_readiness_before_post_repair_review_task(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary

Fixes #360.

This PR closes a runtime-loop gap discovered during Overkill Factory Cockpit dogfooding: a retry-only post-repair authority could be reused after a newer post-retry owner result and independent review, causing `reconcile-ready-work-units` to choose `retry_parent` again instead of requiring a fresh authority decision.

## What Changed

- Scopes existing post-repair authority task markers to the exact `review_task_ref` they were created for.
- Filters authority run results by the latest accepted review task ref.
- Parses the richer Hermes worker metadata shape:
  - nested `independent_review_result` review results with explicit `review_target`;
  - nested `independent_review_result.authority_decision.selected_markers` for authority decisions.
- Resets retry/done authority flags when a newer explicit review result is consumed, so old parent history markers cannot silently authorize another retry.
- Extends the live adapter regression test through the full loop:
  - repair review pass;
  - retry-only authority;
  - retry consumed;
  - newer independent review pass;
  - stale authority rejected;
  - fresh authority created;
  - nested done-authority parsed as `complete_parent`.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_reconcile_ready_work_units_consumes_versioned_post_repair_review_run_metadata -q`
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`

## Live Dogfooding Readback

On the Cockpit dogfooding board, the fixed adapter correctly changed the WU1 route from accidental retry-loop risk to deterministic authority flow:

- fresh review without fresh authority: `awaiting_retry_or_done_authority`, retry count `0`;
- fresh authority created for the latest review;
- fresh authority selected done-only markers;
- dry-run then selected `complete_parent`;
- non-dry completed WU1 only;
- downstream WU2/WU3/WU4 were released afterward and are running under their own workers.

No product completion, release, security/customer-ready state, deployment, irreversible action, or human gate approval is granted by this PR.

## Public Safety

No private dogfooding artifacts, screenshots, raw logs, local paths, or internal evidence are committed.