### PR TITLE
Add worker contracts to product closeout next tasks

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -3991,12 +3991,109 @@ def product_creation_closeout_idempotency_key(
                 "materialization_plan_id": materialization_plan_id,
                 "next_action": next_action,
                 "marker": PRODUCT_CREATION_CLOSEOUT_NEXT_ROUTE_MARKER,
-                "no_spawn_protocol": "create-unassigned-block-assign-v2",
-                "idempotency_version": "v2",
+                "no_spawn_protocol": "create-unassigned-block-assign-v3",
+                "next_task_contract_version": "worker-consumable-v1",
+                "idempotency_version": "v3",
             }
         )
     )
     return f"overkill:product-creation-closeout:{product_creation_plan_id}:{next_action}:{digest}"
+
+
+def product_creation_next_route_contract(next_action: str, closeout: dict[str, Any]) -> dict[str, Any]:
+    product_creation_plan_id = str(closeout.get("product_creation_plan_id") or "product-creation-plan")
+    materialization_plan_id = str(closeout.get("materialization_plan_id") or "ready-work-unit-plan")
+    common = {
+        "source_refs": [
+            f"product-creation-plan:{product_creation_plan_id}",
+            f"ready-work-unit-materialization:{materialization_plan_id}",
+            f"product-creation-closeout:{next_action}",
+        ],
+        "forbidden_actions": [
+            "complete_product_claim",
+            "production_release_approval",
+            "customer_ready_claim",
+            "deploy",
+            "infrastructure_mutation",
+            "secret_access",
+            "private_evidence_publication",
+            "raw_dogfood_log_publication",
+            "local_path_publication",
+        ],
+        "public_private_boundary": {
+            "public_safe_refs_only": True,
+            "raw_private_evidence_embedded": False,
+            "private_runtime_refs_must_be_summarized": True,
+        },
+    }
+    if next_action == "learnback_required":
+        return {
+            **common,
+            "done_definition": [
+                "classify dogfood outcomes into public-safe factory learnings",
+                "identify systemic gaps, rejected non-gaps, and already-fixed gaps",
+                "create or update public-safe improvement issues only when a real factory gap remains",
+                "leave product completion, production promotion, deploy, and customer-ready claims forbidden",
+                "complete only when learnback result includes owner, decision, evidence class, and next action",
+            ],
+            "evidence_expected": [
+                "product creation closeout summary",
+                "release readiness closeout summary",
+                "work-unit aggregate coverage",
+                "blocker and repair history classification",
+                "worker feedback and runtime contract gaps",
+                "public-safe issue/proposal refs for remaining factory improvements",
+            ],
+            "output_contract": {
+                "receipt_field": "learnback_result",
+                "allowed_results": ["PASS", "BLOCK"],
+                "pass_requires": [
+                    "public-safe learnback summary",
+                    "gap classification",
+                    "remaining issue refs or explicit no-new-gap rationale",
+                    "no private evidence embedded",
+                ],
+                "block_requires": ["owner", "reason", "missing_contract_fields", "next_repair_action"],
+                "may_create_public_safe_issue": True,
+            },
+        }
+    if next_action == "release_readiness_required":
+        return {
+            **common,
+            "done_definition": [
+                "prepare release readiness packet",
+                "state smoke, rollback, monitoring, support, human gate and promotion blockers",
+                "create independent review route when review is required",
+                "do not approve production promotion",
+            ],
+            "evidence_expected": [
+                "release plan",
+                "smoke result or reason blocked",
+                "rollback plan",
+                "monitoring/support plan",
+                "human promotion gate status",
+                "visible blockers with owner and next action",
+            ],
+            "output_contract": {
+                "receipt_field": "release_ops_result",
+                "allowed_results": ["PASS", "BLOCK"],
+                "pass_requires": ["release readiness packet", "promotion blockers remain explicit"],
+                "block_requires": ["owner", "reason", "next_repair_action"],
+                "production_promotion_allowed": False,
+            },
+        }
+    return {
+        **common,
+        "done_definition": [
+            "consume the product creation closeout next action",
+            "produce a public-safe result or block with owner, reason and next action",
+        ],
+        "evidence_expected": ["product creation closeout summary", "blocker inventory", "next action decision"],
+        "output_contract": {
+            "allowed_results": ["PASS", "BLOCK"],
+            "block_requires": ["owner", "reason", "next_repair_action"],
+        },
+    }
 
 
 def create_product_creation_closeout_next_task(
@@ -4029,6 +4126,7 @@ def create_product_creation_closeout_next_task(
             "runtime_authority": "hermes_kanban",
             "local_state_authority": False,
             "dispatch_allowed_by_this_step": False,
+            **product_creation_next_route_contract(next_action, closeout),
         }
     )
     task_id = create_blocked_task_before_assignment(

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1190,6 +1190,84 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         dispatch_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "dispatch"]
         self.assertEqual(dispatch_calls, [])
 
