### PR TITLE
Make Hermes board routing deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ public releases.
 
 ## Unreleased
 
+## 1.5.7 - 2026-06-25
+
+- Add `factoryctl reconcile-board`, a deterministic Hermes/Kanban board
+  reconciler that selects the active factory card from board state, computes the
+  phase engine frontier and emits a single allowed next action.
+- Wire Hermes no-idle remediation to the board reconciler so silent boards
+  create deterministic next-artifact tasks instead of generic remediation cards.
+- Block declared future phases from becoming human-gate requests when the
+  computed frontier is still Product SOT or another earlier artifact.
+- Add regressions for F9 architecture/gate claims that must reconcile back to
+  F5 `operator_briefing_package`, plus no-canonical-card and ready-dispatch
+  board states.
+
 ## 1.5.6 - 2026-06-25
 
 - Block Solana/onchain `OVERKILL_VFINAL` F4+ routes unless a structured

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.6.
+is v1.5.7.
 
 It includes:
 
@@ -286,6 +286,9 @@ It includes:
   architecture, repo cleanup, human gates or worker packets;
 - deterministic Phase Engine state so materialized artifacts, not agent prose or
   declared card phase, decide the active frontier and next required artifact;
+- deterministic Hermes/Kanban board reconciliation so a silent board becomes
+  one allowed next-artifact task, native dispatch, or a real bounded gate
+  request instead of agent-chosen phase routing;
 - Hermes completion artifact projection, no-idle remediation controls, Hermes
   update guard, cron-friendly no-idle watchdog and Fast Autonomy Lane contracts.
 
@@ -324,6 +327,8 @@ implementation, proof and boundary.
 - `docs/operations/fast-autonomy-lane.md`: fast autonomous execution limits.
 - `scripts/factory_no_idle_watchdog.py`: Hermes-cron no-idle heartbeat for
   Telegram-first operation.
+- `factoryctl reconcile-board`: deterministic board-level next action from a
+  Hermes/Kanban snapshot.
 - `docs/operations/release-policy.md`: release and versioning policy.
 - `docs/operations/troubleshooting.md`: common failures and recovery path.
 - `docs/architecture/hermes-integration.md`: Hermes adapter architecture.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.6.
+recente é v1.5.7.
 
 Ela inclui:
 
@@ -288,6 +288,9 @@ Ela inclui:
 - Phase Engine determinístico para que artefatos materializados, não prosa de
   agente ou `phase` declarado no card, decidam a fronteira ativa e o próximo
   artefato obrigatório;
+- reconciliação determinística de board Hermes/Kanban para transformar uma fila
+  silenciosa em uma única tarefa de próximo artefato, dispatch nativo ou pedido
+  real de gate limitado, sem rota escolhida pelo agente;
 - projeção de artefato de conclusão Hermes, controles de no-idle, Hermes update
   guard, watchdog de no-idle para Hermes cron e contratos da Fast Autonomy Lane.
 
@@ -323,6 +326,8 @@ apontar sua implementação, prova e limite.
 - `docs/operations/fast-autonomy-lane.md`: limites da execução autônoma rápida.
 - `scripts/factory_no_idle_watchdog.py`: heartbeat de no-idle via Hermes cron
   para operação primária pelo Telegram.
+- `factoryctl reconcile-board`: próxima ação determinística de nível board a
+  partir de um snapshot Hermes/Kanban.
 - `docs/operations/release-policy.md`: política de versão e release.
 - `docs/operations/troubleshooting.md`: falhas comuns e caminho de recuperação.
 - `docs/architecture/hermes-integration.md`: arquitetura do adapter Hermes.

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1242,6 +1242,44 @@ def create_no_idle_remediation_task(
     )
 
 
+def build_board_reconcile_plan_from_rows(*, board: str, rows: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    factoryctl = load_factoryctl()
+    plan = factoryctl.build_board_reconcile_plan({"rows": rows}, board=board)
+    errors = factoryctl.validate_board_reconcile_plan(plan)
+    if errors:
+        raise RuntimeError("factory board reconcile plan is invalid: " + "; ".join(errors))
+    return plan
+
+
+def create_deterministic_reconcile_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    workspace: str,
+    plan: dict[str, Any],
+    runner: Runner,
+) -> str | None:
+    contract = plan.get("create_task_contract")
+    if not isinstance(contract, dict):
+        return None
+    body = contract.get("body")
+    if not isinstance(body, dict):
+        return None
+    digest = idempotency_digest_fragment(contract_digest(body))
+    return create_task(
+        hermes_bin=hermes_bin,
+        board=board,
+        title=str(contract.get("title") or "Factory deterministic reconcile"),
+        body=compact_json_argument(body),
+        assignee=str(contract.get("assignee") or "factory-orchestrator"),
+        idempotency_key=f"overkill:reconcile:{public_safe_slug(board, fallback='board')}:{digest}",
+        created_by=NO_IDLE_AUTHOR,
+        workspace=workspace,
+        blocked=False,
+        runner=runner,
+    )
+
+
 def route_readiness_blockers(path: Path | None, required_worker_ids: list[str]) -> list[str]:
     if path is None:
         return ["route readiness manifest is required before live Hermes dispatch"]
@@ -6536,25 +6574,35 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
     rows = enrich_no_idle_rows(hermes_bin=args.hermes_bin, board=args.board, rows=rows, runner=runner)
     classification = classify_no_idle_state(rows)
     remediation_task_id: str | None = None
+    reconcile_plan: dict[str, Any] | None = None
     if classification.get("remediation_required") and args.create_remediation:
