### PR TITLE
[codex] Add Solana AI Kit domain routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ public releases.
 
 - No unreleased public changes.
 
+## 1.1.0 - 2026-06-19
+
+- Replaced the legacy Solana core pack with `solana-ai-kit-core`, backed by
+  `solanabr/solana-ai-kit@v2.0.2` as the official Solana domain-brain provider.
+- Added deterministic Solana surface inference to worker routing. Worker
+  packets now expose `input_contract.surface_router` with declared, inferred
+  and effective surfaces plus route reasons.
+- Added `domain_brain_provider` to Solana-domain worker packets and dynamically
+  inject `solana-ai-kit` into relevant planning, architecture, build, wallet,
+  QA, integration and security workers.
+- Require `solana_ai_kit_usage_receipt` for real `PASS` results from
+  Solana-domain workers, including cases where Solana was inferred from card
+  content instead of declared in `surfaces`.
+- Expanded public Solana coverage across Anchor, Pinocchio, Token-2022, SPL,
+  NFT, Metaplex, DeFi, AMM, staking, governance, RPC, wallet and transaction
+  surfaces while keeping Factory gates, Hermes state, Receipt Five, signer
+  rules and human approvals above provider guidance.
+
 ## 1.0.0 - 2026-06-16
 
 - Added the operator-first CLI path: `factoryctl doctor`, `factoryctl init` and

--- a/agents/capability-packs.public.json
+++ b/agents/capability-packs.public.json
@@ -135,18 +135,38 @@
       "structured_proofs_required": ["agent.eval-plan", "agent.permission-boundary", "agent.profile-binding"],
       "reference_sources": ["ring prompt-reviewer", "mattpocock/skills", "orca workflow/review"]
     },