+    def test_close_product_creation_run_routes_learnback_with_worker_contract(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            product_creation_plan_path = tmp_path / "product-creation-plan.json"
+            product_creation_plan_path.write_text(
+                (ROOT / "templates" / "product-creation-plan.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            parent_task_id = ready_work_unit_task_ids(fake)[0]
+            block_ready_work_unit_after_release(fake, parent_task_id)
+            add_ready_work_unit_review_run(
+                fake,
+                review_task_id="t_review_pass",
+                parent_task_id=parent_task_id,
+            )
+            close_reviewed_args = adapter.build_parser().parse_args(
+                [
+                    "close-reviewed-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                ]
+            )
+            adapter.close_reviewed_ready_work_units(close_reviewed_args, runner=fake)
+            close_args = adapter.build_parser().parse_args(
+                [
+                    "close-product-creation-run",
+                    "--product-creation-plan",
+                    str(product_creation_plan_path),
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--release-readiness-ref",
+                    "external:public-release-readiness-reviewed",
+                ]
+            )
+            result = adapter.close_product_creation_run(close_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        assert_product_creation_closeout_schema(self, result)
+        self.assertEqual(result["product_creation_run_closeout"]["next_action"], "learnback_required")
+        route_tasks = [
+            task
+            for task in fake.tasks.values()
+            if "product_creation_run_closeout_next_action" in str(task.get("body") or "")
+        ]
+        self.assertEqual(len(route_tasks), 1)
+        body = json.loads(str(route_tasks[0]["body"]))
+        self.assertEqual(body["next_action"], "learnback_required")
+        self.assertEqual(route_tasks[0]["assignee"], "skill-eval-distiller")
+        self.assertIn("done_definition", body)
+        self.assertIn("source_refs", body)
+        self.assertIn("evidence_expected", body)
+        self.assertIn("forbidden_actions", body)
+        self.assertIn("output_contract", body)
+        self.assertEqual(body["public_private_boundary"]["raw_private_evidence_embedded"], False)
+        self.assertFalse(body["complete_product_claim_allowed"])
+        self.assertFalse(body["dispatch_allowed_by_this_step"])
+
     def test_close_product_creation_run_blocks_when_work_unit_review_blocks(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- adds worker-consumable contracts to product closeout next-route tasks
- gives `learnback_required` explicit `done_definition`, `source_refs`, `evidence_expected`, `forbidden_actions`, `output_contract`, and public/private boundary fields
- keeps release-readiness next-route behavior intact while adding a bounded worker contract there too
- bumps the product closeout next-route idempotency version so stale contractless tasks are not reused

Fixes #368

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_routes_learnback_with_worker_contract -q`
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_routes_release_readiness_without_product_claim tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_routes_learnback_with_worker_contract tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_blocks_when_work_unit_review_blocks tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_fails_closed_on_ambiguous_duplicate_task tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_release_readiness_review_pass_completes_parent_without_promotion -q`
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`

## Dogfood Runtime Check

A live learnback task blocked because its generated next-route body lacked `done_definition`, `source_refs`, and `evidence_expected`. This change makes the generated task body worker-consumable and versioned so the factory can create a clean replacement instead of reusing a stale contractless task.