### PR TITLE
Clarify scoped material implementation authority

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -4131,6 +4131,24 @@ def product_creation_next_route_contract(next_action: str, closeout: dict[str, A
                     {"from": "appsec_gate", "to": "independent_review"},
                     {"from": "independent_review", "to": "delivery_handoff"},
                 ],
+                "node_authority_rules": {
+                    "implementation": {
+                        "allowed_after_runtime_gate": ["build_or_repair_scoped_artifact"],
+                        "forbidden_actions_must_not_include": ["implement_product"],
+                        "replacement_for_broad_implementation_forbid": "implement_product_outside_scope",
+                        "forbidden_actions_still_required": [
+                            "complete_product_claim",
+                            "production_release_approval",
+                            "customer_ready_claim",
+                            "deploy",
+                            "infrastructure_mutation",
+                            "secret_access",
+                            "private_evidence_publication",
+                            "raw_dogfood_log_publication",
+                            "local_path_publication",
+                        ],
+                    }
+                },
                 "pass_requires": [
                     "blocked_dependency_graph_ref",
                     "no_spawn_readback_evidence",

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -1451,6 +1451,13 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             {"from": "independent_review", "to": "delivery_handoff"},
             graph_contract["required_edges"],
         )
+        implementation_authority = graph_contract["node_authority_rules"]["implementation"]
+        self.assertIn("build_or_repair_scoped_artifact", implementation_authority["allowed_after_runtime_gate"])
+        self.assertIn("implement_product", implementation_authority["forbidden_actions_must_not_include"])
+        self.assertEqual(
+            implementation_authority["replacement_for_broad_implementation_forbid"],
+            "implement_product_outside_scope",
+        )
         self.assertIn("blocked_dependency_graph_ref", body["output_contract"]["pass_requires"])
         self.assertIn("no_spawn_readback_evidence", body["output_contract"]["pass_requires"])
         self.assertIn("create_loose_material_product_tasks", body["forbidden_actions"])


### PR DESCRIPTION
## Summary
- Clarifies material product graph authority for implementation nodes.
- Allows scoped artifact build/repair only after the runtime gate.
- Keeps broad product implementation, release, deploy, secret access, private evidence publication, and local path publication forbidden.

## Why
The material execution graph can require an implementation node to build or repair a scoped executable artifact. The previous vocabulary could also forbid `implement_product`, creating an ambiguous gate: the worker was asked to implement the scoped artifact while also seeing a broad implementation prohibition.

This makes the contract precise: scoped implementation work is allowed only when explicitly gated; out-of-scope product implementation remains forbidden.

Closes #376.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_close_product_creation_run_requires_material_product_proof_before_promotion_gate -q`
- `python -m unittest tests.test_hermes_live_kanban_adapter -q`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` (`839 tests OK`)
- `git diff --check`