-    "solana-quasar-core": {
-      "pack_id": "solana-quasar-core",
+    "solana-ai-kit-core": {
+      "pack_id": "solana-ai-kit-core",
       "status": "core_ready",
-      "plain_purpose": "Covers Quasar-first Solana program work, PDA/CPI/account maps, compute units, wallet transactions and onchain QA.",
-      "covers_surfaces": ["solana", "solana-quasar", "quasar", "onchain", "program", "instruction", "pda", "account-pda", "cpi", "compute-units", "simulation", "devnet", "wallet", "transaction", "transactions", "signing", "funds", "mainnet"],
-      "existing_workers": ["solana-quasar-builder", "solana-quasar-qa-engineer", "solana-quasar-auditor", "wallet-transaction-builder", "crypto-key-management-specialist", "codex-security"],
+      "plain_purpose": "Covers Solana AI Kit-backed Solana/onchain work, program architecture, PDA/CPI/account maps, compute units, wallet transactions, signer boundaries and onchain QA.",
+      "covers_surfaces": ["solana", "solana-quasar", "quasar", "anchor", "pinocchio", "onchain", "program", "instruction", "pda", "account-pda", "cpi", "compute-units", "simulation", "devnet", "wallet", "transaction", "transactions", "signing", "funds", "mainnet", "rpc", "solana-sdk", "web3.js", "spl-token", "token", "token-2022", "nft", "metaplex", "compressed-nft", "defi", "amm", "staking", "governance", "dao", "solana-pay", "helius", "jupiter", "orca", "raydium"],
+      "existing_workers": ["product-sot-planner", "product-architect", "decomposition-planner", "product-face", "implementation-worker", "backend-api-builder", "integration-builder", "test-automation-builder", "qa-verification-worker", "solana-quasar-builder", "solana-quasar-qa-engineer", "solana-quasar-auditor", "wallet-transaction-builder", "crypto-key-management-specialist", "security-orchestrator", "codex-security"],
       "missing_worker_templates": [],
       "required_before_execution": true,
-      "activation_rule": "Available for Quasar-first work only; Anchor or Pinocchio require a separate optional pack and human decision.",
-      "evidence_required": ["onchain work package", "Auditor result", "signer boundary", "Quasar proof"],
-      "structured_proofs_required": ["solana.work-package", "solana.auditor-result", "solana.devnet-proof", "solana.signer-boundary"],
-      "reference_sources": ["solanabr/solana-claude", "ring security-reviewer"]
+      "activation_rule": "Available when Factory routing declares or infers a Solana-domain surface and Solana AI Kit is the pinned domain-brain provider; Factory gates, signer rules and human approvals still override provider guidance.",
+      "evidence_required": ["Solana AI Kit usage receipt for each real PASS Solana-domain worker result", "onchain work package", "Auditor result", "signer boundary", "Quasar proof when Quasar is used"],
+      "structured_proofs_required": ["solana-ai-kit.usage-receipt", "solana.work-package", "solana.auditor-result", "solana.devnet-proof", "solana.signer-boundary"],
+      "official_brain_provider": {
+        "provider_id": "solana-ai-kit",
+        "source": "https://github.com/solanabr/solana-ai-kit",
+        "pinned_ref": "v2.0.2",
+        "required_before_execution": true,
+        "install_modes": ["pinned-checkout", "agents-install", "claude-code-plugin"],
+        "load_contract": [
+          "Load Solana AI Kit before Solana/onchain planning or execution.",
+          "Use Solana AI Kit agents, commands, skills and MCP guidance as the Solana domain brain.",
+          "Record provider version, loaded sections and deviations in worker result evidence.",
+          "Treat Factory gates, Hermes runtime state, Receipt Five, signer rules and human approvals as higher authority than provider guidance."
+        ],
+        "usage_receipt_required": true,
+        "precedence_policy": [
+          "Overkill Factory gates and human approvals override Solana AI Kit recommendations.",
+          "Hermes cards, worker results and Receipt Five remain the source of truth.",
+          "No Solana AI Kit command may deploy mainnet, read private keys, sign transactions or touch funds without explicit gated authority.",
+          "When provider guidance conflicts with Factory Solana policy, block and request review instead of improvising."
+        ]
+      },
+      "reference_sources": ["solanabr/solana-ai-kit@v2.0.2", "ring security-reviewer"]
     },
     "mobile-app-pack": {
       "pack_id": "mobile-app-pack",

--- a/agents/hermes-profile-bindings.public.json
+++ b/agents/hermes-profile-bindings.public.json
@@ -167,6 +167,7 @@
       "skill_refs": [
         "overkill-factory",
         "hermes-kanban",
+        "solana-ai-kit",
         "solanabr-auditor"
       ],
       "result_schema": "schemas/auditor-result.schema.json",
@@ -1002,6 +1003,7 @@
       "skill_refs": [
         "overkill-factory",
         "hermes-kanban",
+        "solana-ai-kit",
         "solana-quasar",
         "solanabr-auditor"
       ],
@@ -1035,6 +1037,7 @@
       "skill_refs": [
         "overkill-factory",
         "hermes-kanban",
+        "solana-ai-kit",
         "solana-quasar-qa",
         "solanabr-auditor"
       ],

--- a/agents/worker-registry.public.json
+++ b/agents/worker-registry.public.json
@@ -281,6 +281,7 @@
         "risk_effective"
       ],
       "tools": [
+        "Solana AI Kit",
         "solanabr/Auditor",
         "Quasar-aware review"
       ],
@@ -292,6 +293,7 @@
         "missing signer boundary"
       ],
       "evidence_required": [
+        "Solana AI Kit usage receipt",
         "Auditor report",
         "PDA/signers/CPI/CU checks",
         "waiver if not run"
@@ -1002,6 +1004,7 @@
         "done_definition"
       ],
       "tools": [
+        "Solana AI Kit",
         "Quasar toolchain",
         "Solana devnet",
         "Rust tests"
@@ -1014,6 +1017,7 @@
         "mainnet or key access requested"
       ],
       "evidence_required": [
+        "Solana AI Kit usage receipt",
         "diff refs",
         "Quasar build/test refs",
         "PDA/signer map"
@@ -1044,6 +1048,7 @@
         "done_definition"
       ],
       "tools": [
+        "Solana AI Kit",
         "devnet",
         "Quasar tests",
         "simulation",
@@ -1057,6 +1062,7 @@
         "Auditor bypass"
       ],
       "evidence_required": [
+        "Solana AI Kit usage receipt",
         "test logs",
         "devnet/local refs",
         "negative test matrix"

--- a/docs/agents/capability-packs.md
+++ b/docs/agents/capability-packs.md
@@ -13,12 +13,15 @@ controls and specialist executors.
 
 ## How It Works
 
-Every Factory card names its surfaces, such as `frontend`, `api`, `solana`,
-`game`, `ios`, `payment` or `hardware`. Use `responsive` or `mobile-web` for
-browser UI that adapts to mobile screens. Use `ios`, `android`,
-`react-native`, `expo` or `native-mobile` for native mobile work. The broad
-surface `mobile` is intentionally ambiguous and must be refined before
-execution.
+Every Factory card may name its surfaces, such as `frontend`, `api`, `solana`,
+`game`, `ios`, `payment` or `hardware`. `factoryctl` also infers effective
+surfaces from public card routing text, such as outcome, scope, method
+contracts and product/security packets. Worker packets expose this as
+`input_contract.surface_router` with declared, inferred and effective surfaces
+plus the matched route reasons. Use `responsive` or `mobile-web` for browser UI
+that adapts to mobile screens. Use `ios`, `android`, `react-native`, `expo` or
+`native-mobile` for native mobile work. The broad surface `mobile` is
+intentionally ambiguous and must be refined before execution.
 
 `scripts/factoryctl.py validate-card` checks those surfaces against
 `agents/capability-packs.public.json`.
@@ -50,9 +53,18 @@ These packs are ready in the public Factory:
 | `cli-tui-product-pack` | Executable CLI/TUI products with command contracts, terminal transcripts, help UX and package/release proof. |
 | `cloud-native-core` | CI/CD, runtime, deploy wiring, cloud security, observability and rollback planning. |
 | `agent-runtime-core` | Hermes, Factory adapter, profiles, skills, tools, memory, MCP and agentic workflow changes. |
-| `solana-quasar-core` | Quasar-first Solana/onchain program work, wallet transactions, signer boundaries and onchain QA. |
+| `solana-ai-kit-core` | Solana AI Kit-backed Solana/onchain work, wallet transactions, signer boundaries and onchain QA. |
 | `operator-onboarding-pack` | Fresh install, first local smoke, Hermes adapter handoff and first walkthrough. |
 | `public-docs-knowledge-pack` | Public-safe docs, examples, guides and repository navigation for external users. |
+
+For Solana/onchain cards, `solana-ai-kit-core` is the domain-brain pack. The
+Solana-sensitive planning, architecture, build, wallet, QA, integration and
+security workers receive Solana AI Kit from the pinned provider ref in their
+worker packet when declared or inferred Solana surfaces are present. A real
+`PASS` result from those workers must record a Solana AI Kit usage receipt
+before it can satisfy closure. Solana AI Kit guides the domain work; it does
+not replace Hermes, Receipt Five, Factory gates, signer rules or human
+approval.
 
 ## Template Packs
 

--- a/docs/agents/worker-profiles.md
+++ b/docs/agents/worker-profiles.md
@@ -60,7 +60,7 @@ Ready packs:
 | `cli-tui-product-pack` | CLI/TUI command products, terminal UX, transcripts, install/run and package/release proof. |
 | `cloud-native-core` | CI/CD, runtime, cloud, monitoring, rollback and production operations boundaries. |
 | `agent-runtime-core` | Hermes, Factory, profiles, skills, memory, tools, MCP and autonomous workflow changes. |
-| `solana-quasar-core` | Quasar-first Solana/onchain program work, wallet transaction boundaries and onchain QA. |
+| `solana-ai-kit-core` | Solana AI Kit-backed Solana/onchain program work, wallet transaction boundaries and onchain QA. |
 
 Template packs that must be activated before execution:
 
@@ -77,6 +77,15 @@ Template packs that must be activated before execution:
 | `hardware-iot-pack` | hardware/IoT specialist with physical safety proof. |
 
 See `docs/agents/capability-packs.md` for the full rule.
+
+For Solana/onchain work, Solana AI Kit is loaded as the official domain brain
+through `solana-ai-kit-core`. The worker profile still decides authority,
+queueing and receipt fields; Solana-sensitive planning, architecture, build,
+wallet, QA, integration and security worker packets add `solana-ai-kit`
+dynamically when declared or inferred Solana surfaces are present. The packet
+also carries `input_contract.surface_router` so the worker can see why the
+Factory routed it that way. Real `PASS` results require a Solana AI Kit usage
+receipt.
 
 ## How To Read The Table
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.0.0"
+version = "1.1.0"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/capability-pack-registry.schema.json
+++ b/schemas/capability-pack-registry.schema.json
@@ -84,6 +84,42 @@
             "items": { "type": "string", "minLength": 3 }
           },
           "local_smoke_path": { "type": "string", "minLength": 3 },
+          "official_brain_provider": {
+            "type": "object",
+            "required": [
+              "provider_id",
+              "source",
+              "pinned_ref",
+              "required_before_execution",
+              "install_modes",
+              "load_contract",
+              "usage_receipt_required",
+              "precedence_policy"
+            ],
+            "properties": {
+              "provider_id": { "type": "string", "minLength": 3 },
+              "source": { "type": "string", "minLength": 3 },
+              "pinned_ref": { "type": "string", "minLength": 1 },
+              "required_before_execution": { "type": "boolean" },
+              "install_modes": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "load_contract": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 8 }
+              },
+              "usage_receipt_required": { "type": "boolean" },
+              "precedence_policy": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 8 }
+              }
+            },
+            "additionalProperties": false
+          },
           "reference_sources": {
             "type": "array",
             "minItems": 1,

--- a/schemas/worker-packet.schema.json
+++ b/schemas/worker-packet.schema.json
@@ -162,6 +162,60 @@
             "object",
             "null"
           ]
