### PR TITLE
Skip local watchdog state in public JSON validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ public releases.
 
 ## Unreleased
 
+## 1.5.8 - 2026-06-25
+
+- Keep public JSON validation from treating local no-idle watchdog runtime state
+  as a public artifact.
+- Add regression coverage so local operational state does not break release
+  validation after the factory has been used.
+
 ## 1.5.7 - 2026-06-25
 
 - Add `factoryctl reconcile-board`, a deterministic Hermes/Kanban board

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.7.
+is v1.5.8.
 
 It includes:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.7.
+recente é v1.5.8.
 
 Ela inclui:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.7"
+version = "1.5.8"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -57,6 +57,9 @@ SCAN_DIRS = [
 RUNTIME_LOCAL_JSON_DIRS = [
     ROOT / ".tmp" / "factory-runs" / "operator-inbox",
 ]
+RUNTIME_LOCAL_JSON_PATHS = {
+    ROOT / ".tmp" / "factory-runs" / "no-idle-watchdog-state.json",
+}
 
 SCHEMA_OPTIONAL = {
     ".tmp/factory-runs/product-face/console.json",
@@ -2527,6 +2530,9 @@ def validate_public_ref_hygiene(value: Any, at: str = "$") -> list[str]:
 
 def is_runtime_local_json(path: Path) -> bool:
     resolved_path = path.resolve()
+    for runtime_path in RUNTIME_LOCAL_JSON_PATHS:
+        if resolved_path == runtime_path.resolve():
+            return True
     for directory in RUNTIME_LOCAL_JSON_DIRS:
         try:
             resolved_path.relative_to(directory.resolve())

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.7", readme)
+        self.assertIn("v1.5.8", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.7",
+            "v1.5.8",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",

--- a/tests/test_public_json_artifact_validator.py
+++ b/tests/test_public_json_artifact_validator.py
@@ -177,6 +177,23 @@ class PublicJsonArtifactValidatorTest(unittest.TestCase):
 
         self.assertNotIn(f".tmp/factory-runs/operator-inbox/{ack_name}", public_json_paths)
 
+    def test_public_json_discovery_skips_no_idle_watchdog_runtime_state(self) -> None:
+        validator = load_validator()
+        state_path = ROOT / ".tmp" / "factory-runs" / "no-idle-watchdog-state.json"
+        original = state_path.read_text(encoding="utf-8") if state_path.exists() else None
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps({"last_seen": "runtime-local"}), encoding="utf-8")
+
+        try:
+            public_json_paths = {path.relative_to(ROOT).as_posix() for path in validator.iter_public_json()}
+        finally:
+            if original is None:
+                state_path.unlink(missing_ok=True)
+            else:
+                state_path.write_text(original, encoding="utf-8")
+
+        self.assertNotIn(".tmp/factory-runs/no-idle-watchdog-state.json", public_json_paths)
+
     def test_factory_card_schema_rejects_absurd_required_field_shapes(self) -> None:
         validator = load_validator()
         schemas = validator.load_schemas()


### PR DESCRIPTION
## Summary

- Excludes local no-idle watchdog operational state from public JSON artifact discovery.
- Adds regression coverage for the live-workspace validation failure found after installing v1.5.7.
- Bumps the public release line to v1.5.8.

Closes #422.

## Validation

- `python -m unittest discover -s tests -q` (977 tests)
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\validate_promise_implementation_map.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\public_safety_scan.py --summary-json .tmp\factory-runs\public-safety\worktree-summary.json`
- `python scripts\secret_safety_scan.py --summary-json .tmp\factory-runs\public-safety\secret-summary.json`
- `python scripts\worktree_release_inventory.py --out .tmp\factory-runs\release\worktree-release-inventory.json`
- `python scripts\release_integration_preflight.py`