### PR TITLE
Prepare v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ public releases.
 
 ## Unreleased
 
+Nothing yet.
+
+## 1.2.0 - 2026-06-22
+
 - Require a project-level design-system / `DESIGN.md` contract for
   product-facing frontend work, wire it into Product Face validation, worker
   packets, public templates, schemas and examples.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line; the latest public tag is
-v1.1.1. It includes:
+v1.2.0. It includes:
 
 - Universal Signal Intake and route registry;
 - Golden Corpus and signal coverage checks;

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -191,7 +191,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 e a linha atual de release do kernel publico; a tag publica mais
-recente e v1.1.1. Ela inclui:
+recente e v1.2.0. Ela inclui:
 
 - Universal Signal Intake e route registry;
 - Golden Corpus e checks de cobertura de sinais;

--- a/docs/visuals/README.md
+++ b/docs/visuals/README.md
@@ -32,9 +32,9 @@ The HTML visualizations explain those contracts; they do not replace them.
 ## Version Boundary
 
 The current public map is `v1.0.1`. That is the visual surface version, not the
-repository release tag. Release `v1.1.1` includes Solana AI Kit routing, the
-Codex Bridge plugin and Solana/on-chain R4 gate hardening without republishing
-the map.
+repository release tag. Release `v1.2.0` includes Solana AI Kit routing, the
+Codex Bridge plugin, Solana/on-chain R4 gate hardening and the project
+design-system / `DESIGN.md` contract without republishing the map.
 
 For Solana work, capability packs, `input_contract.surface_router`,
 `domain_brain_provider` and `solana_ai_kit_usage_receipt` are authoritative.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.1.1"
+version = "1.2.0"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bumps package and public release docs to `v1.2.0` after the project design-system contract landed.
- Moves the design-system / `DESIGN.md` changelog item from Unreleased into the `1.2.0` release section.
- Clarifies that the public visual map remains `v1.0.1` while repo release `v1.2.0` includes the new contract.

## Validation
- `factoryctl doctor`
- `factoryctl run minimal`
- `python -m unittest discover -s tests -p "test_*.py" -q -b` (886 tests)
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_worker_profiles.py`
- `python scripts/secret_safety_scan.py`
- `python scripts/public_safety_scan.py`
- `python scripts/supply_chain_proof.py --check --no-write`
- `python scripts/validate_public_surface_sync.py --check-published`