+        },
+        "surface_router": {
+          "type": "object",
+          "required": [
+            "declared_surfaces",
+            "inferred_surfaces",
+            "effective_surfaces",
+            "inference_routes"
+          ],
+          "properties": {
+            "declared_surfaces": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 2
+              }
+            },
+            "inferred_surfaces": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 2
+              }
+            },
+            "effective_surfaces": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 2
+              }
+            },
+            "inference_routes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "surface",
+                  "reason"
+                ],
+                "properties": {
+                  "surface": {
+                    "type": "string",
+                    "minLength": 2
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 6
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": true
@@ -340,6 +394,46 @@
     },
     "agent_runtime_hardening_profile": {
       "type": ["object", "null"]
+    },
+    "domain_brain_provider": {
+      "type": "object",
+      "required": [
+        "pack_id",
+        "provider_id",
+        "source",
+        "pinned_ref",
+        "required_before_execution",
+        "install_modes",
+        "load_contract",
+        "usage_receipt_required",
+        "usage_receipt_field",
+        "precedence_policy"
+      ],
+      "properties": {
+        "pack_id": { "type": "string", "minLength": 3 },
+        "provider_id": { "type": "string", "minLength": 3 },
+        "source": { "type": "string", "minLength": 3 },
+        "pinned_ref": { "type": "string", "minLength": 1 },
+        "required_before_execution": { "type": "boolean" },
+        "install_modes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "load_contract": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 8 }
+        },
+        "usage_receipt_required": { "type": "boolean" },
+        "usage_receipt_field": { "type": "string", "minLength": 3 },
+        "precedence_policy": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 8 }
+        }
+      },
+      "additionalProperties": false
     },
     "status": {
       "enum": [

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -140,6 +140,34 @@
         "type": "string"
       }
     },
