### PR TITLE
Fix no-idle repair after failed review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ public releases.
 
 ## Unreleased
 
+## 1.5.13 - 2026-06-25
+
+- Fix Hermes no-idle remediation for failed independent-review blockers:
+  internal `review-failed` states with `factoryctl` validator, artifact or
+  handoff repair instructions now create a targeted factory-owned repair task
+  instead of falling back to stale board reconciliation.
+- Route targeted Product SOT review repairs to `product-sot-planner`, bind the
+  task to the factory workflow, and allow only native Hermes dispatch to run it.
+- Stop the no-idle watchdog from claiming remediation was created when the
+  idempotent task is already terminal, and include structured bridge payloads
+  for human-gate/input events.
+
 ## 1.5.12 - 2026-06-25
 
 - Fix Hermes no-idle classification for pending operator understanding

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.12.
+is v1.5.13.
 
 It includes:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.12.
+recente é v1.5.13.
 
 Ela inclui:
 

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -61,6 +61,7 @@ READY_WORK_UNIT_RECOVERY_AUTHOR = "overkill-factory-recovery"
 READY_WORK_UNIT_RECONCILIATION_AUTHOR = "overkill-factory-reconciliation"
 NO_IDLE_AUTHOR = "overkill-factory-no-idle"
 NO_IDLE_REMEDIATION_MARKER = "factory_no_idle_remediation"
+NO_IDLE_REVIEW_REPAIR_MARKER = "factory_no_idle_review_repair"
 FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID = "overkill-vfinal"
 FACTORY_KANBAN_DEFAULT_STEP_KEY = "F1-intake"
 COMPLETION_ARTIFACT_PROJECTION_MARKER = "completion_artifact_projection"
@@ -886,6 +887,7 @@ def is_factory_owned_repair_task(record: dict[str, Any]) -> bool:
         "factory owned repair",
         "factory_deterministic_reconcile",
         "factory_no_idle_remediation",
+        "factory_no_idle_review_repair",
         "repair human gate decision package",
         "repair package",
         "rebuild the package",
@@ -894,6 +896,39 @@ def is_factory_owned_repair_task(record: dict[str, Any]) -> bool:
         "readable artifact is ready",
     )
     return any(marker in text for marker in markers)
+
+
+def is_review_failed_factory_repair_blocker(record: dict[str, Any]) -> bool:
+    if is_human_gate_decision_ready_blocker(record):
+        return False
+    text = task_record_text(record)
+    review_failed = any(
+        marker in text
+        for marker in (
+            "review-failed",
+            "review failed",
+            "independent review result: fail",
+            "independent review result: block",
+            "fail / block",
+        )
+    )
+    if not review_failed:
+        return False
+    return any(
+        marker in text
+        for marker in (
+            "factoryctl validators fail",
+            "validator failure",
+            "validators fail",
+            "handoff sequencing is inconsistent",
+            "schema-valid",
+            "required fixes",
+            "rerun independent review",
+            "rerun review",
+            "repair before owner",
+            "repair before human",
+        )
+    )
 
 
 def is_operator_understanding_confirmation_blocker(record: dict[str, Any]) -> bool:
@@ -1174,6 +1209,12 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         if is_operator_input_blocker(item)
     ]
     operator_input_refs = sorted(task_record_id(item) for item in operator_input_blockers if task_record_id(item))
+    review_repair_blockers = [
+        item
+        for item in blocked
+        if is_review_failed_factory_repair_blocker(item)
+    ]
+    review_repair_refs = sorted(task_record_id(item) for item in review_repair_blockers if task_record_id(item))
     factory_package_blockers = [
         item
         for item in blocked
@@ -1192,6 +1233,30 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             "human_gate_task_refs": human_gate_refs,
             "operator_input_request": operator_input_request_for_blockers(operator_input_blockers),
             "next_action": "ask the operator for the exact confirmation, correction, or missing input before creating another remediation card",
+            "state": state,
+        }
+    if blocked and review_repair_blockers and len(review_repair_blockers) == len(blocked) and not todo:
+        return {
+            "status": "remediation_required",
+            "classification": "only_factory_review_repair_blockers_seen",
+            "blocked": True,
+            "remediation_required": True,
+            "human_gate_required": False,
+            "operator_input_required": False,
+            "operator_input_task_refs": [],
+            "human_gate_task_refs": human_gate_refs,
+            "factory_owned_package_task_refs": review_repair_refs,
+            "review_repair_task_refs": review_repair_refs,
+            "remediation_strategy": "create_targeted_review_repair_task",
+            "remediation_reason": (
+                "All unfinished visible work is blocked by an independent review failure "
+                "with internal validator, artifact or handoff repair instructions. This is "
+                "factory-owned repair, not operator input and not a human gate."
+            ),
+            "next_action": (
+                "create a targeted repair task from the blocked review report, then let native "
+                "Hermes dispatch run it before any human-gate question"
+            ),
             "state": state,
         }
     if blocked and factory_package_blockers and len(factory_package_blockers) == len(blocked) and not todo:
