### PR TITLE
Harden Kanban-native factory autonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ public releases.
 
 ## Unreleased
 
+## 1.5.9 - 2026-06-25
+
+- Bind factory-created Hermes tasks to native Kanban workflow state when
+  available: `workflow_template_id=overkill-vfinal` plus the deterministic
+  `current_step_key` computed by the phase engine.
+- Harden no-idle classification so missing decision packages, PDF/readback,
+  owner-readable material and repair tasks gated behind their own blocker route
+  to factory-owned repair instead of operator approval bureaucracy.
+- Route missing Solana AI Kit domain-brain state on Solana/onchain F4+ boards as
+  a bounded factory planning repair, not a human approval question.
+- Add regression coverage for SQLite workflow binding, factory-owned package
+  repair, Kanban graph repair and Solana AI Kit route repair.
+- Update Hermes/Telegram-first docs to make no-idle, factory-owned repair and
+  native dispatch boundaries explicit.
+
 ## 1.5.8 - 2026-06-25
 
 - Keep public JSON validation from treating local no-idle watchdog runtime state

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.8.
+is v1.5.9.
 
 It includes:
 
@@ -289,6 +289,14 @@ It includes:
 - deterministic Hermes/Kanban board reconciliation so a silent board becomes
   one allowed next-artifact task, native dispatch, or a real bounded gate
   request instead of agent-chosen phase routing;
+- Kanban-native workflow binding with `workflow_template_id=overkill-vfinal`
+  and deterministic `current_step_key` on factory-created Hermes tasks when the
+  installed Hermes database exposes those fields;
+- no-idle classification that treats missing decision packages, PDF/readback,
+  owner-readable materials and repair tasks gated behind their own blocker as
+  factory-owned repair, not operator approval bureaucracy;
+- Solana AI Kit route repair when Solana/on-chain F4+ planning lacks the
+  required structured domain-brain record;
 - Hermes completion artifact projection, no-idle remediation controls, Hermes
   update guard, cron-friendly no-idle watchdog and Fast Autonomy Lane contracts.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.8.
+recente é v1.5.9.
 
 Ela inclui:
 
@@ -291,6 +291,14 @@ Ela inclui:
 - reconciliação determinística de board Hermes/Kanban para transformar uma fila
   silenciosa em uma única tarefa de próximo artefato, dispatch nativo ou pedido
   real de gate limitado, sem rota escolhida pelo agente;