+    "solana_ai_kit_usage_receipt": {
+      "type": "object",
+      "required": [
+        "provider_id",
+        "source",
+        "pinned_ref",
+        "loaded",
+        "loaded_components",
+        "evidence_refs"
+      ],
+      "properties": {
+        "provider_id": { "const": "solana-ai-kit" },
+        "source": { "const": "https://github.com/solanabr/solana-ai-kit" },
+        "pinned_ref": { "const": "v2.0.2" },
+        "loaded": { "const": true },
+        "loaded_components": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    },
     "artifact_readback": {
       "type": "object",
       "description": "Proof that declared artifact refs were read from a separate downstream worker context before closure.",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -218,6 +218,289 @@ SECRET_DELIVERY_SAFE_MODES = {
     "external_service",
 }
 SECRET_DELIVERY_EXCEPTION_MODES = {"startup_env", "runtime_file"}
+SOLANA_AI_KIT_PACK_ID = "solana-ai-kit-core"
+SOLANA_AI_KIT_USAGE_RECEIPT_FIELD = "solana_ai_kit_usage_receipt"
+SOLANA_DOMAIN_BRAIN_WORKERS = {
+    "backend-api-builder",
+    "codex-security",
+    "crypto-key-management-specialist",
+    "decomposition-planner",
+    "implementation-worker",
+    "integration-builder",
+    "product-architect",
+    "product-face",
+    "product-sot-planner",
+    "qa-verification-worker",
+    "security-orchestrator",
+    "solana-quasar-auditor",
+    "solana-quasar-builder",
+    "solana-quasar-qa-engineer",
+    "test-automation-builder",
+    "wallet-transaction-builder",
+}
+SOLANA_DOMAIN_BRAIN_OUTPUT_FIELDS = {
+    "architecture_result",
+    "backend_api_build_result",
+    "crypto_key_management_result",
+    "decomposition_result",
+    "implementation_result",
+    "integration_build_result",
+    "product_face_result",
+    "product_sot_result",
+    "qa_verification_result",
+    "security_orchestration_result",
+    "security_scan_result",
+    "auditor_result",
+    "solana_quasar_build_result",
+    "solana_quasar_qa_result",
+    "test_automation_result",
+    "wallet_transaction_result",
+}
+SOLANA_DOMAIN_SURFACES = {
+    "account-pda",
+    "anchor",
+    "amm",
+    "compressed-nft",
+    "compute-units",
+    "cpi",
+    "dao",
+    "defi",
+    "devnet",
+    "funds",
+    "governance",
+    "helius",
+    "instruction",
+    "jupiter",
+    "mainnet",
+    "metaplex",
+    "nft",
+    "onchain",
+    "orca",
+    "pda",
+    "pinocchio",
+    "program",
+    "quasar",
+    "raydium",
+    "rpc",
+    "signing",
+    "simulation",
+    "solana",
+    "solana-pay",
+    "solana-sdk",
+    "solana-quasar",
+    "spl-token",
+    "staking",
+    "token",
+    "token-2022",
+    "transaction",
+    "transactions",
+    "wallet",
+    "web3.js",
+}
+SOLANA_SURFACE_ROUTER_ALIASES = {
+    "solana": [
+        "@solana/",
+        "solana",
+        "solana labs",
+        "solana ai kit",
+        "solana-agent-kit",
+    ],
+    "solana-quasar": [
+        "quasar svm",
+        "quasar solana",
+        "quasar program",
+        "quasar toolchain",
+    ],
+    "anchor": [
+        "anchor framework",
+        "anchor program",
+        "anchor_lang",
+        "anchor lang",
+        "anchor.toml",
+    ],
+    "pinocchio": [
+        "pinocchio program",
+        "pinocchio framework",
+        "pinocchio crate",
+    ],
+    "onchain": [
+        "on-chain",
+        "onchain",
+        "sealevel",
+        "sbf program",
+        "bpf loader",
+        "upgrade authority",
+        "program id",
+    ],
+    "program": [
+        "solana program",
+        "onchain program",
+        "program account",
+        "program derived address",
+    ],
+    "instruction": [
+        "solana instruction",
+        "transaction instruction",
+        "instruction data",
+    ],
+    "account-pda": [
+        "program derived address",
+        "program-derived address",
+        "account pda",
+        "pda account",
+    ],
+    "pda": [
+        "program derived address",
+        "program-derived address",
+        "pda",
+    ],
+    "cpi": [
+        "cross program invocation",
+        "cross-program invocation",
+        "cpi account",
+        "cpi instruction",
+    ],
+    "compute-units": [
+        "compute unit",
+        "compute units",
+        "compute budget instruction",
+        "cu budget",
+    ],
+    "devnet": [
+        "solana devnet",
+        "devnet transaction",
+        "devnet program",
+    ],
+    "mainnet": [
+        "mainnet-beta",
+        "mainnet beta",
+        "solana mainnet",
+    ],
+    "wallet": [
+        "@solana/wallet-adapter",
+        "wallet adapter",
+        "phantom wallet",
+        "solflare",
+        "backpack wallet",
+    ],
+    "wallet-ui": [
+        "wallet connect button",
+        "wallet adapter ui",
+    ],
+    "transaction": [
+        "solana transaction",
+        "versioned transaction",
+        "transaction message",
+    ],
+    "transactions": [
+        "solana transactions",
+        "versioned transactions",
+    ],
+    "signing": [
+        "signer boundary",
+        "transaction signer",
+        "signing prompt",
+    ],
+    "funds": [
+        "lamports",
+        "native sol",
+    ],
+    "rpc": [
+        "solana rpc",
+        "getlatestblockhash",
+        "simulate transaction",
+    ],
+    "solana-sdk": [
+        "solana sdk",
+        "solana-client",
+        "solana-program",
+    ],
+    "web3.js": [
+        "@solana/web3.js",
+        "solana web3.js",
+        "connection.confirmtransaction",
+    ],
+    "spl-token": [
+        "spl token",
+        "spl-token",
+        "associated token account",
+        "ata account",
+    ],
+    "token": [
+        "token account",
+        "mint authority",
+        "token mint",
+    ],
+    "token-2022": [
+        "token-2022",
+        "token 2022",
+        "transfer hook",
+        "confidential transfer",
+    ],
+    "nft": [
+        "solana nft",
+        "metadata account",
+    ],
+    "compressed-nft": [
+        "compressed nft",
+        "compressed-nft",
+        "bubblegum",
+        "merkle tree nft",
+    ],
+    "metaplex": [
+        "metaplex",
+        "mpl token metadata",
+        "token metadata program",
+    ],
+    "defi": [
+        "solana defi",
+        "raydium",
+        "jupiter swap",
+        "orca whirlpool",
+    ],
+    "amm": [
+        "automated market maker",
+        "amm pool",
+        "raydium pool",
+        "orca pool",
+    ],
+    "staking": [
+        "stake account",
+        "stake pool",
+        "validator stake",
+    ],
+    "governance": [
+        "spl governance",
+        "governance proposal",
+        "realms",
+    ],
+    "dao": [
+        "dao treasury",
+        "dao governance",
+        "realms dao",
+    ],
+    "solana-pay": [
+        "solana pay",
+        "solana-pay",
+    ],
+    "helius": [
+        "helius",
+        "helius webhook",
+    ],
+    "jupiter": [
+        "jupiter swap",
+        "jupiter quote",
+        "jup.ag",
+    ],
+    "orca": [
+        "orca whirlpool",
+        "orca pool",
+    ],
+    "raydium": [
+        "raydium",
+        "raydium pool",
+    ],
+}
 SECRET_DELIVERY_FORBIDDEN_MODES = {"prompt_context"}
 SECRET_POLICY_FORBIDDEN_KEYS = {
     "secret",
@@ -332,12 +615,29 @@ SOLANA_BUILD_SURFACES = {
     "solana",
     "solana-quasar",
     "quasar",
+    "anchor",
+    "pinocchio",
     "onchain",
     "program",
     "instruction",
     "pda",
     "cpi",
     "account-pda",
+    "rpc",
+    "solana-sdk",
+    "web3.js",
+    "spl-token",
+    "token",
+    "token-2022",
+    "nft",
+    "compressed-nft",
+    "metaplex",
+    "defi",
+    "amm",
+    "staking",
+    "governance",
+    "dao",
+    "solana-pay",
 }
 SOLANA_QA_SURFACES = SOLANA_BUILD_SURFACES | {
     "solana-test",
@@ -369,13 +669,32 @@ ONCHAIN_SURFACES = {
     "solana",
     "solana-quasar",
     "quasar",
+    "anchor",
+    "pinocchio",
     "onchain",
+    "program",
+    "instruction",
     "account-pda",
     "pda",
     "cpi",
     "compute-units",
     "funds",
     "mainnet",
+    "rpc",
+    "solana-sdk",
+    "web3.js",
+    "spl-token",
+    "token",
+    "token-2022",
+    "nft",
+    "compressed-nft",
+    "metaplex",
+    "defi",
+    "amm",
+    "staking",
+    "governance",
+    "dao",
+    "solana-pay",
 }
 SECURITY_SURFACES = {
     "security",
@@ -390,6 +709,18 @@ SECURITY_SURFACES = {
     "onchain",
     "solana",
     "solana-quasar",
+    "anchor",
+    "pinocchio",
+    "pda",
+    "cpi",
+    "signing",
+    "transaction",
+    "transactions",
+    "spl-token",
+    "token-2022",
+    "defi",
+    "staking",
+    "governance",
 }
 PRODUCT_FACE_RESULT_PHASES = {"F11", "F13", "F14", "F15", "F16", "F17"}
 HIGH_RISK = {"R3", "R4"}
@@ -3397,11 +3728,106 @@ def card_parallel_lane_contracts(card: dict[str, Any]) -> list[dict[str, Any]]:
     return [item for item in raw if isinstance(item, dict)]
 
 
-def normalized_surfaces(card: dict[str, Any]) -> set[str]:
+def declared_surfaces(card: dict[str, Any]) -> set[str]:
     raw = card.get("surfaces", [])
     if not isinstance(raw, list):
         return set()
     return {str(value).strip().lower() for value in raw if str(value).strip()}
+
+
+def _surface_router_text_fragments(value: Any, *, depth: int = 0) -> list[str]:
+    if depth > 6 or value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (int, float)):
+        return [str(value)]
+    if isinstance(value, list):
+        fragments: list[str] = []
+        for item in value:
+            fragments.extend(_surface_router_text_fragments(item, depth=depth + 1))
+        return fragments
+    if isinstance(value, dict):
+        fragments = []
+        for key, item in value.items():
+            if str(key).lower() in {"private", "secret", "raw_secret", "credential", "access_token", "api_key", "authorization"}:
+                continue
+            fragments.append(str(key))
+            fragments.extend(_surface_router_text_fragments(item, depth=depth + 1))
+        return fragments
+    return []
+
+
+def _surface_alias_matches(haystack: str, normalized_haystack: str, alias: str) -> bool:
+    alias_lower = alias.lower().strip()
+    if not alias_lower:
+        return False
+    if any(char in alias_lower for char in "@/._"):
+        return alias_lower in haystack
+    normalized_alias = alias_lower.replace("-", " ").replace("_", " ")
+    pattern = r"(?<![a-z0-9])" + re.escape(normalized_alias).replace(r"\ ", r"[\s_-]+") + r"(?![a-z0-9])"
+    return re.search(pattern, normalized_haystack) is not None
+
+
+def inferred_surface_routes(card: dict[str, Any]) -> list[dict[str, str]]:
+    fragments = _surface_router_text_fragments({
+        "title": card.get("title"),
+        "summary": card.get("summary"),
+        "description": card.get("description"),
+        "body": card.get("body"),
+        "notes": card.get("notes"),
+        "source_refs": card.get("source_refs"),
+        "outcome": card.get("outcome"),
+        "acceptance_criteria": card.get("acceptance_criteria"),
+        "scope_in": card.get("scope_in"),
+        "done_definition": card.get("done_definition"),
+        "request_type": card.get("request_type"),
+        "method_contract": card.get("method_contract"),
+        "outcome_contract": card.get("outcome_contract"),
+        "product_sot": card.get("product_sot"),
+        "product_context_packet": card.get("product_context_packet"),
+        "product_creation_plan": card.get("product_creation_plan"),
+        "product_implementation_readiness": card.get("product_implementation_readiness"),
+        "security_contract": card.get("security_contract"),
+        "security_architecture_plan": card.get("security_architecture_plan"),
+        "runtime_contract": card.get("runtime_contract"),
+        "universal_signal_intake": card.get("universal_signal_intake"),
+    })
+    haystack = "\n".join(fragment.lower() for fragment in fragments if str(fragment).strip())
+    normalized_haystack = re.sub(r"[^a-z0-9@/._-]+", " ", haystack)
+    routes: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for surface, aliases in SOLANA_SURFACE_ROUTER_ALIASES.items():
+        for alias in aliases:
+            if _surface_alias_matches(haystack, normalized_haystack, alias):
+                key = f"{surface}:{alias.lower()}"
+                if key not in seen:
+                    routes.append({"surface": surface, "reason": f"matched {alias!r} in card routing text"})
+                    seen.add(key)
+                break
+    inferred_surfaces = {route["surface"] for route in routes}
+    if inferred_surfaces & SOLANA_DOMAIN_SURFACES and "solana" not in inferred_surfaces:
+        routes.append({"surface": "solana", "reason": "derived from Solana-domain surface inference"})
+    return routes
+
+
+def inferred_surfaces(card: dict[str, Any]) -> set[str]:
+    return {route["surface"] for route in inferred_surface_routes(card)}
+
+
+def surface_router_summary(card: dict[str, Any]) -> dict[str, Any]:
+    declared = declared_surfaces(card)
+    inferred = inferred_surface_routes(card)
+    return {
+        "declared_surfaces": sorted(declared),
+        "inferred_surfaces": sorted({route["surface"] for route in inferred} - declared),
+        "effective_surfaces": sorted(declared | {route["surface"] for route in inferred}),
+        "inference_routes": inferred,
+    }
+
+
+def normalized_surfaces(card: dict[str, Any]) -> set[str]:
+    return declared_surfaces(card) | inferred_surfaces(card)
 
 
 def _surface_profile_tokens(card: dict[str, Any]) -> set[str]:
@@ -12047,6 +12473,29 @@ def runtime_decision_profile(card: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def domain_brain_provider_for_worker(worker_id: str, card: dict[str, Any]) -> dict[str, Any] | None:
+    if worker_id not in SOLANA_DOMAIN_BRAIN_WORKERS:
+        return None
+    if not (normalized_surfaces(card) & SOLANA_DOMAIN_SURFACES):
+        return None
+    pack = load_capability_packs().get(SOLANA_AI_KIT_PACK_ID)
+    provider = pack.get("official_brain_provider") if isinstance(pack, dict) else None
+    if not isinstance(provider, dict):
+        return None
+    return {
+        "pack_id": SOLANA_AI_KIT_PACK_ID,
+        "provider_id": provider.get("provider_id"),
+        "source": provider.get("source"),
+        "pinned_ref": provider.get("pinned_ref"),
+        "required_before_execution": provider.get("required_before_execution") is True,
+        "install_modes": _list_items(provider.get("install_modes")),
+        "load_contract": _list_items(provider.get("load_contract")),
+        "usage_receipt_required": provider.get("usage_receipt_required") is True,
+        "usage_receipt_field": SOLANA_AI_KIT_USAGE_RECEIPT_FIELD,
+        "precedence_policy": _list_items(provider.get("precedence_policy")),
+    }
+
+
 def required_worker_ids(card: dict[str, Any]) -> list[str]:
     return [worker_id for worker_id in WORKERS if worker_required(worker_id, card)[0]]
 
@@ -12064,6 +12513,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
         status = "blocked_missing_inputs"
     if required and missing_profile_binding:
         status = "blocked_missing_profile_binding"
+    domain_brain_provider = domain_brain_provider_for_worker(worker_id, card)
 
     packet = {
         "$schema": "https://overkill-factory.dev/schemas/worker-packet.schema.json",
@@ -12095,6 +12545,7 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
             "required_fields": list(worker.required_inputs),
             "missing_fields": missing_inputs,
             "unblock_guidance": unblock_guidance(missing_inputs),
+            "surface_router": surface_router_summary(card),
             "target_repo_paths": card.get("target_repo_paths", []),
             "authority_max": card.get("authority_max"),
             "forbidden_actions": card.get("forbidden_actions", []),
@@ -12159,13 +12610,23 @@ def build_worker_packet(worker_id: str, card: dict[str, Any], source_path: Path)
         },
         "status": status,
     }
+    if domain_brain_provider:
+        packet["domain_brain_provider"] = domain_brain_provider
+        packet["input_contract"]["domain_brain_provider_ref"] = (
+            f"agents/capability-packs.public.json#packs.{SOLANA_AI_KIT_PACK_ID}.official_brain_provider"
+        )
+        packet["output_contract"]["domain_brain_usage_receipt_required"] = True
+        packet["output_contract"]["domain_brain_usage_receipt_field"] = SOLANA_AI_KIT_USAGE_RECEIPT_FIELD
     if profile_binding:
+        skill_refs = _list_items(profile_binding.get("skill_refs"))
+        if domain_brain_provider and "solana-ai-kit" not in skill_refs:
+            skill_refs.append("solana-ai-kit")
         packet["profile_binding"] = {
             "profile_id": profile_binding.get("profile_id"),
             "hermes_profile_name": profile_binding.get("hermes_profile_name"),
             "factory_gate_timing_policy": profile_binding.get("factory_gate_timing_policy"),
             "gate_timing_source": "worker_task.gate_timing_class",
-            "skill_refs": profile_binding.get("skill_refs", []),
+            "skill_refs": skill_refs,
             "result_schema": profile_binding.get("result_schema"),
             "receipt_field": profile_binding.get("receipt_field"),
             "can_mutate_card_state": profile_binding.get("can_mutate_card_state", False),
@@ -12909,6 +13370,53 @@ def _waiver_errors(data: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _solana_ai_kit_usage_receipt_errors(
+    data: dict[str, Any],
+    card: dict[str, Any] | None,
+    evidence_root: Path | None,
+) -> list[str]:
+    record_type = str(data.get("record_type") or "").strip()
+    if record_type not in SOLANA_DOMAIN_BRAIN_OUTPUT_FIELDS:
+        return []
+    if str(data.get("result") or "").strip() != "PASS":
+        return []
+    if str(data.get("evidence_kind") or "").strip() != "real":
+        return []
+
+    record_card_ref = data.get("card_ref") if isinstance(data.get("card_ref"), dict) else {}
+    record_surfaces = normalized_surfaces({"surfaces": record_card_ref.get("surfaces", [])})
+    card_surfaces = normalized_surfaces(card) if isinstance(card, dict) else set()
+    if not ((record_surfaces | card_surfaces) & SOLANA_DOMAIN_SURFACES):
+        return []
+
+    receipt = data.get(SOLANA_AI_KIT_USAGE_RECEIPT_FIELD)
+    if not isinstance(receipt, dict):
+        return [f"{SOLANA_AI_KIT_USAGE_RECEIPT_FIELD} object is required for real PASS Solana worker results"]
+
+    errors: list[str] = []
+    expected_values = {
+        "provider_id": "solana-ai-kit",
+        "source": "https://github.com/solanabr/solana-ai-kit",
+        "pinned_ref": "v2.0.2",
+    }
+    for field, expected in expected_values.items():
+        if receipt.get(field) != expected:
+            errors.append(f"{SOLANA_AI_KIT_USAGE_RECEIPT_FIELD}.{field} must be {expected}")
+    if receipt.get("loaded") is not True:
+        errors.append(f"{SOLANA_AI_KIT_USAGE_RECEIPT_FIELD}.loaded must be true")
+    if not string_list(receipt.get("loaded_components")):
+        errors.append(f"{SOLANA_AI_KIT_USAGE_RECEIPT_FIELD}.loaded_components must contain at least one item")
+    receipt_refs = string_list(receipt.get("evidence_refs"))
+    if not receipt_refs:
+        errors.append(f"{SOLANA_AI_KIT_USAGE_RECEIPT_FIELD}.evidence_refs must contain at least one artifact ref")
+    else:
+        errors.extend(
+            f"{SOLANA_AI_KIT_USAGE_RECEIPT_FIELD}.evidence_refs: {error}"
+            for error in _evidence_ref_errors(receipt_refs, evidence_root)
+        )
+    return errors
+
+
 def _record_specific_errors(data: dict[str, Any], evidence_kind: str) -> list[str]:
     record_type = str(data.get("record_type") or "").strip()
     errors: list[str] = []
@@ -13108,6 +13616,7 @@ def validate_worker_result_record(
         if "synthetic" not in source_text and "validation" not in source_text:
             errors.append("synthetic evidence can only satisfy synthetic/validation cards")
     errors.extend(_waiver_errors(data))
+    errors.extend(_solana_ai_kit_usage_receipt_errors(data, card, evidence_root))
     errors.extend(_record_specific_errors(data, evidence_kind))
     if record_type == "product_face_result" and card is not None:
         errors.extend(validate_product_face_result_against_card(data, card))

--- a/tests/test_capability_packs.py
+++ b/tests/test_capability_packs.py
@@ -139,6 +139,72 @@ class CapabilityPacksTest(unittest.TestCase):
                 self.assertTrue(pack["local_smoke_path"].startswith("python scripts/"))
                 self.assertNotIn(".tmp/", json.dumps(pack))
 
+    def test_solana_ai_kit_is_the_official_solana_core_pack(self) -> None:
+        raw_registry = (ROOT / "agents" / "capability-packs.public.json").read_text(encoding="utf-8")
+        packs = json.loads(raw_registry)["packs"]
+        legacy_pack_id = "solana-" + "quasar-core"
+        legacy_reference_source = "solanabr/" + "solana-" + "claude"
+
+        self.assertIn("solana-ai-kit-core", packs)
+        self.assertNotIn(legacy_pack_id, packs)
+        self.assertNotIn(legacy_reference_source, raw_registry)
+
+        pack = packs["solana-ai-kit-core"]
+        provider = pack["official_brain_provider"]
+        self.assertEqual(pack["pack_id"], "solana-ai-kit-core")
+        self.assertEqual(provider["provider_id"], "solana-ai-kit")
+        self.assertEqual(provider["source"], "https://github.com/solanabr/solana-ai-kit")
+        self.assertEqual(provider["pinned_ref"], "v2.0.2")
+        self.assertTrue(provider["required_before_execution"])
+        self.assertTrue(provider["usage_receipt_required"])
+        self.assertIn("solana-ai-kit.usage-receipt", pack["structured_proofs_required"])
+        self.assertIn("solanabr/solana-ai-kit@v2.0.2", pack["reference_sources"])
+        for surface in ["anchor", "pinocchio", "token-2022", "nft", "defi", "rpc", "solana-pay"]:
+            self.assertIn(surface, pack["covers_surfaces"])
+        for worker_id in ["product-architect", "wallet-transaction-builder", "crypto-key-management-specialist", "codex-security"]:
+            self.assertIn(worker_id, pack["existing_workers"])
+
+    def test_solana_surface_router_infers_solana_from_card_text_without_declared_surface(self) -> None:
+        card = base_card()
+        card["surfaces"] = ["backend"]
+        card["outcome"] = "Build a wallet flow with @solana/web3.js, Token-2022 mint authority and Phantom wallet signing."
+        card["scope_in"] = [
+            "Create the associated token account path.",
+            "Simulate transaction before broadcast.",
+        ]
+
+        surfaces = factoryctl.normalized_surfaces(card)
+
+        self.assertIn("solana", surfaces)
+        self.assertIn("web3.js", surfaces)
+        self.assertIn("token-2022", surfaces)
+        self.assertIn("wallet", surfaces)
+        self.assertEqual(factoryctl.validate_capability_coverage(card), [])
+
+    def test_solana_surface_router_avoids_generic_anchor_link_false_positive(self) -> None:
+        card = base_card()
+        card["surfaces"] = ["frontend"]
+        card["outcome"] = "Add anchor links to the docs navigation."
+        card["scope_in"] = ["HTML anchor link focus state", "Improve table-of-contents scrolling."]
+
+        surfaces = factoryctl.normalized_surfaces(card)
+
+        self.assertNotIn("solana", surfaces)
+        self.assertNotIn("anchor", surfaces)
+
+    def test_solana_surface_router_does_not_infer_from_excluded_scope_only(self) -> None:
+        card = base_card()
+        card["surfaces"] = ["frontend"]
+        card["outcome"] = "Build a public docs landing page."
+        card["scope_in"] = ["Static docs page and navigation."]
+        card["scope_out"] = ["Do not build Solana wallet flows."]
+        card["forbidden_actions"] = ["solana signing", "mainnet write"]
+
+        surfaces = factoryctl.normalized_surfaces(card)
+
+        self.assertNotIn("solana", surfaces)
+        self.assertNotIn("wallet", surfaces)
+
     def test_ready_core_surfaces_pass_capability_coverage(self) -> None:
         card = base_card()
 

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -79,10 +79,12 @@ def worker_result(
         "source_ledger_result": "source-ledger-worker",
         "security_orchestration_result": "security-orchestrator",
         "crypto_key_management_result": "crypto-key-management-specialist",
+        "backend_api_build_result": "backend-api-builder",
         "remote_proof_result": "remote-proof-runner",
         "handoff_packet_result": "handoff-packer",
         "solana_quasar_build_result": "solana-quasar-builder",
         "solana_quasar_qa_result": "solana-quasar-qa-engineer",
+        "wallet_transaction_result": "wallet-transaction-builder",
         "supply_chain_result": "supply-chain-gate",
     }.get(record_type, "fixture-worker")
     card_id = str((source_card or {}).get("card_id") or "VAL-SOLANA-QUASAR-R3")
@@ -185,6 +187,17 @@ def worker_result(
             "evidence_refs": ["README.md"],
         }
     return payload
+
+
+def solana_ai_kit_usage_receipt() -> dict:
+    return {
+        "provider_id": "solana-ai-kit",
+        "source": "https://github.com/solanabr/solana-ai-kit",
+        "pinned_ref": "v2.0.2",
+        "loaded": True,
+        "loaded_components": ["agents", "skills", "commands"],
+        "evidence_refs": ["README.md"],
+    }
 
 
 def human_gate_record(source_card: dict | None = None) -> dict:
@@ -775,6 +788,148 @@ class FactoryCtlTest(unittest.TestCase):
                 "game.playtest-review",
                 "game.runtime-choice",
             ],
+        )
+
+    def test_solana_worker_packet_carries_solana_ai_kit_domain_brain(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+
+        packet = factoryctl.build_worker_packet("solana-quasar-auditor", card, card_path)
+
+        provider = packet["domain_brain_provider"]
+        self.assertEqual(provider["pack_id"], "solana-ai-kit-core")
+        self.assertEqual(provider["provider_id"], "solana-ai-kit")
+        self.assertEqual(provider["source"], "https://github.com/solanabr/solana-ai-kit")
+        self.assertEqual(provider["pinned_ref"], "v2.0.2")
+        self.assertTrue(provider["required_before_execution"])
+        self.assertTrue(provider["usage_receipt_required"])
+        self.assertEqual(provider["usage_receipt_field"], "solana_ai_kit_usage_receipt")
+        self.assertIn("solana-ai-kit", packet["profile_binding"]["skill_refs"])
+        self.assertTrue(packet["output_contract"]["domain_brain_usage_receipt_required"])
+        self.assertEqual(
+            packet["input_contract"]["domain_brain_provider_ref"],
+            "agents/capability-packs.public.json#packs.solana-ai-kit-core.official_brain_provider",
+        )
+
+    def test_solana_domain_brain_reaches_lifecycle_wallet_and_security_workers(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+        card["surfaces"] = ["solana", "wallet", "token-2022", "defi"]
+
+        for worker_id in [
+            "product-sot-planner",
+            "product-architect",
+            "decomposition-planner",
+            "product-face",
+            "wallet-transaction-builder",
+            "crypto-key-management-specialist",
+            "codex-security",
+            "security-orchestrator",
+            "backend-api-builder",
+            "integration-builder",
+            "test-automation-builder",
+        ]:
+            with self.subTest(worker_id=worker_id):
+                packet = factoryctl.build_worker_packet(worker_id, card, card_path)
+                self.assertEqual(packet["domain_brain_provider"]["provider_id"], "solana-ai-kit")
+                self.assertIn("solana-ai-kit", packet["profile_binding"]["skill_refs"])
+
+    def test_solana_domain_brain_uses_inferred_surfaces_when_declared_surface_is_generic(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+        card["surfaces"] = ["backend"]
+        card["outcome"] = "Build a Token-2022 backend using @solana/web3.js and Phantom wallet signing."
+        card["scope_in"] = [
+            "Create associated token account flow.",
+            "Simulate transaction before broadcast.",
+        ]
+
+        packet = factoryctl.build_worker_packet("backend-api-builder", card, card_path)
+
+        self.assertEqual(packet["domain_brain_provider"]["provider_id"], "solana-ai-kit")
+        self.assertIn("solana-ai-kit", packet["profile_binding"]["skill_refs"])
+        self.assertIn("solana", packet["input_contract"]["surface_router"]["inferred_surfaces"])
+        self.assertIn("token-2022", packet["input_contract"]["surface_router"]["effective_surfaces"])
+        self.assertEqual(
+            packet["input_contract"]["domain_brain_provider_ref"],
+            "agents/capability-packs.public.json#packs.solana-ai-kit-core.official_brain_provider",
+        )
+
+    def test_real_solana_worker_result_requires_solana_ai_kit_usage_receipt(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        result = worker_result("solana_quasar_build_result", source_card=card)
+        result["evidence_kind"] = "real"
+        result["reusable_for_product"] = True
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="solana_quasar_build_result",
+            expected_worker_id="solana-quasar-builder",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn(
+            "solana_ai_kit_usage_receipt object is required for real PASS Solana worker results",
+            errors,
+        )
+
+    def test_real_solana_worker_result_requires_receipt_from_inferred_surfaces(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["surfaces"] = ["backend"]
+        card["outcome"] = "Build a Token-2022 backend using @solana/web3.js and Phantom wallet signing."
+        result = worker_result("backend_api_build_result", source_card=card)
+        result["evidence_kind"] = "real"
+        result["reusable_for_product"] = True
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="backend_api_build_result",
+            expected_worker_id="backend-api-builder",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn(
+            "solana_ai_kit_usage_receipt object is required for real PASS Solana worker results",
+            errors,
+        )
+
+    def test_real_solana_worker_result_accepts_valid_solana_ai_kit_usage_receipt(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        result = worker_result("solana_quasar_build_result", source_card=card)
+        result["evidence_kind"] = "real"
+        result["reusable_for_product"] = True
+        result["solana_ai_kit_usage_receipt"] = solana_ai_kit_usage_receipt()
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="solana_quasar_build_result",
+            expected_worker_id="solana-quasar-builder",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_real_wallet_worker_result_requires_solana_ai_kit_usage_receipt_on_solana_card(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["surfaces"] = ["solana", "wallet", "transaction"]
+        result = worker_result("wallet_transaction_result", source_card=card)
+        result["evidence_kind"] = "real"
+        result["reusable_for_product"] = True
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="wallet_transaction_result",
+            expected_worker_id="wallet-transaction-builder",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn(
+            "solana_ai_kit_usage_receipt object is required for real PASS Solana worker results",
+            errors,
         )
 
     def test_worker_packet_carries_sdlc_feedback_loop_ref(self) -> None:
@@ -3782,6 +3937,7 @@ class FactoryCtlTest(unittest.TestCase):
             findings_summary="No blocking finding.",
             next_action="continue",
         )
+        result["solana_ai_kit_usage_receipt"] = solana_ai_kit_usage_receipt()
 
         with tempfile.TemporaryDirectory() as tmp:
             results_dir = Path(tmp)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -44,6 +44,17 @@ sys.modules["public_json_validator_live_test"] = validator
 VALIDATOR_SPEC.loader.exec_module(validator)
 
 
+def solana_ai_kit_usage_receipt() -> dict:
+    return {
+        "provider_id": "solana-ai-kit",
+        "source": "https://github.com/solanabr/solana-ai-kit",
+        "pinned_ref": "v2.0.2",
+        "loaded": True,
+        "loaded_components": ["agents", "skills", "commands"],
+        "evidence_refs": ["README.md"],
+    }
+
+
 class FakeHermes:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
@@ -3645,6 +3656,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 next_action="continue",
             ),
         }
+        receipt_payload["security_orchestration_result"]["solana_ai_kit_usage_receipt"] = solana_ai_kit_usage_receipt()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             readiness = tmp_path / "route-readiness.json"
@@ -4088,6 +4100,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 next_action="continue",
             ),
         }
+        receipt_payload["security_orchestration_result"]["solana_ai_kit_usage_receipt"] = solana_ai_kit_usage_receipt()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             readiness = tmp_path / "route-readiness.json"

--- a/tests/test_hermes_transition_hook.py
+++ b/tests/test_hermes_transition_hook.py
@@ -18,6 +18,17 @@ sys.modules["transition_hook"] = transition_hook
 SPEC.loader.exec_module(transition_hook)
 
 
+def solana_ai_kit_usage_receipt() -> dict:
+    return {
+        "provider_id": "solana-ai-kit",
+        "source": "https://github.com/solanabr/solana-ai-kit",
+        "pinned_ref": "v2.0.2",
+        "loaded": True,
+        "loaded_components": ["agents", "skills", "commands"],
+        "evidence_refs": ["README.md"],
+    }
+
+
 class HermesTransitionHookTest(unittest.TestCase):
     def test_ready_hook_persists_worker_tasks_idempotently(self) -> None:
         card = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
@@ -184,6 +195,7 @@ class HermesTransitionHookTest(unittest.TestCase):
                 next_action="continue",
             ),
         }
+        receipt_payload["security_orchestration_result"]["solana_ai_kit_usage_receipt"] = solana_ai_kit_usage_receipt()
 
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
             tmp_path = Path(tmp)

--- a/tests/test_worker_profiles.py
+++ b/tests/test_worker_profiles.py
@@ -187,6 +187,7 @@ class WorkerProfilesTest(unittest.TestCase):
         tasks = {task["worker_id"]: task for task in plan["worker_tasks"]}
 
         self.assertEqual(tasks["solana-quasar-auditor"]["profile_binding"]["profile_id"], "solana-quasar-auditor.profile.v1")
+        self.assertIn("solana-ai-kit", tasks["solana-quasar-auditor"]["profile_binding"]["skill_refs"])
         self.assertEqual(tasks["codex-security"]["profile_binding"]["receipt_field"], "security_scan_result")
         self.assertEqual(tasks["supply-chain-gate"]["gate_timing_class"], "blocking-before-ready")
         self.assertEqual(tasks["supply-chain-gate"]["queue_class"], "blocking-before-ready")


### PR DESCRIPTION
## What changed

- Replaces the legacy Solana core pack with `solana-ai-kit-core`, pinned to `solanabr/solana-ai-kit@v2.0.2` as the official Solana domain-brain provider.
- Adds deterministic Solana surface inference through `input_contract.surface_router`, including declared, inferred and effective surfaces plus route reasons.
- Adds `domain_brain_provider` to Solana-domain worker packets and dynamically injects `solana-ai-kit` into relevant planning, architecture, build, wallet, QA, integration and security workers.
- Requires `solana_ai_kit_usage_receipt` for real `PASS` results from Solana-domain workers, including inferred-Solana cards.
- Prepares the public package/release metadata for `v1.1.0` and records the release notes in `CHANGELOG.md`.

## Why

The factory should not depend on a human manually declaring `solana` on every card. Solana routing now comes from explicit, auditable factory router signals, while Hermes state, Receipt Five, signer rules and human gates remain higher authority than provider guidance.

## Validation

- `python scripts/factoryctl.py doctor --json`
- `python scripts/quickstart_smoke.py`
- `python scripts/factoryctl.py run minimal --out .tmp/factory-runs/release-v1.1.0/quickstart-result.json --packets-out .tmp/factory-runs/release-v1.1.0/packets`
- `python -m unittest discover -s tests -p "test_*.py" -q` (878 tests locally before final branch cleanup)
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_planning_bundles.py`
- `python scripts/validate_public_surface_sync.py`
- `python scripts/validate_public_surface_sync.py --check-published`
- `python scripts/validate_worker_profiles.py`
- `python scripts/supply_chain_proof.py --check --no-write`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/release_integration_preflight.py --out .tmp/factory-runs/release/release-integration-preflight.json` -> PASS
- `python scripts/worktree_release_inventory.py --out .tmp/factory-runs/release/worktree-release-inventory.json` -> PASS
- Temp venv package/docs smoke: installed `overkill-factory==1.1.0`, ran `factoryctl` outside checkout, ran `overkill-quickstart`, and built MkDocs with `--strict`.
- `rg -n "solana-quasar-core|solanabr/solana-claude" . --glob "!**/.git/**" --glob "!**/.tmp/**"` returned no matches.
- `git diff --check`

## Release boundary

A new GitHub release is appropriate after merge because this changes public schemas and worker contracts, which the repo release policy classifies as a minor release.

`factory_production_readiness.py` remains `BLOCKED` for private/operator runtime gates that are intentionally outside this public repository release: Control Tower private evidence, Hermes vFinal runtime status, real runtime update preflight and prepilot readiness receipts. Those gates were not fabricated or bypassed.
