### PR TITLE
Require material product proof before promotion

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -3948,6 +3948,7 @@ def product_creation_closeout_next_action(
     *,
     product_creation_plan: dict[str, Any],
     release_readiness_ref: str | None,
+    product_delivery_ref: str | None,
     product_promotion_gate_ref: str | None,
     learnback_ref: str | None,
     blocker_decisions: list[str],
@@ -3960,6 +3961,8 @@ def product_creation_closeout_next_action(
         return "blocked_with_owner"
     if not release_readiness_ref and product_creation_plan.get("production_readiness_scope"):
         return "release_readiness_required"
+    if product_creation_plan.get("complete_product_required") is True and not product_delivery_ref:
+        return "material_product_execution_required"
     if not learnback_ref:
         return "learnback_required"
     if product_promotion_gate_ref:
@@ -4079,6 +4082,36 @@ def product_creation_next_route_contract(next_action: str, closeout: dict[str, A
                 "allowed_results": ["PASS", "BLOCK"],
                 "pass_requires": ["release readiness packet", "promotion blockers remain explicit"],
                 "block_requires": ["owner", "reason", "next_repair_action"],
+                "production_promotion_allowed": False,
+            },
+        }
+    if next_action == "material_product_execution_required":
+        return {
+            **common,
+            "done_definition": [
+                "route material product implementation before any promotion gate",
+                "create or repair executable product work units instead of treating planning readiness as product completion",
+                "require product delivery proof before learnback or product promotion can close the product",
+                "do not claim complete product, production release, deploy, or customer-ready status",
+            ],
+            "evidence_expected": [
+                "executable product artifact or product delivery proof bundle",
+                "Product Face Result for visible surfaces with states, journeys, screenshots and viewport evidence",
+                "implementation verification commands and results",
+                "public-safe evidence refs for product delivery proof",
+            ],
+            "output_contract": {
+                "receipt_field": "material_product_execution_result",
+                "allowed_results": ["PASS", "BLOCK"],
+                "pass_requires": [
+                    "product_delivery_ref",
+                    "executable product proof",
+                    "Product Face Result when visible surface exists",
+                    "verification evidence refs",
+                    "remaining release/promotion blockers acknowledged",
+                ],
+                "block_requires": ["owner", "reason", "next_repair_action"],
+                "complete_product_claim_allowed": False,
                 "production_promotion_allowed": False,
             },
         }
@@ -4224,6 +4257,7 @@ def close_product_creation_run(args: argparse.Namespace, runner: Runner = defaul
         board=board,
     )
     release_readiness_ref = ensure_public_safe_optional_ref(args.release_readiness_ref, field="release_readiness_ref")
+    product_delivery_ref = ensure_public_safe_optional_ref(args.product_delivery_ref, field="product_delivery_ref")
     product_promotion_gate_ref = ensure_public_safe_optional_ref(
         args.product_promotion_gate_ref,
         field="product_promotion_gate_ref",
@@ -4407,6 +4441,7 @@ def close_product_creation_run(args: argparse.Namespace, runner: Runner = defaul
     next_action = product_creation_closeout_next_action(
         product_creation_plan=product_creation_plan,
         release_readiness_ref=release_readiness_ref,
+        product_delivery_ref=product_delivery_ref,
         product_promotion_gate_ref=product_promotion_gate_ref,
         learnback_ref=learnback_ref,
         blocker_decisions=blocker_decisions,
@@ -4432,6 +4467,7 @@ def close_product_creation_run(args: argparse.Namespace, runner: Runner = defaul
         "proof_id_coverage": proof_id_coverage,
         "requirement_coverage": requirement_coverage,
         "release_readiness_ref": release_readiness_ref,
+        "product_delivery_ref": product_delivery_ref,
         "product_promotion_gate_ref": product_promotion_gate_ref,
         "learnback_ref": learnback_ref,
         "public_private_boundary": {
@@ -5371,6 +5407,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_close_product_run.add_argument("--hermes-bin", default="hermes")
     p_close_product_run.add_argument("--worker-assignee-prefix", default="")
     p_close_product_run.add_argument("--release-readiness-ref")
+    p_close_product_run.add_argument("--product-delivery-ref")
     p_close_product_run.add_argument("--product-promotion-gate-ref")
     p_close_product_run.add_argument("--learnback-ref")
     p_close_product_run.add_argument("--next-assignee")

--- a/schemas/product-creation-run-closeout.schema.json
+++ b/schemas/product-creation-run-closeout.schema.json
@@ -32,6 +32,7 @@
       "enum": [
         "product_closeout_ready",
         "release_readiness_required",
+        "material_product_execution_required",
         "learnback_required",
         "product_promotion_gate_required",
         "repair_required",
@@ -43,6 +44,7 @@
       "enum": [
         "product_closeout_ready",
         "release_readiness_required",
+        "material_product_execution_required",
         "learnback_required",
         "product_promotion_gate_required",
         "repair_required",
@@ -144,6 +146,7 @@
       }
     },
     "release_readiness_ref": { "type": ["string", "null"] },
+    "product_delivery_ref": { "type": ["string", "null"] },
     "product_promotion_gate_ref": { "type": ["string", "null"] },
     "learnback_ref": { "type": ["string", "null"] },
     "public_private_boundary": {

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1243,6 +1243,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     str(materialization_result_path),
                     "--release-readiness-ref",
                     "external:public-release-readiness-reviewed",
+                    "--product-delivery-ref",
+                    "external:public-product-delivery-reviewed",
                 ]
             )
             result = adapter.close_product_creation_run(close_args, runner=fake)
@@ -1323,6 +1325,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     "external:public-release-readiness-reviewed",
                     "--learnback-ref",
                     "external:public-learnback-reviewed",
+                    "--product-delivery-ref",
+                    "external:public-product-delivery-reviewed",
                 ]
             )
             result = adapter.close_product_creation_run(close_args, runner=fake)
@@ -1347,6 +1351,81 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIn("product_promotion_gate_ref", body["output_contract"]["pass_requires"])
         self.assertFalse(body["complete_product_claim_allowed"])
         self.assertFalse(body["dispatch_allowed_by_this_step"])
+
+    def test_close_product_creation_run_requires_material_product_proof_before_promotion_gate(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _plan, plan_path, readiness_path, materialization_result_path = materialize_template_ready_work_unit(
+                fake=fake,
+                tmp_path=tmp_path,
+            )
+            product_creation_plan_path = tmp_path / "product-creation-plan.json"
+            product_creation_plan_path.write_text(
+                (ROOT / "templates" / "product-creation-plan.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            release_args = adapter.build_parser().parse_args(
+                [
+                    "release-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--route-readiness",
+                    str(readiness_path),
+                ]
+            )
+            adapter.release_ready_work_units(release_args, runner=fake)
+            parent_task_id = ready_work_unit_task_ids(fake)[0]
+            block_ready_work_unit_after_release(fake, parent_task_id)
+            add_ready_work_unit_review_run(
+                fake,
+                review_task_id="t_review_pass",
+                parent_task_id=parent_task_id,
+            )
+            close_reviewed_args = adapter.build_parser().parse_args(
+                [
+                    "close-reviewed-ready-work-units",
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                ]
+            )
+            adapter.close_reviewed_ready_work_units(close_reviewed_args, runner=fake)
+            close_args = adapter.build_parser().parse_args(
+                [
+                    "close-product-creation-run",
+                    "--product-creation-plan",
+                    str(product_creation_plan_path),
+                    "--plan",
+                    str(plan_path),
+                    "--materialization-result",
+                    str(materialization_result_path),
+                    "--release-readiness-ref",
+                    "external:public-release-readiness-reviewed",
+                    "--learnback-ref",
+                    "external:public-learnback-reviewed",
+                ]
+            )
+            result = adapter.close_product_creation_run(close_args, runner=fake)
+
+        assert_live_adapter_result_schema(self, result)
+        assert_product_creation_closeout_schema(self, result)
+        self.assertEqual(result["product_creation_run_closeout"]["next_action"], "material_product_execution_required")
+        route_tasks = [
+            task
+            for task in fake.tasks.values()
+            if "product_creation_run_closeout_next_action" in str(task.get("body") or "")
+        ]
+        self.assertEqual(len(route_tasks), 1)
+        body = json.loads(str(route_tasks[0]["body"]))
+        self.assertEqual(body["next_action"], "material_product_execution_required")
+        self.assertEqual(route_tasks[0]["assignee"], "factory-orchestrator")
+        self.assertIn("product_delivery_ref", body["output_contract"]["pass_requires"])
+        self.assertIn("Product Face Result", " ".join(body["evidence_expected"]))
+        self.assertFalse(body["complete_product_claim_allowed"])
 
     def test_close_product_creation_run_blocks_when_work_unit_review_blocks(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary

- add `product_delivery_ref` to product creation closeout
- route complete-product closeout to `material_product_execution_required` before learnback or promotion when material product proof is missing
- add a blocked next-route contract requiring executable product proof and Product Face Result for visible surfaces
- extend the closeout schema and add regression coverage

Closes #372.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_requires_material_product_proof_before_promotion_gate`
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python -m unittest discover -s tests -p "test_*.py" -q`