### PR TITLE
Enforce kanban artifact readback proof

### DIFF
--- a/docs/architecture/hermes-integration.md
+++ b/docs/architecture/hermes-integration.md
@@ -42,6 +42,8 @@ Before `done`, the adapter should:
 
 - inspect required worker results;
 - reject missing, failed or stale evidence;
+- reject metadata-only `external:kanban-artifact:` evidence unless the worker
+  result includes successful downstream `artifact_readback` proof;
 - compare worker results to Receipt Five;
 - enforce independent review and human gate requirements;
 - return an explicit block reason instead of silently closing.

--- a/docs/automation/worker-automation-v0.md
+++ b/docs/automation/worker-automation-v0.md
@@ -137,6 +137,8 @@ This is separate from the gate report:
 - worker results prove what happened;
 - `scripts/evidence_reconciler.py` chooses the current result per receipt field,
   records superseded stale results and blocks unresolved current failures;
+- `external:kanban-artifact:` refs must include `artifact_readback` proof from a
+  separate worker context before they can satisfy Receipt Five closure;
 - closure summary explains the reconciled evidence set in human-readable form;
 - Receipt Five closes the Kanban transition.
 
@@ -214,6 +216,8 @@ At `done`, Hermes should:
 - run `scripts/evidence_reconciler.py` to produce the current evidence index,
   supersession ledger and `receipt_five_reconciliation_result`;
 - reconcile each result against its expected Receipt Five field;
+- reject `external:kanban-artifact:` refs without successful downstream
+  `artifact_readback` proof;
 - reject Hermes background subagent output unless a worker result explicitly
   marks it `reconciliation_state=reconciled`;
 - reject missing, failed, unsupported or preflight-only results;

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -140,6 +140,61 @@
         "type": "string"
       }
     },
