### PR TITLE
Surface operator understanding no-idle input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ public releases.
 
 ## Unreleased
 
+## 1.5.12 - 2026-06-25
+
+- Fix Hermes no-idle classification for pending operator understanding
+  confirmation: owner-readable Product SOT understanding packets now become
+  `input_required`, not generic factory-owned package remediation.
+- Make the no-idle watchdog name the exact Telegram-facing action for this
+  state: confirm or correct the understanding before Product SOT.
+- Add regressions so `operator_understanding_confirmation` blockers do not
+  create more remediation cards or dispatch workers.
+
 ## 1.5.11 - 2026-06-25
 
 - Harden Hermes runtime reconciliation so template/example scaffold refs,

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.11.
+is v1.5.12.
 
 It includes:
 
@@ -298,6 +298,9 @@ It includes:
 - no-idle classification that treats missing decision packages, PDF/readback,
   owner-readable materials and repair tasks gated behind their own blocker as
   factory-owned repair, not operator approval bureaucracy;
+- no-idle classification that treats pending operator understanding
+  confirmation as operator input, with a clear Telegram-facing request to
+  confirm or correct understanding before Product SOT;
 - blocked Hermes task creation that uses create-unassigned, block-readback,
   then assign-readback so Kanban dispatch cannot race ahead of a gate;
 - Solana AI Kit route repair when Solana/on-chain F4+ planning lacks the

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.11.
+recente é v1.5.12.
 
 Ela inclui:
 
@@ -300,6 +300,9 @@ Ela inclui:
 - classificação de no-idle que trata pacote de decisão, PDF/readback, material
   legível para dono e tarefa de reparo presa atrás do próprio bloqueio como
   reparo da fábrica, não burocracia de aprovação do operador;
+- classificação de no-idle que trata confirmação de entendimento pendente como
+  input do operador, com pedido claro no Telegram para confirmar ou corrigir o
+  entendimento antes da Product SOT;
 - criação bloqueada de tarefas Hermes usando criar-sem-responsável,
   verificar-bloqueio, atribuir e verificar de novo para o dispatch do Kanban
   não passar na frente de um gate;

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -896,6 +896,26 @@ def is_factory_owned_repair_task(record: dict[str, Any]) -> bool:
     return any(marker in text for marker in markers)
 
 
+def is_operator_understanding_confirmation_blocker(record: dict[str, Any]) -> bool:
+    text = task_record_text(record)
+    markers = (
+        "operator_understanding_confirmation",
+        "operator understanding confirmation",
+        "pending_operator_confirmation",
+        "operator_response_ref",
+        "required_before_product_sot",
+        "product_sot_blocked_until_operator_understanding_confirmed",
+        "confirm/correct",
+        "confirm or correct",
+        "confirmar/corrigir",
+        "confirmar ou corrigir",
+        "confirme/corrija",
+        "owner-readable understanding confirmation",
+        "understanding confirmation is pending",
+    )
+    return any(marker in text for marker in markers)
+
+
 def is_operator_input_blocker(record: dict[str, Any]) -> bool:
     text = task_record_text(record)
     external_input_markers = (
@@ -921,7 +941,60 @@ def is_operator_input_blocker(record: dict[str, Any]) -> bool:
         "mint address",
         "token program id",
     )
-    return any(marker in text for marker in external_input_markers)
+    return is_operator_understanding_confirmation_blocker(record) or any(
+        marker in text for marker in external_input_markers
+    )
+
+
+def operator_input_request_for_blockers(blockers: list[dict[str, Any]]) -> dict[str, Any]:
+    if any(is_operator_understanding_confirmation_blocker(item) for item in blockers):
+        return {
+            "request_type": "operator_understanding_confirmation",
+            "reason": (
+                "The factory produced an owner-readable understanding packet and Product SOT "
+                "must remain blocked until the operator confirms or corrects it."
+            ),
+            "required_response": (
+                "confirm the understanding, or send the exact correction to apply before Product SOT"
+            ),
+        }
+    return {
+        "request_type": "factory_blocker_input_or_decision_package",
+        "reason": (
+            "All unfinished visible work is blocked on missing inputs or an unfinished "
+            "human-gate decision package. This is not approval-ready."
+        ),
+        "required_response": (
+            "deliver the missing decision package/materials first, or ask for the exact "
+            "missing source inputs; do not ask the operator to approve a summary-only gate"
+        ),
+    }
+
+
+def dependency_operator_input_request_for_blockers(blockers: list[dict[str, Any]]) -> dict[str, Any]:
+    if any(is_operator_understanding_confirmation_blocker(item) for item in blockers):
+        return {
+            "request_type": "operator_understanding_confirmation",
+            "reason": (
+                "Visible work is dependency-gated by an owner-readable understanding packet "
+                "that needs operator confirmation or correction before Product SOT."
+            ),
+            "required_response": (
+                "confirm the understanding, or provide the exact correction before Product SOT continues"
+            ),
+        }
+    return {
+        "request_type": "factory_blocker_input_or_decision_package",
+        "reason": (
+            "Visible todo work is dependency-gated while at least one blocker still "
+            "needs exact inputs or a complete decision package. Asking for approval now "
+            "would be a false human gate."
+        ),
+        "required_response": (
+            "provide the exact missing inputs, or have the factory deliver the markdown, "
+            "PDF and structured evidence package before requesting a decision"
+        ),
+    }
 
 
 def no_idle_parent_refs(record: dict[str, Any]) -> list[str]:
