### PR TITLE
Harden runtime phase reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ public releases.
 
 ## Unreleased
 
+## 1.5.11 - 2026-06-25
+
+- Harden Hermes runtime reconciliation so template/example scaffold refs,
+  placeholder refs and embedded vFinal template packets do not count as
+  materialized runtime evidence.
+- Keep public template validation useful while forcing `reconcile-board` and
+  no-idle remediation to compute the live frontier from product-specific
+  artifacts only.
+- Add regressions for template-only boards, real-SOT-with-template-method
+  boards and real-method-with-template-architecture boards so the factory
+  cannot jump past F1/F6/F10 from inherited scaffold data.
+- Add a worker-profile boundary that builders must not approve their own work,
+  with public profile validation coverage.
+
 ## 1.5.10 - 2026-06-25
 
 - Fix generic blocked Hermes task creation to use an unassigned-create,

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.10.
+is v1.5.11.
 
 It includes:
 
@@ -289,6 +289,9 @@ It includes:
 - deterministic Hermes/Kanban board reconciliation so a silent board becomes
   one allowed next-artifact task, native dispatch, or a real bounded gate
   request instead of agent-chosen phase routing;
+- runtime-strict phase evidence in Hermes reconciliation, so template/example
+  scaffold refs and placeholder packets cannot make a live product board skip
+  F1/F2/F3/F4 boundaries;
 - Kanban-native workflow binding with `workflow_template_id=overkill-vfinal`
   and deterministic `current_step_key` on factory-created Hermes tasks when the
   installed Hermes database exposes those fields;

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.10.
+recente é v1.5.11.
 
 Ela inclui:
 
@@ -291,6 +291,9 @@ Ela inclui:
 - reconciliação determinística de board Hermes/Kanban para transformar uma fila
   silenciosa em uma única tarefa de próximo artefato, dispatch nativo ou pedido
   real de gate limitado, sem rota escolhida pelo agente;
+- evidência de fase em modo estrito no runtime Hermes, para que refs de
+  template/exemplo e pacotes placeholder não façam um board real pular
+  fronteiras F1/F2/F3/F4;
 - binding nativo de workflow no Kanban com
   `workflow_template_id=overkill-vfinal` e `current_step_key` determinístico nas
   tarefas criadas pela fábrica quando o banco Hermes expõe esses campos;

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -76,6 +76,22 @@ Current automation is intentionally an orchestration and reconciliation layer.
 It does not replace real Codex Security scans, solanabr/Auditor runs,
 screenshots, independent reviews, or human approval records.
 
+## Runtime-Strict Phase Evidence
+
+Hermes runtime reconciliation treats the public factory templates as scaffold,
+not as product evidence. A card copied from `templates/vfinal-factory-card.json`
+may contain example Product SOT, Method Contract, architecture, readiness and
+gate fields. Those fields are valid as examples, but they do not prove that a
+live product produced the corresponding artifacts.
+
+When the no-idle adapter calls `factoryctl reconcile-board`, the phase engine
+runs in runtime-strict mode. In that mode `templates/...`, `source-ledger.md`,
+`factoryctl:gate-report`, bare scaffold refs and embedded placeholder packets
+are ignored for phase advancement. The board can advance only from
+product-specific source, SOT, Method Contract, architecture, readiness and gate
+artifacts. This prevents Telegram, worker prose, copied templates or stale card
+fields from jumping the factory to a later phase.
+
 ## Transition Plan Model
 
 Hermes should treat the factory helper output as a transition plan, not as a

--- a/agents/worker-profiles.public.json
+++ b/agents/worker-profiles.public.json
@@ -3029,6 +3029,7 @@
         "must_not": [
           "expand scope",
           "self-review",
+          "approve its own work",
           "deploy or touch forbidden surfaces"
         ],
         "human_gate_required_when": [
@@ -5254,6 +5255,7 @@
         ],
         "must_not": [
           "change architecture",
+          "approve its own work",
           "waive security controls",
           "invent data contracts"
         ],
@@ -5403,6 +5405,7 @@
         ],
         "must_not": [
           "mutate production data",
+          "approve its own work",
           "skip rollback for destructive changes",
           "invent privacy assumptions"
         ],
@@ -5553,6 +5556,7 @@
         ],
         "must_not": [
           "use Anchor assumptions",
+          "approve its own work",
           "deploy mainnet",
           "touch real keys or funds"
         ],