+- binding nativo de workflow no Kanban com
+  `workflow_template_id=overkill-vfinal` e `current_step_key` determinístico nas
+  tarefas criadas pela fábrica quando o banco Hermes expõe esses campos;
+- classificação de no-idle que trata pacote de decisão, PDF/readback, material
+  legível para dono e tarefa de reparo presa atrás do próprio bloqueio como
+  reparo da fábrica, não burocracia de aprovação do operador;
+- reparo obrigatório da rota Solana AI Kit quando planejamento Solana/on-chain
+  F4+ não tem registro estruturado do cérebro de domínio;
 - projeção de artefato de conclusão Hermes, controles de no-idle, Hermes update
   guard, watchdog de no-idle para Hermes cron e contratos da Fast Autonomy Lane.
 

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -399,12 +399,23 @@ python adapters/hermes/live_kanban_adapter.py no-idle \
 ```
 
 The controller never dispatches workers. It reports native dispatch when ready
-work exists, returns a structured human decision request when explicit human
-gates are present, returns `input_required` when blocked ancestors are asking
-for exact operator/source inputs, returns `dependency_gated` for non-generic
-blocker chains, or creates one safe `factory_no_idle_remediation` card for
-`factory-orchestrator` only when the idle state is genuinely unexplained. The
-next worker launch still belongs to native Hermes dispatch.
+work exists, returns a structured human decision request only when an explicit
+decision-ready human gate remains, returns `input_required` only when blocked
+ancestors are asking for exact external operator/source inputs, returns
+`dependency_gated` for non-generic blocker chains, or creates one deterministic
+factory-owned reconcile task. Missing owner-readable material, PDF/readback,
+`APPROVAL_REQUEST`, `EVIDENCE_INDEX`, `OWNER_REVIEW`, or a summary-only gate is
+internal factory repair, not a human approval request. If a repair task is
+dependency-gated by the same gate/package it is supposed to repair, no-idle
+classifies that as a Kanban graph defect and routes graph/package repair instead
+of asking the operator. The next worker launch still belongs to native Hermes
+dispatch.
+
+Factory-created Hermes tasks also bind the native Kanban workflow fields when
+the installed Hermes database exposes them: `workflow_template_id` is
+`overkill-vfinal`, and `current_step_key` comes from the deterministic phase
+engine. The JSON body carries the same binding as a fallback, but the SQLite
+workflow columns are the preferred runtime state when available.
 
 For a Telegram-first production operator, run the cron-friendly watchdog from
 Hermes instead of waiting for the operator to ask for status:
@@ -426,10 +437,11 @@ does not become noisy.
 
 `input_required` is not a human approval gate. It means the factory found a
 specific blocker asking for exact missing inputs, such as target repo paths,
-package/scan scope, prototype URL/artifact, custody policy or public onchain
+scan scope, prototype URL/artifact, custody policy or public onchain
 identifiers. The operator should provide those inputs or name the source
-artifact the factory must re-read; the watchdog must not keep creating generic
-remediation cards for the same blocker chain.
+artifact the factory must re-read. Package quality, missing PDF/readback and
+missing gate materials stay factory-owned repairs; the watchdog must not keep
+creating generic remediation cards for the same blocker chain.
 
 Before using `--all-nonempty-boards`, archive obsolete boards or exclude them
 explicitly. A board left unarchived is treated as a live factory run.

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import os
 import re
+import sqlite3
 import subprocess  # nosec B404
 import sys
 from pathlib import Path
@@ -60,6 +61,8 @@ READY_WORK_UNIT_RECOVERY_AUTHOR = "overkill-factory-recovery"
 READY_WORK_UNIT_RECONCILIATION_AUTHOR = "overkill-factory-reconciliation"
 NO_IDLE_AUTHOR = "overkill-factory-no-idle"
 NO_IDLE_REMEDIATION_MARKER = "factory_no_idle_remediation"
+FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID = "overkill-vfinal"
+FACTORY_KANBAN_DEFAULT_STEP_KEY = "F1-intake"
 COMPLETION_ARTIFACT_PROJECTION_MARKER = "completion_artifact_projection"
 KANBAN_ARTIFACT_REF_PREFIXES = ("kanban-artifact:", "external:kanban-artifact:", "kanban-attachment:")
 PRIVATE_HERMES_RUNTIME_TOKEN = "/srv/" + "hermes"
@@ -217,6 +220,54 @@ def parse_json_output(output: str, *, command: str) -> Any:
         return json.loads(output or "{}")
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"{command} did not return JSON") from exc
+
+
+def hermes_home_path() -> Path:
+    raw = os.environ.get("HERMES_HOME") or os.environ.get("HOME")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home()
+
+
+def local_kanban_db_path(board: str) -> Path | None:
+    slug = str(board or "").strip()
+    if not slug or not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", slug):
+        return None
+    home = hermes_home_path()
+    if slug == "default":
+        return home / "kanban.db"
+    return home / "kanban" / "boards" / slug / "kanban.db"
+
+
+def apply_native_workflow_state(
+    *,
+    board: str,
+    task_id: str,
+    workflow_template_id: str | None,
+    current_step_key: str | None,
+) -> bool:
+    if not workflow_template_id or not current_step_key:
+        return False
+    db_path = local_kanban_db_path(board)
+    if db_path is None or not db_path.exists():
+        return False
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cols = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+            if len(row) > 1
+        }
+        if {"workflow_template_id", "current_step_key"} - cols:
+            return False
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+            (workflow_template_id, current_step_key, task_id),
+        )
+        conn.commit()
+        return conn.total_changes > 0
+    finally:
+        conn.close()
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -782,30 +833,9 @@ def is_human_gate_package_blocker(record: dict[str, Any]) -> bool:
     return is_human_gate_blocker(record) and not is_human_gate_decision_ready_blocker(record)
 
 
-def is_operator_input_blocker(record: dict[str, Any]) -> bool:
+def is_factory_owned_package_blocker(record: dict[str, Any]) -> bool:
     text = task_record_text(record)
-    input_markers = (
-        "missing input",
-        "missing inputs",
-        "missing required",
-        "missing exact",
-        "missing target",
-        "missing public-safe",
-        "required input",
-        "required inputs",
-        "needed input",
-        "needed inputs",
-        "missing evidence",
-        "missing evidences",
-        "missing proof",
-        "missing proofs",
-        "missing material",
-        "missing package",
-        "missing packet",
-        "missing upstream packet",
-        "no sufficient reviewed packet",
-        "without sufficient reviewed packet",
-        "insufficient reviewed packet",
+    package_markers = (
         "missing operator briefing package",
         "operator briefing package missing",
         "missing operator_briefing_package",
@@ -831,10 +861,55 @@ def is_operator_input_blocker(record: dict[str, Any]) -> bool:
         "pdf missing",
         "no pdf",
         "no material",
+        "owner-readable",
+        "owner readable",
+        "readable package",
+        "readable artifact",
+        "package quality",
+        "artifact quality failure",
+        "material package",
+        "gate package",
+        "decision assets",
+        "attachment missing",
+        "missing attachment",
+        "artifact readback",
+        "missing readback",
+        "delivery assets",
+    )
+    return any(marker in text for marker in package_markers)
+
+
+def is_factory_owned_repair_task(record: dict[str, Any]) -> bool:
+    text = task_record_text(record)
+    markers = (
+        "factory-owned repair",
+        "factory owned repair",
+        "factory_deterministic_reconcile",
+        "factory_no_idle_remediation",
+        "repair human gate decision package",
+        "repair package",
+        "rebuild the package",
+        "owner-facing artifact quality failure",
+        "no renewed decision request",
+        "readable artifact is ready",
+    )
+    return any(marker in text for marker in markers)
+
+
+def is_operator_input_blocker(record: dict[str, Any]) -> bool:
+    text = task_record_text(record)
+    external_input_markers = (
+        "missing input",
+        "missing inputs",
+        "missing exact",
+        "missing target",
+        "missing public-safe",
+        "required input",
+        "required inputs",
+        "needed input",
+        "needed inputs",
         "provide exact",
         "provide requested",
-        "cannot be completed",
-        "cannot complete",
         "target_repo_paths",
         "target url",
         "target_url",
@@ -845,13 +920,8 @@ def is_operator_input_blocker(record: dict[str, Any]) -> bool:
         "custody/signing policy",
         "mint address",
         "token program id",
-        "insumo",
-        "insumos",
-        "faltante",
-        "faltantes",
-        "fornecer",
     )
-    return any(marker in text for marker in input_markers)
+    return any(marker in text for marker in external_input_markers)
 
 
 def no_idle_parent_refs(record: dict[str, Any]) -> list[str]:
@@ -1028,13 +1098,38 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
     operator_input_blockers = [
         item
         for item in blocked
-        if is_operator_input_blocker(item) or is_human_gate_package_blocker(item)
+        if is_operator_input_blocker(item)
     ]
     operator_input_refs = sorted(task_record_id(item) for item in operator_input_blockers if task_record_id(item))
+    factory_package_blockers = [
+        item
+        for item in blocked
+        if is_factory_owned_package_blocker(item) or is_human_gate_package_blocker(item)
+    ]
+    factory_package_refs = sorted(task_record_id(item) for item in factory_package_blockers if task_record_id(item))
+    if blocked and factory_package_blockers and len(factory_package_blockers) == len(blocked) and not todo:
+        return {
+            "status": "remediation_required",
+            "classification": "only_factory_owned_package_blockers_seen",
+            "blocked": True,
+            "remediation_required": True,
+            "human_gate_required": False,
+            "operator_input_required": False,
+            "operator_input_task_refs": [],
+            "human_gate_task_refs": human_gate_refs,
+            "factory_owned_package_task_refs": factory_package_refs,
+            "remediation_reason": (
+                "All unfinished visible work is blocked on a factory-owned decision package, "
+                "owner-readable material, PDF, evidence index, owner review or artifact readback. "
+                "This is internal factory repair, not operator input."
+            ),
+            "next_action": "create a factory-owned package/readback repair task before any human-gate question",
+            "state": state,
+        }
     if blocked and len(operator_input_blockers) == len(blocked) and not todo:
         return {
             "status": "input_required",
-            "classification": "only_input_or_human_gate_package_blockers_seen",
+            "classification": "only_operator_input_blockers_seen",
             "blocked": True,
             "remediation_required": False,
             "human_gate_required": False,
@@ -1084,6 +1179,59 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         input_dependency_refs = [
             ref for ref in blocker_refs if is_operator_input_blocker(blocked_by_task_id.get(ref, {}))
         ]
+        factory_package_dependency_refs = [
+            ref
+            for ref in blocker_refs
+            if is_factory_owned_package_blocker(blocked_by_task_id.get(ref, {}))
+            or is_human_gate_package_blocker(blocked_by_task_id.get(ref, {}))
+        ]
+        repair_todo_refs = [
+            task_record_id(item)
+            for item in todo
+            if task_record_id(item) and is_factory_owned_repair_task(item)
+        ]
+        if repair_todo_refs and (human_gate_dependency_refs or factory_package_dependency_refs):
+            return {
+                "status": "remediation_required",
+                "classification": "factory_repair_task_dependency_gated_by_blocker_it_repairs",
+                "blocked": True,
+                "remediation_required": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "human_gate_task_refs": sorted(set(human_gate_dependency_refs + human_gate_refs)),
+                "operator_input_task_refs": [],
+                "factory_owned_package_task_refs": sorted(set(factory_package_dependency_refs + factory_package_refs)),
+                "dependency_gated_task_refs": sorted(dependency_blockers),
+                "dependency_blocker_task_refs": blocker_refs,
+                "repair_task_refs": sorted(repair_todo_refs),
+                "remediation_reason": (
+                    "A factory-owned repair task is dependency-gated by a blocked gate/package "
+                    "that it is supposed to repair. The repair must be re-created or unlinked as "
+                    "an independent ready work unit with a repairs_task_ref, not as a child of the blocker."
+                ),
+                "next_action": "repair the Kanban dependency graph, then let native Hermes dispatch run the factory-owned repair",
+                "state": state,
+            }
+        if factory_package_dependency_refs or factory_package_refs:
+            return {
+                "status": "remediation_required",
+                "classification": "todo_dependency_gated_by_factory_owned_package_blocker",
+                "blocked": True,
+                "remediation_required": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "human_gate_task_refs": sorted(set(human_gate_dependency_refs + human_gate_refs)),
+                "operator_input_task_refs": [],
+                "factory_owned_package_task_refs": sorted(set(factory_package_dependency_refs + factory_package_refs)),
+                "dependency_gated_task_refs": sorted(dependency_blockers),
+                "dependency_blocker_task_refs": blocker_refs,
+                "remediation_reason": (
+                    "Visible todo work is dependency-gated behind factory-owned package/readback work. "
+                    "The factory must repair the package or dependency graph before asking the operator."
+                ),
+                "next_action": "create targeted factory-owned package/dependency remediation; do not ask for a human-gate decision",
+                "state": state,
+            }
         if input_dependency_refs or operator_input_refs:
             return {
                 "status": "input_required",
@@ -1238,6 +1386,8 @@ def create_no_idle_remediation_task(
         created_by=NO_IDLE_AUTHOR,
         workspace=workspace,
         blocked=False,
+        workflow_template_id=FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID,
+        current_step_key=FACTORY_KANBAN_DEFAULT_STEP_KEY,
         runner=runner,
     )
 
@@ -1276,6 +1426,8 @@ def create_deterministic_reconcile_task(
         created_by=NO_IDLE_AUTHOR,
         workspace=workspace,
         blocked=False,
+        workflow_template_id=str(contract.get("workflow_template_id") or FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID),
+        current_step_key=str(contract.get("current_step_key") or FACTORY_KANBAN_DEFAULT_STEP_KEY),
         runner=runner,
     )
 
@@ -2187,6 +2339,8 @@ def create_task(
     created_by: str,
     workspace: str,
     blocked: bool,
+    workflow_template_id: str | None = None,
+    current_step_key: str | None = None,
     runner: Runner = default_runner,
 ) -> str:
     ensure_non_empty_body(body)
@@ -2210,6 +2364,12 @@ def create_task(
     if blocked:
         args.extend(["--initial-status", "blocked"])
     task_id = parse_task_id(run_checked(args, runner).stdout)
+    apply_native_workflow_state(
+        board=board,
+        task_id=task_id,
+        workflow_template_id=workflow_template_id,
+        current_step_key=current_step_key,
+    )
     if blocked:
         shown_task = show_task(
             hermes_bin=hermes_bin,
@@ -6135,6 +6295,15 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         raise RuntimeError("pre-dispatch route readiness blocked live materialization: " + "; ".join(readiness_blockers))
 
     card_body = card_path.read_text(encoding="utf-8")
+    workflow_template_id = FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID
+    current_step_key = FACTORY_KANBAN_DEFAULT_STEP_KEY
+    try:
+        factoryctl = load_factoryctl()
+        card_data = factoryctl.load_json_like(card_path)
+        phase_engine = factoryctl.factory_phase_engine_state(card_data)
+        current_step_key = factoryctl.factory_workflow_step_key(phase_engine)
+    except Exception:
+        current_step_key = FACTORY_KANBAN_DEFAULT_STEP_KEY
     main_contract_digest = contract_digest(card_body)
     idempotency_contract: dict[str, Any] = {
         "digest_algorithm": CONTRACT_DIGEST_ALGORITHM,
@@ -6172,6 +6341,8 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
         created_by="overkill-factory",
         workspace=f"dir:{ROOT}",
         blocked=True,
+        workflow_template_id=workflow_template_id,
+        current_step_key=current_step_key,
         runner=runner,
     )
     worker_task_ids: dict[str, str] = {}
@@ -6216,6 +6387,8 @@ def materialize(args: argparse.Namespace, runner: Runner = default_runner) -> di
             created_by="overkill-factory",
             workspace=f"dir:{ROOT}",
             blocked=not args.worker_ready,
+            workflow_template_id=workflow_template_id,
+            current_step_key=current_step_key,
             runner=runner,
         )
         worker_task_ids[worker_id] = task_id

--- a/docs/architecture/hermes-integration.md
+++ b/docs/architecture/hermes-integration.md
@@ -62,8 +62,16 @@ only a board-state controller:
 
 - if `running` exists, it reports active work;
 - if `ready` exists, it reports that native Hermes dispatch is the next action;
-- if only explicit human-gate blockers remain, it returns a structured human
-  decision request;
+- if only explicit decision-ready human-gate blockers remain, it returns a
+  structured human decision request;
+- if the blocker is a missing decision package, PDF/readback, owner-readable
+  material or gate artifact, it routes factory-owned repair instead of asking
+  the operator for approval;
+- if a repair task is dependency-gated by the same blocker it should repair, it
+  treats that as a Kanban graph defect and creates a bounded repair route;
+- if Solana/onchain planning at F4 or later lacks the Solana AI Kit domain-brain
+  record, it routes a factory-owned Solana AI Kit repair before architecture or
+  human gates;
 - if unfinished work remains without `ready`, `running` or a sole human gate, it
   runs `factoryctl reconcile-board` over the Kanban snapshot and may create
   exactly one deterministic reconcile card for the next artifact selected by the
@@ -73,6 +81,19 @@ This closes silent idle without creating a shadow dispatcher or bypassing gates.
 The no-idle layer must not ask for a human gate when the board reconciler says
 `phase_engine.human_gate_allowed=false`; it must create or repair the next
 factory-owned artifact instead.
+
+## Kanban Workflow Binding
+
+Factory-created Hermes tasks should carry the native workflow fields exposed by
+Hermes Kanban:
+
+- `workflow_template_id=overkill-vfinal`;
+- `current_step_key=F...` from the deterministic phase engine.
+
+The adapter writes those columns directly when the installed Hermes SQLite
+schema contains them. The task body also carries `kanban_workflow_binding` as a
+fallback when a Hermes installation or remote API does not expose those
+columns. Agents may read those fields, but they do not get to choose them.
 
 ## Gate Timing Classes
 

--- a/docs/getting-started/install-in-hermes.md
+++ b/docs/getting-started/install-in-hermes.md
@@ -108,7 +108,20 @@ When unfinished work is silent, the adapter first runs the deterministic
 `factoryctl reconcile-board` plan. That plan either points to native dispatch,
 repairs the canonical factory card, creates the next required artifact from the
 phase engine, repairs a decision package, or asks for a real bounded decision
-only when `phase_engine.human_gate_allowed=true`.
+only when `phase_engine.human_gate_allowed=true` and the decision package is
+already approval-ready.
+
+Package/readback failures are factory work. If the blocker says the factory has
+not delivered owner-readable material, PDF, `APPROVAL_REQUEST`,
+`EVIDENCE_INDEX`, `OWNER_REVIEW`, or attachment readback, the watchdog should
+route repair and continue through native dispatch instead of asking the
+Telegram operator to approve a summary. If the repair task was accidentally
+linked behind the same blocked gate it repairs, the watchdog treats that as a
+Kanban graph defect and routes a graph/package fix.
+
+For Solana/onchain products, the same path checks for the Solana AI Kit
+domain-brain record before architecture and later gates. Missing Solana AI Kit
+state is a factory-owned planning repair, not a Telegram approval request.
 When the adapter returns `input_required`, the Telegram operator should ask for
 the exact missing inputs instead of saying there is no human action. This is not
 approval bureaucracy; it is source/input collection for a blocked dependency

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,12 @@ left to native Hermes dispatch, missing canonical cards become board-contract
 repair, and a single canonical card can create only the next artifact selected
 by the phase engine. It must not ask for a human gate unless
 `phase_engine.human_gate_allowed=true` and the decision package is complete.
+The reconcile task contract includes `workflow_template_id=overkill-vfinal`,
+the computed `current_step_key`, and a fallback `kanban_workflow_binding` in the
+task body so Hermes/Kanban state, not chat context, carries the current phase.
+For Solana/onchain cards at F4 or later, a missing Solana AI Kit provider or
+usage receipt is a factory-owned route defect and becomes a bounded repair task,
+not an optional architecture opinion and not an operator approval question.
 
 `route-registry` exposes the canonical route matrix used by the validators:
 route class, request types, signal types, required artifacts, workers, recovery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.8"
+version = "1.5.9"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/factory-board-reconcile-plan.schema.json
+++ b/schemas/factory-board-reconcile-plan.schema.json
@@ -48,6 +48,7 @@
         "no_unfinished_work",
         "repair_board_contract",
         "create_next_artifact_task",
+        "repair_domain_brain_route",
         "repair_human_gate_packet",
         "request_operator_input",
         "request_human_gate_decision",
@@ -73,16 +74,19 @@
     "create_task_allowed": { "type": "boolean" },
     "create_task_contract": {
       "type": ["object", "null"],
-      "required": ["title", "assignee", "body"],
+      "required": ["title", "assignee", "workflow_template_id", "current_step_key", "body"],
       "properties": {
         "title": { "type": "string", "minLength": 1 },
         "assignee": { "type": "string", "minLength": 1 },
+        "workflow_template_id": { "const": "overkill-vfinal" },
+        "current_step_key": { "type": "string", "pattern": "^F[0-9]+-[a-z0-9-]+$" },
         "body": {
           "type": "object",
           "required": [
             "packet_type",
             "marker",
             "board",
+            "kanban_workflow_binding",
             "plan_action",
             "phase_engine",
             "required_output",
@@ -98,6 +102,24 @@
             "packet_type": { "const": "factory_deterministic_reconcile_task" },
             "marker": { "const": "factory_deterministic_reconcile" },
             "board": { "type": "string", "minLength": 1 },
+            "kanban_workflow_binding": {
+              "type": "object",
+              "required": [
+                "workflow_template_id",
+                "current_step_key",
+                "runtime_field_required",
+                "fallback_body_binding",
+                "route_authority"
+              ],
+              "properties": {
+                "workflow_template_id": { "const": "overkill-vfinal" },
+                "current_step_key": { "type": "string", "pattern": "^F[0-9]+-[a-z0-9-]+$" },
+                "runtime_field_required": { "const": true },
+                "fallback_body_binding": { "const": true },
+                "route_authority": { "const": "factory_phase_engine" }
+              },
+              "additionalProperties": false
+            },
             "plan_action": { "type": "string", "minLength": 1 },
             "card_id": { "type": "string", "minLength": 1 },
             "phase_engine": { "type": "object" },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -220,6 +220,18 @@ FACTORY_PHASE_ENGINE_PHASE_BY_FRONTIER = {
     "release": "F24",
     "completion": "F22",
 }
+FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID = "overkill-vfinal"
+FACTORY_WORKFLOW_STEP_KEY_BY_FRONTIER = {
+    "intake": "F1-intake",
+    "source_resolution": "F2-source-resolution",
+    "product_sot": "F5-product-sot",
+    "method_contract": "F6-method-contract",
+    "architecture": "F10-architecture",
+    "ready_gate": "F13-ready-gate",
+    "execution": "F15-execution",
+    "release": "F24-release",
+    "completion": "F22-completion",
+}
 FACTORY_PHASE_ENGINE_WORKERS_BY_FRONTIER = {
     "intake": ["factory-orchestrator"],
     "source_resolution": ["source-ledger-worker", "factory-orchestrator"],
@@ -4787,6 +4799,14 @@ def factory_phase_engine_state(card: dict[str, Any]) -> dict[str, Any]:
     if card_phase_rank >= factory_phase_rank("F15"):
         return state("execution", "F15", "worker_packet", "ready gate is materialized and execution is claimed")
     return state("ready_gate", "F13", "gate_report", "ready gate materialized; runtime may execute only through routed workers")
+
+
+def factory_workflow_step_key(phase_engine: dict[str, Any] | None) -> str:
+    if isinstance(phase_engine, dict):
+        frontier = str(phase_engine.get("computed_frontier") or "").strip()
+        if frontier in FACTORY_WORKFLOW_STEP_KEY_BY_FRONTIER:
+            return FACTORY_WORKFLOW_STEP_KEY_BY_FRONTIER[frontier]
+    return FACTORY_WORKFLOW_STEP_KEY_BY_FRONTIER["intake"]
 
 
 def _phase_lock_frontier(card: dict[str, Any]) -> str:
@@ -17785,6 +17805,7 @@ TERMINAL_BOARD_STATUSES = {"done", "complete", "completed", "archived", "cancell
 BOARD_RECONCILE_CREATE_ACTIONS = {
     "repair_board_contract",
     "create_next_artifact_task",
+    "repair_domain_brain_route",
     "repair_human_gate_packet",
     "request_operator_input",
 }
@@ -17937,20 +17958,34 @@ def _board_reconcile_task_contract(
     assignee: str = "factory-orchestrator",
 ) -> dict[str, Any]:
     next_artifact = str((phase_engine or {}).get("next_required_artifact") or "canonical_factory_card").strip()
+    if plan_action == "repair_domain_brain_route":
+        next_artifact = "solana_ai_kit_domain_brain_route"
+    workflow_template_id = FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID
+    current_step_key = factory_workflow_step_key(phase_engine)
     card_id = str((selected_card or {}).get("card_id") or "board").strip() or "board"
     title_action = {
         "repair_board_contract": "Materialize canonical factory card",
         "create_next_artifact_task": f"Materialize {next_artifact}",
+        "repair_domain_brain_route": "Materialize Solana AI Kit route",
         "repair_human_gate_packet": "Repair human gate decision package",
         "request_operator_input": "Prepare bounded operator input request",
     }.get(plan_action, "Reconcile factory board")
     return {
         "title": f"{title_action} for {card_id}",
         "assignee": assignee,
+        "workflow_template_id": workflow_template_id,
+        "current_step_key": current_step_key,
         "body": {
             "packet_type": "factory_deterministic_reconcile_task",
             "marker": "factory_deterministic_reconcile",
             "board": board,
+            "kanban_workflow_binding": {
+                "workflow_template_id": workflow_template_id,
+                "current_step_key": current_step_key,
+                "runtime_field_required": True,
+                "fallback_body_binding": True,
+                "route_authority": "factory_phase_engine",
+            },
             "plan_action": plan_action,
             "card_id": card_id,
             "phase_engine": phase_engine or {},
@@ -18060,13 +18095,28 @@ def build_board_reconcile_plan(
                     + str(phase_engine.get("human_gate_blocked_until_artifact") or phase_engine.get("next_required_artifact") or "required artifact")
                 )
 
+            domain_brain_errors = validate_solana_domain_brain_route(selected_card)
             packet = selected_card.get("human_gate_packet") if isinstance(selected_card.get("human_gate_packet"), dict) else {}
             packet_errors = (
                 validate_human_gate_packet(packet, require_decision_package=True)
                 if phase_allows_human_gate and human_gate_required
                 else []
             )
-            if phase_allows_human_gate and human_gate_required and not packet_errors:
+            if domain_brain_errors:
+                plan_action = "repair_domain_brain_route"
+                reason = "Solana/onchain route is missing the required Solana AI Kit domain-brain record"
+                blocked_reasons.extend(domain_brain_errors)
+                create_task_contract = _board_reconcile_task_contract(
+                    plan_action=plan_action,
+                    board=board,
+                    selected_card=selected_card,
+                    phase_engine=phase_engine,
+                    factory_help=factory_help,
+                    reason=reason,
+                    assignee="factory-orchestrator",
+                )
+                native_dispatch_required_next = True
+            elif phase_allows_human_gate and human_gate_required and not packet_errors:
                 plan_action = "request_human_gate_decision"
                 reason = "phase engine allows a real human gate and the decision package is complete"
                 user_decision_required = True

--- a/scripts/worktree_release_inventory.py
+++ b/scripts/worktree_release_inventory.py
@@ -92,7 +92,18 @@ def classify(path: str, status: str) -> str:
         return "generated_receipt"
     if suffix in SAFE_CLEANUP_SUFFIXES or parts.intersection(SAFE_CLEANUP_PARTS):
         return "safe_cleanup_candidate"
-    if top_level(path) in PRODUCT_TOP_LEVELS or path in {"README.md", "LICENSE", "NOTICE.md", ".env.example"}:
+    if top_level(path) in PRODUCT_TOP_LEVELS or path in {
+        "README.md",
+        "README.pt-BR.md",
+        "CHANGELOG.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "LICENSE",
+        "NOTICE.md",
+        ".env.example",
+        "pyproject.toml",
+        "mkdocs.yml",
+    }:
         return "release_candidate_material"
     if status == "??":
         return "needs_human_review"

--- a/tests/test_factory_board_reconciler.py
+++ b/tests/test_factory_board_reconciler.py
@@ -64,7 +64,11 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertFalse(plan["human_gate_required"])
         self.assertFalse(plan["user_decision_required"])
         self.assertTrue(plan["create_task_allowed"])
+        self.assertEqual(plan["create_task_contract"]["workflow_template_id"], "overkill-vfinal")
+        self.assertEqual(plan["create_task_contract"]["current_step_key"], "F5-product-sot")
         task_body = plan["create_task_contract"]["body"]
+        self.assertEqual(task_body["kanban_workflow_binding"]["workflow_template_id"], "overkill-vfinal")
+        self.assertEqual(task_body["kanban_workflow_binding"]["current_step_key"], "F5-product-sot")
         self.assertFalse(task_body["agent_may_choose_phase"])
         self.assertEqual(task_body["required_output"], "operator_briefing_package")
         self.assertIn("ask for a human gate when phase_engine.human_gate_allowed is false", task_body["forbidden_actions"])
@@ -136,6 +140,8 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
         self.assertEqual(plan["plan_action"], "repair_board_contract")
         self.assertTrue(plan["create_task_allowed"])
+        self.assertEqual(plan["create_task_contract"]["workflow_template_id"], "overkill-vfinal")
+        self.assertEqual(plan["create_task_contract"]["current_step_key"], "F1-intake")
         self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "canonical_factory_card")
         self.assertFalse(plan["create_task_contract"]["body"]["agent_may_choose_phase"])
         self.assertFalse(plan["human_gate_required"])
@@ -179,6 +185,38 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertEqual(plan["plan_action"], "block_invariant_violation")
         self.assertFalse(plan["create_task_allowed"])
         self.assertTrue(any("multiple active canonical factory cards" in item for item in plan["blocked_reasons"]))
+
+    def test_solana_route_gap_reconciles_to_domain_brain_repair_not_human_gate(self) -> None:
+        card = load_vfinal_card()
+        card["phase"] = "F10"
+        card["surfaces"] = ["architecture", "solana", "onchain"]
+        card.pop("capability_pack_contract", None)
+        card.pop("domain_brain_provider", None)
+        card.pop("solana_domain_brain_provider", None)
+        card.pop("solana_ai_kit_usage_receipt", None)
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {
+                        "id": "task-solana-route",
+                        "status": "todo",
+                        "title": "Solana architecture candidate",
+                        "assignee": "product-architect",
+                        "body": json.dumps(card),
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        self.assertEqual(plan["plan_action"], "repair_domain_brain_route")
+        self.assertTrue(plan["create_task_allowed"])
+        self.assertFalse(plan["human_gate_required"])
+        self.assertFalse(plan["user_decision_required"])
+        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "solana_ai_kit_domain_brain_route")
+        self.assertIn("Solana AI Kit", plan["reason"])
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -3736,6 +3737,41 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
 
+    def test_native_workflow_state_updates_hermes_sqlite_columns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            board_dir = home / "kanban" / "boards" / TEST_BOARD
+            board_dir.mkdir(parents=True)
+            db_path = board_dir / "kanban.db"
+            conn = adapter.sqlite3.connect(str(db_path))
+            try:
+                conn.execute(
+                    "CREATE TABLE tasks (id TEXT PRIMARY KEY, workflow_template_id TEXT, current_step_key TEXT)"
+                )
+                conn.execute("INSERT INTO tasks (id) VALUES (?)", (MAIN_TASK_ID,))
+                conn.commit()
+            finally:
+                conn.close()
+
+            with mock.patch.dict(adapter.os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                changed = adapter.apply_native_workflow_state(
+                    board=TEST_BOARD,
+                    task_id=MAIN_TASK_ID,
+                    workflow_template_id="overkill-vfinal",
+                    current_step_key="F5-product-sot",
+                )
+
+            self.assertTrue(changed)
+            conn = adapter.sqlite3.connect(str(db_path))
+            try:
+                row = conn.execute(
+                    "SELECT workflow_template_id, current_step_key FROM tasks WHERE id = ?",
+                    (MAIN_TASK_ID,),
+                ).fetchone()
+            finally:
+                conn.close()
+            self.assertEqual(tuple(row), ("overkill-vfinal", "F5-product-sot"))
+
     def test_no_idle_creates_deterministic_reconcile_card_when_board_is_silent(self) -> None:
         fake = FakeHermes()
         fake.tasks["t_" + "todo0001"] = {
@@ -3832,7 +3868,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
-    def test_no_idle_treats_incomplete_human_gate_package_as_input_required(self) -> None:
+    def test_no_idle_treats_incomplete_human_gate_package_as_factory_repair(self) -> None:
         fake = FakeHermes()
         fake.tasks["t_" + "gate0001"] = {
             "id": "t_" + "gate0001",
@@ -3849,13 +3885,13 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         result = adapter.no_idle(args, runner=fake)
 
         state = result["no_idle_state"]
-        self.assertEqual(state["status"], "input_required")
-        self.assertEqual(state["classification"], "only_input_or_human_gate_package_blockers_seen")
+        self.assertEqual(state["status"], "remediation_required")
+        self.assertEqual(state["classification"], "deterministic_board_reconcile_task_created")
         self.assertFalse(state["human_gate_required"])
-        self.assertTrue(state["operator_input_required"])
-        self.assertIn("decision package", state["next_action"])
-        self.assertIsNone(result["remediation_task_id"])
-        self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
+        self.assertFalse(state["operator_input_required"])
+        self.assertIn("factory-owned", state["remediation_reason"])
+        self.assertIsNotNone(result["remediation_task_id"])
+        self.assertTrue(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
     def test_no_idle_reports_dependency_gated_todo_behind_human_gate_without_remediation(self) -> None:
@@ -3901,6 +3937,50 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIsNone(result["remediation_task_id"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
+    def test_no_idle_repairs_repair_task_gated_by_the_gate_it_repairs(self) -> None:
+        gate_id = "t_" + "gate0001"
+        repair_id = "t_" + "repair01"
+
+        state = adapter.classify_no_idle_state(
+            {
+                "ready": [],
+                "running": [],
+                "todo": [
+                    {
+                        "id": repair_id,
+                        "status": "todo",
+                        "assignee": "factory-orchestrator",
+                        "title": "Repair owner-readable human gate package",
+                        "body": (
+                            "factory-owned repair: rebuild the package; no renewed decision "
+                            "request until readable artifact is ready"
+                        ),
+                        "parents": [gate_id],
+                    }
+                ],
+                "blocked": [
+                    {
+                        "id": gate_id,
+                        "status": "blocked",
+                        "assignee": "human-gate-clerk",
+                        "title": "Human architecture gate",
+                        "body": (
+                            "human gate packet is not approval-ready: missing operator briefing package, "
+                            "APPROVAL_REQUEST, EVIDENCE_INDEX, OWNER_REVIEW and pdf"
+                        ),
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(state["status"], "remediation_required")
+        self.assertEqual(state["classification"], "factory_repair_task_dependency_gated_by_blocker_it_repairs")
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertEqual(state["repair_task_refs"], [repair_id])
+        self.assertEqual(state["factory_owned_package_task_refs"], [gate_id])
+        self.assertIn("re-created or unlinked", state["remediation_reason"])
 
     def test_no_idle_reports_dependency_gated_todo_without_generic_remediation(self) -> None:
         fake = FakeHermes()

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.8", readme)
+        self.assertIn("v1.5.9", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.8",
+            "v1.5.9",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",

--- a/tests/test_worktree_release_inventory.py
+++ b/tests/test_worktree_release_inventory.py
@@ -25,6 +25,9 @@ class WorktreeReleaseInventoryTest(unittest.TestCase):
         report = inventory.build_inventory(
             [
                 (" M", "README.md"),
+                (" M", "README.pt-BR.md"),
+                (" M", "CHANGELOG.md"),
+                (" M", "pyproject.toml"),
                 ("??", ".env.example"),
                 ("??", "schemas/example.schema.json"),
                 ("??", "scripts/example.py"),
@@ -33,7 +36,7 @@ class WorktreeReleaseInventoryTest(unittest.TestCase):
         )
 
         self.assertEqual(report["result"], "ATTENTION")
-        self.assertEqual(report["cleanup_policy"]["release_candidate_entries"], 4)
+        self.assertEqual(report["cleanup_policy"]["release_candidate_entries"], 7)
         self.assertEqual(report["cleanup_policy"]["safe_cleanup_candidates"], 0)
         self.assertFalse(report["cleanup_policy"]["broad_cleanup_allowed"])
 


### PR DESCRIPTION
## Summary
- bind factory-created Hermes tasks to native Kanban workflow state when available
- route no-idle package/readback gaps and self-gated repair tasks to factory-owned repair instead of operator approval
- enforce Solana AI Kit route repair for Solana/onchain F4+ boards and document Telegram-first behavior
- bump public release metadata to v1.5.9

## Validation
- python -m unittest tests.test_factory_board_reconciler tests.test_hermes_live_kanban_adapter
- python -m unittest discover -s tests -q
- python scripts/validate_document_governance.py && python scripts/validate_public_json_artifacts.py && python scripts/validate_worker_profiles.py && python scripts/validate_promise_implementation_map.py && python scripts/validate_planning_bundles.py && python scripts/public_safety_scan.py && python scripts/secret_safety_scan.py
- py -3 -m mkdocs build --strict
- python scripts/release_integration_preflight.py
- python scripts/worktree_release_inventory.py

Closes #424
Closes #425
Closes #426