### PR TITLE
Fix Hermes blocked task dispatch race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ public releases.
 
 ## Unreleased
 
+## 1.5.10 - 2026-06-25
+
+- Fix generic blocked Hermes task creation to use an unassigned-create,
+  block-readback, assign-readback protocol, preventing native Kanban dispatch
+  from racing ahead of a factory gate.
+- Preserve native workflow binding during that safe blocked-create path.
+- Add regression coverage for the `create_task(blocked=True)` path that failed
+  during live runtime smoke validation.
+
 ## 1.5.9 - 2026-06-25
 
 - Bind factory-created Hermes tasks to native Kanban workflow state when

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.9.
+is v1.5.10.
 
 It includes:
 
@@ -295,6 +295,8 @@ It includes:
 - no-idle classification that treats missing decision packages, PDF/readback,
   owner-readable materials and repair tasks gated behind their own blocker as
   factory-owned repair, not operator approval bureaucracy;
+- blocked Hermes task creation that uses create-unassigned, block-readback,
+  then assign-readback so Kanban dispatch cannot race ahead of a gate;
 - Solana AI Kit route repair when Solana/on-chain F4+ planning lacks the
   required structured domain-brain record;
 - Hermes completion artifact projection, no-idle remediation controls, Hermes

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.9.
+recente é v1.5.10.
 
 Ela inclui:
 
@@ -297,6 +297,9 @@ Ela inclui:
 - classificação de no-idle que trata pacote de decisão, PDF/readback, material
   legível para dono e tarefa de reparo presa atrás do próprio bloqueio como
   reparo da fábrica, não burocracia de aprovação do operador;
+- criação bloqueada de tarefas Hermes usando criar-sem-responsável,
+  verificar-bloqueio, atribuir e verificar de novo para o dispatch do Kanban
+  não passar na frente de um gate;
 - reparo obrigatório da rota Solana AI Kit quando planejamento Solana/on-chain
   F4+ não tem registro estruturado do cérebro de domínio;
 - projeção de artefato de conclusão Hermes, controles de no-idle, Hermes update

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -188,6 +188,11 @@ the task is still blocked and has no pre-dispatch `promoted`, `claimed`,
 evidence exists. Complete-product claims remain forbidden until all Product SOT
 scope is reconciled through worker results, review and Receipt Five.
 