@@ -5846,6 +5850,7 @@
         ],
         "must_not": [
           "touch real keys",
+          "approve its own work",
           "move funds",
           "hide signer/custody assumptions"
         ],
@@ -5992,6 +5997,7 @@
         ],
         "must_not": [
           "redesign owned components",
+          "approve its own work",
           "waive missing builder output",
           "hide cross-surface risk"
         ],
@@ -6143,6 +6149,7 @@
         ],
         "must_not": [
           "rewrite acceptance criteria alone",
+          "approve its own work",
           "hide flaky tests",
           "claim manual proof as automation"
         ],
@@ -6293,6 +6300,7 @@
         ],
         "must_not": [
           "release production alone",
+          "approve its own work",
           "store secrets",
           "mutate cloud without gate"
         ],

--- a/docs/concepts/factory-flow.md
+++ b/docs/concepts/factory-flow.md
@@ -77,6 +77,14 @@ the engine blocks the card. For example, a declared F9 architecture or human
 gate package cannot proceed while the computed frontier is still Product SOT and
 the next required artifact is `operator_briefing_package`.
 
+In Hermes/Kanban runtime reconciliation, public scaffold material is not
+evidence. References such as `templates/...`, `source-ledger.md`,
+`factoryctl:gate-report` or embedded placeholder packets copied from
+`templates/vfinal-factory-card.json` do not count as product-specific source,
+SOT, Method Contract, architecture, readiness or gate artifacts. They are useful
+as examples and schemas; a live product board must materialize its own artifacts
+before the phase engine advances.
+
 ## Deterministic Board Reconciler
 
 `factoryctl reconcile-board` applies the phase engine to Hermes/Kanban board
@@ -87,6 +95,9 @@ state. This is the runtime rule for silent boards:
 - no canonical factory card means repair the board contract, not infer a phase;
 - one canonical card means compute its phase engine state and create only the
   next artifact task selected by that state;
+- template/scaffold artifacts are ignored in runtime mode, so a copied public
+  template reconciles back to the first missing product artifact instead of
+  jumping to F9/F13;
 - a human gate can be requested only when the phase engine allows it and the
   decision package is complete.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,12 @@ left to native Hermes dispatch, missing canonical cards become board-contract
 repair, and a single canonical card can create only the next artifact selected
 by the phase engine. It must not ask for a human gate unless
 `phase_engine.human_gate_allowed=true` and the decision package is complete.
+Unlike the public template validation path, board reconciliation runs the phase
+engine in runtime-strict mode: `templates/...`, `source-ledger.md`,
+`factoryctl:gate-report`, bare scaffold refs and placeholder packets copied from
+`templates/vfinal-factory-card.json` do not count as materialized product
+evidence. A live board must carry product-specific artifacts before it can move
+from intake to SOT, method, architecture, readiness or execution.
 The reconcile task contract includes `workflow_template_id=overkill-vfinal`,
 the computed `current_step_key`, and a fallback `kanban_workflow_binding` in the
 task body so Hermes/Kanban state, not chat context, carries the current phase.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.10"
+version = "1.5.11"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4551,12 +4551,120 @@ def factory_phase_rank(phase_id: Any) -> int:
     return base
 
 
