### PR TITLE
Factory V2 deterministic control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ public releases.
 
 ## Unreleased
 
+## 2.0.0 - 2026-06-26
+
+- Add the Factory V2 deterministic control plane: workflow compiled plan,
+  factory command inbox, hash-chained run events, factory run state, decision
+  outbox, promotion packet and reference-superiority claim contracts
+  ([#445](https://github.com/felipegermano17/overkill-factory/issues/445)).
+- Add `scripts/factory_v2_kernel.py` and `factoryctl` commands for compiling the
+  workflow catalog and validating V2 run, command, event log, decision outbox,
+  promotion packet and compiled workflow artifacts.
+- Add public templates and regression coverage for V2 control-plane contracts.
+- Harden the operator bridge so status/question/decision/change/exception/
+  handoff modes require explicit runtime targets, corrupt inbox records are
+  reported instead of hidden, existing-project refs require explicit runtime
+  prefixes and human gate responses require `human_gate_record_ref`.
+- Stop public JSON validation from treating transient `.tmp/factory-runs`
+  runtime evidence as public release surface.
+- Document the Factory V2 control plane and update README/CLI surfaces for the
+  new release line.
+
 ## 1.5.16 - 2026-06-25
 
 - Require Product SOT human gates to deliver a canonical localized Product SOT

--- a/README.md
+++ b/README.md
@@ -263,11 +263,23 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 
 ## Current Release State
 
-Factory v1 is the current public kernel release line. The latest public release
-is v1.5.16.
+Factory V2 is the current public kernel release line. The latest public release
+is v2.0.0.
 
 It includes:
 
+- a deterministic Factory V2 control plane: workflow compiled plan, command
+  inbox, hash-chained run event log, decision outbox, promotion packets and
+  `FactoryRun` validation;
+- `factoryctl compile-workflow`, `validate-factory-run`,
+  `validate-factory-command`, `validate-factory-event-log`,
+  `validate-decision-outbox`, `validate-promotion-packet` and
+  `validate-workflow-compiled-plan`;
+- bridge hardening so status, question, decision, change, exception and handoff
+  requests require an explicit runtime target instead of ambient Hermes state;
+- formal bridge decision records that require `human_gate_record_ref` for human
+  gate responses, keeping chat approval separate from factory authority;
+- public templates and regression tests for the V2 state contracts;
 - Universal Signal Intake, route registry, Golden Corpus and signal coverage;
 - operator interface profiles for Telegram, Discord, Cockpit and bridge use;
 - conversational start before a formal factory start request exists;
@@ -308,10 +320,11 @@ It includes:
 - Hermes completion artifact projection, no-idle remediation controls, Hermes
   update guard, cron-friendly no-idle watchdog and Fast Autonomy Lane contracts.
 
-That claim is intentionally scoped. Factory v1 means the public kernel is
-complete enough to install, inspect, validate and extend. A product built by the
-factory still needs its own source material, Product SOT, worker execution,
-evidence, reviews, human gates and production readiness proof.
+That claim is intentionally scoped. Factory V2 means the public kernel has a
+deterministic control plane that can be installed, inspected, validated and
+extended. A product built by the factory still needs its own source material,
+Product SOT, worker execution, evidence, reviews, human gates and production
+readiness proof.
 Public promises are tracked in
 `docs/operations/promise-to-implementation.md` and
 `docs/promise-implementation-map.public.json`; each major claim must name its
@@ -328,6 +341,8 @@ implementation, proof and boundary.
 - `docs/reference/cli.md`: supported `factoryctl` commands.
 - `docs/architecture/factory-operating-systems.md`: OS registry and production
   claim boundary.
+- `docs/architecture/factory-v2-control-plane.md`: deterministic V2 command,
+  event, decision and promotion contracts.
 - `docs/concepts/factory-flow.md`: production line and state model.
 - `docs/concepts/overkill-factory-method.md`: method guide.
 - `docs/concepts/operator-journey.md`: operator journey.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -266,11 +266,23 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 
 ## Estado Atual De Release
 
-Factory v1 é a linha atual de release do kernel público. A release pública mais
-recente é v1.5.16.
+Factory V2 é a linha atual de release do kernel público. A release pública mais
+recente é v2.0.0.
 
 Ela inclui:
 
+- control plane determinístico da Factory V2: workflow compiled plan, command
+  inbox, event log de run com hash chain, decision outbox, promotion packets e
+  validação de `FactoryRun`;
+- `factoryctl compile-workflow`, `validate-factory-run`,
+  `validate-factory-command`, `validate-factory-event-log`,
+  `validate-decision-outbox`, `validate-promotion-packet` e
+  `validate-workflow-compiled-plan`;
+- endurecimento do bridge para que status, pergunta, decisão, mudança, exceção
+  e handoff exijam alvo runtime explícito em vez de estado Hermes ambiente;
+- registros formais de decisão do bridge exigindo `human_gate_record_ref` para
+  respostas de human gate, separando aprovação em chat de autoridade da fábrica;
+- templates públicos e testes de regressão para os contratos de estado V2;
 - Universal Signal Intake, route registry, Golden Corpus e cobertura de sinais;
 - perfis de interface para Telegram, Discord, Cockpit e bridge;
 - start conversacional antes de existir pedido formal de início da fábrica;
@@ -311,11 +323,11 @@ Ela inclui:
 - projeção de artefato de conclusão Hermes, controles de no-idle, Hermes update
   guard, watchdog de no-idle para Hermes cron e contratos da Fast Autonomy Lane.
 
-Esse claim é deliberadamente limitado. Factory v1 significa que o kernel
-público está completo o suficiente para instalar, inspecionar, validar e
-estender. Um produto criado pela fábrica ainda exige fonte real, Product SOT,
-execução de workers, evidência, revisões, human gates e prova própria de
-production readiness.
+Esse claim é deliberadamente limitado. Factory V2 significa que o kernel
+público tem um control plane determinístico que pode ser instalado,
+inspecionado, validado e estendido. Um produto criado pela fábrica ainda exige
+fonte real, Product SOT, execução de workers, evidência, revisões, human gates e
+prova própria de production readiness.
 As promessas públicas são rastreadas em
 `docs/operations/promise-to-implementation.md` e
 `docs/promise-implementation-map.public.json`; cada claim importante precisa
@@ -328,6 +340,8 @@ apontar sua implementação, prova e limite.
 - `docs/getting-started/install-in-hermes.md`: conectar a fábrica a um runtime Hermes do operador.
 - `docs/governance/document-governance.md`: autoridade documental e fronteira pública.
 - `docs/reference/cli.md`: comandos suportados do `factoryctl`.
+- `docs/architecture/factory-v2-control-plane.md`: contratos determinísticos V2
+  de comando, evento, decisão e promoção.
 - `docs/concepts/factory-flow.md`: linha de produção e modelo de estado.
 - `docs/concepts/overkill-factory-method.md`: guia do método.
 - `docs/concepts/operator-journey.md`: jornada do operador.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ python -m unittest tests.test_open_source_docs -q
 Start with `docs/index.md`, then read
 `docs/getting-started/install-in-hermes.md`,
 `docs/reference/cli.md`, `docs/architecture/factory-operating-systems.md`,
+`docs/architecture/factory-v2-control-plane.md`,
 `docs/concepts/factory-flow.md` and
 `docs/operations/validation-and-release.md`.
 

--- a/docs/architecture/factory-v2-control-plane.md
+++ b/docs/architecture/factory-v2-control-plane.md
@@ -1,0 +1,84 @@
+# Factory V2 Control Plane
+
+> Document status: CURRENT ARCHITECTURE.
+> Current authority: `scripts/factory_v2_kernel.py`, `scripts/factoryctl.py`,
+> `docs/factory-workflow.catalog.json`, `schemas/factory-*.schema.json`,
+> `templates/factory-*.json` and `tests/test_factory_v2_kernel.py`.
+> Runtime boundary: Hermes Kanban remains the runtime source of truth for real
+> cards, workers, comments and transitions. Factory V2 controls how state may
+> advance; it does not replace Hermes.
+
+Factory V2 turns the factory method into a deterministic control plane.
+
+The point is simple: agents can produce work, but agents cannot choose the
+factory route from memory, chat context or card prose. The route is compiled,
+commands are validated, events are hashed, human decisions sit in a decision
+outbox, and promotion needs a packet with evidence.
+
+## What V2 Adds
+
+| Contract | Purpose | Public files |
+| --- | --- | --- |
+| Workflow compiled plan | Converts `docs/factory-workflow.catalog.json` into ordered phases, allowed commands and blocked actions. | `schemas/factory-workflow-compiled-plan.schema.json`, `templates/factory-workflow-compiled-plan.json`, `factoryctl compile-workflow` |
+| Factory command | The only shape accepted for proposed state changes. | `schemas/factory-command.schema.json`, `templates/factory-command.json`, `factoryctl validate-factory-command` |
+| Factory run event | Append-only event record with hash chaining. | `schemas/factory-run-event.schema.json`, `templates/factory-run-event.json`, `factoryctl validate-factory-event-log` |
+| Factory run | Runtime binding for a run, including explicit Hermes target, command inbox, event log, decision outbox and promotion packets. | `schemas/factory-run.schema.json`, `templates/factory-run.json`, `factoryctl validate-factory-run` |
+| Decision outbox | Human decisions that the factory needs but cannot auto-resolve. | `schemas/factory-decision-outbox.schema.json`, `templates/factory-decision-outbox.json`, `factoryctl validate-decision-outbox` |
+| Promotion packet | Evidence required before phase, product or release promotion. | `schemas/factory-promotion-packet.schema.json`, `templates/factory-promotion-packet.json`, `factoryctl validate-promotion-packet` |
+| Reference superiority claim | Public-safe way to claim the factory is stronger than a reference, tied to schema, reducer and test proof. | `schemas/reference-superiority-claim.schema.json`, `templates/reference-superiority-claim.json` |
+
+## Invariants
+
+Factory V2 fails closed on these rules:
+
+- A status, question, decision, change, exception or handoff request must resolve
+  an explicit runtime target before reading Hermes state.
+- A bridge cannot create Hermes boards, create Hermes cards, dispatch workers,
+  close gates, approve human gates or promote work.
+- A new product start uses `factory_must_create_new_board`; an existing project
+  must provide an explicit `kanban:`, `hermes:`, `run:` or `board:` reference.
+- A formal human gate response requires `human_gate_record_ref`; chat text alone
+  is not a gate record.
+- `request_decision` is generated only by explicit human/approval gates, not by
+  planning, understanding confirmation or operator briefing text.
+- Event logs require contiguous sequence numbers, correct previous hashes and
+  correct event hashes.
+- Product or release promotion requires Receipt Five, completion audit, release
+  readiness, rollback, monitoring and human gate record when scope requires it.
+- `.tmp/factory-runs` is runtime evidence, not public release surface.
+
+## CLI Proof
+
+Compile and validate the control plane:
+
+```bash
+factoryctl compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+factoryctl validate-workflow-compiled-plan .tmp/factory-workflow-compiled-plan.json
+factoryctl validate-factory-command templates/factory-command.json
+factoryctl validate-factory-event-log templates/factory-run-event.json
+factoryctl validate-decision-outbox templates/factory-decision-outbox.json
+factoryctl validate-promotion-packet templates/factory-promotion-packet.json
+factoryctl validate-factory-run templates/factory-run.json
+```
+
+Run the focused regression suite:
+
+```bash
+python -m unittest tests.test_factory_v2_kernel tests.test_factory_bridge tests.test_factory_board_reconciler -q
+```
+
+## Why This Matters
+
+V1 added many gates, workers, templates and runtime checks. The hard lesson was
+that too much route authority still lived in agent instructions and local
+context. V2 moves that authority into replayable contracts:
+
+- the catalog says what phases exist;
+- the compiled plan says which commands each phase accepts;
+- commands propose changes;
+- events record accepted or rejected transitions;
+- the decision outbox names real human decisions;
+- promotion packets prove that completion is not just prose.
+
+That is the professional boundary: agents operate inside the factory, while the
+factory control plane decides whether the state can advance.

--- a/docs/operations/promise-to-implementation.md
+++ b/docs/operations/promise-to-implementation.md
@@ -65,6 +65,7 @@ state a limit.
 | Class | Examples | What It Proves | What It Does Not Prove |
 | --- | --- | --- | --- |
 | Local contract proof | first run, human gate packet, Product Face contract | The public repo can validate the shape and local command path. | A live product was built or approved. |
+| Deterministic control-plane proof | Factory V2 compiled workflow, commands, event log, decision outbox and promotion packet | The public repo can fail closed when state does not match the V2 contracts. | The operator's current Hermes board advanced or a product was released. |
 | Runtime integration proof | Hermes runtime floor, no-idle watchdog | The adapter/proof path is implemented and test-covered. | The operator's current Hermes is healthy unless current runtime evidence is supplied. |
 | Capability routing proof | modular packs, Solana AI Kit routing | The router selects packs/workers/proof requirements deterministically. | A missing pack is magically executable. |
 | Operator bridge proof | Codex Bridge plugin and durable inbox | The bridge can forward operator context and decisions. | Codex becomes a worker, watcher, approver or source of truth. |

--- a/docs/operator/overkill-factory-bridge-plugin.md
+++ b/docs/operator/overkill-factory-bridge-plugin.md
@@ -44,8 +44,8 @@ publish to GitHub or make Discord a source of truth.
 For `new_project`, the plugin creates a `factory_bridge_source_envelope` and a
 `factory_bridge_start_request` addressed to `overkill-factory-gerente` /
 `factory-orchestrator`. The factory start path owns board creation. For
-`existing_project`, the operator/runtime must provide an explicit existing board
-or run reference.
+`existing_project`, the operator/runtime must provide an explicit `kanban:`,
+`hermes:`, `run:` or `board:` reference.
 
 Inside the public factory repository, the deterministic factory start path is:
 
@@ -66,6 +66,10 @@ immediately.
 For status requests, the plugin must resolve the explicit runtime target for the
 run before reading Hermes. An ambient/default Hermes store is not proof that a
 configured remote or project-specific Hermes runtime is empty.
+
+For human gate responses, the plugin must create a bridge decision with
+`human_gate_record_ref`. A chat approval is operator input, not the factory gate
+record that closes or promotes work.
 
 ## Inbox
 

--- a/docs/operator/overkill-factory-bridge.md
+++ b/docs/operator/overkill-factory-bridge.md
@@ -102,9 +102,9 @@ the schedule.
 | `intake_bridge` | The operator brings a new product/request/signal. | Create or update a sealed source envelope. Do not summarize, interpret, scope or select truth for the factory. |
 | `start_bridge` | The operator says to start an approved run. | Create a bridge run record plus `factory_bridge_start_request` for `overkill-factory-gerente` / `factory-orchestrator`. Do not create Hermes boards/cards directly. |
 | `resume_bridge` | Codex restarts or the operator returns later. | Read the inbox and summarize pending state. |
-| `status_bridge` | "Como esta?", "quanto falta?", "status". | Read Hermes/factory artifacts and separate proved, inferred, blocked and next action. |
+| `status_bridge` | "Como esta?", "quanto falta?", "status". | Resolve an explicit board/run target, then read Hermes/factory artifacts and separate proved, inferred, blocked and next action. |
 | `question_bridge` | "Por que bloqueou?", "qual worker falhou?". | Explain from artifacts without mutating runtime state. |
-| `decision_bridge` | Approval, rejection, waiver or gate response. | Record a bridge decision and point to the required factory/human-gate artifact. |
+| `decision_bridge` | Approval, rejection, waiver or gate response. | Record a bridge decision and point to the required factory/human-gate artifact. `human_gate_response` requires `human_gate_record_ref`. |
 | `change_bridge` | Pause, resume, change scope, add/remove requirement. | Classify whether the change needs replan, human gate or runtime action. |
 | `exception_bridge` | Hook/script/runtime bridge failure. | Repair the bridge layer or create an incident-style event. |
 | `handoff_bridge` | Another agent/session must continue. | Create a replayable handoff packet. |
@@ -117,7 +117,7 @@ There are two start modes:
 | Project mode | Required behavior |
 | --- | --- |
 | `new_project` | The bridge must mark `factory_must_create_new_board`. It must not provide or select an existing board. Board creation belongs to the factory start path. |
-| `existing_project` | The bridge must require an explicit existing board or run reference from the operator/runtime. It must not guess a board from nearby state. |
+| `existing_project` | The bridge must require an explicit `kanban:`, `hermes:`, `run:` or `board:` reference from the operator/runtime. It must not guess a board from nearby state. |
 
 The canonical handoff is:
 

--- a/docs/promise-implementation-map.public.json
+++ b/docs/promise-implementation-map.public.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/promise-implementation-map.schema.json",
   "record_type": "promise_implementation_map",
-  "map_version": "v1",
-  "updated_at": "2026-06-24",
+  "map_version": "v2",
+  "updated_at": "2026-06-26",
   "status": "current_public_kernel",
   "rules": [
     "A public promise must point to documentation, implementation, proof and a stated boundary.",
@@ -11,6 +11,46 @@
     "If the implementation is partial, blocked or runtime-owned, the boundary must say so plainly."
   ],
   "claims": [
+    {
+      "claim_id": "deterministic-v2-control-plane",
+      "public_promise": "Factory V2 moves route authority into a deterministic control plane with compiled workflow, command inbox, event log, decision outbox and promotion packet contracts.",
+      "claim_level": "local_contract_proof",
+      "documentation_refs": [
+        "README.md",
+        "README.pt-BR.md",
+        "docs/architecture/factory-v2-control-plane.md",
+        "docs/reference/cli.md"
+      ],
+      "implementation_refs": [
+        "docs/factory-workflow.catalog.json",
+        "scripts/factory_v2_kernel.py",
+        "scripts/factoryctl.py",
+        "schemas/factory-workflow-compiled-plan.schema.json",
+        "schemas/factory-command.schema.json",
+        "schemas/factory-run-event.schema.json",
+        "schemas/factory-run.schema.json",
+        "schemas/factory-decision-outbox.schema.json",
+        "schemas/factory-promotion-packet.schema.json",
+        "templates/factory-workflow-compiled-plan.json",
+        "templates/factory-command.json",
+        "templates/factory-run-event.json",
+        "templates/factory-run.json",
+        "templates/factory-decision-outbox.json",
+        "templates/factory-promotion-packet.json"
+      ],
+      "proof_refs": [
+        "tests/test_factory_v2_kernel.py",
+        "tests/test_factory_bridge.py",
+        "tests/test_factory_board_reconciler.py",
+        "tests/test_factory_incident_replay.py"
+      ],
+      "boundary": "This proves deterministic public control-plane contracts and regressions. A live product still requires current Hermes runtime state, worker results, Receipt Five, approvals and product-specific release evidence.",
+      "boundary_refs": [
+        "docs/architecture/factory-v2-control-plane.md",
+        "docs/architecture/hermes-integration.md",
+        "docs/operations/validation-and-release.md"
+      ]
+    },
     {
       "claim_id": "hermes-runtime-floor",
       "public_promise": "Hermes Kanban is the first supported runtime floor; Overkill Factory supplies contracts, gates, worker bindings and validation around it.",

--- a/docs/public-surface.manifest.json
+++ b/docs/public-surface.manifest.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://overkill-factory.dev/schemas/public-surface-manifest.schema.json",
   "record_type": "public_surface_manifest",
-  "manifest_version": "v1",
+  "manifest_version": "v2",
   "created_at": "2026-06-14T00:00:00Z",
   "canonical_sources": [
     "agents/worker-registry.public.json",
     "agents/worker-profiles.public.json",
     "agents/hermes-profile-bindings.public.json",
     "docs/agents/factory-stage-agent-map.md",
+    "docs/architecture/factory-v2-control-plane.md",
     "docs/architecture/factory-operating-systems.md",
     "docs/concepts/factory-flow.md",
     "docs/concepts/operator-journey.md",
@@ -22,9 +23,12 @@
     "planning-bundles/manifest.json",
     "schemas/",
     "templates/hermes-production-proof.json",
+    "templates/factory-run.json",
+    "templates/factory-workflow-compiled-plan.json",
     "templates/method-engine-registry.json",
     "templates/factory-operating-system-registry.json",
     "scripts/factoryctl.py",
+    "scripts/factory_v2_kernel.py",
     "scripts/validate_promise_implementation_map.py",
     "scripts/hermes_runtime_proof.py"
   ],
@@ -231,6 +235,34 @@
       "required_phrases": [
         "Hermes Kanban state plus repo-relative evidence and receipts are the source of truth",
         "they do not close work by themselves"
+      ]
+    },
+    {
+      "surface_id": "factory-v2-control-plane",
+      "path": "docs/architecture/factory-v2-control-plane.md",
+      "surface_type": "concept_doc",
+      "authority_level": "supporting_explanation_not_source_of_truth",
+      "source_refs": [
+        "docs/factory-workflow.catalog.json",
+        "scripts/factory_v2_kernel.py",
+        "scripts/factoryctl.py",
+        "schemas/factory-run.schema.json",
+        "schemas/factory-command.schema.json",
+        "schemas/factory-run-event.schema.json",
+        "schemas/factory-decision-outbox.schema.json",
+        "schemas/factory-promotion-packet.schema.json",
+        "templates/factory-run.json",
+        "tests/test_factory_v2_kernel.py"
+      ],
+      "claim_checks": [
+        "source_refs_exist",
+        "source_of_truth_disclaimer",
+        "no_runtime_proof_claim"
+      ],
+      "required_phrases": [
+        "Hermes Kanban remains the runtime source of truth",
+        "agents can produce work, but agents cannot choose the factory route",
+        "factoryctl compile-workflow"
       ]
     },
     {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,6 +35,39 @@ Creates a Hermes-friendly operator workspace for a product.
 factoryctl init --out ../my-product-factory --project-name my-product
 ```
 
+## Factory V2 Control Plane Commands
+
+These commands validate the deterministic state layer. They do not run workers
+and do not mutate Hermes.
+
+```bash
+factoryctl compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+factoryctl validate-workflow-compiled-plan .tmp/factory-workflow-compiled-plan.json
+factoryctl validate-factory-command templates/factory-command.json
+factoryctl validate-factory-event-log templates/factory-run-event.json
+factoryctl validate-decision-outbox templates/factory-decision-outbox.json
+factoryctl validate-promotion-packet templates/factory-promotion-packet.json
+factoryctl validate-factory-run templates/factory-run.json
+```
+
+`compile-workflow` converts `docs/factory-workflow.catalog.json` into a
+machine-checkable phase plan. The compiled plan defines ordered phases, allowed
+commands, blocked actions and compiler guards. It is generated evidence; the
+catalog remains the editable source.
+
+`validate-factory-run` checks the V2 run boundary: explicit Hermes/Kanban target,
+board creation policy, command inbox, hash-chained event log, decision outbox,
+promotion packets and state authority. It fails when a bridge or adapter tries
+to become the state authority.
+
+`validate-decision-outbox` keeps human gates bounded. A pending human decision
+must point to a required packet and neither the bridge nor the factory may
+auto-approve it.
+
+`validate-promotion-packet` keeps completion from becoming prose. Promotion
+requires Receipt Five, completion audit, release readiness, rollback, monitoring
+and human gate record when the promotion scope requires human authority.
+
 ## Card And Worker Commands
 
 ```bash

--- a/plugins/overkill-factory-bridge/.codex-plugin/plugin.json
+++ b/plugins/overkill-factory-bridge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overkill-factory-bridge",
-  "version": "0.1.0+codex.20260622182349",
+  "version": "0.2.0+codex.20260626000000",
   "description": "Operate Overkill Factory from Codex as the human bridge, not as the factory runtime.",
   "author": {
     "name": "Overkill Factory maintainers",

--- a/plugins/overkill-factory-bridge/scripts/factory_bridge.py
+++ b/plugins/overkill-factory-bridge/scripts/factory_bridge.py
@@ -80,6 +80,7 @@ DECISIONS = {
     "needs_human_gate_record",
 }
 PROJECT_MODES = {"new_project", "existing_project"}
+EXPLICIT_EXISTING_BOARD_REF = re.compile(r"^(?:kanban|hermes|run|board):[A-Za-z0-9_.:/@-]{3,}$")
 
 PRIVATE_SYNC_ROOT = "One" + "Drive"
 PRIVATE_MARKER = re.compile(
@@ -141,6 +142,17 @@ def safe_refs(refs: list[str] | None) -> list[str]:
     return [safe_ref(ref) for ref in refs or []]
 
 
+def validate_existing_board_ref(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("existing_project requires an explicit existing_board_ref")
+    if PRIVATE_MARKER.search(raw) or Path(raw.replace("\\", "/")).is_absolute():
+        raise ValueError("existing_board_ref must be an explicit runtime ref, not a private/local path")
+    if not EXPLICIT_EXISTING_BOARD_REF.search(raw):
+        raise ValueError("existing_board_ref must start with kanban:, hermes:, run:, or board:")
+    return raw
+
+
 def validate_choice(name: str, value: str, choices: set[str]) -> None:
     if value not in choices:
         raise ValueError(f"{name} must be one of {', '.join(sorted(choices))}: {value}")
@@ -170,10 +182,11 @@ def build_target_board_policy(project_mode: str, existing_board_ref: str | None 
         }
     if not raw_existing:
         raise ValueError("existing_project requires an explicit existing_board_ref")
+    existing_ref = validate_existing_board_ref(raw_existing)
     return {
         "policy": "use_explicit_existing_board",
         "requires_new_hermes_board": False,
-        "existing_board_ref": safe_ref(raw_existing),
+        "existing_board_ref": existing_ref,
         "requires_explicit_existing_board_ref": True,
         "board_creation_owner": "existing_runtime",
         "factory_start_path_required": True,
@@ -233,14 +246,40 @@ def stable_event_id(
     return f"fbe_{digest}"
 
 
-def read_jsonl(path: Path) -> list[dict[str, Any]]:
+def read_jsonl_with_errors(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if not path.exists():
-        return []
+        return [], []
     rows: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    errors: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if not line.strip():
             continue
-        rows.append(json.loads(line))
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(
+                {
+                    "file": path.name,
+                    "line": line_number,
+                    "error": f"invalid JSONL record: {exc.msg}",
+                }
+            )
+            continue
+        if not isinstance(parsed, dict):
+            errors.append(
+                {
+                    "file": path.name,
+                    "line": line_number,
+                    "error": "JSONL record must be an object",
+                }
+            )
+            continue
+        rows.append(parsed)
+    return rows, errors
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows, _errors = read_jsonl_with_errors(path)
     return rows
 
 
@@ -340,9 +379,10 @@ def event_is_acked(event: dict[str, Any], acked_ids: set[str]) -> bool:
 
 def summarize_inbox(*, inbox_dir: Path | str | None = None, max_items: int = 10) -> dict[str, Any]:
     inbox = normalize_inbox_dir(inbox_dir)
-    events = read_jsonl(inbox / EVENTS_FILE)
-    pending = read_jsonl(inbox / PENDING_FILE)
-    acks = read_jsonl(inbox / ACKS_FILE)
+    events, event_errors = read_jsonl_with_errors(inbox / EVENTS_FILE)
+    pending, pending_errors = read_jsonl_with_errors(inbox / PENDING_FILE)
+    acks, ack_errors = read_jsonl_with_errors(inbox / ACKS_FILE)
+    read_errors = event_errors + pending_errors + ack_errors
     acked_ids = {str(ack.get("event_id") or "") for ack in acks}
     open_pending = [event for event in pending if not event_is_acked(event, acked_ids)]
     open_pending.sort(key=lambda row: str(row.get("created_at") or ""))
@@ -356,6 +396,15 @@ def summarize_inbox(*, inbox_dir: Path | str | None = None, max_items: int = 10)
         "pending_count": len(open_pending),
         "pending_events": open_pending[:max_items],
         "recent_events": recent_events,
+        "inbox_health": {
+            "inbox_dir_exists": inbox.exists(),
+            "events_file_exists": (inbox / EVENTS_FILE).exists(),
+            "pending_file_exists": (inbox / PENDING_FILE).exists(),
+            "acks_file_exists": (inbox / ACKS_FILE).exists(),
+            "jsonl_error_count": len(read_errors),
+            "jsonl_errors": read_errors[:max_items],
+            "status": "warning" if read_errors or not inbox.exists() else "ok",
+        },
         "authority": bridge_authority(),
     }
 
@@ -422,10 +471,23 @@ def classify_prompt(prompt: str) -> dict[str, Any]:
     if any(term in normalized for term in ("aprenda", "learnback", "melhore a fabrica", "melhorar a fabrica", "factory mechanic")):
         mode = "learnback_forwarding"
         reason = "operator supplied learnback; bridge forwards it without activating changes"
+    requires_runtime_target = mode in {
+        "status_bridge",
+        "question_bridge",
+        "decision_bridge",
+        "change_bridge",
+        "exception_bridge",
+        "handoff_bridge",
+    }
     return {
         "record_type": "factory_bridge_prompt_classification",
         "bridge_mode": mode,
         "reason": reason,
+        "runtime_target_contract": {
+            "explicit_runtime_target_ref_required": requires_runtime_target,
+            "ambient_runtime_allowed": False,
+            "bridge_may_guess_runtime_target": False,
+        },
         "authority": prompt_authority(),
     }
 
@@ -452,6 +514,17 @@ def format_hook_context(summary: dict[str, Any], classification: dict[str, Any] 
     ]
     if classification:
         lines.append(f"Bridge mode: {classification['bridge_mode']} ({classification['reason']}).")
+        runtime_contract = classification.get("runtime_target_contract") or {}
+        if runtime_contract.get("explicit_runtime_target_ref_required"):
+            lines.append("Runtime target: explicit board/run ref required before reading Hermes state.")
+        lines.append("Runtime target: ambient/default Hermes store is not authority.")
+    health = summary.get("inbox_health") or {}
+    if health.get("status") != "ok":
+        lines.append("Inbox health: warning.")
+        if not health.get("inbox_dir_exists"):
+            lines.append("- operator inbox directory does not exist yet")
+        for error in health.get("jsonl_errors") or []:
+            lines.append(f"- {error.get('file')} line {error.get('line')}: {error.get('error')}")
     pending = summary.get("pending_events", [])
     lines.append(f"Pending operator events: {summary.get('pending_count', 0)}.")
     for event in pending[:5]:
@@ -517,10 +590,17 @@ def build_decision_record(
     actor: str,
     summary: str,
     evidence_refs: list[str] | None = None,
+    human_gate_record_ref: str | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
     validate_choice("decision_type", decision_type, DECISION_TYPES)
     validate_choice("decision", decision, DECISIONS)
+    if decision_type == "human_gate_response" and not human_gate_record_ref:
+        raise ValueError("human_gate_response requires --human-gate-record-ref")
+    clean_evidence_refs = safe_refs(evidence_refs)
+    clean_human_gate_record_ref = safe_ref(human_gate_record_ref) if human_gate_record_ref else None
+    if decision_type == "human_gate_response" and clean_human_gate_record_ref not in clean_evidence_refs:
+        clean_evidence_refs.append(str(clean_human_gate_record_ref))
     return {
         "$schema": DECISION_SCHEMA,
         "record_type": "factory_bridge_decision",
@@ -530,7 +610,8 @@ def build_decision_record(
         "decision": decision,
         "actor": actor,
         "summary": summary,
-        "evidence_refs": safe_refs(evidence_refs),
+        "evidence_refs": clean_evidence_refs,
+        "human_gate_record_ref": clean_human_gate_record_ref,
         "created_at": created_at or utc_now(),
         "authority": {
             "closes_factory_gate": False,
@@ -797,6 +878,7 @@ def command_decision_record(args: argparse.Namespace) -> int:
         actor=args.actor,
         summary=args.summary,
         evidence_refs=args.evidence_ref,
+        human_gate_record_ref=args.human_gate_record_ref,
     )
     write_json(args.out, record)
     return 0
@@ -896,6 +978,7 @@ def build_parser() -> argparse.ArgumentParser:
     decision.add_argument("--actor", required=True)
     decision.add_argument("--summary", required=True)
     decision.add_argument("--evidence-ref", action="append", default=[])
+    decision.add_argument("--human-gate-record-ref")
     decision.add_argument("--out", type=Path)
     decision.set_defaults(func=command_decision_record)
 

--- a/plugins/overkill-factory-bridge/skills/overkill-factory-bridge/SKILL.md
+++ b/plugins/overkill-factory-bridge/skills/overkill-factory-bridge/SKILL.md
@@ -103,6 +103,7 @@ python scripts/factory_bridge.py decision-record \
   --actor product_owner \
   --summary "Release waits for rollback evidence." \
   --evidence-ref external:operator:release-decision \
+  --human-gate-record-ref external:operator:human-gate-record \
   --out .tmp/factory-runs/example/bridge-decision.json
 ```
 
@@ -117,6 +118,8 @@ python scripts/factory_bridge.py handoff \
 ## Authority Rules
 
 - A bridge decision is not a human gate record.
+- `human_gate_response` requires `human_gate_record_ref`; chat text alone does
+  not close or approve a factory gate.
 - A bridge event is not runtime evidence.
 - A status summary is not Receipt Five.
 - A source envelope is not Product SOT.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "1.5.16"
+version = "2.0.0"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/schemas/factory-bridge-decision.schema.json
+++ b/schemas/factory-bridge-decision.schema.json
@@ -54,6 +54,7 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
     },
+    "human_gate_record_ref": { "type": ["string", "null"], "minLength": 3 },
     "created_at": { "type": "string", "minLength": 10 },
     "authority": {
       "type": "object",
@@ -72,5 +73,5 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/schemas/factory-command.schema.json
+++ b/schemas/factory-command.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-command.schema.json",
+  "title": "Factory Command",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "command_id",
+    "run_id",
+    "command_type",
+    "expected_version",
+    "idempotency_key",
+    "created_at",
+    "source",
+    "authority",
+    "payload"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-command.schema.json" },
+    "record_type": { "const": "factory_command" },
+    "command_id": { "type": "string", "minLength": 3 },
+    "run_id": { "type": "string", "minLength": 3 },
+    "command_type": {
+      "enum": [
+        "start_run",
+        "advance_phase",
+        "materialize_worker",
+        "request_decision",
+        "record_decision",
+        "repair_required",
+        "promote",
+        "release",
+        "learnback_candidate"
+      ]
+    },
+    "expected_version": { "type": "integer", "minimum": 0 },
+    "idempotency_key": { "type": "string", "minLength": 8 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "source": {
+      "type": "object",
+      "required": ["source_type", "source_ref"],
+      "properties": {
+        "source_type": {
+          "enum": ["operator", "factoryctl", "hermes_adapter", "worker", "reviewer", "automation", "learnback"]
+        },
+        "source_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "authority": {
+      "type": "object",
+      "required": [
+        "reducer_must_accept",
+        "bridge_may_execute",
+        "bridge_may_approve_human_gate",
+        "adapter_may_decide_business_rule"
+      ],
+      "properties": {
+        "reducer_must_accept": { "const": true },
+        "bridge_may_execute": { "const": false },
+        "bridge_may_approve_human_gate": { "const": false },
+        "adapter_may_decide_business_rule": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "payload": {
+      "type": "object",
+      "required": ["summary"],
+      "properties": {
+        "summary": { "type": "string", "minLength": 3 },
+        "phase_id": { "type": "string", "minLength": 2 },
+        "worker_id": { "type": "string", "minLength": 3 },
+        "decision_id": { "type": "string", "minLength": 3 },
+        "artifact_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "blocked_reason": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-decision-outbox.schema.json
+++ b/schemas/factory-decision-outbox.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-decision-outbox.schema.json",
+  "title": "Factory Decision Outbox",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "outbox_id",
+    "run_id",
+    "created_at",
+    "pending_decisions",
+    "authority"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-decision-outbox.schema.json" },
+    "record_type": { "const": "factory_decision_outbox" },
+    "outbox_id": { "type": "string", "minLength": 3 },
+    "run_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "pending_decisions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "decision_id",
+          "event_id",
+          "decision_type",
+          "authority_required",
+          "required_packet_ref",
+          "status",
+          "bridge_may_resolve",
+          "factory_may_auto_approve"
+        ],
+        "properties": {
+          "decision_id": { "type": "string", "minLength": 3 },
+          "event_id": { "type": "string", "minLength": 3 },
+          "decision_type": {
+            "enum": [
+              "human_gate",
+              "scope_change",
+              "risk_acceptance",
+              "release_approval",
+              "funds_or_custody",
+              "mainnet_or_production",
+              "security_exception"
+            ]
+          },
+          "authority_required": {
+            "enum": ["human_operator", "reviewer", "security_owner", "risk_owner", "release_owner"]
+          },
+          "required_packet_ref": { "type": "string", "minLength": 3 },
+          "status": { "enum": ["pending", "resolved", "cancelled"] },
+          "bridge_may_resolve": { "const": false },
+          "factory_may_auto_approve": { "const": false },
+          "recorded_decision_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "authority": {
+      "type": "object",
+      "required": ["operator_decides", "bridge_records_only", "reducer_consumes_decision"],
+      "properties": {
+        "operator_decides": { "const": true },
+        "bridge_records_only": { "const": true },
+        "reducer_consumes_decision": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-promotion-packet.schema.json
+++ b/schemas/factory-promotion-packet.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-promotion-packet.schema.json",
+  "title": "Factory Promotion Packet",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "packet_id",
+    "run_id",
+    "created_at",
+    "promotion_scope",
+    "source_state_ref",
+    "receipt_five_ref",
+    "completion_audit_ref",
+    "release_readiness_ref",
+    "rollback_ref",
+    "monitoring_ref",
+    "decision",
+    "evidence_refs",
+    "authority"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-promotion-packet.schema.json" },
+    "record_type": { "const": "factory_promotion_packet" },
+    "packet_id": { "type": "string", "minLength": 3 },
+    "run_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "promotion_scope": { "enum": ["work_unit", "phase", "slice", "product", "release"] },
+    "source_state_ref": { "type": "string", "minLength": 3 },
+    "receipt_five_ref": { "type": "string", "minLength": 3 },
+    "completion_audit_ref": { "type": "string", "minLength": 3 },
+    "release_readiness_ref": { "type": "string", "minLength": 3 },
+    "rollback_ref": { "type": "string", "minLength": 3 },
+    "monitoring_ref": { "type": "string", "minLength": 3 },
+    "human_gate_record_ref": { "type": ["string", "null"], "minLength": 3 },
+    "decision": { "enum": ["approve", "request_changes", "reject", "block"] },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "authority": {
+      "type": "object",
+      "required": [
+        "promotion_reducer_required",
+        "worker_may_self_promote",
+        "bridge_may_promote",
+        "release_requires_rollback"
+      ],
+      "properties": {
+        "promotion_reducer_required": { "const": true },
+        "worker_may_self_promote": { "const": false },
+        "bridge_may_promote": { "const": false },
+        "release_requires_rollback": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-run-event.schema.json
+++ b/schemas/factory-run-event.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-run-event.schema.json",
+  "title": "Factory Run Event",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "event_id",
+    "run_id",
+    "sequence",
+    "event_type",
+    "created_at",
+    "previous_event_hash",
+    "event_hash",
+    "payload"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-run-event.schema.json" },
+    "record_type": { "const": "factory_run_event" },
+    "event_id": { "type": "string", "minLength": 3 },
+    "run_id": { "type": "string", "minLength": 3 },
+    "sequence": { "type": "integer", "minimum": 1 },
+    "event_type": {
+      "enum": [
+        "run_started",
+        "command_accepted",
+        "command_rejected",
+        "phase_advanced",
+        "worker_materialized",
+        "human_decision_requested",
+        "human_decision_recorded",
+        "repair_required",
+        "promotion_packet_created",
+        "release_ready",
+        "run_completed",
+        "learnback_candidate_created"
+      ]
+    },
+    "created_at": { "type": "string", "minLength": 10 },
+    "command_id": { "type": "string", "minLength": 3 },
+    "previous_event_hash": {
+      "type": ["string", "null"],
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "event_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "payload": {
+      "type": "object",
+      "required": ["summary"],
+      "properties": {
+        "summary": { "type": "string", "minLength": 3 },
+        "phase_id": { "type": "string", "minLength": 2 },
+        "status": { "type": "string", "minLength": 3 },
+        "artifact_refs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-run.schema.json
+++ b/schemas/factory-run.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-run.schema.json",
+  "title": "Factory Run",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "run_id",
+    "state_version",
+    "status",
+    "created_at",
+    "current_phase_id",
+    "runtime_target",
+    "board_binding",
+    "command_inbox",
+    "event_log",
+    "decision_outbox",
+    "promotion_packets",
+    "authority"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-run.schema.json" },
+    "record_type": { "const": "factory_run" },
+    "run_id": { "type": "string", "minLength": 3 },
+    "state_version": { "type": "integer", "minimum": 0 },
+    "status": { "enum": ["intake", "planning", "ready", "running", "blocked", "awaiting_human", "release_ready", "completed"] },
+    "created_at": { "type": "string", "minLength": 10 },
+    "updated_at": { "type": "string", "minLength": 10 },
+    "current_phase_id": { "type": "string", "minLength": 2 },
+    "runtime_target": {
+      "type": "object",
+      "required": ["runtime", "runtime_target_ref", "ambient_runtime_allowed"],
+      "properties": {
+        "runtime": { "const": "hermes_kanban" },
+        "runtime_target_ref": { "type": "string", "minLength": 3 },
+        "ambient_runtime_allowed": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "board_binding": {
+      "type": "object",
+      "required": ["binding_ref", "board_policy", "board_ref"],
+      "properties": {
+        "binding_ref": { "type": "string", "minLength": 3 },
+        "board_policy": { "enum": ["factory_must_create_new_board", "explicit_existing_board"] },
+        "board_ref": { "type": ["string", "null"], "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "command_inbox": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "event_log": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "decision_outbox": { "type": "object" },
+    "promotion_packets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "compiled_workflow_plan_ref": { "type": "string", "minLength": 3 },
+    "authority": {
+      "type": "object",
+      "required": [
+        "state_authority",
+        "transition_authority",
+        "bridge_may_mutate",
+        "adapter_may_decide"
+      ],
+      "properties": {
+        "state_authority": { "const": "factory_event_log" },
+        "transition_authority": { "const": "transition_reducer" },
+        "bridge_may_mutate": { "const": false },
+        "adapter_may_decide": { "const": false }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-workflow-compiled-plan.schema.json
+++ b/schemas/factory-workflow-compiled-plan.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-workflow-compiled-plan.schema.json",
+  "title": "Factory Workflow Compiled Plan",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "plan_id",
+    "compiled_at",
+    "catalog_ref",
+    "catalog_version",
+    "phase_count",
+    "phases",
+    "compiler_guards"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-workflow-compiled-plan.schema.json" },
+    "record_type": { "const": "factory_workflow_compiled_plan" },
+    "plan_id": { "type": "string", "minLength": 3 },
+    "compiled_at": { "type": "string", "minLength": 10 },
+    "catalog_ref": { "type": "string", "minLength": 3 },
+    "catalog_version": { "type": "string", "minLength": 1 },
+    "phase_count": { "type": "integer", "minimum": 1 },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "phase_id",
+          "phase_index",
+          "phase_name",
+          "required_artifacts",
+          "required_gates",
+          "required_workers",
+          "allowed_commands",
+          "blocked_actions",
+          "next_phase_id",
+          "auto_pass_allowed"
+        ],
+        "properties": {
+          "phase_id": { "type": "string", "minLength": 2 },
+          "phase_index": { "type": "integer", "minimum": 1 },
+          "phase_name": { "type": "string", "minLength": 3 },
+          "required_artifacts": { "type": "array", "items": { "type": "string" } },
+          "required_gates": { "type": "array", "items": { "type": "string" } },
+          "required_workers": { "type": "array", "items": { "type": "string" } },
+          "allowed_commands": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "advance_phase",
+                "materialize_worker",
+                "request_decision",
+                "repair_required",
+                "promote",
+                "release",
+                "learnback_candidate"
+              ]
+            }
+          },
+          "blocked_actions": { "type": "array", "items": { "type": "string" } },
+          "next_phase_id": { "type": ["string", "null"], "minLength": 2 },
+          "auto_pass_allowed": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "compiler_guards": {
+      "type": "object",
+      "required": [
+        "duplicate_phase_ids_blocked",
+        "unknown_next_phase_blocked",
+        "human_gate_requires_decision_outbox",
+        "worker_materialization_requires_dispatch_readiness"
+      ],
+      "properties": {
+        "duplicate_phase_ids_blocked": { "const": true },
+        "unknown_next_phase_blocked": { "const": true },
+        "human_gate_requires_decision_outbox": { "const": true },
+        "worker_materialization_requires_dispatch_readiness": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/reference-superiority-claim.schema.json
+++ b/schemas/reference-superiority-claim.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/reference-superiority-claim.schema.json",
+  "title": "Reference Superiority Claim",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "claim_id",
+    "created_at",
+    "reference",
+    "claim",
+    "v2_mechanism",
+    "negative_fixture_ref",
+    "proof_refs",
+    "public_claim_allowed"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/reference-superiority-claim.schema.json" },
+    "record_type": { "const": "reference_superiority_claim" },
+    "claim_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "reference": {
+      "type": "object",
+      "required": ["name", "source_ref", "commit_ref"],
+      "properties": {
+        "name": { "type": "string", "minLength": 2 },
+        "source_ref": { "type": "string", "minLength": 3 },
+        "commit_ref": { "type": "string", "minLength": 7 }
+      },
+      "additionalProperties": false
+    },
+    "claim": { "type": "string", "minLength": 12 },
+    "v2_mechanism": {
+      "type": "object",
+      "required": ["schema_ref", "reducer_or_validator_ref", "runtime_or_test_ref"],
+      "properties": {
+        "schema_ref": { "type": "string", "minLength": 3 },
+        "reducer_or_validator_ref": { "type": "string", "minLength": 3 },
+        "runtime_or_test_ref": { "type": "string", "minLength": 3 }
+      },
+      "additionalProperties": false
+    },
+    "negative_fixture_ref": { "type": "string", "minLength": 3 },
+    "proof_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "public_claim_allowed": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factory_bridge.py
+++ b/scripts/factory_bridge.py
@@ -80,6 +80,7 @@ DECISIONS = {
     "needs_human_gate_record",
 }
 PROJECT_MODES = {"new_project", "existing_project"}
+EXPLICIT_EXISTING_BOARD_REF = re.compile(r"^(?:kanban|hermes|run|board):[A-Za-z0-9_.:/@-]{3,}$")
 
 PRIVATE_SYNC_ROOT = "One" + "Drive"
 PRIVATE_MARKER = re.compile(
@@ -141,6 +142,17 @@ def safe_refs(refs: list[str] | None) -> list[str]:
     return [safe_ref(ref) for ref in refs or []]
 
 
+def validate_existing_board_ref(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("existing_project requires an explicit existing_board_ref")
+    if PRIVATE_MARKER.search(raw) or Path(raw.replace("\\", "/")).is_absolute():
+        raise ValueError("existing_board_ref must be an explicit runtime ref, not a private/local path")
+    if not EXPLICIT_EXISTING_BOARD_REF.search(raw):
+        raise ValueError("existing_board_ref must start with kanban:, hermes:, run:, or board:")
+    return raw
+
+
 def validate_choice(name: str, value: str, choices: set[str]) -> None:
     if value not in choices:
         raise ValueError(f"{name} must be one of {', '.join(sorted(choices))}: {value}")
@@ -170,10 +182,11 @@ def build_target_board_policy(project_mode: str, existing_board_ref: str | None 
         }
     if not raw_existing:
         raise ValueError("existing_project requires an explicit existing_board_ref")
+    existing_ref = validate_existing_board_ref(raw_existing)
     return {
         "policy": "use_explicit_existing_board",
         "requires_new_hermes_board": False,
-        "existing_board_ref": safe_ref(raw_existing),
+        "existing_board_ref": existing_ref,
         "requires_explicit_existing_board_ref": True,
         "board_creation_owner": "existing_runtime",
         "factory_start_path_required": True,
@@ -233,14 +246,40 @@ def stable_event_id(
     return f"fbe_{digest}"
 
 
-def read_jsonl(path: Path) -> list[dict[str, Any]]:
+def read_jsonl_with_errors(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if not path.exists():
-        return []
+        return [], []
     rows: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    errors: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if not line.strip():
             continue
-        rows.append(json.loads(line))
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(
+                {
+                    "file": path.name,
+                    "line": line_number,
+                    "error": f"invalid JSONL record: {exc.msg}",
+                }
+            )
+            continue
+        if not isinstance(parsed, dict):
+            errors.append(
+                {
+                    "file": path.name,
+                    "line": line_number,
+                    "error": "JSONL record must be an object",
+                }
+            )
+            continue
+        rows.append(parsed)
+    return rows, errors
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows, _errors = read_jsonl_with_errors(path)
     return rows
 
 
@@ -340,9 +379,10 @@ def event_is_acked(event: dict[str, Any], acked_ids: set[str]) -> bool:
 
 def summarize_inbox(*, inbox_dir: Path | str | None = None, max_items: int = 10) -> dict[str, Any]:
     inbox = normalize_inbox_dir(inbox_dir)
-    events = read_jsonl(inbox / EVENTS_FILE)
-    pending = read_jsonl(inbox / PENDING_FILE)
-    acks = read_jsonl(inbox / ACKS_FILE)
+    events, event_errors = read_jsonl_with_errors(inbox / EVENTS_FILE)
+    pending, pending_errors = read_jsonl_with_errors(inbox / PENDING_FILE)
+    acks, ack_errors = read_jsonl_with_errors(inbox / ACKS_FILE)
+    read_errors = event_errors + pending_errors + ack_errors
     acked_ids = {str(ack.get("event_id") or "") for ack in acks}
     open_pending = [event for event in pending if not event_is_acked(event, acked_ids)]
     open_pending.sort(key=lambda row: str(row.get("created_at") or ""))
@@ -356,6 +396,15 @@ def summarize_inbox(*, inbox_dir: Path | str | None = None, max_items: int = 10)
         "pending_count": len(open_pending),
         "pending_events": open_pending[:max_items],
         "recent_events": recent_events,
+        "inbox_health": {
+            "inbox_dir_exists": inbox.exists(),
+            "events_file_exists": (inbox / EVENTS_FILE).exists(),
+            "pending_file_exists": (inbox / PENDING_FILE).exists(),
+            "acks_file_exists": (inbox / ACKS_FILE).exists(),
+            "jsonl_error_count": len(read_errors),
+            "jsonl_errors": read_errors[:max_items],
+            "status": "warning" if read_errors or not inbox.exists() else "ok",
+        },
         "authority": bridge_authority(),
     }
 
@@ -422,10 +471,23 @@ def classify_prompt(prompt: str) -> dict[str, Any]:
     if any(term in normalized for term in ("aprenda", "learnback", "melhore a fabrica", "melhorar a fabrica", "factory mechanic")):
         mode = "learnback_forwarding"
         reason = "operator supplied learnback; bridge forwards it without activating changes"
+    requires_runtime_target = mode in {
+        "status_bridge",
+        "question_bridge",
+        "decision_bridge",
+        "change_bridge",
+        "exception_bridge",
+        "handoff_bridge",
+    }
     return {
         "record_type": "factory_bridge_prompt_classification",
         "bridge_mode": mode,
         "reason": reason,
+        "runtime_target_contract": {
+            "explicit_runtime_target_ref_required": requires_runtime_target,
+            "ambient_runtime_allowed": False,
+            "bridge_may_guess_runtime_target": False,
+        },
         "authority": prompt_authority(),
     }
 
@@ -452,6 +514,17 @@ def format_hook_context(summary: dict[str, Any], classification: dict[str, Any] 
     ]
     if classification:
         lines.append(f"Bridge mode: {classification['bridge_mode']} ({classification['reason']}).")
+        runtime_contract = classification.get("runtime_target_contract") or {}
+        if runtime_contract.get("explicit_runtime_target_ref_required"):
+            lines.append("Runtime target: explicit board/run ref required before reading Hermes state.")
+        lines.append("Runtime target: ambient/default Hermes store is not authority.")
+    health = summary.get("inbox_health") or {}
+    if health.get("status") != "ok":
+        lines.append("Inbox health: warning.")
+        if not health.get("inbox_dir_exists"):
+            lines.append("- operator inbox directory does not exist yet")
+        for error in health.get("jsonl_errors") or []:
+            lines.append(f"- {error.get('file')} line {error.get('line')}: {error.get('error')}")
     pending = summary.get("pending_events", [])
     lines.append(f"Pending operator events: {summary.get('pending_count', 0)}.")
     for event in pending[:5]:
@@ -517,10 +590,17 @@ def build_decision_record(
     actor: str,
     summary: str,
     evidence_refs: list[str] | None = None,
+    human_gate_record_ref: str | None = None,
     created_at: str | None = None,
 ) -> dict[str, Any]:
     validate_choice("decision_type", decision_type, DECISION_TYPES)
     validate_choice("decision", decision, DECISIONS)
+    if decision_type == "human_gate_response" and not human_gate_record_ref:
+        raise ValueError("human_gate_response requires --human-gate-record-ref")
+    clean_evidence_refs = safe_refs(evidence_refs)
+    clean_human_gate_record_ref = safe_ref(human_gate_record_ref) if human_gate_record_ref else None
+    if decision_type == "human_gate_response" and clean_human_gate_record_ref not in clean_evidence_refs:
+        clean_evidence_refs.append(str(clean_human_gate_record_ref))
     return {
         "$schema": DECISION_SCHEMA,
         "record_type": "factory_bridge_decision",
@@ -530,7 +610,8 @@ def build_decision_record(
         "decision": decision,
         "actor": actor,
         "summary": summary,
-        "evidence_refs": safe_refs(evidence_refs),
+        "evidence_refs": clean_evidence_refs,
+        "human_gate_record_ref": clean_human_gate_record_ref,
         "created_at": created_at or utc_now(),
         "authority": {
             "closes_factory_gate": False,
@@ -797,6 +878,7 @@ def command_decision_record(args: argparse.Namespace) -> int:
         actor=args.actor,
         summary=args.summary,
         evidence_refs=args.evidence_ref,
+        human_gate_record_ref=args.human_gate_record_ref,
     )
     write_json(args.out, record)
     return 0
@@ -896,6 +978,7 @@ def build_parser() -> argparse.ArgumentParser:
     decision.add_argument("--actor", required=True)
     decision.add_argument("--summary", required=True)
     decision.add_argument("--evidence-ref", action="append", default=[])
+    decision.add_argument("--human-gate-record-ref")
     decision.add_argument("--out", type=Path)
     decision.set_defaults(func=command_decision_record)
 

--- a/scripts/factory_v2_kernel.py
+++ b/scripts/factory_v2_kernel.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Deterministic Overkill Factory V2 state contracts.
+
+This module is intentionally small and boring. Agents may draft artifacts, but
+Factory V2 state changes must pass through command, event, decision and
+promotion contracts that can be replayed without trusting agent memory.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from validate_public_json_artifacts import load_schemas, validate_node
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORKFLOW_CATALOG = ROOT / "docs" / "factory-workflow.catalog.json"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def load_json_array_or_object(path: Path) -> list[Any] | dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, (list, dict)):
+        raise ValueError(f"{path} must contain a JSON object or array")
+    return data
+
+
+def _schema_errors(schema_name: str, value: dict[str, Any], at: str) -> list[str]:
+    schemas = load_schemas()
+    schema = schemas[schema_name]
+    return validate_node(schema, value, at, schemas=schemas, root_schema=schema)
+
+
+def _payload(value: dict[str, Any]) -> dict[str, Any]:
+    payload = value.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _refs(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def validate_factory_command(command: dict[str, Any], at: str = "factory_command") -> list[str]:
+    errors = _schema_errors("factory-command.schema.json", command, at)
+    command_type = command.get("command_type")
+    payload = _payload(command)
+
+    phase_bound_commands = {
+        "advance_phase",
+        "materialize_worker",
+        "request_decision",
+        "record_decision",
+        "repair_required",
+        "promote",
+        "release",
+        "learnback_candidate",
+    }
+    if command_type in phase_bound_commands and not payload.get("phase_id"):
+        errors.append(f"{at}.payload.phase_id: required for {command_type}")
+    if command_type == "materialize_worker" and not payload.get("worker_id"):
+        errors.append(f"{at}.payload.worker_id: required for materialize_worker")
+    if command_type in {"request_decision", "record_decision"} and not payload.get("decision_id"):
+        errors.append(f"{at}.payload.decision_id: required for {command_type}")
+    if command_type == "request_decision" and not _refs(payload.get("artifact_refs")):
+        errors.append(f"{at}.payload.artifact_refs: decision requests require an evidence packet")
+    if command_type == "repair_required" and not payload.get("blocked_reason"):
+        errors.append(f"{at}.payload.blocked_reason: required for repair_required")
+    if command_type in {"promote", "release"} and not _refs(payload.get("artifact_refs")):
+        errors.append(f"{at}.payload.artifact_refs: required for {command_type}")
+    return errors
+
+
+def factory_event_hash(event: dict[str, Any]) -> str:
+    normalized = copy.deepcopy(event)
+    normalized.pop("event_hash", None)
+    encoded = json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def validate_factory_run_event(event: dict[str, Any], at: str = "factory_run_event") -> list[str]:
+    errors = _schema_errors("factory-run-event.schema.json", event, at)
+    expected_hash = factory_event_hash(event)
+    if event.get("event_hash") != expected_hash:
+        errors.append(f"{at}.event_hash: expected {expected_hash}")
+    event_type = event.get("event_type")
+    payload = _payload(event)
+    if event_type in {"phase_advanced", "worker_materialized", "human_decision_requested"} and not payload.get("phase_id"):
+        errors.append(f"{at}.payload.phase_id: required for {event_type}")
+    if event_type == "human_decision_requested" and not _refs(payload.get("artifact_refs")):
+        errors.append(f"{at}.payload.artifact_refs: human decisions require a delivered packet")
+    return errors
+
+
+def normalize_event_log(value: list[Any] | dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(value, dict) and value.get("record_type") == "factory_run_event":
+        return [value]
+    raw_events = value.get("event_log") if isinstance(value, dict) else value
+    if not isinstance(raw_events, list):
+        raise ValueError("event log input must be a JSON array or an object with event_log")
+    events: list[dict[str, Any]] = []
+    for index, item in enumerate(raw_events):
+        if not isinstance(item, dict):
+            raise ValueError(f"event_log[{index}] must be a JSON object")
+        events.append(item)
+    return events
+
+
+def validate_factory_event_log(events: list[dict[str, Any]], at: str = "event_log") -> list[str]:
+    errors: list[str] = []
+    previous_hash: str | None = None
+    seen_hashes: set[str] = set()
+    for index, event in enumerate(events):
+        event_at = f"{at}[{index}]"
+        errors.extend(validate_factory_run_event(event, event_at))
+        expected_sequence = index + 1
+        if event.get("sequence") != expected_sequence:
+            errors.append(f"{event_at}.sequence: expected contiguous sequence {expected_sequence}")
+        if index == 0 and event.get("previous_event_hash") is not None:
+            errors.append(f"{event_at}.previous_event_hash: first event must use null previous hash")
+        if index > 0 and event.get("previous_event_hash") != previous_hash:
+            errors.append(f"{event_at}.previous_event_hash: must equal previous event hash")
+        event_hash = event.get("event_hash")
+        if isinstance(event_hash, str):
+            if event_hash in seen_hashes:
+                errors.append(f"{event_at}.event_hash: duplicate event hash")
+            seen_hashes.add(event_hash)
+            previous_hash = event_hash
+    return errors
+
+
+def validate_factory_decision_outbox(outbox: dict[str, Any], at: str = "factory_decision_outbox") -> list[str]:
+    errors = _schema_errors("factory-decision-outbox.schema.json", outbox, at)
+    for index, decision in enumerate(outbox.get("pending_decisions") or []):
+        if not isinstance(decision, dict):
+            continue
+        decision_at = f"{at}.pending_decisions[{index}]"
+        if decision.get("status") == "pending" and not decision.get("required_packet_ref"):
+            errors.append(f"{decision_at}.required_packet_ref: pending decisions require a packet")
+        if decision.get("status") == "resolved" and not decision.get("recorded_decision_ref"):
+            errors.append(f"{decision_at}.recorded_decision_ref: resolved decisions require recorded human decision")
+        if decision.get("decision_type") == "human_gate" and decision.get("authority_required") != "human_operator":
+            errors.append(f"{decision_at}.authority_required: human_gate decisions require human_operator authority")
+    return errors
+
+
+def validate_factory_promotion_packet(packet: dict[str, Any], at: str = "factory_promotion_packet") -> list[str]:
+    errors = _schema_errors("factory-promotion-packet.schema.json", packet, at)
+    evidence_refs = set(_refs(packet.get("evidence_refs")))
+    for required_field in ("receipt_five_ref", "completion_audit_ref", "release_readiness_ref"):
+        required_ref = packet.get(required_field)
+        if isinstance(required_ref, str) and required_ref not in evidence_refs:
+            errors.append(f"{at}.evidence_refs: must include {required_field} {required_ref}")
+    if packet.get("promotion_scope") in {"product", "release"} and not packet.get("human_gate_record_ref"):
+        errors.append(f"{at}.human_gate_record_ref: product/release promotion requires human gate record")
+    if packet.get("decision") == "approve" and packet.get("promotion_scope") == "release":
+        for required_field in ("rollback_ref", "monitoring_ref"):
+            value = str(packet.get(required_field) or "")
+            if value.startswith(("todo:", "missing:", "blocked:")):
+                errors.append(f"{at}.{required_field}: release approval cannot use unresolved placeholder")
+    return errors
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _phase_allows_human_decision(phase: dict[str, Any]) -> bool:
+    text = " ".join(str(item) for item in _as_list(phase.get("required_gates")))
+    lowered = text.lower()
+    return "human" in lowered or "approval" in lowered
+
+
+def _phase_allows_promotion(phase: dict[str, Any]) -> bool:
+    text = " ".join(
+        str(item)
+        for item in [phase.get("phase_name")]
+        + _as_list(phase.get("required_gates"))
+        + _as_list(phase.get("allowed_next_actions"))
+        + _as_list(phase.get("completion_detection"))
+    )
+    lowered = text.lower()
+    return any(token in lowered for token in ("promotion", "promote", "release", "completion", "receipt", "done"))
+
+
+def _allowed_commands_for_phase(phase: dict[str, Any]) -> list[str]:
+    commands = ["advance_phase", "repair_required"]
+    if _as_list(phase.get("required_workers")):
+        commands.append("materialize_worker")
+    if _phase_allows_human_decision(phase):
+        commands.append("request_decision")
+    if _phase_allows_promotion(phase):
+        commands.append("promote")
+    phase_name = str(phase.get("phase_name") or "").lower()
+    if "release" in phase_name or "production" in phase_name:
+        commands.append("release")
+    if "learnback" in phase_name or "maturity" in phase_name:
+        commands.append("learnback_candidate")
+    return sorted(set(commands), key=commands.index)
+
+
+def compile_workflow_catalog(
+    catalog: dict[str, Any],
+    *,
+    catalog_ref: str = "docs/factory-workflow.catalog.json",
+    plan_id: str | None = None,
+    compiled_at: str | None = None,
+) -> dict[str, Any]:
+    source_phases = _as_list(catalog.get("phases"))
+    phases: list[dict[str, Any]] = []
+    for index, phase in enumerate(source_phases):
+        if not isinstance(phase, dict):
+            continue
+        next_phase = source_phases[index + 1] if index + 1 < len(source_phases) and isinstance(source_phases[index + 1], dict) else None
+        required_artifacts = [str(item) for item in _as_list(phase.get("required_artifacts"))]
+        required_gates = [str(item) for item in _as_list(phase.get("required_gates"))]
+        required_workers = [str(item) for item in _as_list(phase.get("required_workers"))]
+        phases.append(
+            {
+                "phase_id": str(phase.get("phase_id") or ""),
+                "phase_index": index + 1,
+                "phase_name": str(phase.get("phase_name") or ""),
+                "required_artifacts": required_artifacts,
+                "required_gates": required_gates,
+                "required_workers": required_workers,
+                "allowed_commands": _allowed_commands_for_phase(phase),
+                "blocked_actions": [str(item) for item in _as_list(phase.get("blocked_actions"))],
+                "next_phase_id": str(next_phase.get("phase_id")) if next_phase else None,
+                "auto_pass_allowed": not required_artifacts and not required_gates and not required_workers,
+            }
+        )
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-workflow-compiled-plan.schema.json",
+        "record_type": "factory_workflow_compiled_plan",
+        "plan_id": plan_id or f"{catalog.get('factory_method_version', 'factory')}-{catalog.get('catalog_version', 'v0')}",
+        "compiled_at": compiled_at or utc_now(),
+        "catalog_ref": catalog_ref,
+        "catalog_version": str(catalog.get("catalog_version") or "unknown"),
+        "phase_count": len(phases),
+        "phases": phases,
+        "compiler_guards": {
+            "duplicate_phase_ids_blocked": True,
+            "unknown_next_phase_blocked": True,
+            "human_gate_requires_decision_outbox": True,
+            "worker_materialization_requires_dispatch_readiness": True,
+        },
+    }
+
+
+def validate_factory_workflow_compiled_plan(plan: dict[str, Any], at: str = "factory_workflow_compiled_plan") -> list[str]:
+    errors = _schema_errors("factory-workflow-compiled-plan.schema.json", plan, at)
+    phases = [phase for phase in plan.get("phases", []) if isinstance(phase, dict)]
+    if plan.get("phase_count") != len(phases):
+        errors.append(f"{at}.phase_count: must match phases length")
+    phase_ids = [phase.get("phase_id") for phase in phases]
+    duplicate_phase_ids = sorted({phase_id for phase_id in phase_ids if phase_ids.count(phase_id) > 1})
+    if duplicate_phase_ids:
+        errors.append(f"{at}.phases: duplicate phase ids {', '.join(str(item) for item in duplicate_phase_ids)}")
+    known_phase_ids = {phase_id for phase_id in phase_ids if isinstance(phase_id, str)}
+    for index, phase in enumerate(phases):
+        phase_at = f"{at}.phases[{index}]"
+        expected_index = index + 1
+        if phase.get("phase_index") != expected_index:
+            errors.append(f"{phase_at}.phase_index: expected {expected_index}")
+        next_phase_id = phase.get("next_phase_id")
+        if next_phase_id is not None and next_phase_id not in known_phase_ids:
+            errors.append(f"{phase_at}.next_phase_id: unknown phase {next_phase_id}")
+        if "request_decision" in phase.get("allowed_commands", []) and not any(
+            "human" in str(gate).lower() or "approval" in str(gate).lower()
+            for gate in _as_list(phase.get("required_gates"))
+        ):
+            errors.append(f"{phase_at}.allowed_commands: request_decision requires human/approval gate")
+    return errors
+
+
+def validate_factory_run(run: dict[str, Any], at: str = "factory_run") -> list[str]:
+    errors = _schema_errors("factory-run.schema.json", run, at)
+
+    runtime_target = run.get("runtime_target") if isinstance(run.get("runtime_target"), dict) else {}
+    if runtime_target.get("ambient_runtime_allowed") is not False:
+        errors.append(f"{at}.runtime_target.ambient_runtime_allowed: must be false")
+    if not runtime_target.get("runtime_target_ref"):
+        errors.append(f"{at}.runtime_target.runtime_target_ref: explicit Hermes/Kanban target is required")
+
+    board_binding = run.get("board_binding") if isinstance(run.get("board_binding"), dict) else {}
+    board_policy = board_binding.get("board_policy")
+    board_ref = board_binding.get("board_ref")
+    if board_policy == "factory_must_create_new_board" and board_ref is not None:
+        errors.append(f"{at}.board_binding.board_ref: new-board policy must start without board_ref")
+    if board_policy == "explicit_existing_board" and not board_ref:
+        errors.append(f"{at}.board_binding.board_ref: existing-board policy requires explicit board_ref")
+
+    commands = run.get("command_inbox") if isinstance(run.get("command_inbox"), list) else []
+    for index, command in enumerate(commands):
+        if isinstance(command, dict):
+            errors.extend(validate_factory_command(command, f"{at}.command_inbox[{index}]"))
+        else:
+            errors.append(f"{at}.command_inbox[{index}]: expected object")
+
+    events = run.get("event_log") if isinstance(run.get("event_log"), list) else []
+    if all(isinstance(event, dict) for event in events):
+        errors.extend(validate_factory_event_log(events, f"{at}.event_log"))
+    else:
+        errors.append(f"{at}.event_log: all events must be objects")
+    if isinstance(run.get("state_version"), int) and run["state_version"] < len(events):
+        errors.append(f"{at}.state_version: must be greater than or equal to event log length")
+
+    decision_outbox = run.get("decision_outbox")
+    if isinstance(decision_outbox, dict):
+        errors.extend(validate_factory_decision_outbox(decision_outbox, f"{at}.decision_outbox"))
+    else:
+        errors.append(f"{at}.decision_outbox: expected object")
+
+    for index, packet in enumerate(run.get("promotion_packets") or []):
+        if isinstance(packet, dict):
+            errors.extend(validate_factory_promotion_packet(packet, f"{at}.promotion_packets[{index}]"))
+        else:
+            errors.append(f"{at}.promotion_packets[{index}]: expected object")
+    return errors

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -56,6 +56,17 @@ from factory_operating_systems import (  # noqa: E402
     validate_operating_system_registry_semantics,
     validate_operating_system_scorecard_semantics,
 )
+from factory_v2_kernel import (  # noqa: E402
+    compile_workflow_catalog,
+    load_json_array_or_object,
+    normalize_event_log,
+    validate_factory_command,
+    validate_factory_decision_outbox,
+    validate_factory_event_log,
+    validate_factory_promotion_packet,
+    validate_factory_run,
+    validate_factory_workflow_compiled_plan,
+)
 from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
 
 
@@ -19296,6 +19307,55 @@ def command_validate_reconcile_board(args: argparse.Namespace) -> int:
     return 0
 
 
+def _print_validation_result(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+def command_compile_workflow(args: argparse.Namespace) -> int:
+    plan = compile_workflow_catalog(
+        load_json_like(args.catalog),
+        catalog_ref=args.catalog_ref,
+        plan_id=args.plan_id,
+        compiled_at=args.compiled_at,
+    )
+    errors = validate_factory_workflow_compiled_plan(plan)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+    write_json(args.out, plan)
+    return 1 if errors else 0
+
+
+def command_validate_workflow_compiled_plan(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_factory_workflow_compiled_plan(load_json_like(args.path)))
+
+
+def command_validate_factory_command(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_factory_command(load_json_like(args.path)))
+
+
+def command_validate_factory_event_log(args: argparse.Namespace) -> int:
+    events = normalize_event_log(load_json_array_or_object(args.path))
+    return _print_validation_result(validate_factory_event_log(events))
+
+
+def command_validate_decision_outbox(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_factory_decision_outbox(load_json_like(args.path)))
+
+
+def command_validate_promotion_packet(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_factory_promotion_packet(load_json_like(args.path)))
+
+
+def command_validate_factory_run(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_factory_run(load_json_like(args.path)))
+
+
 def command_validate_receipt(args: argparse.Namespace) -> int:
     errors = validate_receipt(load_json_like(args.path))
     if errors:
@@ -20363,6 +20423,41 @@ def build_parser() -> argparse.ArgumentParser:
     validate_reconcile_board_parser = sub.add_parser("validate-reconcile-board")
     validate_reconcile_board_parser.add_argument("path", type=Path)
     validate_reconcile_board_parser.set_defaults(func=command_validate_reconcile_board)
+
+    compile_workflow_parser = sub.add_parser(
+        "compile-workflow",
+        help="Compile the public factory workflow catalog into a deterministic executable phase plan.",
+    )
+    compile_workflow_parser.add_argument("--catalog", type=Path, default=ROOT / "docs" / "factory-workflow.catalog.json")
+    compile_workflow_parser.add_argument("--catalog-ref", default="docs/factory-workflow.catalog.json")
+    compile_workflow_parser.add_argument("--plan-id")
+    compile_workflow_parser.add_argument("--compiled-at")
+    compile_workflow_parser.add_argument("--out", type=Path, default=ROOT / ".tmp" / "factory-workflow-compiled-plan.json")
+    compile_workflow_parser.set_defaults(func=command_compile_workflow)
+
+    validate_workflow_plan_parser = sub.add_parser("validate-workflow-compiled-plan")
+    validate_workflow_plan_parser.add_argument("path", type=Path)
+    validate_workflow_plan_parser.set_defaults(func=command_validate_workflow_compiled_plan)
+
+    validate_factory_command_parser = sub.add_parser("validate-factory-command")
+    validate_factory_command_parser.add_argument("path", type=Path)
+    validate_factory_command_parser.set_defaults(func=command_validate_factory_command)
+
+    validate_factory_event_log_parser = sub.add_parser("validate-factory-event-log")
+    validate_factory_event_log_parser.add_argument("path", type=Path)
+    validate_factory_event_log_parser.set_defaults(func=command_validate_factory_event_log)
+
+    validate_decision_outbox_parser = sub.add_parser("validate-decision-outbox")
+    validate_decision_outbox_parser.add_argument("path", type=Path)
+    validate_decision_outbox_parser.set_defaults(func=command_validate_decision_outbox)
+
+    validate_promotion_packet_parser = sub.add_parser("validate-promotion-packet")
+    validate_promotion_packet_parser.add_argument("path", type=Path)
+    validate_promotion_packet_parser.set_defaults(func=command_validate_promotion_packet)
+
+    validate_factory_run_parser = sub.add_parser("validate-factory-run")
+    validate_factory_run_parser.add_argument("path", type=Path)
+    validate_factory_run_parser.set_defaults(func=command_validate_factory_run)
 
     validate_receipt_parser = sub.add_parser("validate-receipt")
     validate_receipt_parser.add_argument("path", type=Path)

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -47,7 +47,6 @@ PUBLIC_SCHEMA_DIRS = [
 ]
 SCAN_DIRS = [
     ROOT / "examples",
-    ROOT / ".tmp" / "factory-runs",
     ROOT / "agents",
     ROOT / "templates",
     ROOT / "docs",

--- a/skills/codex/overkill-factory-bridge/SKILL.md
+++ b/skills/codex/overkill-factory-bridge/SKILL.md
@@ -101,6 +101,7 @@ python scripts/factory_bridge.py decision-record \
   --actor product_owner \
   --summary "Release waits for rollback evidence." \
   --evidence-ref external:operator:release-decision \
+  --human-gate-record-ref external:operator:human-gate-record \
   --out .tmp/factory-runs/example/bridge-decision.json
 ```
 
@@ -115,6 +116,8 @@ python scripts/factory_bridge.py handoff \
 ## Authority Rules
 
 - A bridge decision is not a human gate record.
+- `human_gate_response` requires `human_gate_record_ref`; chat text alone does
+  not close or approve a factory gate.
 - A bridge event is not runtime evidence.
 - A status summary is not Receipt Five.
 - A source envelope is not Product SOT.

--- a/skills/codex/overkill-factory/SKILL.md
+++ b/skills/codex/overkill-factory/SKILL.md
@@ -18,11 +18,14 @@ different runtime.
 3. If Hermes runtime state matters, use the `hermes-kanban` skill and inspect
    the real Hermes runtime/board before mutating anything.
 4. Do not promote work from planning to execution without the matching gate.
-5. For external research, check existing local artifacts/source ledgers before
+5. For Factory V2 work, compile or inspect the workflow plan and validate the
+   `FactoryRun`/command/event/decision/promotion contracts before trusting an
+   agent's route choice.
+6. For external research, check existing local artifacts/source ledgers before
    recapturing browser or social content.
-6. Do not put raw study extraction, screenshots, private ledgers, local paths,
+7. Do not put raw study extraction, screenshots, private ledgers, local paths,
    private links or internal product names into the public factory repository.
-7. If the work touches the public GitHub repository, treat GitHub as a product
+8. If the work touches the public GitHub repository, treat GitHub as a product
    surface for an external operator with their own Hermes, not as an archive of
    this workspace.
 
@@ -55,6 +58,18 @@ source intake -> source resolution -> Product SOT -> alignment questions
 ```
 
 ## Required Contracts
+
+For Factory V2, treat these as the control-plane contracts:
+
+- `factory_workflow_compiled_plan`
+- `factory_command`
+- `factory_run_event`
+- `factory_run`
+- `factory_decision_outbox`
+- `factory_promotion_packet`
+
+The agent may create artifacts. The route comes from the compiled workflow,
+phase engine, board reconciler, command reducer and Hermes runtime state.
 
 For Factory 10 / Overkill V3.5 cards, require:
 
@@ -115,6 +130,8 @@ Load only what is needed:
 - `references/open-source-github.md` when assessing or changing the public
   GitHub repository, README, folder architecture, onboarding, examples, CI,
   release hygiene, public safety, or comparisons with other open-source repos.
+- `docs/architecture/factory-v2-control-plane.md` when working on deterministic
+  state, phase jumps, command/event logs, decision outbox or promotion packets.
 - `agents/worker-registry.public.json`, `agents/worker-profiles.public.json`
   and `agents/hermes-profile-bindings.public.json` before changing worker
   profiles or dispatch behavior.
@@ -131,6 +148,8 @@ When inside the `overkill-factory` repository, prefer the repo-level
 ```bash
 python scripts/factoryctl.py gate-report --card path/to/card.md
 python scripts/factoryctl.py worker-packet --worker all --card path/to/card.md --out path/to/output-dir
+python scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+python scripts/factoryctl.py validate-factory-run templates/factory-run.json
 python scripts/validate_worker_profiles.py
 ```
 
@@ -152,6 +171,9 @@ running on the Hermes adapter.
   agent cannot continue the area from the document, the document is not done.
 - Explain which registry or reducer rule selected a gate or worker, and which
   alternatives were rejected by contract.
+- Do not let an agent identity select a phase, worker, gate or promotion path.
+  It must point to workflow, phase-engine, board-reconciler, command, event-log,
+  decision-outbox or promotion-packet evidence.
 - Treat older methodology notes as evidence, not as truth by default.
 - Planning may continue with missing access. Material execution must not start
   until indispensable access/capabilities are ready or explicitly blocked.

--- a/templates/factory-command.json
+++ b/templates/factory-command.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-command.schema.json",
+  "record_type": "factory_command",
+  "command_id": "cmd-001",
+  "run_id": "run-001",
+  "command_type": "start_run",
+  "expected_version": 0,
+  "idempotency_key": "idem-0001",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "source": {
+    "source_type": "operator",
+    "source_ref": "external:operator:telegram"
+  },
+  "authority": {
+    "reducer_must_accept": true,
+    "bridge_may_execute": false,
+    "bridge_may_approve_human_gate": false,
+    "adapter_may_decide_business_rule": false
+  },
+  "payload": {
+    "summary": "Start factory run from sealed source envelope."
+  }
+}

--- a/templates/factory-decision-outbox.json
+++ b/templates/factory-decision-outbox.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-decision-outbox.schema.json",
+  "record_type": "factory_decision_outbox",
+  "outbox_id": "outbox-001",
+  "run_id": "run-001",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "pending_decisions": [
+    {
+      "decision_id": "decision-001",
+      "event_id": "event-019",
+      "decision_type": "human_gate",
+      "authority_required": "human_operator",
+      "required_packet_ref": "artifacts/operator-briefing-package.json",
+      "status": "pending",
+      "bridge_may_resolve": false,
+      "factory_may_auto_approve": false
+    }
+  ],
+  "authority": {
+    "operator_decides": true,
+    "bridge_records_only": true,
+    "reducer_consumes_decision": true
+  }
+}

--- a/templates/factory-promotion-packet.json
+++ b/templates/factory-promotion-packet.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-promotion-packet.schema.json",
+  "record_type": "factory_promotion_packet",
+  "packet_id": "promotion-001",
+  "run_id": "run-001",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "promotion_scope": "phase",
+  "source_state_ref": "artifacts/factory-run.json",
+  "receipt_five_ref": "artifacts/receipt-five.json",
+  "completion_audit_ref": "artifacts/completion-audit.json",
+  "release_readiness_ref": "artifacts/release-readiness.json",
+  "rollback_ref": "artifacts/rollback-plan.json",
+  "monitoring_ref": "artifacts/monitoring-plan.json",
+  "human_gate_record_ref": null,
+  "decision": "block",
+  "evidence_refs": [
+    "artifacts/receipt-five.json",
+    "artifacts/completion-audit.json",
+    "artifacts/release-readiness.json"
+  ],
+  "authority": {
+    "promotion_reducer_required": true,
+    "worker_may_self_promote": false,
+    "bridge_may_promote": false,
+    "release_requires_rollback": true
+  }
+}

--- a/templates/factory-run-event.json
+++ b/templates/factory-run-event.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-run-event.schema.json",
+  "record_type": "factory_run_event",
+  "event_id": "event-001",
+  "run_id": "run-001",
+  "sequence": 1,
+  "event_type": "run_started",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "previous_event_hash": null,
+  "payload": {
+    "summary": "Factory run started from explicit operator signal."
+  },
+  "event_hash": "sha256:def33025eb2e667dec61fb2c48f1585364469ae0e91e1f9f9237b36d1207d617"
+}

--- a/templates/factory-run.json
+++ b/templates/factory-run.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-run.schema.json",
+  "record_type": "factory_run",
+  "run_id": "run-001",
+  "state_version": 1,
+  "status": "planning",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "current_phase_id": "F1",
+  "runtime_target": {
+    "runtime": "hermes_kanban",
+    "runtime_target_ref": "hermes:board:example-product",
+    "ambient_runtime_allowed": false
+  },
+  "board_binding": {
+    "binding_ref": "binding-001",
+    "board_policy": "factory_must_create_new_board",
+    "board_ref": null
+  },
+  "command_inbox": [
+    {
+      "$schema": "https://overkill-factory.dev/schemas/factory-command.schema.json",
+      "record_type": "factory_command",
+      "command_id": "cmd-001",
+      "run_id": "run-001",
+      "command_type": "start_run",
+      "expected_version": 0,
+      "idempotency_key": "idem-0001",
+      "created_at": "2026-06-26T00:00:00+00:00",
+      "source": {
+        "source_type": "operator",
+        "source_ref": "external:operator:telegram"
+      },
+      "authority": {
+        "reducer_must_accept": true,
+        "bridge_may_execute": false,
+        "bridge_may_approve_human_gate": false,
+        "adapter_may_decide_business_rule": false
+      },
+      "payload": {
+        "summary": "Start factory run from sealed source envelope."
+      }
+    }
+  ],
+  "event_log": [
+    {
+      "$schema": "https://overkill-factory.dev/schemas/factory-run-event.schema.json",
+      "record_type": "factory_run_event",
+      "event_id": "event-001",
+      "run_id": "run-001",
+      "sequence": 1,
+      "event_type": "run_started",
+      "created_at": "2026-06-26T00:00:00+00:00",
+      "previous_event_hash": null,
+      "payload": {
+        "summary": "Factory run started from explicit operator signal."
+      },
+      "event_hash": "sha256:def33025eb2e667dec61fb2c48f1585364469ae0e91e1f9f9237b36d1207d617"
+    }
+  ],
+  "decision_outbox": {
+    "$schema": "https://overkill-factory.dev/schemas/factory-decision-outbox.schema.json",
+    "record_type": "factory_decision_outbox",
+    "outbox_id": "outbox-001",
+    "run_id": "run-001",
+    "created_at": "2026-06-26T00:00:00+00:00",
+    "pending_decisions": [],
+    "authority": {
+      "operator_decides": true,
+      "bridge_records_only": true,
+      "reducer_consumes_decision": true
+    }
+  },
+  "promotion_packets": [],
+  "authority": {
+    "state_authority": "factory_event_log",
+    "transition_authority": "transition_reducer",
+    "bridge_may_mutate": false,
+    "adapter_may_decide": false
+  }
+}

--- a/templates/factory-workflow-compiled-plan.json
+++ b/templates/factory-workflow-compiled-plan.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-workflow-compiled-plan.schema.json",
+  "record_type": "factory_workflow_compiled_plan",
+  "plan_id": "OVERKILL_VFINAL-v1-example",
+  "compiled_at": "2026-06-26T00:00:00+00:00",
+  "catalog_ref": "docs/factory-workflow.catalog.json",
+  "catalog_version": "v1",
+  "phase_count": 1,
+  "phases": [
+    {
+      "phase_id": "F1",
+      "phase_index": 1,
+      "phase_name": "Intake",
+      "required_artifacts": [
+        "operator_interface_profile",
+        "factory_start_conversation",
+        "universal_signal_intake",
+        "source_refs",
+        "source_resolution_packet"
+      ],
+      "required_gates": [
+        "Source Gate"
+      ],
+      "required_workers": [
+        "factory-orchestrator"
+      ],
+      "allowed_commands": [
+        "advance_phase",
+        "repair_required",
+        "materialize_worker"
+      ],
+      "blocked_actions": [
+        "route implementation before source resolution",
+        "create Product SOT from raw input",
+        "require the operator to poll for status"
+      ],
+      "next_phase_id": null,
+      "auto_pass_allowed": false
+    }
+  ],
+  "compiler_guards": {
+    "duplicate_phase_ids_blocked": true,
+    "unknown_next_phase_blocked": true,
+    "human_gate_requires_decision_outbox": true,
+    "worker_materialization_requires_dispatch_readiness": true
+  }
+}

--- a/templates/reference-superiority-claim.json
+++ b/templates/reference-superiority-claim.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/reference-superiority-claim.schema.json",
+  "record_type": "reference_superiority_claim",
+  "claim_id": "claim-001",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "reference": {
+    "name": "reference-product-factory",
+    "source_ref": "external:public:reference-repository",
+    "commit_ref": "external:public:reference-commit"
+  },
+  "claim": "Factory V2 blocks phase jumps with a compiled workflow plan and event-log reducer.",
+  "v2_mechanism": {
+    "schema_ref": "schemas/factory-workflow-compiled-plan.schema.json",
+    "reducer_or_validator_ref": "scripts/factory_v2_kernel.py",
+    "runtime_or_test_ref": "tests/test_factory_v2_kernel.py"
+  },
+  "negative_fixture_ref": "fixtures/incidents/phase-jump-blocked-by-earlier-phase.json",
+  "proof_refs": [
+    "tests/test_factory_v2_kernel.py::FactoryV2KernelTests"
+  ],
+  "public_claim_allowed": true
+}

--- a/tests/test_factory_bridge.py
+++ b/tests/test_factory_bridge.py
@@ -199,6 +199,14 @@ class FactoryBridgeTest(unittest.TestCase):
         self.assertEqual(run["target_board_policy"]["existing_board_ref"], "kanban:existing-board")
         self.assertFalse(run["target_board_policy"]["requires_new_hermes_board"])
 
+        with self.assertRaises(ValueError):
+            bridge.build_run_record(
+                run_id="run-gamma",
+                goal="Continue existing factory run.",
+                project_mode="existing_project",
+                existing_board_ref="existing-board",
+            )
+
     def test_source_envelope_and_start_request_cli_emit_bridge_only_artifacts(self) -> None:
         with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
             envelope_path = Path(tmp) / "source-envelope.json"
@@ -274,15 +282,50 @@ class FactoryBridgeTest(unittest.TestCase):
                 actor="product_owner",
                 summary="Release waits for rollback evidence.",
                 evidence_refs=["external:operator:release-decision"],
+                human_gate_record_ref="external:operator:human-gate-record",
             )
             handoff = bridge.build_handoff_packet(run_id="run-alpha", inbox_dir=inbox)
 
             self.assertEqual(decision["record_type"], "factory_bridge_decision")
             self.assertEqual(decision["decision"], "changes_requested")
+            self.assertEqual(decision["human_gate_record_ref"], "external:operator:human-gate-record")
+            self.assertIn("external:operator:human-gate-record", decision["evidence_refs"])
             self.assertFalse(decision["authority"]["closes_factory_gate"])
             self.assertIn("record structured response", handoff["safe_next_actions"])
             self.assertIn("close Hermes card without Receipt Five", handoff["forbidden_actions"])
             self.assertEqual(handoff["pending_operator_events"][0]["event_id"], event["event_id"])
+
+            with self.assertRaises(ValueError):
+                bridge.build_decision_record(
+                    run_id="run-alpha",
+                    event_id=event["event_id"],
+                    decision_type="human_gate_response",
+                    decision="approved",
+                    actor="product_owner",
+                    summary="Approved in chat only.",
+                )
+
+    def test_corrupt_or_missing_inbox_is_reported_in_hook_context(self) -> None:
+        bridge = load_bridge()
+        with tempfile.TemporaryDirectory(dir=ROOT) as tmp:
+            missing_response = bridge.codex_hook_response(
+                {"hook_event_name": "UserPromptSubmit", "prompt": "status da fabrica"},
+                inbox_dir=Path(tmp) / "missing-inbox",
+            )
+            inbox = Path(tmp) / "operator-inbox"
+            inbox.mkdir()
+            (inbox / "pending.jsonl").write_text("{bad json\n", encoding="utf-8")
+            corrupt_response = bridge.codex_hook_response(
+                {"hook_event_name": "UserPromptSubmit", "prompt": "status da fabrica"},
+                inbox_dir=inbox,
+            )
+
+        missing_context = missing_response["hookSpecificOutput"]["additionalContext"]
+        corrupt_context = corrupt_response["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("Inbox health: warning", missing_context)
+        self.assertIn("operator inbox directory does not exist yet", missing_context)
+        self.assertIn("Runtime target: explicit board/run ref required", missing_context)
+        self.assertIn("invalid JSONL record", corrupt_context)
 
     def test_public_skill_and_architecture_document_the_bridge_modes(self) -> None:
         skill = (ROOT / "skills" / "codex" / "overkill-factory-bridge" / "SKILL.md").read_text(encoding="utf-8")

--- a/tests/test_factory_v2_kernel.py
+++ b/tests/test_factory_v2_kernel.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def load_script(name: str) -> Any:
+    path = SCRIPT_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+kernel = load_script("factory_v2_kernel")
+factoryctl = load_script("factoryctl")
+
+
+def hashed_event(**overrides: Any) -> dict[str, Any]:
+    event = {
+        "$schema": "https://overkill-factory.dev/schemas/factory-run-event.schema.json",
+        "record_type": "factory_run_event",
+        "event_id": "event-001",
+        "run_id": "run-001",
+        "sequence": 1,
+        "event_type": "run_started",
+        "created_at": "2026-06-26T00:00:00+00:00",
+        "previous_event_hash": None,
+        "payload": {"summary": "Factory run started from explicit operator signal."},
+    }
+    event.update(overrides)
+    event["event_hash"] = kernel.factory_event_hash(event)
+    return event
+
+
+def valid_command(command_type: str = "start_run", **payload: Any) -> dict[str, Any]:
+    merged_payload = {"summary": "Start factory run from sealed source envelope."}
+    merged_payload.update(payload)
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-command.schema.json",
+        "record_type": "factory_command",
+        "command_id": "cmd-001",
+        "run_id": "run-001",
+        "command_type": command_type,
+        "expected_version": 0,
+        "idempotency_key": "idem-0001",
+        "created_at": "2026-06-26T00:00:00+00:00",
+        "source": {"source_type": "operator", "source_ref": "external:operator:telegram"},
+        "authority": {
+            "reducer_must_accept": True,
+            "bridge_may_execute": False,
+            "bridge_may_approve_human_gate": False,
+            "adapter_may_decide_business_rule": False,
+        },
+        "payload": merged_payload,
+    }
+
+
+def valid_decision_outbox() -> dict[str, Any]:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-decision-outbox.schema.json",
+        "record_type": "factory_decision_outbox",
+        "outbox_id": "outbox-001",
+        "run_id": "run-001",
+        "created_at": "2026-06-26T00:00:00+00:00",
+        "pending_decisions": [],
+        "authority": {
+            "operator_decides": True,
+            "bridge_records_only": True,
+            "reducer_consumes_decision": True,
+        },
+    }
+
+
+def valid_factory_run() -> dict[str, Any]:
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/factory-run.schema.json",
+        "record_type": "factory_run",
+        "run_id": "run-001",
+        "state_version": 1,
+        "status": "planning",
+        "created_at": "2026-06-26T00:00:00+00:00",
+        "current_phase_id": "F1",
+        "runtime_target": {
+            "runtime": "hermes_kanban",
+            "runtime_target_ref": "hermes:board:example-product",
+            "ambient_runtime_allowed": False,
+        },
+        "board_binding": {
+            "binding_ref": "binding-001",
+            "board_policy": "factory_must_create_new_board",
+            "board_ref": None,
+        },
+        "command_inbox": [valid_command()],
+        "event_log": [hashed_event()],
+        "decision_outbox": valid_decision_outbox(),
+        "promotion_packets": [],
+        "authority": {
+            "state_authority": "factory_event_log",
+            "transition_authority": "transition_reducer",
+            "bridge_may_mutate": False,
+            "adapter_may_decide": False,
+        },
+    }
+
+
+class FactoryV2KernelTests(unittest.TestCase):
+    def test_workflow_compiler_keeps_early_phases_out_of_human_decision_outbox(self) -> None:
+        catalog = json.loads((ROOT / "docs" / "factory-workflow.catalog.json").read_text(encoding="utf-8"))
+
+        plan = kernel.compile_workflow_catalog(catalog, compiled_at="2026-06-26T00:00:00+00:00")
+
+        self.assertEqual(kernel.validate_factory_workflow_compiled_plan(plan), [])
+        phase_commands = {phase["phase_id"]: set(phase["allowed_commands"]) for phase in plan["phases"]}
+        for phase_id in ("F1", "F2", "F3", "F4", "F5"):
+            self.assertNotIn("request_decision", phase_commands[phase_id])
+        self.assertIn("request_decision", phase_commands["F9"])
+        self.assertIn("request_decision", phase_commands["F19"])
+
+    def test_event_log_hash_chain_rejects_broken_previous_hash(self) -> None:
+        first = hashed_event()
+        second = hashed_event(
+            event_id="event-002",
+            sequence=2,
+            event_type="phase_advanced",
+            previous_event_hash="sha256:" + ("0" * 64),
+            payload={"summary": "Advanced to source ledger.", "phase_id": "F2"},
+        )
+
+        errors = kernel.validate_factory_event_log([first, second])
+
+        self.assertTrue(any("previous_event_hash" in error for error in errors), errors)
+
+    def test_request_decision_command_requires_delivered_packet(self) -> None:
+        command = valid_command("request_decision", phase_id="F19", decision_id="decision-001")
+
+        errors = kernel.validate_factory_command(command)
+
+        self.assertTrue(any("artifact_refs" in error for error in errors), errors)
+
+    def test_factory_run_requires_explicit_non_ambient_hermes_target(self) -> None:
+        run = valid_factory_run()
+        run["runtime_target"]["ambient_runtime_allowed"] = True
+
+        errors = kernel.validate_factory_run(run)
+
+        self.assertTrue(any("ambient_runtime_allowed" in error for error in errors), errors)
+
+    def test_valid_factory_run_contract_passes(self) -> None:
+        self.assertEqual(kernel.validate_factory_run(valid_factory_run()), [])
+
+    def test_factoryctl_v2_commands_validate_generated_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "compiled-plan.json"
+            self.assertEqual(
+                factoryctl.main_with_args_for_test(
+                    [
+                        "compile-workflow",
+                        "--compiled-at",
+                        "2026-06-26T00:00:00+00:00",
+                        "--out",
+                        str(out),
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(factoryctl.main_with_args_for_test(["validate-workflow-compiled-plan", str(out)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,7 +58,9 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v1.5.16", readme)
+        self.assertIn("v2.0.0", readme)
+        self.assertIn("Factory V2", readme)
+        self.assertIn("docs/architecture/factory-v2-control-plane.md", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
@@ -83,6 +85,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "docs/operations/validation-and-release.md",
             "docs/operations/release-policy.md",
             "docs/architecture/factory-operating-systems.md",
+            "docs/architecture/factory-v2-control-plane.md",
             "docs/architecture/hermes-integration.md",
             "docs/getting-started/install-in-hermes.md",
             "docs/reference/cli.md",
@@ -140,7 +143,9 @@ class OpenSourceDocsTest(unittest.TestCase):
             "não um atalho de MVP",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v1.5.16",
+            "v2.0.0",
+            "Factory V2",
+            "docs/architecture/factory-v2-control-plane.md",
             "codex plugin marketplace add .",
             "codex plugin add overkill-factory-bridge@overkill-factory",
             "docs/operations/promise-to-implementation.md",


### PR DESCRIPTION
## Summary
- Implements the Factory V2 deterministic control plane: compiled workflow plan, factory command, hash-chained run events, FactoryRun, decision outbox, promotion packet and reference-superiority claim contracts.
- Adds `scripts/factory_v2_kernel.py` plus `factoryctl` compile/validate commands for V2 contracts.
- Hardens the operator bridge and plugin: explicit runtime target for status/question/decision/change/handoff, visible inbox health, explicit existing board refs, and `human_gate_record_ref` for human gate responses.
- Updates README/PT-BR, CLI docs, V2 architecture doc, promise map, public surface manifest, Codex skills, plugin package and changelog for v2.0.0.

Closes #445.

## Validation
- `python -m py_compile scripts\factory_v2_kernel.py scripts\factoryctl.py scripts\factory_bridge.py plugins\overkill-factory-bridge\scripts\factory_bridge.py`
- `python scripts\validate_public_json_artifacts.py`
- `python scripts\validate_promise_implementation_map.py`
- `python scripts\validate_public_surface_sync.py`
- `python scripts\validate_document_governance.py`
- `python scripts\validate_worker_profiles.py`
- `python scripts\validate_planning_bundles.py`
- `python scripts\public_safety_scan.py`
- `python scripts\secret_safety_scan.py`
- `python -m unittest discover -s tests -p "test_*.py" -q` (1010 tests)
- `python scripts\factoryctl.py doctor`
- `python scripts\factoryctl.py run minimal --out .tmp\v2-quickstart-result.json --packets-out .tmp\v2-minimal-worker-packets`
- `python scripts\supply_chain_proof.py --check --no-write`

## Boundaries
- This is public kernel/control-plane proof, not a claim that any private product runtime is production-ready.
- Hermes Kanban, worker results, Receipt Five and real human gate records remain runtime authority.
- The VM/private runtime was not mutated in this PR.