+The same blocked-first protocol applies to every factory-created Hermes task
+that starts blocked. A blocked task must not be created with an assignee already
+attached, because native Kanban dispatch can observe that assignment before the
+gate is durably blocked.
+
 Ready work-unit packets and the resulting Hermes task contracts also carry both
 a `context_boundary` and a resolved `work_unit_context_packet`. Workers may
 inspect only named allowed refs plus artifacts created for the current

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1684,6 +1684,37 @@ def task_readback_comments(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
+def task_has_active_idempotency_replay_evidence(payload: dict[str, Any]) -> bool:
+    task = task_readback_task(payload)
+    if task_readback_assignee(payload):
+        return True
+    if task.get("current_run_id") or task.get("run_id") or task.get("worker_pid"):
+        return True
+    if task_readback_comments(payload):
+        return True
+    runs = payload.get("runs")
+    if not isinstance(runs, list):
+        runs = task.get("runs")
+    if isinstance(runs, list) and runs:
+        return True
+    replay_event_kinds = {
+        "assigned",
+        "claimed",
+        "completed",
+        "done",
+        "running",
+        "spawned",
+        "unblocked",
+    }
+    for event in task_readback_events(payload):
+        if not isinstance(event, dict):
+            continue
+        kind = str(event.get("kind") or event.get("type") or event.get("event") or event.get("action") or "")
+        if kind.strip().lower() in replay_event_kinds:
+            return True
+    return False
+
+
 def task_readback_parents(payload: dict[str, Any]) -> list[str]:
     raw_parents = payload.get("parents")
     if not isinstance(raw_parents, list):
@@ -2344,6 +2375,21 @@ def create_task(
     runner: Runner = default_runner,
 ) -> str:
     ensure_non_empty_body(body)
+    if blocked:
+        return create_blocked_task_before_assignment(
+            hermes_bin=hermes_bin,
+            board=board,
+            title=title,
+            body=body,
+            assignee=assignee,
+            idempotency_key=idempotency_key,
+            created_by=created_by,
+            workspace=workspace,
+            blocked_reason="Overkill Factory gate starts blocked until required authority evidence passes.",
+            workflow_template_id=workflow_template_id,
+            current_step_key=current_step_key,
+            runner=runner,
+        )
     args = hermes_kanban(
         hermes_bin,
         board,
@@ -2361,8 +2407,6 @@ def create_task(
         workspace,
         "--json",
     )
-    if blocked:
-        args.extend(["--initial-status", "blocked"])
     task_id = parse_task_id(run_checked(args, runner).stdout)
     apply_native_workflow_state(
         board=board,
@@ -2370,24 +2414,6 @@ def create_task(
         workflow_template_id=workflow_template_id,
         current_step_key=current_step_key,
     )
-    if blocked:
-        shown_task = show_task(
-            hermes_bin=hermes_bin,
-            board=board,
-            task_id=task_id,
-            runner=runner,
-        )
-        status = task_status(shown_task)
-        if status in ACTIVE_OR_TERMINAL_STATUSES:
-            return task_id
-        if not task_has_blocked_event(shown_task):
-            ensure_blocked_event(
-                hermes_bin=hermes_bin,
-                board=board,
-                task_id=task_id,
-                reason="Overkill Factory gate starts blocked until required authority evidence passes.",
-                runner=runner,
-            )
     return task_id
 
 
@@ -2402,6 +2428,8 @@ def create_blocked_task_before_assignment(
     created_by: str,
     workspace: str,
     blocked_reason: str,
+    workflow_template_id: str | None = None,
+    current_step_key: str | None = None,
     runner: Runner = default_runner,
 ) -> str:
     ensure_non_empty_body(body)
@@ -2425,6 +2453,18 @@ def create_blocked_task_before_assignment(
             runner,
         ).stdout
     )
+    apply_native_workflow_state(
+        board=board,
+        task_id=task_id,
+        workflow_template_id=workflow_template_id,
+        current_step_key=current_step_key,
+    )
+    created_task = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+    if (
+        task_readback_status(created_task) in ACTIVE_OR_TERMINAL_STATUSES
+        and task_has_active_idempotency_replay_evidence(created_task)
+    ):
+        return task_id
     ensure_blocked_event(
         hermes_bin=hermes_bin,
         board=board,
@@ -2450,6 +2490,8 @@ def create_blocked_task_before_assignment(
     ensure_no_pre_dispatch_activity(assigned_task, task_id=task_id)
     if task_readback_status(assigned_task) != "blocked":
         raise RuntimeError(f"Hermes task {task_id} is not blocked after assignment")
+    if task_readback_assignee(assigned_task) != assignee:
+        raise RuntimeError(f"Hermes task {task_id} assignee readback does not match target profile")
     return task_id
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.9"
+version = "1.5.10"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3772,6 +3772,59 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 conn.close()
             self.assertEqual(tuple(row), ("overkill-vfinal", "F5-product-sot"))
 
+    def test_create_task_blocked_uses_unassigned_block_assign_protocol(self) -> None:
+        fake = FakeHermes()
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            board_dir = home / "kanban" / "boards" / TEST_BOARD
+            board_dir.mkdir(parents=True)
+            db_path = board_dir / "kanban.db"
+            conn = adapter.sqlite3.connect(str(db_path))
+            try:
+                conn.execute(
+                    "CREATE TABLE tasks (id TEXT PRIMARY KEY, workflow_template_id TEXT, current_step_key TEXT)"
+                )
+                conn.execute("INSERT INTO tasks (id) VALUES (?)", ("t_" + "00000001",))
+                conn.commit()
+            finally:
+                conn.close()
+
+            with mock.patch.dict(adapter.os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                task_id = adapter.create_task(
+                    hermes_bin="hermes",
+                    board=TEST_BOARD,
+                    title="Blocked gate",
+                    body=json.dumps({"task_type": "human_gate_package"}),
+                    assignee="factory-orchestrator",
+                    idempotency_key="blocked-create-race",
+                    created_by="test",
+                    workspace="scratch",
+                    blocked=True,
+                    workflow_template_id="overkill-vfinal",
+                    current_step_key="F5-product-sot",
+                    runner=fake,
+                )
+
+            conn = adapter.sqlite3.connect(str(db_path))
+            try:
+                row = conn.execute(
+                    "SELECT workflow_template_id, current_step_key FROM tasks WHERE id = ?",
+                    (task_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+
+        create_call = next(call for call in fake.calls if len(call) >= 5 and call[4] == "create")
+        block_call = next(call for call in fake.calls if len(call) >= 5 and call[4] == "block")
+        assign_call = next(call for call in fake.calls if len(call) >= 5 and call[4] == "assign")
+        self.assertNotIn("--assignee", create_call)
+        self.assertNotIn("--initial-status", create_call)
+        self.assertLess(fake.calls.index(create_call), fake.calls.index(block_call))
+        self.assertLess(fake.calls.index(block_call), fake.calls.index(assign_call))
+        self.assertEqual(fake.tasks[task_id]["status"], "blocked")
+        self.assertEqual(fake.tasks[task_id]["assignee"], "factory-orchestrator")
+        self.assertEqual(tuple(row), ("overkill-vfinal", "F5-product-sot"))
+
     def test_no_idle_creates_deterministic_reconcile_card_when_board_is_silent(self) -> None:
         fake = FakeHermes()
         fake.tasks["t_" + "todo0001"] = {

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.9", readme)
+        self.assertIn("v1.5.10", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.9",
+            "v1.5.10",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
## Summary
- route every generic factory-created blocked Hermes task through create-unassigned -> block-readback -> assign-readback
- preserve native workflow binding in the safe blocked-create path
- add regression coverage for the create_task(blocked=True) race found by live runtime smoke

## Validation
- python -m unittest tests.test_hermes_live_kanban_adapter -q
- python -m unittest tests.test_open_source_docs tests.test_worktree_release_inventory -q
- python -m unittest discover -s tests -q
- python scripts/validate_document_governance.py
- python scripts/validate_public_json_artifacts.py
- python scripts/validate_worker_profiles.py
- python scripts/validate_promise_implementation_map.py
- python scripts/validate_planning_bundles.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- py -3 -m mkdocs build --strict
- python scripts/release_integration_preflight.py
- python scripts/worktree_release_inventory.py

Fixes #428