### PR TITLE
Route product promotion gate explicitly

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -3964,7 +3964,7 @@ def product_creation_closeout_next_action(
         return "learnback_required"
     if product_promotion_gate_ref:
         return "product_closeout_ready"
-    return "blocked_with_owner"
+    return "product_promotion_gate_required"
 
 
 def product_creation_closeout_next_assignee(next_action: str, override: str | None) -> str:
@@ -4079,6 +4079,36 @@ def product_creation_next_route_contract(next_action: str, closeout: dict[str, A
                 "allowed_results": ["PASS", "BLOCK"],
                 "pass_requires": ["release readiness packet", "promotion blockers remain explicit"],
                 "block_requires": ["owner", "reason", "next_repair_action"],
+                "production_promotion_allowed": False,
+            },
+        }
+    if next_action == "product_promotion_gate_required":
+        return {
+            **common,
+            "done_definition": [
+                "obtain or record an explicit product promotion human gate",
+                "verify release readiness and learnback refs are present before asking for promotion",
+                "block with owner, reason, and next action if the human gate is absent or denied",
+                "do not claim complete product, production release, deploy, or customer-ready status",
+            ],
+            "evidence_expected": [
+                "product creation closeout summary",
+                "release readiness reviewed ref",
+                "learnback reviewed ref",
+                "explicit product promotion human gate decision",
+            ],
+            "output_contract": {
+                "receipt_field": "product_promotion_gate_result",
+                "allowed_results": ["PASS", "BLOCK"],
+                "pass_requires": [
+                    "product_promotion_gate_ref",
+                    "public-safe gate decision",
+                    "decision authority",
+                    "promotion scope",
+                    "remaining forbidden actions acknowledged",
+                ],
+                "block_requires": ["owner", "reason", "next_repair_action"],
+                "complete_product_claim_allowed": False,
                 "production_promotion_allowed": False,
             },
         }

--- a/schemas/product-creation-run-closeout.schema.json
+++ b/schemas/product-creation-run-closeout.schema.json
@@ -33,6 +33,7 @@
         "product_closeout_ready",
         "release_readiness_required",
         "learnback_required",
+        "product_promotion_gate_required",
         "repair_required",
         "human_gate_required",
         "blocked_with_owner"
@@ -43,6 +44,7 @@
         "product_closeout_ready",
         "release_readiness_required",
         "learnback_required",
+        "product_promotion_gate_required",
         "repair_required",
         "human_gate_required",
         "blocked_with_owner"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1268,6 +1268,86 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["complete_product_claim_allowed"])
         self.assertFalse(body["dispatch_allowed_by_this_step"])
 
+    def test_close_product_creation_run_routes_missing_product_promotion_gate_explicitly(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            product_creation_plan_path = tmp_path / "product-creation-plan.json"
+            product_creation_plan_path.write_text(
+                (ROOT / "templates" / "product-creation-plan.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            parent_task_id = ready_work_unit_task_ids(fake)[0]
+            block_ready_work_unit_after_release(fake, parent_task_id)
+            add_ready_work_unit_review_run(
+                fake,
+                review_task_id="t_review_pass",
+                parent_task_id=parent_task_id,
+            )
+            close_reviewed_args = adapter.build_parser().parse_args(
+                [
+                    "close-reviewed-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                ]
+            )
+            adapter.close_reviewed_ready_work_units(close_reviewed_args, runner=fake)
+            close_args = adapter.build_parser().parse_args(
+                [
+                    "close-product-creation-run",
+                    "--product-creation-plan",
+                    str(product_creation_plan_path),
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--release-readiness-ref",
+                    "external:public-release-readiness-reviewed",
+                    "--learnback-ref",
+                    "external:public-learnback-reviewed",
+                ]
+            )
+            result = adapter.close_product_creation_run(close_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        assert_product_creation_closeout_schema(self, result)
+        self.assertEqual(result["product_creation_run_closeout"]["next_action"], "product_promotion_gate_required")
+        self.assertEqual(
+            result["product_creation_next_route_task_ids"],
+            {"product_promotion_gate_required": adapter.PUBLIC_SAFE_KANBAN_REF},
+        )
+        route_tasks = [
+            task
+            for task in fake.tasks.values()
+            if "product_creation_run_closeout_next_action" in str(task.get("body") or "")
+        ]
+        self.assertEqual(len(route_tasks), 1)
+        body = json.loads(str(route_tasks[0]["body"]))
+        self.assertEqual(body["next_action"], "product_promotion_gate_required")
+        self.assertEqual(route_tasks[0]["assignee"], "factory-orchestrator")
+        self.assertIn("explicit product promotion human gate", " ".join(body["done_definition"]))
+        self.assertIn("product_promotion_gate_ref", body["output_contract"]["pass_requires"])
+        self.assertFalse(body["complete_product_claim_allowed"])
+        self.assertFalse(body["dispatch_allowed_by_this_step"])
+
     def test_close_product_creation_run_blocks_when_work_unit_review_blocks(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- route missing product promotion gate as explicit `product_promotion_gate_required` instead of generic `blocked_with_owner`
- add a worker-consumable closeout contract for the human promotion gate route
- extend the product creation closeout schema and add regression coverage

Closes #370.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_routes_missing_product_promotion_gate_explicitly`
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`