@@ -1448,6 +1513,125 @@ def create_no_idle_remediation_task(
         current_step_key=FACTORY_KANBAN_DEFAULT_STEP_KEY,
         runner=runner,
     )
+
+
+def no_idle_review_repair_assignee(blockers: list[dict[str, Any]], fallback: str) -> str:
+    text = " ".join(task_record_text(item) for item in blockers)
+    if any(
+        marker in text
+        for marker in (
+            "product sot",
+            "product_sot",
+            "outcome_contract",
+            "full_product_sot_scope_coverage",
+            "scope_in",
+            "scope_out",
+        )
+    ):
+        return "product-sot-planner"
+    if any(marker in text for marker in ("method_contract", "method contract", "architecture")):
+        return "factory-orchestrator"
+    return fallback or "factory-orchestrator"
+
+
+def no_idle_review_repair_body(
+    *,
+    board: str,
+    classification: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "packet_type": "factory_no_idle_review_repair_request",
+        "marker": NO_IDLE_REVIEW_REPAIR_MARKER,
+        "board": board,
+        "objective": (
+            "Repair the factory-owned package rejected by independent review and "
+            "route it back to review without asking the operator."
+        ),
+        "blocked_review_task_refs": classification.get("review_repair_task_refs") or [],
+        "observed_no_idle_state": classification,
+        "kanban_workflow_binding": {
+            "workflow_template_id": FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID,
+            "current_step_key": "F5-product-sot",
+            "runtime_field_required": True,
+            "fallback_body_binding": True,
+            "route_authority": "factory_phase_engine",
+        },
+        "required_actions": [
+            "inspect the blocked independent review task, comments and report artifact",
+            "repair the exact validator, public-safety, artifact or handoff failures named by the review",
+            "rerun the relevant factoryctl validators before returning the package",
+            "route a fresh independent-reviewer task or unblock the reviewed path only after evidence passes",
+        ],
+        "forbidden_actions": [
+            "ask the operator for approval or input for internal validator repair",
+            "treat review repair as a human gate",
+            "approve Product SOT, method, architecture, release, funds, secrets or production",
+            "advance downstream phases while the reviewed package still fails validators",
+            "create another generic board reconcile card instead of the targeted repair",
+        ],
+        "human_gate_required": False,
+        "operator_input_required": False,
+        "native_dispatch_required_next": True,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+    }
+
+
+def create_no_idle_review_repair_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    workspace: str,
+    assignee: str,
+    classification: dict[str, Any],
+    blockers: list[dict[str, Any]],
+    runner: Runner,
+) -> str:
+    body = no_idle_review_repair_body(board=board, classification=classification)
+    digest = idempotency_digest_fragment(contract_digest(body))
+    repair_assignee = no_idle_review_repair_assignee(blockers, assignee)
+    return create_task(
+        hermes_bin=hermes_bin,
+        board=board,
+        title="Repair failed independent review package",
+        body=compact_json_argument(body),
+        assignee=repair_assignee,
+        idempotency_key=f"overkill:no-idle-review-repair:{public_safe_slug(board, fallback='board')}:{digest}",
+        created_by=NO_IDLE_AUTHOR,
+        workspace=workspace,
+        blocked=False,
+        workflow_template_id=FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID,
+        current_step_key="F5-product-sot",
+        runner=runner,
+    )
+
+
+def remediation_task_runtime_metadata(
+    *,
+    hermes_bin: str,
+    board: str,
+    task_id: str | None,
+    runner: Runner,
+) -> dict[str, Any]:
+    if not task_id:
+        return {
+            "remediation_task_created": False,
+            "remediation_task_status": None,
+            "remediation_task_stale": False,
+            "native_dispatch_required_next": False,
+        }
+    try:
+        payload = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+        status = task_readback_status(payload)
+    except RuntimeError:
+        status = ""
+    stale = status in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES
+    return {
+        "remediation_task_created": not stale,
+        "remediation_task_status": status or "unknown",
+        "remediation_task_stale": stale,
+        "native_dispatch_required_next": status in {"ready", "unknown", ""},
+    }
 
 
 def build_board_reconcile_plan_from_rows(*, board: str, rows: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
@@ -6848,27 +7032,80 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
     classification = classify_no_idle_state(rows)
     remediation_task_id: str | None = None
     reconcile_plan: dict[str, Any] | None = None
+    targeted_remediation_plan: dict[str, Any] | None = None
     if classification.get("remediation_required") and args.create_remediation:
-        reconcile_plan = build_board_reconcile_plan_from_rows(board=args.board, rows=rows)
-        remediation_task_id = create_deterministic_reconcile_task(
-            hermes_bin=args.hermes_bin,
-            board=args.board,
-            workspace=args.workspace,
-            plan=reconcile_plan,
-            runner=runner,
-        )
         classification = dict(classification)
-        classification["board_reconcile_plan"] = reconcile_plan
-        classification["remediation_task_created"] = remediation_task_id is not None
-        classification["remediation_task_ref"] = remediation_task_id
-        classification["native_dispatch_required_next"] = bool(
-            remediation_task_id and reconcile_plan.get("native_dispatch_required_next") is True
-        )
-        classification["classification"] = (
-            "deterministic_board_reconcile_task_created"
-            if remediation_task_id
-            else str(reconcile_plan.get("plan_action") or classification.get("classification"))
-        )
+        if classification.get("remediation_strategy") == "create_targeted_review_repair_task":
+            blockers = [
+                item for item in rows.get("blocked", [])
+                if is_review_failed_factory_repair_blocker(item)
+            ]
+            targeted_remediation_plan = {
+                "record_type": "factory_no_idle_targeted_repair_plan",
+                "plan_action": "repair_failed_independent_review_package",
+                "board": args.board,
+                "blocked_review_task_refs": classification.get("review_repair_task_refs") or [],
+                "assignee": no_idle_review_repair_assignee(blockers, args.assignee),
+                "native_dispatch_required_next": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+            }
+            remediation_task_id = create_no_idle_review_repair_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                workspace=args.workspace,
+                assignee=args.assignee,
+                classification=classification,
+                blockers=blockers,
+                runner=runner,
+            )
+            task_runtime = remediation_task_runtime_metadata(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=remediation_task_id,
+                runner=runner,
+            )
+            classification["targeted_remediation_plan"] = targeted_remediation_plan
+            classification["remediation_task_ref"] = remediation_task_id
+            classification.update(task_runtime)
+            classification["native_dispatch_required_next"] = bool(
+                remediation_task_id
+                and targeted_remediation_plan.get("native_dispatch_required_next") is True
+                and task_runtime.get("native_dispatch_required_next") is True
+            )
+            classification["classification"] = (
+                "deterministic_targeted_review_repair_task_created"
+                if remediation_task_id and not classification.get("remediation_task_stale")
+                else "targeted_review_repair_task_not_created"
+            )
+        else:
+            reconcile_plan = build_board_reconcile_plan_from_rows(board=args.board, rows=rows)
+            remediation_task_id = create_deterministic_reconcile_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                workspace=args.workspace,
+                plan=reconcile_plan,
+                runner=runner,
+            )
+            task_runtime = remediation_task_runtime_metadata(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=remediation_task_id,
+                runner=runner,
+            )
+            classification["board_reconcile_plan"] = reconcile_plan
+            classification["remediation_task_ref"] = remediation_task_id
+            classification.update(task_runtime)
+            classification["native_dispatch_required_next"] = bool(
+                remediation_task_id
+                and reconcile_plan.get("native_dispatch_required_next") is True
+                and task_runtime.get("native_dispatch_required_next") is True
+            )
+            classification["classification"] = (
+                "deterministic_board_reconcile_task_created"
+                if remediation_task_id and not classification.get("remediation_task_stale")
+                else str(reconcile_plan.get("plan_action") or classification.get("classification"))
+            )
     envelope = {
         "$schema": LIVE_ADAPTER_SCHEMA,
         "mode": "no-idle",
@@ -6876,6 +7113,7 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
         "blocked": bool(classification.get("blocked")),
         "no_idle_state": classification,
         "board_reconcile_plan": reconcile_plan,
+        "targeted_remediation_plan": targeted_remediation_plan,
         "remediation_task_id": remediation_task_id,
         "hook": {
             "runtime_authority": "hermes_kanban",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.12"
+version = "1.5.13"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/factory_no_idle_watchdog.py
+++ b/scripts/factory_no_idle_watchdog.py
@@ -173,6 +173,7 @@ def emit_operator_event(
     status: str,
     requires_user: bool,
     summary: str,
+    payload: dict[str, Any] | None,
     inbox_dir: Path,
     runner: Runner = default_runner,
 ) -> None:
@@ -205,6 +206,8 @@ def emit_operator_event(
     ]
     if requires_user:
         argv.append("--requires-user")
+    if payload is not None:
+        argv.extend(["--payload-json", json.dumps(payload, ensure_ascii=False, separators=(",", ":"))])
     completed = runner(argv)
     if completed.returncode != 0:
         raise RuntimeError(
@@ -220,6 +223,13 @@ def no_idle_signature(no_idle_result: dict[str, Any], dispatch_result: dict[str,
     counts = state.get("state") if isinstance(state.get("state"), dict) else {}
     dispatch_state = dispatch_result.get("dispatch_observed_state") if isinstance(dispatch_result, dict) else {}
     spawned = dispatch_result.get("spawned") if isinstance(dispatch_result, dict) else []
+    remediation_task_ref = no_idle_result.get("remediation_task_id")
+    explicit_remediation_created = state.get("remediation_task_created")
+    remediation_created = (
+        explicit_remediation_created is True
+        if explicit_remediation_created is not None
+        else bool(remediation_task_ref)
+    )
     return {
         "status": state.get("status"),
         "classification": state.get("classification"),
@@ -228,12 +238,20 @@ def no_idle_signature(no_idle_result: dict[str, Any], dispatch_result: dict[str,
             for key, value in counts.items()
             if isinstance(value, dict) and key in {"ready", "running", "todo", "blocked"}
         },
-        "remediation_task_created": bool(no_idle_result.get("remediation_task_id")),
+        "remediation_strategy": state.get("remediation_strategy"),
+        "remediation_task_created": remediation_created,
+        "remediation_task_status": state.get("remediation_task_status"),
+        "remediation_task_stale": state.get("remediation_task_stale") is True,
         "human_gate_required": state.get("human_gate_required") is True,
         "operator_input_required": state.get("operator_input_required") is True,
         "human_gate_task_refs": sorted(state.get("human_gate_task_refs") or []),
         "operator_input_task_refs": sorted(state.get("operator_input_task_refs") or []),
+        "factory_owned_package_task_refs": sorted(state.get("factory_owned_package_task_refs") or []),
+        "review_repair_task_refs": sorted(state.get("review_repair_task_refs") or []),
         "dependency_blocker_task_refs": sorted(state.get("dependency_blocker_task_refs") or []),
+        "human_decision_request": state.get("human_decision_request")
+        if isinstance(state.get("human_decision_request"), dict)
+        else None,
         "operator_input_request": state.get("operator_input_request")
         if isinstance(state.get("operator_input_request"), dict)
         else None,
@@ -244,6 +262,7 @@ def no_idle_signature(no_idle_result: dict[str, Any], dispatch_result: dict[str,
 
 def summarize_board(board: str, signature: dict[str, Any]) -> str:
     status = signature.get("status")
+    classification = str(signature.get("classification") or "")
     counts = signature.get("counts") if isinstance(signature.get("counts"), dict) else {}
     spawned = signature.get("spawned_count") or 0
     if status == "human_gate_required":
@@ -265,9 +284,33 @@ def summarize_board(board: str, signature: dict[str, Any]) -> str:
             f"acao do operador requerida. todo={counts.get('todo', 0)} blocked={counts.get('blocked', 0)}."
         )
     if status == "remediation_required":
+        if "review_repair" in classification:
+            if signature.get("remediation_task_created") is True:
+                return (
+                    f"[Overkill Factory] {board}: review interno bloqueou por reparo da fábrica; "
+                    f"reparo interno criado/acionado. todo={counts.get('todo', 0)} "
+                    f"blocked={counts.get('blocked', 0)}."
+                )
+            return (
+                f"[Overkill Factory] {board}: review interno bloqueou por reparo da fábrica; "
+                f"remediação direcionada ainda não materializada. todo={counts.get('todo', 0)} "
+                f"blocked={counts.get('blocked', 0)}."
+            )
+        if signature.get("remediation_task_created") is True:
+            return (
+                f"[Overkill Factory] {board}: no-idle detectado; remediação segura "
+                f"criada/confirmada. todo={counts.get('todo', 0)} blocked={counts.get('blocked', 0)}."
+            )
+        if signature.get("remediation_task_stale") is True:
+            return (
+                f"[Overkill Factory] {board}: no-idle detectado; a remediação idempotente existente "
+                f"já está concluída e não destravou a fila. todo={counts.get('todo', 0)} "
+                f"blocked={counts.get('blocked', 0)}."
+            )
         return (
-            f"[Overkill Factory] {board}: no-idle detectado; remediação segura "
-            f"criada/confirmada. todo={counts.get('todo', 0)} blocked={counts.get('blocked', 0)}."
+            f"[Overkill Factory] {board}: no-idle detectado; remediação segura necessária, "
+            f"mas ainda não materializada. todo={counts.get('todo', 0)} "
+            f"blocked={counts.get('blocked', 0)}."
         )
     if status == "dependency_gated":
         return (
@@ -331,11 +374,19 @@ def process_board(
         "remediation_required",
         "dependency_gated",
     }:
+        event_payload = {
+            "board": board,
+            "status": signature.get("status"),
+            "summary": summary,
+            "requires_user": requires_user,
+            "signature": signature,
+        }
         emit_operator_event(
             board=board,
             status=str(signature.get("status") or ""),
             requires_user=requires_user,
             summary=summary,
+            payload=event_payload,
             inbox_dir=inbox_dir,
             runner=runner,
         )

--- a/tests/test_factory_no_idle_watchdog.py
+++ b/tests/test_factory_no_idle_watchdog.py
@@ -115,6 +115,49 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
         self.assertIn("--create-remediation", no_idle_call)
         self.assertEqual(dispatch_call[2], "dispatch")
 
+    def test_watchdog_names_review_repair_and_calls_native_dispatch(self) -> None:
+        fake = FakeRunner()
+        fake.no_idle_payloads["product-alpha"] = {
+            "mode": "no-idle",
+            "board": "product-alpha",
+            "remediation_task_id": "kanban:redacted",
+            "no_idle_state": {
+                "status": "remediation_required",
+                "classification": "deterministic_targeted_review_repair_task_created",
+                "remediation_strategy": "create_targeted_review_repair_task",
+                "remediation_task_created": True,
+                "remediation_task_status": "ready",
+                "review_repair_task_refs": ["kanban:redacted-review"],
+                "native_dispatch_required_next": True,
+                "state": {
+                    "todo": {"count": 0},
+                    "blocked": {"count": 1},
+                    "ready": {"count": 0},
+                    "running": {"count": 0},
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            state_file = Path(tmp) / "state.json"
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                result = watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--create-remediation",
+                        "--dispatch",
+                        "--state-file",
+                        str(state_file),
+                    ],
+                    runner=fake,
+                )
+
+        self.assertEqual(result, 0)
+        self.assertIn("review interno bloqueou", buffer.getvalue())
+        dispatch_call = next(call for call in fake.calls if len(call) > 2 and call[2] == "dispatch")
+        self.assertEqual(dispatch_call[2], "dispatch")
+
     def test_watchdog_does_not_repeat_same_message(self) -> None:
         fake = FakeRunner()
         fake.no_idle_payloads["product-alpha"] = {
@@ -238,6 +281,9 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
         emit_call = next(call for call in fake.calls if len(call) > 2 and call[2] == "emit-event")
         self.assertIn("--requires-user", emit_call)
         self.assertIn("decision_requested", emit_call)
+        payload = json.loads(emit_call[emit_call.index("--payload-json") + 1])
+        self.assertEqual(payload["signature"]["operator_input_task_refs"], ["kanban:redacted-blocker"])
+        self.assertTrue(payload["requires_user"])
 
     def test_watchdog_names_operator_understanding_confirmation(self) -> None:
         fake = FakeRunner()
@@ -284,6 +330,8 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
         self.assertFalse(any(len(call) > 2 and call[2] == "dispatch" for call in fake.calls))
         emit_call = next(call for call in fake.calls if len(call) > 2 and call[2] == "emit-event")
         self.assertIn("--requires-user", emit_call)
+        payload = json.loads(emit_call[emit_call.index("--payload-json") + 1])
+        self.assertEqual(payload["signature"]["operator_input_request"]["request_type"], "operator_understanding_confirmation")
 
     def test_human_gate_emits_event_without_dispatch(self) -> None:
         fake = FakeRunner()
@@ -295,6 +343,11 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
                 "status": "human_gate_required",
                 "classification": "only_human_gate_blockers_seen",
                 "human_gate_required": True,
+                "human_gate_task_refs": ["kanban:redacted-gate"],
+                "human_decision_request": {
+                    "request_type": "factory_human_gate_decision",
+                    "required_response": "approve, reject or request changes",
+                },
                 "state": {"blocked": {"count": 1}},
             },
         }
@@ -318,6 +371,9 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
         emit_call = next(call for call in fake.calls if len(call) > 2 and call[2] == "emit-event")
         self.assertIn("--requires-user", emit_call)
         self.assertIn("human_gate_required", emit_call)
+        payload = json.loads(emit_call[emit_call.index("--payload-json") + 1])
+        self.assertEqual(payload["signature"]["human_gate_task_refs"], ["kanban:redacted-gate"])
+        self.assertEqual(payload["signature"]["human_decision_request"]["request_type"], "factory_human_gate_decision")
 
 
 if __name__ == "__main__":

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3989,6 +3989,63 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertTrue(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_creates_targeted_repair_for_failed_independent_review(self) -> None:
+        fake = FakeHermes()
+        review_id = "t_" + "review01"
+        fake.tasks[review_id] = {
+            "id": review_id,
+            "status": "blocked",
+            "assignee": "independent-reviewer",
+            "title": "F3 - Independent review of Product SOT candidate",
+            "latest_summary": (
+                "review-failed: Product SOT package source meaning is aligned, but "
+                "required factoryctl validators fail and handoff sequencing is inconsistent."
+            ),
+            "body": "review Product SOT, outcome_contract and full_product_sot_scope_coverage",
+            "comments": [
+                {
+                    "author": "independent-reviewer",
+                    "body": (
+                        "Independent review result: FAIL / BLOCK. Required fixes: repair "
+                        "factoryctl validators fail, preserve candidate-only, rerun independent review."
+                    ),
+                }
+            ],
+            "events": [
+                {
+                    "type": "blocked",
+                    "reason": "review-failed: validators fail; rerun independent review after repair",
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["status"], "remediation_required")
+        self.assertEqual(state["classification"], "deterministic_targeted_review_repair_task_created")
+        self.assertEqual(state["remediation_strategy"], "create_targeted_review_repair_task")
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertTrue(state["remediation_task_created"])
+        self.assertEqual(state["remediation_task_status"], "ready")
+        self.assertTrue(state["native_dispatch_required_next"])
+        self.assertIsNone(result["board_reconcile_plan"])
+        self.assertIsNotNone(result["targeted_remediation_plan"])
+        created_task = next(
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("marker") == "factory_no_idle_review_repair"
+        )
+        self.assertEqual(created_task["status"], "ready")
+        self.assertEqual(created_task["assignee"], "product-sot-planner")
+        body = json.loads(str(created_task["body"]))
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F5-product-sot")
+        self.assertIn("ask the operator for approval or input for internal validator repair", body["forbidden_actions"])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_reports_dependency_gated_todo_behind_human_gate_without_remediation(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0001"

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.12", readme)
+        self.assertIn("v1.5.13", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.12",
+            "v1.5.13",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
Closes #434.

## What changed

- Classifies failed independent-review blockers with validator/artifact/handoff repair instructions as internal factory remediation, not human gate/input.
- Creates a targeted no-idle review repair card, routes Product SOT repairs to `product-sot-planner`, and binds it to the factory workflow.
- Prevents the no-idle watchdog from claiming remediation was created when the idempotent task is already terminal.
- Adds structured bridge payloads for human-gate/input watchdog events.
- Bumps public release metadata to v1.5.13.

## Validation

- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_factory_no_idle_watchdog -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_worker_profiles.py`
- `python scripts/validate_promise_implementation_map.py`
- `python scripts/validate_planning_bundles.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `git diff --check`