### PR TITLE
Require route repair card scope contract

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -2111,6 +2111,60 @@ def ready_work_unit_post_repair_review_idempotency_key(*, plan_task: dict[str, A
     return f"{base}:post-repair-review:{digest}"
 
 
+def ready_work_unit_route_repair_scope_contract(plan_task: dict[str, Any]) -> dict[str, Any]:
+    body_contract = plan_task.get("body_contract") if isinstance(plan_task.get("body_contract"), dict) else {}
+    context_packet = body_contract.get("work_unit_context_packet")
+    context_packet = context_packet if isinstance(context_packet, dict) else {}
+    embedded_payloads = context_packet.get("embedded_payloads")
+    embedded_payloads = embedded_payloads if isinstance(embedded_payloads, dict) else {}
+    current_work_unit = embedded_payloads.get("current_work_unit")
+    current_work_unit = current_work_unit if isinstance(current_work_unit, dict) else {}
+
+    def first_text(field: str) -> str:
+        for source in (body_contract, current_work_unit, plan_task):
+            value = source.get(field) if isinstance(source, dict) else None
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def first_list(field: str) -> list[str]:
+        for source in (body_contract, current_work_unit, plan_task):
+            value = source.get(field) if isinstance(source, dict) else None
+            if isinstance(value, list):
+                items = [str(item).strip() for item in value if str(item or "").strip()]
+                if items:
+                    return items
+        return []
+
+    phase = first_text("phase")
+    risk_effective = first_text("risk_effective")
+    surfaces = first_list("surfaces")
+    missing = [
+        field
+        for field, present in (
+            ("phase", bool(phase)),
+            ("risk_effective", bool(risk_effective)),
+            ("surfaces", bool(surfaces)),
+        )
+        if not present
+    ]
+    return {
+        "phase": phase,
+        "risk_effective": risk_effective,
+        "surfaces": surfaces,
+        "route_repair_contract": {
+            "required_card_fields": ["phase", "risk_effective", "surfaces"],
+            "phase": phase,
+            "risk_effective": risk_effective,
+            "surfaces": surfaces,
+            "source_contract_missing": missing,
+            "source_contract_status": "PASS" if not missing else "BLOCK",
+            "block_if_missing": True,
+            "authority_boundary": "route repair only; no product completion, release, deployment, customer-ready status, security waiver or human gate approval",
+        },
+    }
+
+
 def ready_work_unit_post_repair_review_body(
     *,
     plan_task: dict[str, Any],
@@ -2131,6 +2185,7 @@ def ready_work_unit_post_repair_review_body(
     return {
         "packet_type": "ready_work_unit_post_repair_review_request",
         "marker": READY_WORK_UNIT_POST_REPAIR_REVIEW_REQUIRED_MARKER,
+        **ready_work_unit_route_repair_scope_contract(plan_task),
         "parent_packet_id": packet_id,
         "parent_work_unit_id": work_unit_id,
         "parent_task_ref": parent_task_id,
@@ -2324,6 +2379,7 @@ def ready_work_unit_post_repair_authority_idempotency_key(
 
 def ready_work_unit_post_repair_authority_body(
     *,
+    plan_task: dict[str, Any],
     parent_task_id: str,
     packet_id: str,
     work_unit_id: str,
@@ -2332,6 +2388,7 @@ def ready_work_unit_post_repair_authority_body(
     return {
         "packet_type": "ready_work_unit_post_repair_authority_request",
         "marker": READY_WORK_UNIT_POST_REPAIR_AUTHORITY_REQUIRED_MARKER,
+        **ready_work_unit_route_repair_scope_contract(plan_task),
         "parent_packet_id": packet_id,
         "parent_work_unit_id": work_unit_id,
         "parent_task_ref": parent_task_id,
@@ -2399,6 +2456,7 @@ def create_post_repair_authority_task(
     runner: Runner = default_runner,
 ) -> str:
     body = ready_work_unit_post_repair_authority_body(
+        plan_task=plan_task,
         parent_task_id=parent_task_id,
         packet_id=packet_id,
         work_unit_id=work_unit_id,

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -2396,6 +2396,42 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             any("ready_work_unit_post_repair_review_task_created" in str(comment.get("body")) for comment in parent_comments)
         )
 
+    def test_post_repair_tasks_include_explicit_phase_risk_and_surfaces_contract(self) -> None:
+        plan = two_step_ready_work_unit_plan()
+        plan_task = plan["tasks"][0]
+
+        review_body = adapter.ready_work_unit_post_repair_review_body(
+            plan_task=plan_task,
+            parent_task_id="t_parent",
+            packet_id="ready-work-unit-packet-work-unit-001",
+            work_unit_id="work-unit-001",
+        )
+        authority_body = adapter.ready_work_unit_post_repair_authority_body(
+            parent_task_id="t_parent",
+            packet_id="ready-work-unit-packet-work-unit-001",
+            work_unit_id="work-unit-001",
+            review_result={
+                "review_task_ref": "t_review",
+                "repair_task_ref": "t_repair",
+                "marker": "ready_work_unit_repair_review_passed",
+                "status": "PASS",
+            },
+            plan_task=plan_task,
+        )
+
+        for body in (review_body, authority_body):
+            self.assertEqual(body["phase"], "F12")
+            self.assertEqual(body["risk_effective"], "R2")
+            self.assertEqual(
+                body["surfaces"],
+                ["code", "release path", "rollback", "monitoring", "support", "customer readiness"],
+            )
+            self.assertEqual(body["route_repair_contract"]["phase"], "F12")
+            self.assertEqual(body["route_repair_contract"]["risk_effective"], "R2")
+            self.assertIn("phase", body["route_repair_contract"]["required_card_fields"])
+            self.assertIn("risk_effective", body["route_repair_contract"]["required_card_fields"])
+            self.assertIn("surfaces", body["route_repair_contract"]["required_card_fields"])
+
     def test_reconcile_ready_work_units_reuses_existing_post_repair_review_task(self) -> None:
         fake = FakeHermes()
         plan = two_step_ready_work_unit_plan()


### PR DESCRIPTION
## Summary

Fixes #380.

This PR hardens ready-work-unit post-repair cards so route-repair review and authority tasks carry explicit scope classification instead of requiring reviewers to infer it from surrounding runtime state.

## What changed

- Adds a route-repair scope contract extracted from the canonical ready-work-unit `body_contract`.
- Injects explicit `phase`, `risk_effective`, and `surfaces` into post-repair review cards.
- Injects the same scope contract into post-repair authority cards.
- Marks missing scope fields as `source_contract_status: BLOCK` inside the route repair contract so future workers/reviewers can see the gap directly.
- Adds a regression test covering both post-repair review and authority bodies.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_post_repair_tasks_include_explicit_phase_risk_and_surfaces_contract`
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_reconcile_ready_work_units_creates_post_repair_review_task tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_reconcile_ready_work_units_reuses_existing_post_repair_review_task tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_reconcile_ready_work_units_consumes_versioned_post_repair_review_run_metadata`
- `python -m unittest tests.test_hermes_live_kanban_adapter`
- `python -m unittest discover -s tests`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`
- `python scripts/release_integration_preflight.py`

## Boundary

This is runtime-contract hardening only. It does not claim any product is complete, promoted, released, deployed, or customer-ready.