-        remediation_task_id = create_no_idle_remediation_task(
+        reconcile_plan = build_board_reconcile_plan_from_rows(board=args.board, rows=rows)
+        remediation_task_id = create_deterministic_reconcile_task(
             hermes_bin=args.hermes_bin,
             board=args.board,
             workspace=args.workspace,
-            assignee=args.assignee,
-            classification=classification,
+            plan=reconcile_plan,
             runner=runner,
         )
         classification = dict(classification)
-        classification["remediation_task_created"] = True
+        classification["board_reconcile_plan"] = reconcile_plan
+        classification["remediation_task_created"] = remediation_task_id is not None
         classification["remediation_task_ref"] = remediation_task_id
-        classification["native_dispatch_required_next"] = True
+        classification["native_dispatch_required_next"] = bool(
+            remediation_task_id and reconcile_plan.get("native_dispatch_required_next") is True
+        )
+        classification["classification"] = (
+            "deterministic_board_reconcile_task_created"
+            if remediation_task_id
+            else str(reconcile_plan.get("plan_action") or classification.get("classification"))
+        )
     envelope = {
         "$schema": LIVE_ADAPTER_SCHEMA,
         "mode": "no-idle",
         "board": args.board,
         "blocked": bool(classification.get("blocked")),
         "no_idle_state": classification,
+        "board_reconcile_plan": reconcile_plan,
         "remediation_task_id": remediation_task_id,
         "hook": {
             "runtime_authority": "hermes_kanban",

--- a/docs/architecture/hermes-integration.md
+++ b/docs/architecture/hermes-integration.md
@@ -65,10 +65,14 @@ only a board-state controller:
 - if only explicit human-gate blockers remain, it returns a structured human
   decision request;
 - if unfinished work remains without `ready`, `running` or a sole human gate, it
-  may create one safe remediation card and leaves worker launch to native
-  dispatch.
+  runs `factoryctl reconcile-board` over the Kanban snapshot and may create
+  exactly one deterministic reconcile card for the next artifact selected by the
+  phase engine.
 
 This closes silent idle without creating a shadow dispatcher or bypassing gates.
+The no-idle layer must not ask for a human gate when the board reconciler says
+`phase_engine.human_gate_allowed=false`; it must create or repair the next
+factory-owned artifact instead.
 
 ## Gate Timing Classes
 

--- a/docs/concepts/factory-flow.md
+++ b/docs/concepts/factory-flow.md
@@ -77,6 +77,23 @@ the engine blocks the card. For example, a declared F9 architecture or human
 gate package cannot proceed while the computed frontier is still Product SOT and
 the next required artifact is `operator_briefing_package`.
 
+## Deterministic Board Reconciler
+
+`factoryctl reconcile-board` applies the phase engine to Hermes/Kanban board
+state. This is the runtime rule for silent boards:
+
+- `running` means observe running work;
+- `ready` means native Hermes dispatch is the next action;
+- no canonical factory card means repair the board contract, not infer a phase;
+- one canonical card means compute its phase engine state and create only the
+  next artifact task selected by that state;
+- a human gate can be requested only when the phase engine allows it and the
+  decision package is complete.
+
+This keeps Telegram, Discord, Codex bridge and status messages as operator
+views. They can show the reconciled state, but they do not choose F1, F2, F3 or
+F9 from conversation history.
+
 ## User Role
 
 The normal user provides material, goals, constraints, access when required,

--- a/docs/getting-started/install-in-hermes.md
+++ b/docs/getting-started/install-in-hermes.md
@@ -104,6 +104,11 @@ This gives the factory a heartbeat without giving the watchdog authority over
 the product. It may create safe remediation work and trigger native dispatch. It
 must not close human gates, execute factory work as the manager, or approve
 production, mainnet, funds, signing, secrets, billing or destructive actions.
+When unfinished work is silent, the adapter first runs the deterministic
+`factoryctl reconcile-board` plan. That plan either points to native dispatch,
+repairs the canonical factory card, creates the next required artifact from the
+phase engine, repairs a decision package, or asks for a real bounded decision
+only when `phase_engine.human_gate_allowed=true`.
 When the adapter returns `input_required`, the Telegram operator should ask for
 the exact missing inputs instead of saying there is no human action. This is not
 approval bureaucracy; it is source/input collection for a blocked dependency

--- a/docs/promise-implementation-map.public.json
+++ b/docs/promise-implementation-map.public.json
@@ -329,16 +329,19 @@
         "docs/architecture/hermes-integration.md"
       ],
       "implementation_refs": [
+        "scripts/factoryctl.py",
         "scripts/factory_no_idle_watchdog.py",
         "adapters/hermes/live_kanban_adapter.py",
+        "schemas/factory-board-reconcile-plan.schema.json",
         "schemas/factory-bridge-event.schema.json"
       ],
       "proof_refs": [
+        "tests/test_factory_board_reconciler.py",
         "tests/test_factory_no_idle_watchdog.py",
         "tests/test_hermes_live_kanban_adapter.py",
         "tests/test_operator_experience.py"
       ],
-      "boundary": "The watchdog is a board-state controller. It must not become a shadow scheduler, approve gates, complete work or replace native Hermes dispatch.",
+      "boundary": "The watchdog is a board-state controller. Silent boards must pass through deterministic board reconciliation before any remediation card is created. It must not become a shadow scheduler, approve gates, complete work, choose phases from prose or replace native Hermes dispatch.",
       "boundary_refs": [
         "docs/architecture/hermes-integration.md",
         "docs/operator/overkill-factory-bridge.md"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -88,6 +88,8 @@ factoryctl gate-report --card examples/minimal-hermes-project/card.md
 factoryctl unblock-plan --card examples/minimal-hermes-project/card.md
 factoryctl recovery-plan --card examples/minimal-hermes-project/card.md --receipt .tmp/receipt.json --worker-results-dir .tmp/worker-results
 factoryctl help-next --card examples/minimal-hermes-project/card.md --worker-results-dir .tmp/worker-results --out .tmp/factory-help.json
+factoryctl reconcile-board --board product-alpha --snapshot .tmp/hermes-board-snapshot.json --out .tmp/factory-board-reconcile-plan.json
+factoryctl validate-reconcile-board .tmp/factory-board-reconcile-plan.json
 factoryctl worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 factoryctl transition-plan --card examples/minimal-hermes-project/card.md --from-status draft --to-status ready
 factoryctl status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
@@ -106,6 +108,13 @@ next required artifact, allowed current workers and human-gate allowance. A card
 that declares a later phase such as F9 while the computed frontier still needs
 `operator_briefing_package` or `method_contract` is blocked before the operator
 is asked for a decision.
+
+`reconcile-board` applies that rule to a Hermes/Kanban board snapshot. It is the
+deterministic no-idle decision contract: running work is observed, ready work is
+left to native Hermes dispatch, missing canonical cards become board-contract
+repair, and a single canonical card can create only the next artifact selected
+by the phase engine. It must not ask for a human gate unless
+`phase_engine.human_gate_allowed=true` and the decision package is complete.
 
 `route-registry` exposes the canonical route matrix used by the validators:
 route class, request types, signal types, required artifacts, workers, recovery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.6"
+version = "1.5.7"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/factory-board-reconcile-plan.schema.json
+++ b/schemas/factory-board-reconcile-plan.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-board-reconcile-plan.schema.json",
+  "title": "Factory Board Reconcile Plan",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "created_at",
+    "board",
+    "deterministic",
+    "agent_route_authority",
+    "runtime_authority",
+    "local_state_authority",
+    "status_counts",
+    "plan_action",
+    "reason",
+    "blocked_reasons",
+    "selected_card",
+    "phase_engine",
+    "factory_help",
+    "create_task_allowed",
+    "create_task_contract",
+    "native_dispatch_required_next",
+    "human_gate_required",
+    "operator_input_required",
+    "user_decision_required",
+    "operator_decision_policy",
+    "limits"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-board-reconcile-plan.schema.json" },
+    "record_type": { "const": "factory_board_reconcile_plan" },
+    "created_at": { "type": "string", "minLength": 1 },
+    "board": { "type": "string", "minLength": 1 },
+    "deterministic": { "const": true },
+    "agent_route_authority": { "const": false },
+    "runtime_authority": { "const": "hermes_kanban" },
+    "local_state_authority": { "const": false },
+    "status_counts": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "plan_action": {
+      "enum": [
+        "observe_running",
+        "dispatch_ready",
+        "no_unfinished_work",
+        "repair_board_contract",
+        "create_next_artifact_task",
+        "repair_human_gate_packet",
+        "request_operator_input",
+        "request_human_gate_decision",
+        "block_invariant_violation"
+      ]
+    },
+    "reason": { "type": "string", "minLength": 1 },
+    "blocked_reasons": { "type": "array", "items": { "type": "string" } },
+    "selected_card": {
+      "type": ["object", "null"],
+      "required": ["task_ref", "status", "title", "assignee", "selection_reason"],
+      "properties": {
+        "task_ref": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "assignee": { "type": "string" },
+        "selection_reason": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "phase_engine": { "type": ["object", "null"] },
+    "factory_help": { "type": ["object", "null"] },
+    "create_task_allowed": { "type": "boolean" },
+    "create_task_contract": {
+      "type": ["object", "null"],
+      "required": ["title", "assignee", "body"],
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "assignee": { "type": "string", "minLength": 1 },
+        "body": {
+          "type": "object",
+          "required": [
+            "packet_type",
+            "marker",
+            "board",
+            "plan_action",
+            "phase_engine",
+            "required_output",
+            "reason",
+            "runtime_authority",
+            "local_state_authority",
+            "agent_may_choose_phase",
+            "allowed_actions",
+            "forbidden_actions",
+            "native_dispatch_required_next"
+          ],
+          "properties": {
+            "packet_type": { "const": "factory_deterministic_reconcile_task" },
+            "marker": { "const": "factory_deterministic_reconcile" },
+            "board": { "type": "string", "minLength": 1 },
+            "plan_action": { "type": "string", "minLength": 1 },
+            "card_id": { "type": "string", "minLength": 1 },
+            "phase_engine": { "type": "object" },
+            "factory_next_action": { "type": ["object", "null"] },
+            "required_output": { "type": "string", "minLength": 1 },
+            "reason": { "type": "string", "minLength": 1 },
+            "runtime_authority": { "const": "hermes_kanban" },
+            "local_state_authority": { "const": false },
+            "agent_may_choose_phase": { "const": false },
+            "allowed_actions": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "forbidden_actions": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "native_dispatch_required_next": { "const": true }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "native_dispatch_required_next": { "type": "boolean" },
+    "human_gate_required": { "type": "boolean" },
+    "operator_input_required": { "type": "boolean" },
+    "user_decision_required": { "type": "boolean" },
+    "operator_decision_policy": {
+      "type": "object",
+      "required": [
+        "human_gate_only_when_phase_engine_allows",
+        "planning_continuation_approval_forbidden",
+        "decision_package_required_before_question",
+        "summary_only_gate_forbidden"
+      ],
+      "properties": {
+        "human_gate_only_when_phase_engine_allows": { "const": true },
+        "planning_continuation_approval_forbidden": { "const": true },
+        "decision_package_required_before_question": { "const": true },
+        "summary_only_gate_forbidden": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -17781,6 +17781,400 @@ def build_factory_help(
     }
 
 
+TERMINAL_BOARD_STATUSES = {"done", "complete", "completed", "archived", "cancelled", "canceled"}
+BOARD_RECONCILE_CREATE_ACTIONS = {
+    "repair_board_contract",
+    "create_next_artifact_task",
+    "repair_human_gate_packet",
+    "request_operator_input",
+}
+
+
+def _task_status(task: dict[str, Any], fallback: str = "") -> str:
+    return str(task.get("status") or task.get("state") or fallback or "").strip().lower()
+
+
+def _task_public_ref(task: dict[str, Any]) -> str:
+    raw = str(task.get("id") or task.get("task_id") or task.get("card_id") or "kanban:unknown").strip()
+    return public_safe_kanban_ref(raw) or "kanban:<redacted>"
+
+
+def _task_public_title(task: dict[str, Any]) -> str:
+    return str(task.get("title") or task.get("name") or task.get("summary") or "Untitled Hermes task").strip()
+
+
+def _json_object_from_possible_string(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or not text.startswith("{"):
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _factory_card_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    if str(payload.get("factory_method_version") or "").strip() or str(payload.get("record_type") or "") == "factory_card":
+        return copy.deepcopy(payload)
+    for key in ("card", "factory_card", "canonical_card", "source_card"):
+        nested = payload.get(key)
+        if isinstance(nested, dict) and (
+            str(nested.get("factory_method_version") or "").strip()
+            or str(nested.get("record_type") or "") == "factory_card"
+        ):
+            return copy.deepcopy(nested)
+    return None
+
+
+def factory_card_from_task(task: dict[str, Any]) -> dict[str, Any] | None:
+    for key in ("card", "factory_card", "canonical_card", "metadata", "body", "description", "result"):
+        payload = _json_object_from_possible_string(task.get(key))
+        if not isinstance(payload, dict):
+            continue
+        card = _factory_card_from_payload(payload)
+        if card is not None:
+            return card
+    return None
+
+
+def board_rows_from_snapshot(snapshot: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    rows: dict[str, list[dict[str, Any]]] = {status: [] for status in ("ready", "running", "todo", "blocked", "done")}
+    raw_rows = snapshot.get("rows") if isinstance(snapshot.get("rows"), dict) else snapshot.get("tasks_by_status")
+    if isinstance(raw_rows, dict):
+        for status, items in raw_rows.items():
+            normalized = str(status or "").strip().lower()
+            if not isinstance(items, list):
+                continue
+            rows.setdefault(normalized, [])
+            for item in items:
+                if isinstance(item, dict):
+                    task = dict(item)
+                    task.setdefault("status", normalized)
+                    rows[normalized].append(task)
+        return rows
+
+    raw_tasks = snapshot.get("tasks") or snapshot.get("cards") or []
+    if isinstance(raw_tasks, list):
+        for item in raw_tasks:
+            if not isinstance(item, dict):
+                continue
+            status = _task_status(item, "unknown")
+            rows.setdefault(status, []).append(dict(item))
+    return rows
+
+
+def board_status_counts(rows: dict[str, list[dict[str, Any]]]) -> dict[str, int]:
+    return {status: len(items) for status, items in sorted(rows.items()) if items}
+
+
+def board_reconcile_task_ref(task: dict[str, Any], *, status: str) -> dict[str, Any]:
+    return sanitize_public_refs(
+        {
+            "task_ref": _task_public_ref(task),
+            "status": status,
+            "title": _task_public_title(task),
+            "assignee": str(task.get("assignee") or task.get("owner") or "").strip(),
+        }
+    )
+
+
+def select_canonical_board_card(rows: dict[str, list[dict[str, Any]]]) -> tuple[dict[str, Any] | None, dict[str, Any] | None, list[str]]:
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    for status, items in rows.items():
+        normalized_status = str(status or "").strip().lower()
+        if normalized_status in TERMINAL_BOARD_STATUSES:
+            continue
+        for task in items:
+            card = factory_card_from_task(task)
+            if card is not None:
+                candidates.append((normalized_status, task, card))
+    if not candidates:
+        return None, None, []
+
+    distinct_ids = {
+        str(card.get("card_id") or card.get("slice_id") or _task_public_title(task)).strip()
+        for _status, task, card in candidates
+    }
+    distinct_ids.discard("")
+    if len(distinct_ids) > 1:
+        refs = [
+            f"{status}:{_task_public_ref(task)}:{card.get('card_id') or card.get('slice_id') or 'unknown-card'}"
+            for status, task, card in candidates
+        ]
+        return None, None, [
+            "board has multiple active canonical factory cards; reconcile one active frontier before creating more work: "
+            + ", ".join(sorted(refs))
+        ]
+
+    status_rank = {"running": 0, "in_progress": 0, "doing": 0, "ready": 1, "blocked": 2, "todo": 3}
+    candidates.sort(
+        key=lambda item: (
+            status_rank.get(item[0], 9),
+            factory_phase_rank(item[2].get("phase")),
+            str(item[2].get("card_id") or ""),
+            _task_public_title(item[1]),
+        )
+    )
+    status, task, card = candidates[0]
+    selected = board_reconcile_task_ref(task, status=status)
+    selected["selection_reason"] = "single canonical non-terminal factory card selected by status and phase rank"
+    return card, selected, []
+
+
+def _board_reconcile_task_contract(
+    *,
+    plan_action: str,
+    board: str,
+    selected_card: dict[str, Any] | None,
+    phase_engine: dict[str, Any] | None,
+    factory_help: dict[str, Any] | None,
+    reason: str,
+    assignee: str = "factory-orchestrator",
+) -> dict[str, Any]:
+    next_artifact = str((phase_engine or {}).get("next_required_artifact") or "canonical_factory_card").strip()
+    card_id = str((selected_card or {}).get("card_id") or "board").strip() or "board"
+    title_action = {
+        "repair_board_contract": "Materialize canonical factory card",
+        "create_next_artifact_task": f"Materialize {next_artifact}",
+        "repair_human_gate_packet": "Repair human gate decision package",
+        "request_operator_input": "Prepare bounded operator input request",
+    }.get(plan_action, "Reconcile factory board")
+    return {
+        "title": f"{title_action} for {card_id}",
+        "assignee": assignee,
+        "body": {
+            "packet_type": "factory_deterministic_reconcile_task",
+            "marker": "factory_deterministic_reconcile",
+            "board": board,
+            "plan_action": plan_action,
+            "card_id": card_id,
+            "phase_engine": phase_engine or {},
+            "factory_next_action": (factory_help or {}).get("factory_next_action") if factory_help else None,
+            "required_output": next_artifact,
+            "reason": reason,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "agent_may_choose_phase": False,
+            "allowed_actions": [
+                "inspect Hermes board and durable artifacts",
+                f"create or repair only {next_artifact}",
+                "record fresh evidence or a bounded blocker",
+                "leave downstream phases frozen until factory_phase_engine recomputes the frontier",
+            ],
+            "forbidden_actions": [
+                "choose a later phase from title, chat, memory, prose or declared phase alone",
+                "ask for a human gate when phase_engine.human_gate_allowed is false",
+                "approve or waive human gates",
+                "start implementation, deploy, release, spend funds or touch production",
+            ],
+            "native_dispatch_required_next": True,
+        },
+    }
+
+
+def build_board_reconcile_plan(
+    snapshot: dict[str, Any],
+    *,
+    board: str = "unknown-board",
+    catalog_path: Path | None = None,
+) -> dict[str, Any]:
+    rows = board_rows_from_snapshot(snapshot)
+    counts = board_status_counts(rows)
+    running = rows.get("running", []) + rows.get("in_progress", []) + rows.get("doing", [])
+    ready = rows.get("ready", [])
+    unfinished = [
+        task
+        for status, items in rows.items()
+        if status not in TERMINAL_BOARD_STATUSES
+        for task in items
+    ]
+    blocked_reasons: list[str] = []
+    selected_card: dict[str, Any] | None = None
+    selected_ref: dict[str, Any] | None = None
+    phase_engine: dict[str, Any] | None = None
+    factory_help: dict[str, Any] | None = None
+    user_decision_required = False
+    human_gate_required = False
+    operator_input_required = False
+    create_task_contract: dict[str, Any] | None = None
+
+    if running:
+        plan_action = "observe_running"
+        reason = "running Hermes work exists; no reconcile task is allowed"
+        native_dispatch_required_next = False
+    elif ready:
+        plan_action = "dispatch_ready"
+        reason = "ready Hermes work exists; native Hermes dispatch is the next action"
+        native_dispatch_required_next = True
+    elif not unfinished:
+        plan_action = "no_unfinished_work"
+        reason = "no non-terminal Hermes work was observed"
+        native_dispatch_required_next = False
+    else:
+        selected_card, selected_ref, selection_errors = select_canonical_board_card(rows)
+        blocked_reasons.extend(selection_errors)
+        native_dispatch_required_next = False
+        if selection_errors:
+            plan_action = "block_invariant_violation"
+            reason = selection_errors[0]
+        elif selected_card is None:
+            plan_action = "repair_board_contract"
+            reason = "unfinished board has no canonical factory card; phase cannot be inferred from task prose"
+            create_task_contract = _board_reconcile_task_contract(
+                plan_action=plan_action,
+                board=board,
+                selected_card=None,
+                phase_engine=None,
+                factory_help=None,
+                reason=reason,
+            )
+            native_dispatch_required_next = True
+        else:
+            phase_engine = factory_phase_engine_state(selected_card)
+            factory_help = build_factory_help(selected_card, Path("<kanban-card>"), catalog_path=catalog_path)
+            gate_report = factory_help.get("gate_status")
+            user_decisions = [
+                item for item in factory_help.get("user_decision_required", []) if isinstance(item, dict)
+            ]
+            raw_human_decisions = [
+                item for item in user_decisions if str(item.get("decision_type") or "") == "authority_required"
+            ]
+            product_intent_decisions = [
+                item for item in user_decisions if str(item.get("decision_type") or "") == "product_intent_confirmation"
+            ]
+            phase_allows_human_gate = phase_engine.get("human_gate_allowed") is True
+            human_gate_requested_early = bool(raw_human_decisions) and not phase_allows_human_gate
+            human_decisions = raw_human_decisions if phase_allows_human_gate else []
+            if human_decisions:
+                human_gate_required = True
+            if product_intent_decisions:
+                operator_input_required = True
+            if human_gate_requested_early:
+                blocked_reasons.append(
+                    "premature human gate request suppressed until "
+                    + str(phase_engine.get("human_gate_blocked_until_artifact") or phase_engine.get("next_required_artifact") or "required artifact")
+                )
+
+            packet = selected_card.get("human_gate_packet") if isinstance(selected_card.get("human_gate_packet"), dict) else {}
+            packet_errors = (
+                validate_human_gate_packet(packet, require_decision_package=True)
+                if phase_allows_human_gate and human_gate_required
+                else []
+            )
+            if phase_allows_human_gate and human_gate_required and not packet_errors:
+                plan_action = "request_human_gate_decision"
+                reason = "phase engine allows a real human gate and the decision package is complete"
+                user_decision_required = True
+            elif phase_allows_human_gate and human_gate_required and packet_errors:
+                plan_action = "repair_human_gate_packet"
+                reason = "human gate was requested before a complete decision package existed"
+                blocked_reasons.extend(packet_errors)
+                create_task_contract = _board_reconcile_task_contract(
+                    plan_action=plan_action,
+                    board=board,
+                    selected_card=selected_card,
+                    phase_engine=phase_engine,
+                    factory_help=factory_help,
+                    reason=reason,
+                    assignee="human-gate-clerk",
+                )
+                native_dispatch_required_next = True
+            elif product_intent_decisions and not phase_engine.get("phase_mismatch"):
+                plan_action = "request_operator_input"
+                reason = "operator understanding confirmation is a product input, not an approval gate"
+                user_decision_required = True
+                create_task_contract = _board_reconcile_task_contract(
+                    plan_action=plan_action,
+                    board=board,
+                    selected_card=selected_card,
+                    phase_engine=phase_engine,
+                    factory_help=factory_help,
+                    reason=reason,
+                )
+                native_dispatch_required_next = True
+            else:
+                plan_action = "create_next_artifact_task"
+                reason = str(
+                    (factory_help.get("factory_next_action") or {}).get("why")
+                    or phase_engine.get("decision_basis")
+                    or "deterministic phase engine selected the next artifact"
+                )
+                create_task_contract = _board_reconcile_task_contract(
+                    plan_action=plan_action,
+                    board=board,
+                    selected_card=selected_card,
+                    phase_engine=phase_engine,
+                    factory_help=factory_help,
+                    reason=reason,
+                    assignee=str((factory_help.get("factory_next_action") or {}).get("owner") or "factory-orchestrator"),
+                )
+                native_dispatch_required_next = True
+            if gate_report == "blocked":
+                blocked_reasons.extend(_list_items(factory_help.get("blocked_because")))
+
+    return sanitize_public_refs(
+        {
+            "$schema": "https://overkill-factory.dev/schemas/factory-board-reconcile-plan.schema.json",
+            "record_type": "factory_board_reconcile_plan",
+            "created_at": utc_now(),
+            "board": board,
+            "deterministic": True,
+            "agent_route_authority": False,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "status_counts": counts,
+            "plan_action": plan_action,
+            "reason": reason,
+            "blocked_reasons": sorted(set(blocked_reasons)),
+            "selected_card": selected_ref,
+            "phase_engine": phase_engine,
+            "factory_help": factory_help,
+            "create_task_allowed": plan_action in BOARD_RECONCILE_CREATE_ACTIONS,
+            "create_task_contract": create_task_contract,
+            "native_dispatch_required_next": native_dispatch_required_next,
+            "human_gate_required": human_gate_required,
+            "operator_input_required": operator_input_required,
+            "user_decision_required": user_decision_required,
+            "operator_decision_policy": {
+                "human_gate_only_when_phase_engine_allows": True,
+                "planning_continuation_approval_forbidden": True,
+                "decision_package_required_before_question": True,
+                "summary_only_gate_forbidden": True,
+            },
+            "limits": [
+                "This plan does not execute workers, approve gates or replace Hermes dispatch.",
+                "Agents may follow only the create_task_contract or wait/dispatch action selected here.",
+            ],
+        }
+    )
+
+
+def validate_board_reconcile_plan(plan: dict[str, Any]) -> list[str]:
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-board-reconcile-plan.schema.json")
+    errors: list[str] = []
+    if schema:
+        errors.extend(validate_node(schema, plan, "factory_board_reconcile_plan", schemas=schemas, root_schema=schema))
+    if plan.get("deterministic") is not True:
+        errors.append("factory_board_reconcile_plan.deterministic must be true")
+    if plan.get("agent_route_authority") is not False:
+        errors.append("factory_board_reconcile_plan.agent_route_authority must be false")
+    if plan.get("human_gate_required") is True:
+        phase_engine = plan.get("phase_engine") if isinstance(plan.get("phase_engine"), dict) else {}
+        if phase_engine.get("human_gate_allowed") is not True:
+            errors.append("factory_board_reconcile_plan cannot require human gate while phase_engine.human_gate_allowed is false")
+    if plan.get("plan_action") == "request_human_gate_decision" and plan.get("user_decision_required") is not True:
+        errors.append("request_human_gate_decision requires user_decision_required=true")
+    if plan.get("create_task_allowed") is True and not isinstance(plan.get("create_task_contract"), dict):
+        errors.append("create_task_allowed=true requires create_task_contract")
+    return errors
+
+
 def validate_status_snapshot(snapshot: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if not isinstance(snapshot.get("source_refs"), list) or not snapshot.get("source_refs"):
@@ -18412,6 +18806,30 @@ def command_phase_engine(args: argparse.Namespace) -> int:
     state = factory_phase_engine_state(load_json_like(args.card))
     write_json(args.out, state)
     return 1 if state.get("phase_mismatch") or state.get("lock_phase_mismatch") or state.get("lock_frontier_mismatch") else 0
+
+
+def command_reconcile_board(args: argparse.Namespace) -> int:
+    plan = build_board_reconcile_plan(
+        load_json_like(args.snapshot),
+        board=args.board,
+        catalog_path=args.catalog,
+    )
+    errors = validate_board_reconcile_plan(plan)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+    write_json(args.out, plan)
+    return 1 if errors or args.enforce and plan.get("plan_action") in {"block_invariant_violation"} else 0
+
+
+def command_validate_reconcile_board(args: argparse.Namespace) -> int:
+    errors = validate_board_reconcile_plan(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
 
 
 def command_validate_receipt(args: argparse.Namespace) -> int:
@@ -19461,6 +19879,21 @@ def build_parser() -> argparse.ArgumentParser:
     phase_engine_parser.add_argument("--card", type=Path, required=True)
     phase_engine_parser.add_argument("--out", type=Path)
     phase_engine_parser.set_defaults(func=command_phase_engine)
+
+    reconcile_board_parser = sub.add_parser(
+        "reconcile-board",
+        help="Compute the deterministic board-level next action from Hermes/Kanban state.",
+    )
+    reconcile_board_parser.add_argument("--snapshot", type=Path, required=True)
+    reconcile_board_parser.add_argument("--board", required=True)
+    reconcile_board_parser.add_argument("--catalog", type=Path)
+    reconcile_board_parser.add_argument("--out", type=Path)
+    reconcile_board_parser.add_argument("--enforce", action="store_true")
+    reconcile_board_parser.set_defaults(func=command_reconcile_board)
+
+    validate_reconcile_board_parser = sub.add_parser("validate-reconcile-board")
+    validate_reconcile_board_parser.add_argument("path", type=Path)
+    validate_reconcile_board_parser.set_defaults(func=command_validate_reconcile_board)
 
     validate_receipt_parser = sub.add_parser("validate-receipt")
     validate_receipt_parser.add_argument("path", type=Path)

--- a/tests/test_factory_board_reconciler.py
+++ b/tests/test_factory_board_reconciler.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import unittest
+from unittest import mock
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+SPEC = importlib.util.spec_from_file_location("factoryctl_board_reconciler", MODULE_PATH)
+assert SPEC is not None
+factoryctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factoryctl_board_reconciler"] = factoryctl
+SPEC.loader.exec_module(factoryctl)
+
+
+def load_vfinal_card() -> dict:
+    return factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+
+
+def sot_without_owner_packet_card() -> dict:
+    card = load_vfinal_card()
+    card["phase"] = "F9"
+    card["surfaces"] = ["architecture", "planning"]
+    card["autonomy_mode"] = "planning_only"
+    card["risk_initial"] = "R2"
+    card["risk_effective"] = "R2"
+    card.pop("factory_phase_lock", None)
+    card.pop("operator_briefing_package_ref", None)
+    card.pop("owner_review_ref", None)
+    card["review"]["human_gate_required"] = False
+    card["review"]["CTO_gate_required"] = False
+    return card
+
+
+class FactoryBoardReconcilerTest(unittest.TestCase):
+    def test_declared_f9_without_owner_material_reconciles_to_f5_artifact_not_human_gate(self) -> None:
+        card = sot_without_owner_packet_card()
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {
+                        "id": "task-phasejump",
+                        "status": "todo",
+                        "title": "Architecture gate",
+                        "assignee": "human-gate-clerk",
+                        "body": json.dumps(card),
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        self.assertEqual(plan["plan_action"], "create_next_artifact_task")
+        self.assertEqual(plan["phase_engine"]["computed_phase_id"], "F5")
+        self.assertEqual(plan["phase_engine"]["next_required_artifact"], "operator_briefing_package")
+        self.assertFalse(plan["human_gate_required"])
+        self.assertFalse(plan["user_decision_required"])
+        self.assertTrue(plan["create_task_allowed"])
+        task_body = plan["create_task_contract"]["body"]
+        self.assertFalse(task_body["agent_may_choose_phase"])
+        self.assertEqual(task_body["required_output"], "operator_briefing_package")
+        self.assertIn("ask for a human gate when phase_engine.human_gate_allowed is false", task_body["forbidden_actions"])
+
+    def test_premature_human_gate_request_is_suppressed_until_phase_engine_allows_it(self) -> None:
+        card = sot_without_owner_packet_card()
+        card["phase"] = "F5"
+        card["review"]["human_gate_required"] = True
+        snapshot = {
+            "rows": {
+                "blocked": [
+                    {
+                        "id": "task-earlygate",
+                        "status": "blocked",
+                        "title": "Human architecture gate",
+                        "assignee": "human-gate-clerk",
+                        "body": json.dumps(card),
+                    }
+                ]
+            }
+        }
+
+        misleading_help = {
+            "gate_status": "blocked",
+            "factory_next_action": {
+                "owner": "human-gate-clerk",
+                "action": "ask operator for architecture approval",
+                "why": "legacy helper requested authority too early",
+            },
+            "user_decision_required": [
+                {
+                    "decision_type": "authority_required",
+                    "reason": "legacy helper requested authority too early",
+                    "user_action": "approve or reject",
+                    "factory_prepares": "human gate packet",
+                }
+            ],
+            "blocked_because": [],
+        }
+        with mock.patch.object(factoryctl, "build_factory_help", return_value=misleading_help):
+            plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        self.assertEqual(plan["plan_action"], "create_next_artifact_task")
+        self.assertEqual(plan["phase_engine"]["computed_phase_id"], "F5")
+        self.assertFalse(plan["human_gate_required"])
+        self.assertFalse(plan["user_decision_required"])
+        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "operator_briefing_package")
+        self.assertTrue(
+            any("premature human gate request suppressed" in item for item in plan["blocked_reasons"])
+        )
+
+    def test_unfinished_board_without_canonical_card_repairs_contract_instead_of_guessing_phase(self) -> None:
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {
+                        "id": "task-nocard",
+                        "status": "todo",
+                        "title": "Continue planning",
+                        "body": json.dumps({"objective": "continue planning"}),
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        self.assertEqual(plan["plan_action"], "repair_board_contract")
+        self.assertTrue(plan["create_task_allowed"])
+        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "canonical_factory_card")
+        self.assertFalse(plan["create_task_contract"]["body"]["agent_may_choose_phase"])
+        self.assertFalse(plan["human_gate_required"])
+
+    def test_ready_work_uses_native_dispatch_not_reconcile_task(self) -> None:
+        snapshot = {
+            "rows": {
+                "ready": [
+                    {
+                        "id": "task-ready",
+                        "status": "ready",
+                        "title": "Worker task",
+                        "body": "{}",
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(plan["plan_action"], "dispatch_ready")
+        self.assertFalse(plan["create_task_allowed"])
+        self.assertTrue(plan["native_dispatch_required_next"])
+        self.assertIsNone(plan["create_task_contract"])
+
+    def test_multiple_active_cards_block_instead_of_selecting_from_context(self) -> None:
+        card_a = sot_without_owner_packet_card()
+        card_b = copy.deepcopy(card_a)
+        card_b["card_id"] = "OF-VFINAL-002"
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {"id": "task-carda", "status": "todo", "body": json.dumps(card_a)},
+                    {"id": "task-cardb", "status": "todo", "body": json.dumps(card_b)},
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(plan["plan_action"], "block_invariant_violation")
+        self.assertFalse(plan["create_task_allowed"])
+        self.assertTrue(any("multiple active canonical factory cards" in item for item in plan["blocked_reasons"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3736,7 +3736,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
 
-    def test_no_idle_creates_safe_remediation_card_when_board_is_silent(self) -> None:
+    def test_no_idle_creates_deterministic_reconcile_card_when_board_is_silent(self) -> None:
         fake = FakeHermes()
         fake.tasks["t_" + "todo0001"] = {
             "id": "t_" + "todo0001",
@@ -3752,24 +3752,65 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         result = adapter.no_idle(args, runner=fake)
 
         self.assertEqual(result["no_idle_state"]["status"], "remediation_required")
+        self.assertEqual(result["no_idle_state"]["classification"], "deterministic_board_reconcile_task_created")
         self.assertTrue(result["no_idle_state"]["remediation_task_created"])
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "repair_board_contract")
         self.assertEqual(result["remediation_task_id"], adapter.PUBLIC_SAFE_KANBAN_REF)
         created_task = next(
             task for task in fake.tasks.values()
-            if json.loads(str(task.get("body") or "{}")).get("marker") == adapter.NO_IDLE_REMEDIATION_MARKER
+            if json.loads(str(task.get("body") or "{}")).get("marker") == "factory_deterministic_reconcile"
         )
         self.assertEqual(created_task["status"], "ready")
         body = json.loads(str(created_task["body"]))
-        self.assertFalse(body["dispatch_allowed_by_this_step"])
+        self.assertEqual(body["plan_action"], "repair_board_contract")
         self.assertTrue(body["native_dispatch_required_next"])
-        self.assertEqual(body["deterministic_phase_contract"]["route_authority"], "factory_phase_engine")
-        self.assertTrue(body["deterministic_phase_contract"]["generic_frontier_selection_forbidden"])
+        self.assertFalse(body["agent_may_choose_phase"])
         self.assertIn("approve or waive human gates", body["forbidden_actions"])
         self.assertIn(
-            "decide the next factory phase from prose, memory, title, comments or declared card phase alone",
+            "choose a later phase from title, chat, memory, prose or declared phase alone",
             body["forbidden_actions"],
         )
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
+    def test_no_idle_reconciles_declared_f9_to_f5_owner_package_before_gate(self) -> None:
+        fake = FakeHermes()
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        card["phase"] = "F9"
+        card["surfaces"] = ["architecture", "planning"]
+        card["autonomy_mode"] = "planning_only"
+        card["risk_initial"] = "R2"
+        card["risk_effective"] = "R2"
+        card.pop("factory_phase_lock", None)
+        card.pop("operator_briefing_package_ref", None)
+        card["review"]["human_gate_required"] = False
+        card["review"]["CTO_gate_required"] = False
+        fake.tasks["t_" + "phasejump1"] = {
+            "id": "t_" + "phasejump1",
+            "status": "todo",
+            "assignee": "human-gate-clerk",
+            "title": "Human architecture gate",
+            "body": json.dumps(card),
+            "events": [],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        plan = result["board_reconcile_plan"]
+        self.assertEqual(plan["plan_action"], "create_next_artifact_task")
+        self.assertEqual(plan["phase_engine"]["computed_phase_id"], "F5")
+        self.assertEqual(plan["phase_engine"]["next_required_artifact"], "operator_briefing_package")
+        self.assertFalse(plan["human_gate_required"])
+        created_task = next(
+            task for task in fake.tasks.values()
+            if json.loads(str(task.get("body") or "{}")).get("marker") == "factory_deterministic_reconcile"
+        )
+        body = json.loads(str(created_task["body"]))
+        self.assertEqual(body["required_output"], "operator_briefing_package")
+        self.assertEqual(body["plan_action"], "create_next_artifact_task")
+        self.assertFalse(body["agent_may_choose_phase"])
 
     def test_no_idle_reports_human_gate_without_remediation(self) -> None:
         fake = FakeHermes()

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.6", readme)
+        self.assertIn("v1.5.7", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.6",
+            "v1.5.7",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
## Summary

- Adds `factoryctl reconcile-board`, a deterministic Hermes/Kanban board-level reconciler.
- Wires no-idle remediation to create only the reconciler-selected task instead of generic remediation work.
- Prevents declared future phases, title/prose/chat context, or premature gate wording from becoming route authority.
- Documents the runtime rule and bumps the public release line to v1.5.7.

Closes #420.

## Validation

- `python -m unittest discover -s tests -q` (976 tests)
- `python scripts\public_safety_scan.py --summary-json .tmp\factory-runs\public-safety\worktree-summary.json`
- `python scripts\secret_safety_scan.py --summary-json .tmp\factory-runs\public-safety\secret-summary.json`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\validate_promise_implementation_map.py`
- `python scripts\worktree_release_inventory.py --out .tmp\factory-runs\release\worktree-release-inventory.json`
- `python scripts\release_integration_preflight.py`