+    "artifact_readback": {
+      "type": "object",
+      "description": "Proof that declared artifact refs were read from a separate downstream worker context before closure.",
+      "required": [
+        "status",
+        "checked_from",
+        "refs"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "PASS",
+            "BLOCKED"
+          ]
+        },
+        "checked_from": {
+          "enum": [
+            "separate_worker_context",
+            "downstream_worker_context"
+          ]
+        },
+        "refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "ref",
+              "readable"
+            ],
+            "properties": {
+              "ref": {
+                "type": "string",
+                "minLength": 3
+              },
+              "readable": {
+                "type": "boolean"
+              },
+              "sha256": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$"
+              },
+              "schema_valid": {
+                "type": "boolean"
+              },
+              "readback_error": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
     "operational_evidence_bundle_refs": {
       "type": "array",
       "items": {

--- a/scripts/evidence_reconciler.py
+++ b/scripts/evidence_reconciler.py
@@ -31,6 +31,45 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def is_kanban_artifact_ref(ref: Any) -> bool:
+    value = str(ref or "").strip()
+    return value.startswith(("kanban-artifact:", "external:kanban-artifact:"))
+
+
+def artifact_readback_errors(data: dict[str, Any]) -> list[str]:
+    refs = [ref for ref in factoryctl.string_list(data.get("evidence_refs")) if is_kanban_artifact_ref(ref)]
+    if not refs:
+        return []
+
+    proof = data.get("artifact_readback")
+    if not isinstance(proof, dict):
+        return ["unreadable evidence refs: " + ", ".join(refs)]
+    if str(proof.get("status") or "").strip().upper() != "PASS":
+        return ["unreadable evidence refs: " + ", ".join(refs)]
+    if str(proof.get("checked_from") or "").strip() not in {
+        "separate_worker_context",
+        "downstream_worker_context",
+    }:
+        return ["artifact_readback.checked_from must prove separate downstream readback"]
+
+    raw_items = proof.get("refs")
+    if not isinstance(raw_items, list):
+        return ["unreadable evidence refs: " + ", ".join(refs)]
+    by_ref = {
+        str(item.get("ref") or "").strip(): item
+        for item in raw_items
+        if isinstance(item, dict)
+    }
+    unreadable = [
+        ref
+        for ref in refs
+        if not isinstance(by_ref.get(ref), dict) or by_ref[ref].get("readable") is not True
+    ]
+    if unreadable:
+        return ["unreadable evidence refs: " + ", ".join(unreadable)]
+    return []
+
+
 def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict[str, Any]:
     record_type = str(data.get("record_type") or "").strip()
     worker_ref = data.get("worker") if isinstance(data.get("worker"), dict) else {}
@@ -42,6 +81,7 @@ def result_entry(card: dict[str, Any], path: Path, data: dict[str, Any]) -> dict
         card=card,
         evidence_root=ROOT,
     )
+    validation_errors.extend(artifact_readback_errors(data))
     authority = data.get("promotion_authority") if isinstance(data.get("promotion_authority"), dict) else {}
     superseded_by = data.get("superseded_by") or authority.get("superseded_by")
     evidence_ref = factoryctl.source_card_ref(path)

--- a/tests/test_evidence_reconciler.py
+++ b/tests/test_evidence_reconciler.py
@@ -275,6 +275,70 @@ class EvidenceReconcilerTest(unittest.TestCase):
         self.assertEqual(result["result"], "BLOCKED")
         self.assertTrue(result["blocking_findings"])
 
+    def test_unreadable_effective_evidence_ref_blocks_receipt_five(self) -> None:
+        card = closure_card()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            tmp_path = Path(tmp)
+            results_dir = tmp_path / "worker-results"
+            results_dir.mkdir()
+            write_results(card, results_dir)
+            security = result_for("codex-security", card, "2026-06-06T00:50:00+00:00")
+            security["evidence_refs"] = [
+                "external:kanban-artifact:t_fixture/artifacts/missing-security-proof.json"
+            ]
+            results_dir.joinpath("codex-security.json").write_text(
+                factoryctl.json.dumps(security, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            index = evidence_reconciler.reconcile(card, results_dir)
+
+        self.assertFalse(index["receipt_five_ready"])
+        self.assertIn(
+            "security_scan_result",
+            {item["record_type"] for item in index["blocking_current_results"]},
+        )
+        security_result = index["effective_results"]["security_scan_result"]
+        self.assertFalse(security_result["valid_for_closure"])
+        self.assertIn(
+            "unreadable evidence refs: external:kanban-artifact:t_fixture/artifacts/missing-security-proof.json",
+            security_result["validation_errors"],
+        )
+
+    def test_readable_kanban_artifact_refs_can_satisfy_receipt_five(self) -> None:
+        card = closure_card()
+        ref = "external:kanban-artifact:t_fixture/artifacts/security-proof.json"
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            tmp_path = Path(tmp)
+            results_dir = tmp_path / "worker-results"
+            results_dir.mkdir()
+            write_results(card, results_dir)
+            security = result_for("codex-security", card, "2026-06-06T00:50:00+00:00")
+            security["evidence_refs"] = [ref]
+            security["artifact_readback"] = {
+                "status": "PASS",
+                "checked_from": "separate_worker_context",
+                "refs": [
+                    {
+                        "ref": ref,
+                        "readable": True,
+                        "sha256": "sha256:" + "0" * 64,
+                    }
+                ],
+            }
+            results_dir.joinpath("codex-security.json").write_text(
+                factoryctl.json.dumps(security, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            index = evidence_reconciler.reconcile(card, results_dir)
+
+        self.assertTrue(index["receipt_five_ready"])
+        self.assertEqual(
+            index["effective_results"]["security_scan_result"]["validation_errors"],
+            [],
+        )
+
     def test_extra_result_path_is_indexed_with_worker_results(self) -> None:
         card = closure_card()
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
@@ -392,6 +456,15 @@ class EvidenceReconcilerTest(unittest.TestCase):
             "sdlc_feedback_loop_refs",
             schema["properties"]["receipt_five_reconciliation_result"]["properties"],
         )
+
+    def test_worker_result_schema_declares_artifact_readback(self) -> None:
+        schema = json.loads((ROOT / "schemas" / "worker-result.schema.json").read_text(encoding="utf-8"))
+
+        self.assertIn("artifact_readback", schema["properties"])
+        artifact_readback = schema["properties"]["artifact_readback"]
+        self.assertIn("status", artifact_readback["required"])
+        self.assertIn("checked_from", artifact_readback["required"])
+        self.assertIn("refs", artifact_readback["required"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #383.

This PR makes `external:kanban-artifact:` evidence fail closed unless the worker result includes downstream artifact readback proof. The previous contract allowed a worker to declare a kanban artifact ref in metadata while downstream gates still had no proof that another worker could actually read the artifact bytes. That creates a false Receipt Five path.

## Changes

- Adds `artifact_readback` to `schemas/worker-result.schema.json`.
- Updates `scripts/evidence_reconciler.py` to reject `kanban-artifact:` and `external:kanban-artifact:` evidence refs without successful separate/downstream readback.
- Adds regression tests for unreadable artifact refs blocking closure and readable refs satisfying closure.
- Documents the adapter/done-hook invariant in the worker automation and Hermes integration docs.

## Validation

- `python -m unittest tests.test_evidence_reconciler -v`
- `python -m unittest tests.test_factoryctl tests.test_hermes_transition_hook`
- `python -m unittest @mods` across 67 `tests/test_*.py` modules: 844 tests passed
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\release_integration_preflight.py`

## Residual Risk

This PR enforces the public contract and prevents false closure. It does not recover already-missing private dogfooding artifacts. The Cockpit dogfood should rerun the blocked downstream gates after this contract lands and the runtime/exporter provides real readback records.