@@ -1107,6 +1180,20 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         if is_factory_owned_package_blocker(item) or is_human_gate_package_blocker(item)
     ]
     factory_package_refs = sorted(task_record_id(item) for item in factory_package_blockers if task_record_id(item))
+    if blocked and len(operator_input_blockers) == len(blocked) and not todo:
+        return {
+            "status": "input_required",
+            "classification": "only_operator_input_blockers_seen",
+            "blocked": True,
+            "remediation_required": False,
+            "human_gate_required": False,
+            "operator_input_required": True,
+            "operator_input_task_refs": operator_input_refs,
+            "human_gate_task_refs": human_gate_refs,
+            "operator_input_request": operator_input_request_for_blockers(operator_input_blockers),
+            "next_action": "ask the operator for the exact confirmation, correction, or missing input before creating another remediation card",
+            "state": state,
+        }
     if blocked and factory_package_blockers and len(factory_package_blockers) == len(blocked) and not todo:
         return {
             "status": "remediation_required",
@@ -1124,30 +1211,6 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
                 "This is internal factory repair, not operator input."
             ),
             "next_action": "create a factory-owned package/readback repair task before any human-gate question",
-            "state": state,
-        }
-    if blocked and len(operator_input_blockers) == len(blocked) and not todo:
-        return {
-            "status": "input_required",
-            "classification": "only_operator_input_blockers_seen",
-            "blocked": True,
-            "remediation_required": False,
-            "human_gate_required": False,
-            "operator_input_required": True,
-            "operator_input_task_refs": operator_input_refs,
-            "human_gate_task_refs": human_gate_refs,
-            "operator_input_request": {
-                "request_type": "factory_blocker_input_or_decision_package",
-                "reason": (
-                    "All unfinished visible work is blocked on missing inputs or an unfinished "
-                    "human-gate decision package. This is not approval-ready."
-                ),
-                "required_response": (
-                    "deliver the missing decision package/materials first, or ask for the exact "
-                    "missing source inputs; do not ask the operator to approve a summary-only gate"
-                ),
-            },
-            "next_action": "prepare/deliver the decision package or ask for exact missing inputs before any human approval request",
             "state": state,
         }
     if blocked and len(human_gate_blockers) == len(blocked) and not todo:
@@ -1248,18 +1311,13 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
                 "operator_input_task_refs": sorted(set(input_dependency_refs + operator_input_refs)),
                 "dependency_gated_task_refs": sorted(dependency_blockers),
                 "dependency_blocker_task_refs": blocker_refs,
-                "operator_input_request": {
-                    "request_type": "factory_blocker_input_or_decision_package",
-                    "reason": (
-                        "Visible todo work is dependency-gated while at least one blocker still "
-                        "needs exact inputs or a complete decision package. Asking for approval now "
-                        "would be a false human gate."
-                    ),
-                    "required_response": (
-                        "provide the exact missing inputs, or have the factory deliver the markdown, "
-                        "PDF and structured evidence package before requesting a decision"
-                    ),
-                },
+                "operator_input_request": dependency_operator_input_request_for_blockers(
+                    [
+                        blocked_by_task_id[ref]
+                        for ref in set(input_dependency_refs + operator_input_refs)
+                        if ref in blocked_by_task_id
+                    ]
+                ),
                 "next_action": "resolve missing inputs or deliver the decision package before asking for a human-gate decision",
                 "state": state,
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.11"
+version = "1.5.12"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/factory_no_idle_watchdog.py
+++ b/scripts/factory_no_idle_watchdog.py
@@ -234,6 +234,9 @@ def no_idle_signature(no_idle_result: dict[str, Any], dispatch_result: dict[str,
         "human_gate_task_refs": sorted(state.get("human_gate_task_refs") or []),
         "operator_input_task_refs": sorted(state.get("operator_input_task_refs") or []),
         "dependency_blocker_task_refs": sorted(state.get("dependency_blocker_task_refs") or []),
+        "operator_input_request": state.get("operator_input_request")
+        if isinstance(state.get("operator_input_request"), dict)
+        else None,
         "dispatch": dispatch_state,
         "spawned_count": len(spawned) if isinstance(spawned, list) else 0,
     }
@@ -251,6 +254,12 @@ def summarize_board(board: str, signature: dict[str, Any]) -> str:
             )
         return f"[Overkill Factory] {board}: gate humano real pendente."
     if status == "input_required":
