### PR TITLE
Enforce Solana AI Kit domain brain for F4 routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ public releases.
 
 ## Unreleased
 
+## 1.5.6 - 2026-06-25
+
+- Block Solana/onchain `OVERKILL_VFINAL` F4+ routes unless a structured
+  `solana-ai-kit-core` domain-brain record is present through universal signal
+  intake, capability pack contract, direct domain brain provider state, or a
+  valid Solana AI Kit usage receipt.
+- Add transition-plan regression coverage so Hermes/adapter promotion cannot
+  move Solana architecture, specialist planning, worker routing or execution
+  from prose-only Solana/Quasar mentions.
+
 ## 1.5.5 - 2026-06-24
 
 - Add the deterministic Factory Phase Engine state contract, schema and

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.5.
+is v1.5.6.
 
 It includes:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.5.
+recente é v1.5.6.
 
 Ela inclui:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.5"
+version = "1.5.6"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -2162,6 +2162,88 @@ def validate_capability_coverage(card: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _solana_ai_kit_provider_record(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    provider_id = str(value.get("provider_id") or "").strip()
+    pack_id = str(value.get("pack_id") or "").strip()
+    source = str(value.get("source") or "").strip()
+    if provider_id != "solana-ai-kit":
+        return False
+    return (
+        (pack_id == SOLANA_AI_KIT_PACK_ID or source == "https://github.com/solanabr/solana-ai-kit")
+        and pack_id in {"", SOLANA_AI_KIT_PACK_ID}
+        and source in {"", "https://github.com/solanabr/solana-ai-kit"}
+    )
+
+
+def solana_domain_brain_materialized(card: dict[str, Any]) -> bool:
+    """Return true only when Solana AI Kit is recorded as structured route state."""
+
+    for field in ("domain_brain_provider", "solana_domain_brain_provider"):
+        if _solana_ai_kit_provider_record(card.get(field)):
+            return True
+
+    intake = card.get("universal_signal_intake") if isinstance(card.get("universal_signal_intake"), dict) else {}
+    domain = intake.get("domain_routing") if isinstance(intake.get("domain_routing"), dict) else {}
+    if domain:
+        pack_ids = {str(pack).strip() for pack in _list_items(domain.get("capability_pack_ids"))}
+        provider_ref = str(domain.get("official_brain_provider_ref") or "").strip()
+        if (
+            SOLANA_AI_KIT_PACK_ID in pack_ids
+            and domain.get("official_brain_provider_required") is True
+            and f"packs.{SOLANA_AI_KIT_PACK_ID}.official_brain_provider" in provider_ref
+        ):
+            return True
+
+    contract = card.get("capability_pack_contract")
+    if SOLANA_AI_KIT_PACK_ID in _activated_capability_pack_ids(contract):
+        return True
+    if isinstance(contract, dict) and str(contract.get("pack_id") or "").strip() == SOLANA_AI_KIT_PACK_ID:
+        return True
+
+    for field in SOLANA_DOMAIN_BRAIN_OUTPUT_FIELDS:
+        result = card.get(field)
+        if isinstance(result, dict) and _solana_ai_kit_usage_receipt_errors(result, card, ROOT) == []:
+            return True
+
+    return False
+
+
+def solana_domain_brain_required_for_card(card: dict[str, Any]) -> bool:
+    if card.get("factory_method_version") != "OVERKILL_VFINAL":
+        return False
+    if not (normalized_surfaces(card) & SOLANA_DOMAIN_SURFACES):
+        return False
+
+    phase_rank = factory_phase_rank(card.get("phase"))
+    f4_rank = factory_phase_rank("F4")
+    if phase_rank >= f4_rank:
+        return True
+
+    return _phase_engine_any_materialized(
+        card,
+        "method_contract",
+        "architecture_candidate",
+        "security_architecture_plan",
+        "specialist_decision_packet",
+        "product_creation_plan",
+        "product_implementation_readiness",
+        "onchain_work_package",
+    )
+
+
+def validate_solana_domain_brain_route(card: dict[str, Any]) -> list[str]:
+    if not solana_domain_brain_required_for_card(card):
+        return []
+    if solana_domain_brain_materialized(card):
+        return []
+    return [
+        "Solana/onchain F4+ route requires an explicit solana-ai-kit-core domain brain record "
+        "before architecture, specialist planning, worker routing or execution"
+    ]
+
+
 def worker_result_schema_path(worker_id: str) -> str:
     binding = load_profile_bindings().get(worker_id) or {}
     schema_path = str(binding.get("result_schema") or "schemas/worker-result.schema.json").strip()
@@ -6010,6 +6092,7 @@ def validate_card(data: dict[str, Any]) -> list[str]:
     errors.extend(validate_vfinal_card_contract(data))
     errors.extend(validate_canonical_runtime_gate(data))
     errors.extend(validate_capability_coverage(data))
+    errors.extend(validate_solana_domain_brain_route(data))
     errors.extend(validate_agent_runtime_hardening_profile(data))
     if data.get("factory_method_version") == "OVERKILL_VFINAL":
         if not isinstance(data.get("reasoning_policy"), dict):

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -860,6 +860,60 @@ class FactoryCtlTest(unittest.TestCase):
             "agents/capability-packs.public.json#packs.solana-ai-kit-core.official_brain_provider",
         )
 
+    def test_vfinal_solana_f4_blocks_without_structured_solana_ai_kit_route(self) -> None:
+        card_path = ROOT / "templates" / "vfinal-factory-card.json"
+        card = factoryctl.load_json_like(card_path)
+        card["phase"] = "F4"
+        card["surfaces"] = ["architecture", "solana", "onchain"]
+        card.pop("universal_signal_intake", None)
+        card["universal_signal_intake_ref"] = "templates/universal-signal-intake.json"
+
+        errors = factoryctl.validate_solana_domain_brain_route(card)
+        plan = factoryctl.build_transition_plan(card, card_path, from_status="todo", to_status="ready")
+
+        expected = (
+            "Solana/onchain F4+ route requires an explicit solana-ai-kit-core domain brain record "
+            "before architecture, specialist planning, worker routing or execution"
+        )
+        self.assertIn(expected, errors)
+        self.assertIn(expected, plan["blocked_reasons"])
+
+    def test_vfinal_solana_f4_accepts_structured_solana_ai_kit_intake_route(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["phase"] = "F4"
+        card["surfaces"] = ["architecture", "solana", "onchain"]
+        card["universal_signal_intake"] = factoryctl.build_universal_signal_intake(
+            route_class="product_creation",
+            request_type="product_new",
+            signal_type="product_paper",
+            summary_public_safe="Solana onchain digital bank product start.",
+            signal_ref_public_safe="external:solana-bank-start-sources",
+            target_surface="Solana onchain bank with wallet, Token-2022 and Quasar architecture",
+            owner="operator",
+            source_class="operator_supplied",
+            sensitivity_class="public_safe_summary",
+            freshness="fresh",
+            risk_initial="R4",
+            materiality="material",
+            intake_id="intake-solana-bank",
+        )
+
+        self.assertTrue(factoryctl.solana_domain_brain_materialized(card))
+        self.assertEqual(factoryctl.validate_solana_domain_brain_route(card), [])
+
+    def test_vfinal_solana_f4_rejects_label_only_solana_ai_kit_provider_record(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["phase"] = "F4"
+        card["surfaces"] = ["architecture", "solana", "onchain"]
+        card["domain_brain_provider"] = {"provider_id": "solana-ai-kit"}
+
+        self.assertFalse(factoryctl.solana_domain_brain_materialized(card))
+        self.assertTrue(factoryctl.validate_solana_domain_brain_route(card))
+
+        card["domain_brain_provider"]["pack_id"] = "solana-ai-kit-core"
+        self.assertTrue(factoryctl.solana_domain_brain_materialized(card))
+        self.assertEqual(factoryctl.validate_solana_domain_brain_route(card), [])
+
     def test_real_solana_worker_result_requires_solana_ai_kit_usage_receipt(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         result = worker_result("solana_quasar_build_result", source_card=card)

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.5", readme)
+        self.assertIn("v1.5.6", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.5",
+            "v1.5.6",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
## Summary

- fail closed for Solana/onchain `OVERKILL_VFINAL` F4+ routes without structured `solana-ai-kit-core` domain-brain state
- accept only deterministic route records: universal signal intake, capability pack contract, provider record with pack/source, or valid usage receipt
- bump public release docs/version to `v1.5.6`

## Validation

- `python -m unittest tests.test_factoryctl.FactoryCtlTest.test_vfinal_solana_f4_blocks_without_structured_solana_ai_kit_route tests.test_factoryctl.FactoryCtlTest.test_vfinal_solana_f4_accepts_structured_solana_ai_kit_intake_route tests.test_factoryctl.FactoryCtlTest.test_vfinal_solana_f4_rejects_label_only_solana_ai_kit_provider_record -q`
- `python -m unittest discover -s tests -q` — 970 tests OK
- `python scripts/public_safety_scan.py --git-ref HEAD --summary-json .tmp/factory-runs/public-safety/head-summary.json`
- `python scripts/secret_safety_scan.py --summary-json .tmp/factory-runs/public-safety/secret-summary.json`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_worker_profiles.py`
- `python scripts/validate_promise_implementation_map.py`
- `python scripts/release_integration_preflight.py` — PASS

Closes #417