### PR TITLE
Classify delivered Product SOT gates as human gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ public releases.
 
 ## Unreleased
 
+## 1.5.15 - 2026-06-25
+
+- Fix post-delivery no-idle classification for Product SOT owner gates
+  ([#438](https://github.com/felipegermano17/overkill-factory/issues/438)):
+  a `human-gate-clerk` task that has already delivered Markdown/PDF,
+  `APPROVAL_REQUEST`, `EVIDENCE_INDEX`, `OWNER_REVIEW` and validation evidence
+  is now treated as a real `human_gate_required` state, not as another generic
+  factory package repair.
+- Give delivered human-gate packages precedence over internal package-repair
+  heuristics, even when the task text contains words such as "decision package",
+  "PDF" or "evidence index".
+
 ## 1.5.14 - 2026-06-25
 
 - Fix Hermes no-idle handling after a failed review has already been repaired

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory v1 is the current public kernel release line. The latest public release
-is v1.5.14.
+is v1.5.15.
 
 It includes:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.14.
+recente é v1.5.15.
 
 Ela inclui:
 

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -825,6 +825,12 @@ def is_human_gate_decision_ready_blocker(record: dict[str, Any]) -> bool:
             "approval request delivered",
             "owner review delivered",
             "pdf delivered",
+            "package prepared and delivered",
+            "decision package prepared and delivered",
+            "owner decision package prepared and delivered",
+            "product sot owner decision package prepared and delivered",
+            "after delivered product sot package",
+            "after reading package",
             "ready for owner decision",
             "ready for operator decision",
         )
@@ -1314,12 +1320,6 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         if is_review_failed_factory_repair_blocker(item)
     ]
     review_repair_refs = sorted(task_record_id(item) for item in review_repair_blockers if task_record_id(item))
-    factory_package_blockers = [
-        item
-        for item in blocked
-        if is_factory_owned_package_blocker(item) or is_human_gate_package_blocker(item)
-    ]
-    factory_package_refs = sorted(task_record_id(item) for item in factory_package_blockers if task_record_id(item))
     if blocked and len(operator_input_blockers) == len(blocked) and not todo:
         return {
             "status": "input_required",
@@ -1332,6 +1332,25 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             "human_gate_task_refs": human_gate_refs,
             "operator_input_request": operator_input_request_for_blockers(operator_input_blockers),
             "next_action": "ask the operator for the exact confirmation, correction, or missing input before creating another remediation card",
+            "state": state,
+        }
+    if blocked and len(human_gate_blockers) == len(blocked) and not todo:
+        return {
+            "status": "human_gate_required",
+            "classification": "only_human_gate_blockers_seen",
+            "blocked": True,
+            "remediation_required": False,
+            "human_gate_required": True,
+            "operator_input_required": bool(operator_input_refs),
+            "human_gate_task_refs": human_gate_refs,
+            "operator_input_task_refs": operator_input_refs,
+            "ignored_superseded_blocked_task_refs": ignored_superseded_blocked_refs,
+            "human_decision_request": {
+                "request_type": "factory_human_gate_decision",
+                "reason": "All unfinished visible work is blocked on explicit human-gate tasks.",
+                "required_response": "approve, reject, waive, revise scope, or provide requested input in the human-gate artifact",
+            },
+            "next_action": "ask the operator for the human-gate decision",
             "state": state,
         }
     if blocked and review_repair_blockers and len(review_repair_blockers) == len(blocked) and not todo:
@@ -1358,6 +1377,13 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             ),
             "state": state,
         }
+    factory_package_blockers = [
+        item
+        for item in blocked
+        if not is_human_gate_decision_ready_blocker(item)
+        and (is_factory_owned_package_blocker(item) or is_human_gate_package_blocker(item))
+    ]
+    factory_package_refs = sorted(task_record_id(item) for item in factory_package_blockers if task_record_id(item))
     if blocked and factory_package_blockers and len(factory_package_blockers) == len(blocked) and not todo:
         return {
             "status": "remediation_required",
@@ -1375,24 +1401,6 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
                 "This is internal factory repair, not operator input."
             ),
             "next_action": "create a factory-owned package/readback repair task before any human-gate question",