-def _has_card_artifact(card: dict[str, Any], artifact_type: str) -> bool:
+PHASE_ENGINE_SCAFFOLD_REF_PREFIXES = ("templates/", "examples/")
+PHASE_ENGINE_SCAFFOLD_REF_VALUES = {
+    "factoryctl:gate-report",
+    "source-ledger.md",
+}
+PHASE_ENGINE_SCAFFOLD_BARE_REF_VALUES = {"product_sot"}
+PHASE_ENGINE_SCAFFOLD_TEXT_MARKERS = (
+    "a short, concrete description",
+    "acceptance example or scenario",
+    "bounded slice",
+    "concrete product result",
+    "describe the concrete result",
+    "observable acceptance criterion",
+    "primary user or actor",
+    "product_slice_id",
+    "target user",
+    "template only",
+    "to be filled by execution",
+    "what the worker may do",
+    "what the worker must not do",
+)
+
+
+def _phase_engine_scaffold_ref(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return True
+    normalized = text.replace("\\", "/").lower()
+    if normalized.startswith(PHASE_ENGINE_SCAFFOLD_REF_PREFIXES):
+        return True
+    if normalized in PHASE_ENGINE_SCAFFOLD_REF_VALUES:
+        return True
+    return False
+
+
+def _phase_engine_scaffold_score(value: Any, *, depth: int = 0) -> int:
+    if depth > 6:
+        return 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized:
+            return 1
+        return sum(1 for marker in PHASE_ENGINE_SCAFFOLD_TEXT_MARKERS if marker in normalized)
+    if isinstance(value, list):
+        return sum(_phase_engine_scaffold_score(item, depth=depth + 1) for item in value)
+    if isinstance(value, dict):
+        return sum(_phase_engine_scaffold_score(item, depth=depth + 1) for item in value.values())
+    return 0
+
+
+def _phase_engine_contains_scaffold_ref(value: Any, *, depth: int = 0) -> bool:
+    if depth > 6:
+        return False
+    if isinstance(value, str):
+        return _phase_engine_scaffold_ref(value)
+    if isinstance(value, list):
+        return any(_phase_engine_contains_scaffold_ref(item, depth=depth + 1) for item in value)
+    if isinstance(value, dict):
+        return any(_phase_engine_contains_scaffold_ref(item, depth=depth + 1) for item in value.values())
+    return False
+
+
+def _phase_engine_value_materialized(
+    value: Any,
+    *,
+    allow_scaffold_artifacts: bool,
+    ref_like: bool = False,
+) -> bool:
+    if isinstance(value, dict):
+        if not value:
+            return False
+        if not allow_scaffold_artifacts:
+            if _phase_engine_scaffold_score(value) >= 2:
+                return False
+            if _phase_engine_contains_scaffold_ref(value):
+                return False
+        return True
+    if isinstance(value, list):
+        return any(
+            _phase_engine_value_materialized(
+                item,
+                allow_scaffold_artifacts=allow_scaffold_artifacts,
+                ref_like=ref_like or isinstance(item, str),
+            )
+            for item in value
+        )
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return False
+        if not allow_scaffold_artifacts and ref_like and text.lower() in PHASE_ENGINE_SCAFFOLD_BARE_REF_VALUES:
+            return False
+        if not allow_scaffold_artifacts and (
+            _phase_engine_scaffold_ref(text)
+            or _phase_engine_scaffold_score(text) > 0
+        ):
+            return False
+        if ref_like:
+            return _phase_lock_public_ref_ok(text)
+        return True
+    return False
+
+
+def _has_card_artifact(
+    card: dict[str, Any],
+    artifact_type: str,
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> bool:
     value = card.get(artifact_type)
-    if isinstance(value, dict) and value:
+    if _phase_engine_value_materialized(value, allow_scaffold_artifacts=allow_scaffold_artifacts):
         return True
     ref = str(card.get(f"{artifact_type}_ref") or "").strip()
-    if ref:
+    if _phase_engine_value_materialized(ref, allow_scaffold_artifacts=allow_scaffold_artifacts, ref_like=True):
         return True
     return False
 
@@ -4586,28 +4694,50 @@ def factory_phase_engine_frontier_rank(frontier: Any) -> int:
         return -1
 
 
-def _phase_engine_field_materialized(card: dict[str, Any], field: str) -> bool:
+def _phase_engine_field_materialized(
+    card: dict[str, Any],
+    field: str,
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> bool:
     value = card.get(field)
-    if isinstance(value, dict) and value:
-        return True
-    if isinstance(value, list) and value:
-        return True
-    if isinstance(value, str) and value.strip():
-        if field.endswith("_ref") or field == "canonical_product_sot_ref":
-            return _phase_lock_public_ref_ok(value)
+    if _phase_engine_value_materialized(
+        value,
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+        ref_like=field.endswith("_ref") or field == "canonical_product_sot_ref",
+    ):
         return True
 
     lock = _factory_phase_lock(card)
     refs = lock.get("materialized_artifact_refs") if isinstance(lock.get("materialized_artifact_refs"), dict) else {}
-    if _phase_lock_public_ref_ok(refs.get(field)):
+    if _phase_engine_value_materialized(
+        refs.get(field),
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+        ref_like=True,
+    ):
         return True
-    if not field.endswith("_ref") and _phase_lock_public_ref_ok(refs.get(f"{field}_ref")):
+    if not field.endswith("_ref") and _phase_engine_value_materialized(
+        refs.get(f"{field}_ref"),
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+        ref_like=True,
+    ):
         return True
     return False
 
 
-def _phase_engine_any_materialized(card: dict[str, Any], *fields: str) -> bool:
-    return any(_phase_engine_field_materialized(card, field) for field in fields)
+def _phase_engine_any_materialized(
+    card: dict[str, Any],
+    *fields: str,
+    allow_scaffold_artifacts: bool = True,
+) -> bool:
+    return any(
+        _phase_engine_field_materialized(
+            card,
+            field,
+            allow_scaffold_artifacts=allow_scaffold_artifacts,
+        )
+        for field in fields
+    )
 
 
 def _phase_engine_frontier_state(
@@ -4665,7 +4795,11 @@ def _phase_engine_frontier_state(
     }
 
 
-def factory_phase_engine_state(card: dict[str, Any]) -> dict[str, Any]:
+def factory_phase_engine_state(
+    card: dict[str, Any],
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> dict[str, Any]:
     """Compute the active factory frontier from artifacts, not agent prose."""
     surfaces = normalized_surfaces(card)
     card_phase_rank = factory_phase_rank(card.get("phase"))
@@ -4675,46 +4809,70 @@ def factory_phase_engine_state(card: dict[str, Any]) -> dict[str, Any]:
         "factory_start_conversation",
         "source_resolution_packet",
         "source_refs",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
     )
     product_sot = _phase_engine_any_materialized(
         card,
         "product_sot",
         "product_sot_ref",
         "canonical_product_sot_ref",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
     )
     source_resolution = (
         product_sot
-        or _phase_engine_any_materialized(card, "product_source_ledger", "source_resolution_packet")
+        or _phase_engine_any_materialized(
+            card,
+            "product_source_ledger",
+            "source_resolution_packet",
+            allow_scaffold_artifacts=allow_scaffold_artifacts,
+        )
     )
     understanding = (
         product_sot
-        or _phase_engine_any_materialized(card, "operator_understanding_confirmation", "outcome_contract")
+        or _phase_engine_any_materialized(
+            card,
+            "operator_understanding_confirmation",
+            "outcome_contract",
+            allow_scaffold_artifacts=allow_scaffold_artifacts,
+        )
     )
-    outcome = product_sot or _phase_engine_any_materialized(card, "outcome_contract", "discovery_brief")
+    outcome = product_sot or _phase_engine_any_materialized(
+        card,
+        "outcome_contract",
+        "discovery_brief",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+    )
     full_scope = _phase_engine_any_materialized(
         card,
         "full_product_sot_scope_coverage",
         "full_product_sot_scope_coverage_ref",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
     )
-    owner_surface = product_sot_owner_surface_delivered(card)
-    method_done = method_contract_materialized(card)
+    owner_surface = product_sot_owner_surface_delivered(
+        card,
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+    )
+    method_done = method_contract_materialized(card, allow_scaffold_artifacts=allow_scaffold_artifacts)
     architecture_done = _phase_engine_any_materialized(
         card,
         "architecture_packet",
         "architecture_packet_ref",
         "security_architecture_plan",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
     )
     product_creation_done = _phase_engine_any_materialized(
         card,
         "product_creation_plan",
         "product_creation_plan_ref",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
     )
     readiness_done = _phase_engine_any_materialized(
         card,
         "product_implementation_readiness",
         "autonomy_readiness_packet",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
     )
-    ready_gate_done = ready_gate_materialized(card)
+    ready_gate_done = ready_gate_materialized(card, allow_scaffold_artifacts=allow_scaffold_artifacts)
     artifacts = {
         "source_input": source_input,
         "source_resolution": source_resolution,
@@ -4843,56 +5001,132 @@ def _phase_lock_allowed_surfaces(frontier: str) -> set[str]:
     return allowed
 
 
-def product_sot_owner_surface_delivered(card: dict[str, Any]) -> bool:
+def product_sot_owner_surface_delivered(
+    card: dict[str, Any],
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> bool:
     lock = _factory_phase_lock(card)
     owner_surface = lock.get("owner_surface_first") if isinstance(lock.get("owner_surface_first"), dict) else {}
     if owner_surface.get("product_sot_review_packet_delivered") is True:
         review_ref = _phase_lock_ref(owner_surface.get("product_sot_review_packet_ref"))
         briefing_ref = _phase_lock_ref(owner_surface.get("operator_briefing_package_ref"))
-        if (not review_ref or _phase_lock_public_ref_ok(review_ref)) and (
-            not briefing_ref or _phase_lock_public_ref_ok(briefing_ref)
+        if (
+            not review_ref
+            or _phase_engine_value_materialized(
+                review_ref,
+                allow_scaffold_artifacts=allow_scaffold_artifacts,
+                ref_like=True,
+            )
+        ) and (
+            not briefing_ref
+            or _phase_engine_value_materialized(
+                briefing_ref,
+                allow_scaffold_artifacts=allow_scaffold_artifacts,
+                ref_like=True,
+            )
         ):
             return True
 
     return (
-        _has_card_artifact(card, "product_sot")
-        and _has_card_artifact(card, "full_product_sot_scope_coverage")
+        _has_card_artifact(card, "product_sot", allow_scaffold_artifacts=allow_scaffold_artifacts)
+        and _has_card_artifact(
+            card,
+            "full_product_sot_scope_coverage",
+            allow_scaffold_artifacts=allow_scaffold_artifacts,
+        )
         and (
-            _has_card_artifact(card, "operator_briefing_package")
-            or _phase_lock_public_ref_ok(card.get("operator_briefing_package_ref"))
-            or _phase_lock_public_ref_ok(card.get("owner_review_ref"))
+            _has_card_artifact(
+                card,
+                "operator_briefing_package",
+                allow_scaffold_artifacts=allow_scaffold_artifacts,
+            )
+            or _phase_engine_value_materialized(
+                card.get("operator_briefing_package_ref"),
+                allow_scaffold_artifacts=allow_scaffold_artifacts,
+                ref_like=True,
+            )
+            or _phase_engine_value_materialized(
+                card.get("owner_review_ref"),
+                allow_scaffold_artifacts=allow_scaffold_artifacts,
+                ref_like=True,
+            )
         )
     )
 
 
-def method_contract_materialized(card: dict[str, Any]) -> bool:
+def method_contract_materialized(
+    card: dict[str, Any],
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> bool:
     lock = _factory_phase_lock(card)
     refs = lock.get("materialized_artifact_refs") if isinstance(lock.get("materialized_artifact_refs"), dict) else {}
-    return _has_card_artifact(card, "method_contract") or _phase_lock_public_ref_ok(refs.get("method_contract_ref"))
+    return _has_card_artifact(
+        card,
+        "method_contract",
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+    ) or _phase_engine_value_materialized(
+        refs.get("method_contract_ref"),
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+        ref_like=True,
+    )
 
 
-def ready_gate_materialized(card: dict[str, Any]) -> bool:
+def ready_gate_materialized(
+    card: dict[str, Any],
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> bool:
     lock = _factory_phase_lock(card)
     refs = lock.get("materialized_artifact_refs") if isinstance(lock.get("materialized_artifact_refs"), dict) else {}
     review = card.get("review") if isinstance(card.get("review"), dict) else {}
     return (
-        _has_card_artifact(card, "product_implementation_readiness")
-        or _phase_lock_public_ref_ok(refs.get("ready_gate_ref"))
+        _has_card_artifact(
+            card,
+            "product_implementation_readiness",
+            allow_scaffold_artifacts=allow_scaffold_artifacts,
+        )
+        or _phase_engine_value_materialized(
+            refs.get("ready_gate_ref"),
+            allow_scaffold_artifacts=allow_scaffold_artifacts,
+            ref_like=True,
+        )
         or review.get("ready_gate_passed") is True
     )
 
 
-def factory_phase_lock_projection(card: dict[str, Any]) -> dict[str, Any]:
+def factory_phase_lock_projection(
+    card: dict[str, Any],
+    *,
+    allow_scaffold_artifacts: bool = True,
+) -> dict[str, Any]:
     surfaces = normalized_surfaces(card)
-    frontier = _phase_lock_frontier(card)
-    current_phase_id = _factory_phase_lock_current_phase_id(card)
+    strict_phase_engine = (
+        factory_phase_engine_state(card, allow_scaffold_artifacts=False)
+        if not allow_scaffold_artifacts
+        else None
+    )
+    frontier = (
+        str(strict_phase_engine.get("computed_frontier") or "")
+        if isinstance(strict_phase_engine, dict)
+        else _phase_lock_frontier(card)
+    )
+    current_phase_id = (
+        str(strict_phase_engine.get("computed_phase_id") or "")
+        if isinstance(strict_phase_engine, dict)
+        else _factory_phase_lock_current_phase_id(card)
+    )
     lock = _factory_phase_lock(card)
     downstream_freeze = bool(lock.get("downstream_freeze_active", False))
     if not downstream_freeze:
         downstream_freeze = factory_phase_rank(card.get("phase")) > factory_phase_rank(current_phase_id)
-    sot_delivered = product_sot_owner_surface_delivered(card)
-    method_done = method_contract_materialized(card)
-    ready_done = ready_gate_materialized(card)
+    sot_delivered = product_sot_owner_surface_delivered(
+        card,
+        allow_scaffold_artifacts=allow_scaffold_artifacts,
+    )
+    method_done = method_contract_materialized(card, allow_scaffold_artifacts=allow_scaffold_artifacts)
+    ready_done = ready_gate_materialized(card, allow_scaffold_artifacts=allow_scaffold_artifacts)
     downstream_surface_seen = bool(surfaces & DOWNSTREAM_PHASE_LOCK_SURFACES)
     return {
         "active_frontier": frontier,
@@ -17714,9 +17948,10 @@ def build_factory_help(
     catalog_path: Path | None = None,
     worker_results_dir: Path | None = None,
     receipt: dict[str, Any] | None = None,
+    allow_scaffold_artifacts: bool = True,
 ) -> dict[str, Any]:
     catalog = load_workflow_catalog(catalog_path)
-    phase_engine = factory_phase_engine_state(card)
+    phase_engine = factory_phase_engine_state(card, allow_scaffold_artifacts=allow_scaffold_artifacts)
     phase_row = workflow_phase_by_id(catalog, str(phase_engine.get("computed_phase_id") or "")) or workflow_phase_for_card(card, catalog)
     gate_report = build_gate_report(card)
     recovery_plan = build_factory_recovery_plan(
@@ -17748,7 +17983,7 @@ def build_factory_help(
         }
     blocked_workers = _list_items(gate_report.get("blocked_workers"))
     validation_errors = _list_items(gate_report.get("card_validation_errors"))
-    phase_lock = factory_phase_lock_projection(card)
+    phase_lock = factory_phase_lock_projection(card, allow_scaffold_artifacts=allow_scaffold_artifacts)
     phase_lock_blocked = any("factory_phase_lock" in error for error in validation_errors)
     phase_engine_blocked = any("factory_phase_engine" in error for error in validation_errors)
     user_decisions = [] if phase_lock_blocked or phase_engine_blocked else user_decisions_for_card(card, gate_report)
@@ -18070,8 +18305,13 @@ def build_board_reconcile_plan(
             )
             native_dispatch_required_next = True
         else:
-            phase_engine = factory_phase_engine_state(selected_card)
-            factory_help = build_factory_help(selected_card, Path("<kanban-card>"), catalog_path=catalog_path)
+            phase_engine = factory_phase_engine_state(selected_card, allow_scaffold_artifacts=False)
+            factory_help = build_factory_help(
+                selected_card,
+                Path("<kanban-card>"),
+                catalog_path=catalog_path,
+                allow_scaffold_artifacts=False,
+            )
             gate_report = factory_help.get("gate_status")
             user_decisions = [
                 item for item in factory_help.get("user_decision_required", []) if isinstance(item, dict)

--- a/tests/test_factory_board_reconciler.py
+++ b/tests/test_factory_board_reconciler.py
@@ -23,8 +23,50 @@ def load_vfinal_card() -> dict:
     return factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
 
 
+def materialize_product_sot_frontier(card: dict) -> dict:
+    card["universal_signal_intake"] = {
+        "record_type": "universal_signal_intake",
+        "intake_id": "runtime-intake-001",
+        "source_ref_public_safe": "external:operator:source-envelope",
+    }
+    card["product_source_ledger"] = {
+        "record_type": "product_source_ledger",
+        "ledger_id": "runtime-source-ledger-001",
+        "claim_table": [
+            {
+                "claim_id": "claim-001",
+                "claim": "Product Alpha is an operations product with web and admin surfaces.",
+                "claim_class": "fact",
+                "status": "promoted",
+                "source_refs": ["external:operator:source-envelope"],
+            }
+        ],
+    }
+    card["outcome_contract"] = {
+        "record_type": "outcome_contract",
+        "outcome": "Produce the complete product planning baseline before architecture.",
+        "users_or_actors": ["Brazilian web3 user", "operator"],
+        "success_signals": ["scope is covered", "open risks are named"],
+    }
+    card["product_sot"] = {
+        "record_type": "product_sot",
+        "what_it_is": "Product Alpha is an operations product with onboarding and operator surfaces.",
+        "scope_in": ["onboarding", "operator administration"],
+        "scope_out": ["production deploy", "credential transfer"],
+        "evidence_refs": ["external:operator:source-envelope"],
+    }
+    card["full_product_sot_scope_coverage"] = {
+        "record_type": "full_product_sot_scope_coverage",
+        "coverage_state": "covered_for_owner_review",
+        "covered_requirement_ids": ["REQ-001", "REQ-002"],
+        "evidence_refs": ["external:operator:source-envelope"],
+    }
+    return card
+
+
 def sot_without_owner_packet_card() -> dict:
     card = load_vfinal_card()
+    materialize_product_sot_frontier(card)
     card["phase"] = "F9"
     card["surfaces"] = ["architecture", "planning"]
     card["autonomy_mode"] = "planning_only"
@@ -72,6 +114,95 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertFalse(task_body["agent_may_choose_phase"])
         self.assertEqual(task_body["required_output"], "operator_briefing_package")
         self.assertIn("ask for a human gate when phase_engine.human_gate_allowed is false", task_body["forbidden_actions"])
+
+    def test_template_scaffold_does_not_count_as_runtime_artifacts(self) -> None:
+        card = load_vfinal_card()
+        card["phase"] = "F13"
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {
+                        "id": "task-template-copy",
+                        "status": "todo",
+                        "title": "Copied public template",
+                        "assignee": "factory-orchestrator",
+                        "body": json.dumps(card),
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha-runtime")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        self.assertEqual(plan["phase_engine"]["computed_phase_id"], "F1")
+        self.assertEqual(plan["phase_engine"]["next_required_artifact"], "universal_signal_intake")
+        self.assertFalse(plan["phase_engine"]["artifacts"]["source_input"])
+        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "universal_signal_intake")
+
+    def test_runtime_reconciler_does_not_count_template_method_after_real_sot(self) -> None:
+        card = sot_without_owner_packet_card()
+        card["phase"] = "F10"
+        card["operator_briefing_package"] = {
+            "record_type": "operator_briefing_package",
+            "artifact_ref": "external:operator:product-sot-briefing",
+            "formats": ["markdown", "pdf"],
+        }
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {
+                        "id": "task-template-method",
+                        "status": "todo",
+                        "title": "Architecture from copied template",
+                        "assignee": "product-architect",
+                        "body": json.dumps(card),
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(plan["phase_engine"]["computed_phase_id"], "F6")
+        self.assertEqual(plan["phase_engine"]["next_required_artifact"], "method_contract")
+        self.assertFalse(plan["phase_engine"]["artifacts"]["method_contract"])
+        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "method_contract")
+
+    def test_runtime_reconciler_does_not_count_template_architecture_after_real_method(self) -> None:
+        card = sot_without_owner_packet_card()
+        card["phase"] = "F11"
+        card["operator_briefing_package"] = {
+            "record_type": "operator_briefing_package",
+            "artifact_ref": "external:operator:product-sot-briefing",
+            "formats": ["markdown", "pdf"],
+        }
+        card["method_contract"] = {
+            "record_type": "method_contract",
+            "selected_method": "spec-first",
+            "canonical_scope_source": "external:operator:product-sot",
+            "required_artifacts": ["architecture_packet", "product_creation_plan"],
+        }
+        snapshot = {
+            "rows": {
+                "todo": [
+                    {
+                        "id": "task-template-architecture",
+                        "status": "todo",
+                        "title": "Execution plan from copied template",
+                        "assignee": "decomposition-planner",
+                        "body": json.dumps(card),
+                    }
+                ]
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(plan["phase_engine"]["computed_phase_id"], "F10")
+        self.assertEqual(plan["phase_engine"]["next_required_artifact"], "architecture_packet")
+        self.assertFalse(plan["phase_engine"]["artifacts"]["architecture_packet"])
+        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "architecture_packet")
 
     def test_premature_human_gate_request_is_suppressed_until_phase_engine_allows_it(self) -> None:
         card = sot_without_owner_packet_card()

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -57,6 +57,47 @@ def solana_ai_kit_usage_receipt() -> dict:
     }
 
 
+def materialize_product_sot_frontier(card: dict) -> dict:
+    card["universal_signal_intake"] = {
+        "record_type": "universal_signal_intake",
+        "intake_id": "runtime-intake-001",
+        "source_ref_public_safe": "external:operator:source-envelope",
+    }
+    card["product_source_ledger"] = {
+        "record_type": "product_source_ledger",
+        "ledger_id": "runtime-source-ledger-001",
+        "claim_table": [
+            {
+                "claim_id": "claim-001",
+                "claim": "Product Alpha is an operations product with web and admin surfaces.",
+                "claim_class": "fact",
+                "status": "promoted",
+                "source_refs": ["external:operator:source-envelope"],
+            }
+        ],
+    }
+    card["outcome_contract"] = {
+        "record_type": "outcome_contract",
+        "outcome": "Produce the complete product planning baseline before architecture.",
+        "users_or_actors": ["Brazilian web3 user", "operator"],
+        "success_signals": ["scope is covered", "open risks are named"],
+    }
+    card["product_sot"] = {
+        "record_type": "product_sot",
+        "what_it_is": "Product Alpha is an operations product with onboarding and operator surfaces.",
+        "scope_in": ["onboarding", "operator administration"],
+        "scope_out": ["production deploy", "credential transfer"],
+        "evidence_refs": ["external:operator:source-envelope"],
+    }
+    card["full_product_sot_scope_coverage"] = {
+        "record_type": "full_product_sot_scope_coverage",
+        "coverage_state": "covered_for_owner_review",
+        "covered_requirement_ids": ["REQ-001", "REQ-002"],
+        "evidence_refs": ["external:operator:source-envelope"],
+    }
+    return card
+
+
 class FakeHermes:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
@@ -3864,6 +3905,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
     def test_no_idle_reconciles_declared_f9_to_f5_owner_package_before_gate(self) -> None:
         fake = FakeHermes()
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        materialize_product_sot_frontier(card)
         card["phase"] = "F9"
         card["surfaces"] = ["architecture", "planning"]
         card["autonomy_mode"] = "planning_only"

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.10", readme)
+        self.assertIn("v1.5.11", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.10",
+            "v1.5.11",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",

--- a/tests/test_worker_permission_classes.py
+++ b/tests/test_worker_permission_classes.py
@@ -14,6 +14,9 @@ class WorkerPermissionClassesTest(unittest.TestCase):
         self.matrix = json.loads(
             (ROOT / "agents" / "worker-permission-classes.public.json").read_text(encoding="utf-8")
         )
+        self.profiles = json.loads(
+            (ROOT / "agents" / "worker-profiles.public.json").read_text(encoding="utf-8")
+        )
 
     def test_every_public_worker_has_permission_class(self):
         worker_ids = {worker["worker_id"] for worker in self.registry["workers"]}
@@ -40,6 +43,18 @@ class WorkerPermissionClassesTest(unittest.TestCase):
             self.assertTrue(spec["plain_purpose"].strip(), class_id)
             self.assertGreaterEqual(len(spec["must_not"]), 1, class_id)
             self.assertGreaterEqual(len(spec["evidence_required"]), 1, class_id)
+
+    def test_builders_carry_no_self_approval_boundary_in_profile(self):
+        profiles = self.profiles["profiles"]
+        builder_ids = [
+            worker_id
+            for worker_id, class_id in self.matrix["worker_assignments"].items()
+            if class_id == "builder"
+        ]
+
+        for worker_id in builder_ids:
+            must_not = " ".join(profiles[worker_id]["authority"]["must_not"]).lower()
+            self.assertIn("approve", must_not, worker_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make Hermes board reconciliation run the phase engine in runtime-strict mode
- reject template/example scaffold refs, placeholder refs and embedded vFinal template packets as live phase evidence
- add regressions for copied-template F13, real-SOT with template method, and real-method with template architecture/readiness
- add explicit no-self-approval boundary to builder worker profiles
- bump public release metadata to v1.5.11

## Validation
- `python -m unittest discover -s tests -q` -> 985 tests OK
- `python scripts/factory_production_readiness.py --out .tmp/deterministic-runtime-closure/production-readiness-v1.5.11.json` -> PASS
- `python scripts/release_integration_preflight.py` -> PASS after commit
- `python scripts/public_safety_scan.py --git-ref HEAD` -> OK
- `python scripts/secret_safety_scan.py` -> OK
- direct strict phase probe: vFinal template default `F13/gate_report`, runtime-strict `F1/universal_signal_intake`

Fixes #430