+        request = signature.get("operator_input_request") if isinstance(signature.get("operator_input_request"), dict) else {}
+        if request.get("request_type") == "operator_understanding_confirmation":
+            return (
+                f"[Overkill Factory] {board}: aguardando sua confirmação/correção do entendimento "
+                f"antes da Product SOT. todo={counts.get('todo', 0)} blocked={counts.get('blocked', 0)}."
+            )
         return (
             f"[Overkill Factory] {board}: fila presa por insumos faltantes; "
             f"acao do operador requerida. todo={counts.get('todo', 0)} blocked={counts.get('blocked', 0)}."

--- a/tests/test_factory_no_idle_watchdog.py
+++ b/tests/test_factory_no_idle_watchdog.py
@@ -239,6 +239,52 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
         self.assertIn("--requires-user", emit_call)
         self.assertIn("decision_requested", emit_call)
 
+    def test_watchdog_names_operator_understanding_confirmation(self) -> None:
+        fake = FakeRunner()
+        fake.no_idle_payloads["product-alpha"] = {
+            "mode": "no-idle",
+            "board": "product-alpha",
+            "remediation_task_id": None,
+            "no_idle_state": {
+                "status": "input_required",
+                "classification": "only_operator_input_blockers_seen",
+                "operator_input_required": True,
+                "operator_input_task_refs": ["kanban:redacted-blocker"],
+                "operator_input_request": {
+                    "request_type": "operator_understanding_confirmation",
+                    "required_response": "confirm the understanding or send corrections before Product SOT",
+                },
+                "state": {
+                    "todo": {"count": 0},
+                    "blocked": {"count": 1},
+                    "ready": {"count": 0},
+                    "running": {"count": 0},
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--dispatch",
+                        "--emit-events",
+                        "--state-file",
+                        str(Path(tmp) / "state.json"),
+                        "--inbox-dir",
+                        str(Path(tmp) / "inbox"),
+                    ],
+                    runner=fake,
+                )
+
+        output = buffer.getvalue()
+        self.assertIn("aguardando sua confirmação/correção do entendimento", output)
+        self.assertFalse(any(len(call) > 2 and call[2] == "dispatch" for call in fake.calls))
+        emit_call = next(call for call in fake.calls if len(call) > 2 and call[2] == "emit-event")
+        self.assertIn("--requires-user", emit_call)
+
     def test_human_gate_emits_event_without_dispatch(self) -> None:
         fake = FakeRunner()
         fake.no_idle_payloads["product-alpha"] = {

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4147,6 +4147,52 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_reports_operator_understanding_confirmation_as_input_not_remediation(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "under01"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "factory-orchestrator",
+            "title": "Product Alpha source resolution",
+            "latest_summary": (
+                "review-required: source-resolution artifacts are materialized, but owner-readable "
+                "operator_understanding_confirmation is pending. Confirm/correct it before Product SOT."
+            ),
+            "body": json.dumps(
+                {
+                    "record_type": "operator_understanding_confirmation",
+                    "confirmation_state": {"status": "pending_operator_confirmation"},
+                    "operator_response_ref": "pending:kanban-human-unblock-or-comment",
+                    "blocking_rules": {
+                        "product_sot_blocked_until_operator_understanding_confirmed": True,
+                    },
+                }
+            ),
+            "events": [
+                {
+                    "kind": "blocked",
+                    "payload": {
+                        "reason": "understanding confirmation is pending before Product SOT",
+                    },
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["status"], "input_required")
+        self.assertEqual(state["classification"], "only_operator_input_blockers_seen")
+        self.assertTrue(state["operator_input_required"])
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["remediation_required"])
+        self.assertEqual(state["operator_input_request"]["request_type"], "operator_understanding_confirmation")
+        self.assertIsNone(result["remediation_task_id"])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_reports_parallel_human_gate_and_input_blockers(self) -> None:
         gate_id = "t_" + "gate0001"
         blocker_id = "t_" + "block001"

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.11", readme)
+        self.assertIn("v1.5.12", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.11",
+            "v1.5.12",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
## Summary
- classify pending `operator_understanding_confirmation` blockers as `input_required`, even when the blocker text also contains owner-readable/package markers
- make the no-idle watchdog tell the Telegram operator the actual action: confirm or correct understanding before Product SOT
- prevent this state from creating more remediation cards or dispatching workers
- bump public release metadata to v1.5.12

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_factory_no_idle_watchdog tests.test_open_source_docs -q` -> 125 tests OK
- `python scripts/public_safety_scan.py` -> OK
- `python scripts/secret_safety_scan.py` -> OK
- `python scripts/validate_public_json_artifacts.py` -> OK
- `python scripts/validate_promise_implementation_map.py` -> OK
- `python scripts/release_integration_preflight.py` -> PASS

Fixes #432