-            "state": state,
-        }
-    if blocked and len(human_gate_blockers) == len(blocked) and not todo:
-        return {
-            "status": "human_gate_required",
-            "classification": "only_human_gate_blockers_seen",
-            "blocked": True,
-            "remediation_required": False,
-            "human_gate_required": True,
-            "operator_input_required": bool(operator_input_refs),
-            "human_gate_task_refs": human_gate_refs,
-            "operator_input_task_refs": operator_input_refs,
-            "human_decision_request": {
-                "request_type": "factory_human_gate_decision",
-                "reason": "All unfinished visible work is blocked on explicit human-gate tasks.",
-                "required_response": "approve, reject, waive, revise scope, or provide requested input in the human-gate artifact",
-            },
-            "next_action": "ask the operator for the human-gate decision",
             "state": state,
         }
     dependency_blockers = dependency_gated_todo_blockers(todo, rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.14"
+version = "1.5.15"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4129,6 +4129,104 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIn("ask for a decision from a chat summary without the decision package material", body["forbidden_actions"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_treats_delivered_product_sot_package_as_human_gate(self) -> None:
+        fake = FakeHermes()
+        failed_review_id = "t_" + "review01"
+        repair_id = "t_" + "repair01"
+        pass_review_id = "t_" + "review02"
+        gate_id = "t_" + "gate0001"
+        fake.tasks[failed_review_id] = {
+            "id": failed_review_id,
+            "status": "blocked",
+            "assignee": "independent-reviewer",
+            "title": "F3 - Independent review of Product SOT candidate",
+            "latest_summary": "review-failed: required factoryctl validators fail",
+            "body": "review Product SOT package",
+            "events": [{"type": "blocked", "reason": "review-failed: validators fail"}],
+        }
+        fake.tasks[repair_id] = {
+            "id": repair_id,
+            "status": "done",
+            "assignee": "product-sot-planner",
+            "title": "Repair failed independent review package",
+            "body": json.dumps(
+                {
+                    "marker": "factory_no_idle_review_repair",
+                    "blocked_review_task_refs": [failed_review_id],
+                }
+            ),
+            "events": [{"type": "completed", "payload": {"summary": "repair complete"}}],
+        }
+        fake.tasks[pass_review_id] = {
+            "id": pass_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "F3 - Independent review of repaired Product SOT candidate",
+            "latest_summary": (
+                "Independent review PASS for the repaired Product SOT candidate package; "
+                "next gate is owner/Product SOT approval or rebaseline before method-contract planning."
+            ),
+            "body": "review repaired Product SOT package",
+            "parents": [repair_id],
+            "events": [
+                {
+                    "type": "completed",
+                    "payload": {
+                        "summary": (
+                            "Independent review PASS; owner/Product SOT approval or rebaseline "
+                            "is still required before method-contract planning."
+                        )
+                    },
+                }
+            ],
+        }
+        fake.tasks[gate_id] = {
+            "id": gate_id,
+            "status": "blocked",
+            "assignee": "human-gate-clerk",
+            "title": "Prepare Product SOT owner decision package",
+            "body": json.dumps({"marker": "factory_no_idle_post_review_gate_package"}),
+            "latest_summary": (
+                "Human decision required after delivered Product SOT package: choose approve "
+                "Product SOT candidate for method-contract planning only, request exact changes, or rebaseline."
+            ),
+            "comments": [
+                {
+                    "author": "human-gate-clerk",
+                    "body": (
+                        "Product SOT owner decision package prepared and delivered before the decision question. "
+                        "Decision package refs include Markdown, PDF, APPROVAL_REQUEST, EVIDENCE_INDEX, OWNER_REVIEW "
+                        "and validation receipt. No human decision has been recorded by this worker."
+                    ),
+                }
+            ],
+            "events": [
+                {
+                    "kind": "blocked",
+                    "payload": {
+                        "reason": (
+                            "Human decision required after delivered Product SOT package: choose approve "
+                            "Product SOT candidate for method-contract planning only, request exact changes, or rebaseline."
+                        )
+                    },
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["status"], "human_gate_required")
+        self.assertEqual(state["classification"], "only_human_gate_blockers_seen")
+        self.assertTrue(state["human_gate_required"])
+        self.assertFalse(state["remediation_required"])
+        self.assertEqual(state["human_gate_task_refs"], ["kanban:<redacted>"])
+        self.assertEqual(state["ignored_superseded_blocked_task_refs"], ["kanban:<redacted>"])
+        self.assertIsNone(result["remediation_task_id"])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_reports_dependency_gated_todo_behind_human_gate_without_remediation(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0001"

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.14", readme)
+        self.assertIn("v1.5.15", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -140,7 +140,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.14",
+            "v1.5.15",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
## Summary
- classify delivered Product SOT owner packages as real `human_gate_required` states
- add delivered-package markers to human gate decision-ready detection
- prevent generic factory package repair heuristics from overriding a delivered human-gate package
- add regression test for the live KAXIS shape: superseded failed review + PASS repaired review + delivered owner decision package
- bump release docs/version to `v1.5.15`

Fixes #438.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_factory_no_idle_watchdog tests.test_open_source_docs -q`
- `python -m unittest discover -s tests -p "test_*.py" -q`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\validate_promise_implementation_map.py`
- `python scripts\validate_planning_bundles.py`
- `git diff --check`