### PR TITLE
Add V2 doc implementation overclaim gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,8 @@ implementation, proof and boundary.
 - `docs/getting-started/install-in-hermes.md`: connect to an operator-owned Hermes runtime.
 - `docs/reference/cli.md`: supported `factoryctl` commands.
 - `docs/architecture/factory-v2-control-plane.md`: deterministic control plane.
-- `templates/v2-study-traceability.json`: proof that raw V2 study claims were implemented.
+- `templates/v2-study-traceability.json`: raw V2 claim ledger with bounded truth levels, evidence refs and known gaps.
+- `templates/v2-doc-implementation-obligations.json`: obligations that prevent documented V2 work from being mistaken for implemented code.
 - `templates/factory-v2-readiness-claim.json`: scoped readiness claim contract.
 - `docs/operations/promise-to-implementation.md`: public promise-to-proof audit.
 
@@ -316,6 +317,8 @@ python scripts/validate_public_json_artifacts.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_promise_implementation_map.py
 python scripts/validate_planning_bundles.py
+python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
+python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/public_safety_scan.py
 python scripts/secret_safety_scan.py
 python scripts/validate_public_surface_sync.py --check-published

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -305,7 +305,8 @@ apontar sua implementação, prova e limite.
 - `docs/getting-started/install-in-hermes.md`: conectar a um runtime Hermes do operador.
 - `docs/reference/cli.md`: comandos suportados do `factoryctl`.
 - `docs/architecture/factory-v2-control-plane.md`: control plane determinístico.
-- `templates/v2-study-traceability.json`: prova de que os estudos brutos da V2 foram implementados.
+- `templates/v2-study-traceability.json`: ledger dos claims brutos da V2 com nível de verdade, evidência e lacunas conhecidas.
+- `templates/v2-doc-implementation-obligations.json`: obrigações que impedem trabalho documentado de ser confundido com código implementado.
 - `templates/factory-v2-readiness-claim.json`: contrato de readiness com escopo explícito.
 - `docs/operations/promise-to-implementation.md`: auditoria pública promessa-prova.
 
@@ -319,6 +320,8 @@ python scripts/validate_public_json_artifacts.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_promise_implementation_map.py
 python scripts/validate_planning_bundles.py
+python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
+python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/public_safety_scan.py
 python scripts/secret_safety_scan.py
 python scripts/validate_public_surface_sync.py --check-published

--- a/docs/architecture/factory-v2-control-plane.md
+++ b/docs/architecture/factory-v2-control-plane.md
@@ -26,7 +26,8 @@ outbox, and promotion needs a packet with evidence.
 | Decision outbox | Human decisions that the factory needs but cannot auto-resolve. | `schemas/factory-decision-outbox.schema.json`, `templates/factory-decision-outbox.json`, `factoryctl validate-decision-outbox` |
 | Promotion packet | Evidence required before phase, product or release promotion. | `schemas/factory-promotion-packet.schema.json`, `templates/factory-promotion-packet.json`, `factoryctl validate-promotion-packet` |
 | Phase graph | Canonical V2 taxonomy: product phases stay linear; human gates and operator projections are events/views, not phases. | `schemas/factory-phase-graph.schema.json`, `templates/factory-phase-graph.json`, `factoryctl validate-phase-graph` |
-| V2 study traceability | No-simplification ledger that binds raw V2 study claims to schemas, runtime commands, tests and negative fixtures. | `schemas/v2-study-traceability.schema.json`, `templates/v2-study-traceability.json`, `factoryctl validate-v2-study-traceability` |
+| V2 study traceability | No-simplification ledger that binds raw V2 study claims to bounded truth levels, evidence refs, claim boundaries, known gaps and next actions. | `schemas/v2-study-traceability.schema.json`, `templates/v2-study-traceability.json`, `factoryctl validate-v2-study-traceability` |
+| V2 doc implementation obligations | Fails validation when documented V2 obligations are overclaimed as implemented without matching public artifacts, tests and fixture proof. | `schemas/v2-doc-implementation-obligations.schema.json`, `templates/v2-doc-implementation-obligations.json`, `factoryctl validate-v2-doc-implementation-obligations` |
 | Worker authority contract | Makes worker profiles operational only; route, gate, waiver and promotion authority stay in reducers and registries. | `schemas/worker-authority-contract.schema.json`, `templates/worker-authority-contract.json`, `factoryctl validate-worker-authority-contract` |
 | Product Experience control plane | Governs design, brand, frontend, operator UX and Product Face as first-class product surfaces. | `schemas/product-experience-control-plane.schema.json`, `templates/product-experience-control-plane.json`, `factoryctl validate-product-experience-control-plane` |
 | Capability acquisition contract | Requires reference search, template match, create/install attempt and smoke/eval before missing capability can block. | `schemas/capability-acquisition-contract.schema.json`, `templates/capability-acquisition-contract.json`, `factoryctl validate-capability-acquisition-contract` |
@@ -68,6 +69,7 @@ factoryctl validate-promotion-packet templates/factory-promotion-packet.json
 factoryctl validate-factory-run templates/factory-run.json
 factoryctl validate-phase-graph templates/factory-phase-graph.json
 factoryctl validate-v2-study-traceability templates/v2-study-traceability.json
+factoryctl validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 factoryctl validate-worker-authority-contract templates/worker-authority-contract.json
 factoryctl validate-product-experience-control-plane templates/product-experience-control-plane.json
 factoryctl validate-capability-acquisition-contract templates/capability-acquisition-contract.json

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,6 +50,7 @@ factoryctl validate-promotion-packet templates/factory-promotion-packet.json
 factoryctl validate-factory-run templates/factory-run.json
 factoryctl validate-phase-graph templates/factory-phase-graph.json
 factoryctl validate-v2-study-traceability templates/v2-study-traceability.json
+factoryctl validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 factoryctl validate-worker-authority-contract templates/worker-authority-contract.json
 factoryctl validate-product-experience-control-plane templates/product-experience-control-plane.json
 factoryctl validate-capability-acquisition-contract templates/capability-acquisition-contract.json
@@ -80,9 +81,15 @@ the main line, while human gates and operator projections are events or views,
 not route phases. Legacy labels such as F8A, F14 and F19 must resolve through
 explicit aliases instead of becoming new product stages.
 
-`validate-v2-study-traceability` is the no-simplification guard. Every P0 claim
-from the raw V2 studies must point to implementation, schemas, runtime commands,
-tests and negative fixtures before the factory can claim the study was applied.
+`validate-v2-study-traceability` is the no-simplification guard. Every raw V2
+claim must declare a bounded truth level, claim boundary, known gaps, next
+action, evidence refs and negative fixtures before the factory can make a public
+claim about it. The old broad status `implemented` is invalid on purpose.
+
+`validate-v2-doc-implementation-obligations` is the overclaim guard. It lists
+documented V2 obligations that still need code, tests, runtime proof or
+production evidence, and fails validation if an obligation claims a stronger
+truth level than its public artifacts support.
 
 `validate-worker-authority-contract` keeps workers as operators, not routers.
 Profiles may produce artifacts, but phase selection, specialist selection, gate

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -43,7 +43,11 @@ schemas are:
 
 - `factory-phase-graph.schema.json`: canonical product phases plus non-product
   event/view aliases.
-- `v2-study-traceability.schema.json`: raw-study claim to implementation proof.
+- `v2-study-traceability.schema.json`: raw-study claim to bounded truth level,
+  evidence, known gaps and next action.
+- `v2-doc-implementation-obligations.schema.json`: doc-vs-code parity ledger
+  that prevents documented V2 obligations from being overclaimed as
+  implemented.
 - `worker-authority-contract.schema.json`: worker profiles cannot own route,
   gate, waiver or promotion decisions.
 - `product-experience-control-plane.schema.json`: design, brand, frontend,
@@ -67,6 +71,7 @@ Run schema and public artifact checks:
 
 ```bash
 python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
+python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/factoryctl.py validate-worker-authority-contract templates/worker-authority-contract.json
 python scripts/factoryctl.py validate-product-experience-control-plane templates/product-experience-control-plane.json
 python scripts/validate_public_json_artifacts.py

--- a/schemas/v2-doc-implementation-obligations.schema.json
+++ b/schemas/v2-doc-implementation-obligations.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/v2-doc-implementation-obligations.schema.json",
+  "title": "Overkill Factory V2 Doc Implementation Obligations",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "obligation_set_id",
+    "created_at",
+    "factory_method_version",
+    "source_traceability_ref",
+    "truth_levels",
+    "obligations",
+    "closure_policy"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/v2-doc-implementation-obligations.schema.json"
+    },
+    "record_type": {
+      "const": "v2_doc_implementation_obligations"
+    },
+    "obligation_set_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
+    "source_traceability_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "truth_levels": {
+      "type": "array",
+      "minItems": 9,
+      "items": {
+        "enum": [
+          "missing",
+          "doc_only",
+          "contract_only",
+          "kernel_implemented",
+          "runtime_integrated",
+          "runtime_proven",
+          "production_proven",
+          "blocked_pending_runtime_proof",
+          "deferred_with_reason"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "obligations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "obligation_id",
+          "priority",
+          "source_docs",
+          "obligation",
+          "required_artifact_refs",
+          "implemented_artifact_refs",
+          "validation_refs",
+          "negative_fixture_refs",
+          "minimum_truth_level_required",
+          "current_truth_level",
+          "gap_summary",
+          "next_action",
+          "blocks_claim_ids",
+          "public_claims_blocked"
+        ],
+        "properties": {
+          "obligation_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "priority": {
+            "enum": ["P0", "P1", "P2"]
+          },
+          "source_docs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "obligation": {
+            "type": "string",
+            "minLength": 20
+          },
+          "required_artifact_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "implemented_artifact_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "validation_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "negative_fixture_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "minimum_truth_level_required": {
+            "enum": [
+              "missing",
+              "doc_only",
+              "contract_only",
+              "kernel_implemented",
+              "runtime_integrated",
+              "runtime_proven",
+              "production_proven",
+              "blocked_pending_runtime_proof",
+              "deferred_with_reason"
+            ]
+          },
+          "current_truth_level": {
+            "enum": [
+              "missing",
+              "doc_only",
+              "contract_only",
+              "kernel_implemented",
+              "runtime_integrated",
+              "runtime_proven",
+              "production_proven",
+              "blocked_pending_runtime_proof",
+              "deferred_with_reason"
+            ]
+          },
+          "gap_summary": {
+            "type": "string",
+            "minLength": 20
+          },
+          "next_action": {
+            "type": "string",
+            "minLength": 10
+          },
+          "blocks_claim_ids": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "public_claims_blocked": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "closure_policy": {
+      "type": "object",
+      "required": [
+        "implemented_status_forbidden",
+        "overclaim_fails_validation",
+        "partial_obligation_requires_gap_and_next_action",
+        "current_truth_level_must_have_matching_public_evidence"
+      ],
+      "properties": {
+        "implemented_status_forbidden": { "const": true },
+        "overclaim_fails_validation": { "const": true },
+        "partial_obligation_requires_gap_and_next_action": { "const": true },
+        "current_truth_level_must_have_matching_public_evidence": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/v2-study-traceability.schema.json
+++ b/schemas/v2-study-traceability.schema.json
@@ -33,22 +33,44 @@
           "priority",
           "source_doc",
           "claim",
+          "claim_boundary",
           "schema_refs",
           "runtime_refs",
           "test_refs",
           "negative_fixture_refs",
-          "status"
+          "status",
+          "known_gaps",
+          "next_action"
         ],
         "properties": {
           "claim_id": { "type": "string", "minLength": 3 },
           "priority": { "enum": ["P0", "P1", "P2"] },
           "source_doc": { "type": "string", "minLength": 3 },
           "claim": { "type": "string", "minLength": 20 },
-          "schema_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
-          "runtime_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
-          "test_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
-          "negative_fixture_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
-          "status": { "enum": ["implemented", "blocked_pending_runtime_proof", "deferred_with_reason"] }
+          "claim_boundary": { "type": "string", "minLength": 20 },
+          "schema_refs": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "runtime_refs": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "test_refs": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "negative_fixture_refs": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "status": {
+            "enum": [
+              "missing",
+              "doc_only",
+              "contract_only",
+              "kernel_implemented",
+              "runtime_integrated",
+              "runtime_proven",
+              "production_proven",
+              "blocked_pending_runtime_proof",
+              "deferred_with_reason"
+            ]
+          },
+          "known_gaps": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 10 },
+            "uniqueItems": true
+          },
+          "next_action": { "type": "string", "minLength": 10 }
         },
         "additionalProperties": false
       }
@@ -56,16 +78,18 @@
     "closure_policy": {
       "type": "object",
       "required": [
-        "p0_doc_only_forbidden",
-        "p0_contract_only_forbidden",
-        "runtime_or_test_required_for_every_p0",
-        "negative_fixture_required_for_every_p0"
+        "implemented_status_forbidden",
+        "partial_status_requires_known_gaps",
+        "truth_level_must_match_evidence",
+        "runtime_or_production_claim_requires_runtime_proof",
+        "negative_fixture_required_for_kernel_or_stronger_p0"
       ],
       "properties": {
-        "p0_doc_only_forbidden": { "const": true },
-        "p0_contract_only_forbidden": { "const": true },
-        "runtime_or_test_required_for_every_p0": { "const": true },
-        "negative_fixture_required_for_every_p0": { "const": true }
+        "implemented_status_forbidden": { "const": true },
+        "partial_status_requires_known_gaps": { "const": true },
+        "truth_level_must_match_evidence": { "const": true },
+        "runtime_or_production_claim_requires_runtime_proof": { "const": true },
+        "negative_fixture_required_for_kernel_or_stronger_p0": { "const": true }
       },
       "additionalProperties": false
     }

--- a/scripts/factory_operating_systems.py
+++ b/scripts/factory_operating_systems.py
@@ -109,6 +109,7 @@ FACTORYCTL_COMMANDS = {
     "validate-operating-systems",
     "validate-phase-graph",
     "validate-product-experience-control-plane",
+    "validate-v2-doc-implementation-obligations",
     "validate-v2-study-traceability",
     "validate-worker-authority-contract",
     "validate-promotion-packet",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -19405,6 +19405,53 @@ def _traceability_ref_path(ref: str) -> Path | None:
     return ROOT / path
 
 
+V2_TRUTH_LEVEL_RANK = {
+    "missing": 0,
+    "doc_only": 1,
+    "contract_only": 2,
+    "kernel_implemented": 3,
+    "runtime_integrated": 4,
+    "runtime_proven": 5,
+    "production_proven": 6,
+    "blocked_pending_runtime_proof": 2,
+    "deferred_with_reason": 1,
+}
+
+V2_PARTIAL_TRUTH_LEVELS = {
+    "missing",
+    "doc_only",
+    "contract_only",
+    "kernel_implemented",
+    "runtime_integrated",
+    "blocked_pending_runtime_proof",
+    "deferred_with_reason",
+}
+
+
+def _v2_truth_rank(status: str) -> int:
+    return V2_TRUTH_LEVEL_RANK.get(status, -1)
+
+
+def _ref_field_paths_exist(refs: list[Any], *, claim_id: str, field: str, errors: list[str]) -> None:
+    for ref in refs:
+        path = _traceability_ref_path(str(ref))
+        if path is not None and not path.exists():
+            errors.append(f"{claim_id}: {field} missing referenced path {ref}")
+
+
+def _has_runtime_integration_ref(refs: list[Any]) -> bool:
+    for ref in refs:
+        text = str(ref)
+        if text.startswith(("adapters/", "scripts/", "tests/")) or "hermes" in text.lower() or "runtime" in text.lower():
+            return True
+    return False
+
+
+def _has_runtime_proof_ref(refs: list[Any]) -> bool:
+    proof_markers = ("hermes", "runtime", "worker-result", "receipt", "evidence", "replay")
+    return any(any(marker in str(ref).lower() for marker in proof_markers) for ref in refs)
+
+
 def validate_v2_study_traceability(packet: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -19428,23 +19475,130 @@ def validate_v2_study_traceability(packet: dict[str, Any]) -> list[str]:
 
         priority = str(claim.get("priority") or "")
         status = str(claim.get("status") or "")
-        if priority == "P0" and status != "implemented":
-            errors.append(f"{claim_id}: P0 study finding must be implemented, got {status or 'missing'}")
+        known_gaps = _list_items(claim.get("known_gaps"))
+        next_action = str(claim.get("next_action") or "").strip()
+        if status == "implemented":
+            errors.append(f"{claim_id}: status 'implemented' is forbidden; use explicit V2 truth levels")
+        if status in V2_PARTIAL_TRUTH_LEVELS and not known_gaps:
+            errors.append(f"{claim_id}: partial truth level {status} requires known_gaps")
+        if status in V2_PARTIAL_TRUTH_LEVELS and not next_action:
+            errors.append(f"{claim_id}: partial truth level {status} requires next_action")
 
         for field in ("schema_refs", "runtime_refs", "test_refs", "negative_fixture_refs"):
             refs = _list_items(claim.get(field))
-            if priority == "P0" and not refs:
-                errors.append(f"{claim_id}: P0 requires {field}")
-            for ref in refs:
-                path = _traceability_ref_path(str(ref))
-                if path is not None and not path.exists():
-                    errors.append(f"{claim_id}: {field} missing referenced path {ref}")
+            _ref_field_paths_exist(refs, claim_id=claim_id, field=field, errors=errors)
+
+        schema_refs = _list_items(claim.get("schema_refs"))
+        runtime_refs = _list_items(claim.get("runtime_refs"))
+        test_refs = _list_items(claim.get("test_refs"))
+        negative_refs = _list_items(claim.get("negative_fixture_refs"))
+        rank = _v2_truth_rank(status)
+        if priority == "P0" and rank >= _v2_truth_rank("contract_only") and not schema_refs:
+            errors.append(f"{claim_id}: {status} P0 claim requires schema_refs")
+        if priority == "P0" and rank >= _v2_truth_rank("kernel_implemented"):
+            if not test_refs:
+                errors.append(f"{claim_id}: {status} P0 claim requires test_refs")
+            if not negative_refs:
+                errors.append(f"{claim_id}: {status} P0 claim requires negative_fixture_refs")
+        if priority == "P0" and rank >= _v2_truth_rank("runtime_integrated") and not runtime_refs:
+            errors.append(f"{claim_id}: {status} P0 claim requires runtime_refs")
+        if priority == "P0" and rank >= _v2_truth_rank("runtime_proven") and not _has_runtime_proof_ref(runtime_refs + test_refs):
+            errors.append(f"{claim_id}: {status} requires runtime proof refs")
+        if priority == "P0" and rank >= _v2_truth_rank("production_proven"):
+            if not any("release" in str(ref).lower() or "production" in str(ref).lower() for ref in runtime_refs + test_refs):
+                errors.append(f"{claim_id}: production_proven requires production or release proof refs")
 
     return errors
 
 
 def command_validate_v2_study_traceability(args: argparse.Namespace) -> int:
     return _print_validation_result(validate_v2_study_traceability(load_json_like(args.path)))
+
+
+def validate_v2_doc_implementation_obligations(
+    packet: dict[str, Any],
+    traceability_packet: dict[str, Any] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("v2-doc-implementation-obligations.schema.json")
+    if not isinstance(schema, dict):
+        return ["v2-doc-implementation-obligations schema is not bundled"]
+    errors.extend(validate_node(schema, packet, "v2_doc_implementation_obligations", schemas=schemas, root_schema=schema))
+
+    truth_levels = set(_list_items(packet.get("truth_levels")))
+    if "implemented" in truth_levels:
+        errors.append("truth_levels must not include broad 'implemented'")
+    missing_truth_levels = sorted(set(V2_TRUTH_LEVEL_RANK) - truth_levels)
+    if missing_truth_levels:
+        errors.append("truth_levels missing: " + ", ".join(missing_truth_levels))
+
+    claim_statuses: dict[str, str] = {}
+    if isinstance(traceability_packet, dict):
+        for claim in traceability_packet.get("claims", []):
+            if isinstance(claim, dict):
+                claim_statuses[str(claim.get("claim_id") or "")] = str(claim.get("status") or "")
+
+    obligation_ids: set[str] = set()
+    for index, obligation in enumerate(packet.get("obligations", []), start=1):
+        if not isinstance(obligation, dict):
+            continue
+        obligation_id = str(obligation.get("obligation_id") or f"obligation-{index}")
+        if obligation_id in obligation_ids:
+            errors.append(f"obligations[{index}].obligation_id duplicates {obligation_id}")
+        obligation_ids.add(obligation_id)
+
+        current = str(obligation.get("current_truth_level") or "")
+        minimum = str(obligation.get("minimum_truth_level_required") or "")
+        if current == "implemented" or minimum == "implemented":
+            errors.append(f"{obligation_id}: broad truth level 'implemented' is forbidden")
+        current_rank = _v2_truth_rank(current)
+        minimum_rank = _v2_truth_rank(minimum)
+        gap_summary = str(obligation.get("gap_summary") or "").strip()
+        next_action = str(obligation.get("next_action") or "").strip()
+        if current_rank < minimum_rank and (not gap_summary or not next_action):
+            errors.append(f"{obligation_id}: below minimum truth level requires gap_summary and next_action")
+
+        implemented_refs = _list_items(obligation.get("implemented_artifact_refs"))
+        validation_refs = _list_items(obligation.get("validation_refs"))
+        negative_refs = _list_items(obligation.get("negative_fixture_refs"))
+        if current == "missing" and (implemented_refs or validation_refs or negative_refs):
+            errors.append(f"{obligation_id}: missing obligation must not list implemented, validation or negative refs")
+        if current_rank >= _v2_truth_rank("contract_only") and not implemented_refs:
+            errors.append(f"{obligation_id}: {current} requires implemented_artifact_refs")
+        if current_rank >= _v2_truth_rank("kernel_implemented"):
+            if not validation_refs:
+                errors.append(f"{obligation_id}: {current} requires validation_refs")
+            if not negative_refs:
+                errors.append(f"{obligation_id}: {current} requires negative_fixture_refs")
+        if current_rank >= _v2_truth_rank("runtime_integrated") and not _has_runtime_integration_ref(implemented_refs + validation_refs):
+            errors.append(f"{obligation_id}: {current} requires runtime integration proof refs")
+        if current_rank >= _v2_truth_rank("production_proven") and not any(
+            "release" in str(ref).lower() or "production" in str(ref).lower()
+            for ref in implemented_refs + validation_refs
+        ):
+            errors.append(f"{obligation_id}: production_proven requires production or release proof refs")
+
+        for field in ("implemented_artifact_refs", "validation_refs", "negative_fixture_refs"):
+            _ref_field_paths_exist(_list_items(obligation.get(field)), claim_id=obligation_id, field=field, errors=errors)
+
+        if claim_statuses and current_rank < minimum_rank:
+            for claim_id in _list_items(obligation.get("blocks_claim_ids")):
+                claim_status = claim_statuses.get(claim_id)
+                if claim_status and _v2_truth_rank(claim_status) >= minimum_rank:
+                    errors.append(
+                        f"{obligation_id}: blocks {claim_id}, but traceability status {claim_status} "
+                        f"meets/exceeds required {minimum}"
+                    )
+
+    return errors
+
+
+def command_validate_v2_doc_implementation_obligations(args: argparse.Namespace) -> int:
+    traceability_packet = load_json_like(args.traceability) if args.traceability else None
+    return _print_validation_result(
+        validate_v2_doc_implementation_obligations(load_json_like(args.path), traceability_packet)
+    )
 
 
 READINESS_REQUIRED_EVIDENCE = {
@@ -20681,6 +20835,11 @@ def build_parser() -> argparse.ArgumentParser:
     validate_traceability_parser = sub.add_parser("validate-v2-study-traceability")
     validate_traceability_parser.add_argument("path", type=Path)
     validate_traceability_parser.set_defaults(func=command_validate_v2_study_traceability)
+
+    validate_doc_obligations_parser = sub.add_parser("validate-v2-doc-implementation-obligations")
+    validate_doc_obligations_parser.add_argument("path", type=Path)
+    validate_doc_obligations_parser.add_argument("--traceability", type=Path)
+    validate_doc_obligations_parser.set_defaults(func=command_validate_v2_doc_implementation_obligations)
 
     validate_readiness_claim_parser = sub.add_parser("validate-readiness-claim")
     validate_readiness_claim_parser.add_argument("path", type=Path)

--- a/scripts/secret_safety_scan.py
+++ b/scripts/secret_safety_scan.py
@@ -19,7 +19,8 @@ from typing import Iterator
 
 ROOT = Path(__file__).resolve().parents[1]
 SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico", ".pdf", ".tgz", ".zip"}
-SKIP_PARTS = {".git", "__pycache__"}
+SKIP_PARTS = {".git", ".tmp", ".pytest_cache", ".venv", "__pycache__", "build", "dist", "node_modules", "site", "venv"}
+SKIP_PART_SUFFIXES = (".egg-info",)
 
 SECRET_PATTERNS = [
     re.compile(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----"),
@@ -59,7 +60,9 @@ def entropy(value: str) -> float:
 def should_scan(path: Path) -> bool:
     if path.suffix.lower() in SKIP_SUFFIXES:
         return False
-    return not any(part in SKIP_PARTS for part in path.parts)
+    if any(part in SKIP_PARTS for part in path.parts):
+        return False
+    return not any(part.endswith(SKIP_PART_SUFFIXES) for part in path.parts)
 
 
 def allowed_fixture_line(line: str) -> bool:
@@ -80,6 +83,8 @@ def iter_scan_paths(root: Path) -> Iterator[Path]:
     for entry in entries:
         try:
             if any(part in SKIP_PARTS for part in entry.parts):
+                continue
+            if any(part.endswith(SKIP_PART_SUFFIXES) for part in entry.parts):
                 continue
             if entry.is_dir():
                 yield from iter_scan_paths(entry)

--- a/skills/codex/overkill-factory/SKILL.md
+++ b/skills/codex/overkill-factory/SKILL.md
@@ -157,6 +157,7 @@ python scripts/factoryctl.py worker-packet --worker all --card path/to/card.md -
 python scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 python scripts/factoryctl.py validate-factory-run templates/factory-run.json
 python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
+python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/factoryctl.py validate-worker-authority-contract templates/worker-authority-contract.json
 python scripts/factoryctl.py validate-product-experience-control-plane templates/product-experience-control-plane.json
 python scripts/factoryctl.py validate-capability-acquisition-contract templates/capability-acquisition-contract.json

--- a/templates/README.md
+++ b/templates/README.md
@@ -45,8 +45,11 @@ only in Hermes.
 For deterministic Factory V2 work, start from these templates:
 
 - `factory-phase-graph.json`: the canonical phase graph and legacy aliases.
-- `v2-study-traceability.json`: the ledger proving raw-study claims were not
-  simplified away.
+- `v2-study-traceability.json`: the ledger mapping raw-study claims to bounded
+  truth levels, evidence refs, claim boundaries, known gaps and next actions.
+- `v2-doc-implementation-obligations.json`: the ledger of documented V2
+  obligations that still need code, tests or runtime proof before stronger
+  public claims are allowed.
 - `worker-authority-contract.json`: the worker authority boundary.
 - `product-experience-control-plane.json`: the Product Experience governance
   surface for design, brand, frontend and operator UX.
@@ -66,6 +69,7 @@ Run template and schema checks:
 ```bash
 python scripts/factoryctl.py validate-phase-graph templates/factory-phase-graph.json
 python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
+python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/factoryctl.py validate-worker-authority-contract templates/worker-authority-contract.json
 python scripts/factoryctl.py validate-product-experience-control-plane templates/product-experience-control-plane.json
 python scripts/factoryctl.py validate-capability-acquisition-contract templates/capability-acquisition-contract.json

--- a/templates/v2-doc-implementation-obligations.json
+++ b/templates/v2-doc-implementation-obligations.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/v2-doc-implementation-obligations.schema.json",
+  "record_type": "v2_doc_implementation_obligations",
+  "obligation_set_id": "overkill-factory-v2-doc-implementation-obligations-2026-06-26",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "source_traceability_ref": "templates/v2-study-traceability.json",
+  "truth_levels": [
+    "missing",
+    "doc_only",
+    "contract_only",
+    "kernel_implemented",
+    "runtime_integrated",
+    "runtime_proven",
+    "production_proven",
+    "blocked_pending_runtime_proof",
+    "deferred_with_reason"
+  ],
+  "obligations": [
+    {
+      "obligation_id": "V2-DOC-P0-001-profile-compatibility-aliases",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md",
+        "external:local-study:OVERKILL_FACTORY_V2_DOC_IMPLEMENTATION_REAUDIT_2026-06-26.md"
+      ],
+      "obligation": "Legacy worker ids that have misleading authority or obsolete names must move through an explicit compatibility alias ledger with target profile, status and expiry.",
+      "required_artifact_refs": [
+        "schemas/profile-compatibility-alias.schema.json",
+        "agents/profile-compatibility-aliases.public.json",
+        "templates/profile-compatibility-alias.json"
+      ],
+      "implemented_artifact_refs": [],
+      "validation_refs": [],
+      "negative_fixture_refs": [],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "missing",
+      "gap_summary": "No profile compatibility alias schema, public alias ledger or migration template exists yet.",
+      "next_action": "Create the alias contract and public ledger before claiming agent migration complete.",
+      "blocks_claim_ids": [
+        "V2-P0-005-agent-process-authority-is-forbidden"
+      ],
+      "public_claims_blocked": [
+        "agent migration complete",
+        "legacy profile names fully remediated"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-002-skill-provider-registry",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md",
+        "external:local-study:OVERKILL_FACTORY_V2_AGENT_CONFIG_PROCESS_EXTRACTION_STUDY_2026-06-26.md"
+      ],
+      "obligation": "Agent-vs-skill boundaries need a provider registry and resolution report so specialist capability can be bound without hiding process authority inside profile prose.",
+      "required_artifact_refs": [
+        "schemas/skill-provider-registry.schema.json",
+        "agents/skill-provider-registry.public.json",
+        "schemas/skill-ref-resolution-report.schema.json",
+        "scripts/validate_agent_vs_skill_boundaries.py"
+      ],
+      "implemented_artifact_refs": [],
+      "validation_refs": [],
+      "negative_fixture_refs": [],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "missing",
+      "gap_summary": "No provider registry, resolution report schema or agent-vs-skill boundary validator exists.",
+      "next_action": "Implement skill provider registry and boundary validator before claiming skill routing maturity.",
+      "blocks_claim_ids": [
+        "V2-P0-005-agent-process-authority-is-forbidden",
+        "V2-P0-012-capability-acquisition-before-specialist-block"
+      ],
+      "public_claims_blocked": [
+        "skills and agents fully normalized",
+        "missing specialists resolved before block"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-003-capability-acquisition-operational-lane",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md"
+      ],
+      "obligation": "Missing specialist handling must execute a real acquisition lane: search packs and reference repositories, create or install a candidate, run smoke and eval, then activate or block with evidence.",
+      "required_artifact_refs": [
+        "schemas/capability-acquisition-contract.schema.json",
+        "schemas/capability-pack-registry.schema.json",
+        "schemas/capability-pack-activation-ledger.schema.json",
+        "scripts/factoryctl.py::validate_capability_acquisition_contract"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/capability-acquisition-contract.schema.json",
+        "schemas/capability-pack-registry.schema.json",
+        "schemas/capability-pack-activation-ledger.schema.json",
+        "scripts/factoryctl.py::validate_capability_acquisition_contract"
+      ],
+      "validation_refs": [
+        "tests/test_capability_packs.py",
+        "tests/test_product_method_sot_planning.py"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/v2-p0-negative-fixtures.json"
+      ],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "contract_only",
+      "gap_summary": "Contracts and tests exist, but the full automated acquisition lane is not implemented as a runtime path.",
+      "next_action": "Build the acquisition lane before allowing specialist absence to auto-block product progress.",
+      "blocks_claim_ids": [
+        "V2-P0-012-capability-acquisition-before-specialist-block"
+      ],
+      "public_claims_blocked": [
+        "capability acquisition fully operational",
+        "missing specialist handling is autonomous"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-004-product-method-runtime",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_CROSS_STUDY_BLUEPRINT_2026-06-26.md",
+        "external:local-study:OVERKILL_FACTORY_V2_CONTRACT_LEDGER_2026-06-26.md"
+      ],
+      "obligation": "The product method runtime needs explicit run-plan, full-product manifest, surface stack plan, vertical slice graph, work-unit dispatch readiness, product E2E release proof and QA repair loop state.",
+      "required_artifact_refs": [
+        "schemas/factory-run-plan.schema.json",
+        "schemas/full-product-run-manifest.schema.json",
+        "schemas/product-surface-stack-plan.schema.json",
+        "schemas/vertical-slice-graph.schema.json",
+        "schemas/work-unit-dispatch-readiness.schema.json",
+        "schemas/product-e2e-release-proof.schema.json",
+        "schemas/qa-repair-loop-state.schema.json"
+      ],
+      "implemented_artifact_refs": [],
+      "validation_refs": [],
+      "negative_fixture_refs": [],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "missing",
+      "gap_summary": "The public repo has adjacent planning contracts, but the full product method runtime contract set is missing.",
+      "next_action": "Create the product method runtime contract set and validators before claiming full product build coverage.",
+      "blocks_claim_ids": [
+        "V2-P0-002-control-plane-owns-route-and-transition"
+      ],
+      "public_claims_blocked": [
+        "any product can be decomposed and run end to end by V2",
+        "full product runtime is implemented"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-005-hermes-total-reducer-and-replay",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_HERMES_REAL_COMPATIBILITY_STUDY_2026-06-26.md",
+        "external:local-study:OVERKILL_FACTORY_V2_FINAL_ARCHITECTURE_2026-06-26.md"
+      ],
+      "obligation": "All Hermes mutations must flow through a command queue and replayable reducer proof so agent, bridge and adapter paths cannot mutate state outside the deterministic lane.",
+      "required_artifact_refs": [
+        "schemas/hermes-blocked-first-protocol-receipt.schema.json",
+        "schemas/hermes-reducer-mutation-proof.schema.json",
+        "adapters/hermes/live_kanban_adapter.py",
+        "scripts/factory_v2_kernel.py::validate_factory_event_log"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/hermes-reducer-mutation-proof.schema.json",
+        "adapters/hermes/live_kanban_adapter.py",
+        "scripts/factory_v2_kernel.py::validate_factory_event_log"
+      ],
+      "validation_refs": [
+        "tests/test_hermes_live_kanban_adapter.py",
+        "tests/test_factory_v2_kernel.py"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/incidents/f3-blocked-f4-ready.json"
+      ],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "contract_only",
+      "gap_summary": "Reducer proof and adapter checks exist, but command queue and replay coverage are not total across all Hermes mutation paths.",
+      "next_action": "Centralize Hermes mutations through command queue and replay before claiming runtime-integrated determinism.",
+      "blocks_claim_ids": [
+        "V2-P0-002-control-plane-owns-route-and-transition"
+      ],
+      "public_claims_blocked": [
+        "Hermes reducer monopoly is complete",
+        "all runtime mutation paths are replayable"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-006-operator-delivery-notification-os",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_HERMES_USER_UX_STUDY_2026-06-26.md"
+      ],
+      "obligation": "Human-facing decisions need channel-aware delivery receipts, notification policy and channel packs so Telegram, Discord and Cockpit can prove what the operator received before asking for a decision.",
+      "required_artifact_refs": [
+        "schemas/operator-delivery-receipt.schema.json",
+        "schemas/operator-notification-policy.schema.json",
+        "schemas/operator-channel-pack.schema.json"
+      ],
+      "implemented_artifact_refs": [],
+      "validation_refs": [],
+      "negative_fixture_refs": [],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "missing",
+      "gap_summary": "No delivery receipt, notification policy or channel pack schema exists.",
+      "next_action": "Add channel delivery contracts before claiming human gates are reliable on operator chat surfaces.",
+      "blocks_claim_ids": [
+        "V2-P0-009-human-gates-require-delivered-decision-packets"
+      ],
+      "public_claims_blocked": [
+        "human gate delivery is fully proved",
+        "Telegram operator UX is complete"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-007-product-experience-evidence-stack",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_HERMES_USER_UX_STUDY_2026-06-26.md",
+        "external:local-study:OVERKILL_FACTORY_V2_FINAL_REVIEW_AND_HARDENING_2026-06-26.md"
+      ],
+      "obligation": "Product Experience needs detailed brand strategy, identity system, component registry, accessibility report, visual regression proof and Storybook-equivalent catalog before interface maturity can be claimed.",
+      "required_artifact_refs": [
+        "schemas/brand-strategy.schema.json",
+        "schemas/identity-system.schema.json",
+        "schemas/component-registry.schema.json",
+        "schemas/accessibility-report.schema.json",
+        "schemas/visual-regression-proof.schema.json",
+        "schemas/storybook-equivalent-catalog.schema.json"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/product-experience-control-plane.schema.json",
+        "schemas/product-experience-plan.schema.json",
+        "schemas/project-design-system.schema.json",
+        "schemas/professional-design-process.schema.json",
+        "schemas/reference-quality-packet.schema.json"
+      ],
+      "validation_refs": [
+        "tests/test_operator_experience.py",
+        "tests/test_factory_self_improvement.py",
+        "tests/test_factoryctl.py"
+      ],
+      "negative_fixture_refs": [
+        "examples/cards/v35_invalid_product_face.md"
+      ],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "contract_only",
+      "gap_summary": "The control plane exists, but the detailed brand/front/design evidence stack is incomplete.",
+      "next_action": "Materialize the detailed design/frontend contracts and validators before calling Product Experience complete.",
+      "blocks_claim_ids": [
+        "V2-P0-006-product-experience-is-a-control-plane"
+      ],
+      "public_claims_blocked": [
+        "Product Experience OS is complete",
+        "frontend and brand process is fully implemented"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-008-security-os-runtime-matrix",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_FINAL_REVIEW_AND_HARDENING_2026-06-26.md"
+      ],
+      "obligation": "Security must have route contracts, state ledger, capability broker, capability leases and security profiles so architecture security is enforceable before material work.",
+      "required_artifact_refs": [
+        "schemas/security-route-contract.schema.json",
+        "schemas/security-state-ledger.schema.json",
+        "schemas/capability-broker.schema.json",
+        "schemas/capability-lease.schema.json",
+        "schemas/security-profile.schema.json"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/security-contract.schema.json",
+        "schemas/security-architecture-plan.schema.json",
+        "schemas/privacy-compliance-plan.schema.json",
+        "schemas/supply-chain-proof.schema.json"
+      ],
+      "validation_refs": [
+        "tests/test_runtime_hardening.py",
+        "tests/test_factoryctl.py"
+      ],
+      "negative_fixture_refs": [
+        "examples/cards/v35_invalid_security_no_scan.md"
+      ],
+      "minimum_truth_level_required": "runtime_integrated",
+      "current_truth_level": "contract_only",
+      "gap_summary": "Core security contracts exist, but the full Security OS runtime matrix is not materialized.",
+      "next_action": "Build the Security OS runtime matrix before claiming born-secure architecture is complete.",
+      "blocks_claim_ids": [
+        "V2-P0-008-security-is-born-in-architecture"
+      ],
+      "public_claims_blocked": [
+        "Security OS is complete",
+        "architecture security is fully runtime-enforced"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-009-reference-superiority-harness",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_REFERENCE_COMPARISON_FINAL_STUDY_2026-06-26.md"
+      ],
+      "obligation": "Reference superiority claims need a reference-derived negative fixture schema, corpus and runner so public comparison claims are proven instead of argued.",
+      "required_artifact_refs": [
+        "schemas/reference-derived-negative-fixture.schema.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json",
+        "scripts/validate_reference_superiority.py"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/reference-superiority-claim.schema.json",
+        "templates/reference-superiority-claim.json"
+      ],
+      "validation_refs": [
+        "tests/test_factory_v2_kernel.py"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/v2-p0-negative-fixtures.json"
+      ],
+      "minimum_truth_level_required": "kernel_implemented",
+      "current_truth_level": "contract_only",
+      "gap_summary": "A claim contract exists, but no dedicated reference-derived fixture corpus or runner exists.",
+      "next_action": "Build the reference superiority runner before making broad stronger-than-reference claims.",
+      "blocks_claim_ids": [
+        "V2-P0-010-reference-superiority-claims-need-proof"
+      ],
+      "public_claims_blocked": [
+        "better than every reference repo",
+        "reference superiority is proven across the corpus"
+      ]
+    },
+    {
+      "obligation_id": "V2-DOC-P0-010-doc-implementation-gate",
+      "priority": "P0",
+      "source_docs": [
+        "external:local-study:OVERKILL_FACTORY_V2_DOC_IMPLEMENTATION_REAUDIT_2026-06-26.md"
+      ],
+      "obligation": "The repository must fail validation when a V2 study claim uses an overbroad implementation status or when an obligation claims a higher truth level than its public artifacts support.",
+      "required_artifact_refs": [
+        "schemas/v2-study-traceability.schema.json",
+        "schemas/v2-doc-implementation-obligations.schema.json",
+        "templates/v2-study-traceability.json",
+        "templates/v2-doc-implementation-obligations.json",
+        "scripts/factoryctl.py::validate_v2_study_traceability",
+        "scripts/factoryctl.py::validate_v2_doc_implementation_obligations"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/v2-study-traceability.schema.json",
+        "schemas/v2-doc-implementation-obligations.schema.json",
+        "templates/v2-study-traceability.json",
+        "templates/v2-doc-implementation-obligations.json",
+        "scripts/factoryctl.py::validate_v2_study_traceability",
+        "scripts/factoryctl.py::validate_v2_doc_implementation_obligations"
+      ],
+      "validation_refs": [
+        "tests/test_factory_v2_kernel.py::FactoryV2KernelTests"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/v2-p0-negative-fixtures.json"
+      ],
+      "minimum_truth_level_required": "kernel_implemented",
+      "current_truth_level": "kernel_implemented",
+      "gap_summary": "This gate is kernel implemented in the public repo, but it is not runtime_proven against a live Hermes release process.",
+      "next_action": "Use this gate in release checks and attach live CI evidence before claiming runtime_proven release governance.",
+      "blocks_claim_ids": [
+        "V2-P0-011-readiness-claims-use-truth-levels"
+      ],
+      "public_claims_blocked": [
+        "V2 studies are fully implemented end to end",
+        "doc-vs-code parity is production proven"
+      ]
+    }
+  ],
+  "closure_policy": {
+    "implemented_status_forbidden": true,
+    "overclaim_fails_validation": true,
+    "partial_obligation_requires_gap_and_next_action": true,
+    "current_truth_level_must_have_matching_public_evidence": true
+  }
+}

--- a/templates/v2-study-traceability.json
+++ b/templates/v2-study-traceability.json
@@ -14,7 +14,8 @@
     "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md",
     "external:local-study:OVERKILL_FACTORY_V2_FINAL_REVIEW_AND_HARDENING_2026-06-26.md",
     "external:local-study:OVERKILL_FACTORY_V2_REFERENCE_COMPARISON_FINAL_STUDY_2026-06-26.md",
-    "external:local-study:OVERKILL_FACTORY_V2_STUDY_IMPLEMENTATION_GAP_AUDIT_2026-06-26.md"
+    "external:local-study:OVERKILL_FACTORY_V2_STUDY_IMPLEMENTATION_GAP_AUDIT_2026-06-26.md",
+    "external:local-study:OVERKILL_FACTORY_V2_DOC_IMPLEMENTATION_REAUDIT_2026-06-26.md"
   ],
   "claims": [
     {
@@ -22,6 +23,7 @@
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_STUDY_IMPLEMENTATION_GAP_AUDIT_2026-06-26.md",
       "claim": "Product phases, human gates and operator projections must be distinct so legacy labels cannot let later work run while earlier product phases are blocked.",
+      "claim_boundary": "Public kernel proof: schemas, phase graph, reconciler rules and regression fixtures exist. This is not proof that every live Hermes board is currently healthy.",
       "schema_refs": [
         "schemas/factory-phase-graph.schema.json",
         "schemas/factory-workflow-compiled-plan.schema.json"
@@ -38,13 +40,18 @@
         "fixtures/v2/phase-jump-blocked-by-earlier-phase.json",
         "fixtures/incidents/f3-blocked-f4-ready.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "A specific live Hermes product run still needs runtime evidence before this can be called runtime_proven."
+      ],
+      "next_action": "Attach live Hermes run proof when promoting a specific product board."
     },
     {
       "claim_id": "V2-P0-002-control-plane-owns-route-and-transition",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_FINAL_ARCHITECTURE_2026-06-26.md",
       "claim": "Agents, bridges and adapters may produce work or carry messages, but route choice, phase advance and promotion must be decided by the deterministic control plane.",
+      "claim_boundary": "Public kernel proof covers command, event, decision, promotion and adapter boundaries. It does not yet prove reducer monopoly across every possible Hermes mutation path.",
       "schema_refs": [
         "schemas/factory-command.schema.json",
         "schemas/factory-run-event.schema.json",
@@ -66,13 +73,18 @@
         "fixtures/incidents/f3-blocked-f4-ready.json",
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Hermes command queue, event replay and reducer monopoly are not yet total across all mutation surfaces."
+      ],
+      "next_action": "Promote to runtime_integrated only after all Hermes mutations flow through command queue and replay checks."
     },
     {
       "claim_id": "V2-P0-003-critical-card-contracts-are-schema-backed",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_CONTRACT_LEDGER_2026-06-26.md",
       "claim": "Runtime, security, method, onchain, access and human-gate fields on a card must be real contracts, not open prose objects.",
+      "claim_boundary": "Public kernel proof validates schema-backed card contracts and negative examples. It does not prove that every private live card has already been migrated.",
       "schema_refs": [
         "schemas/factory-card.schema.json",
         "schemas/runtime-contract.schema.json",
@@ -94,13 +106,18 @@
         "examples/cards/v35_invalid_r4_no_gate.md",
         "fixtures/incidents/text-only-human-gate.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Private live Hermes cards require separate migration evidence before runtime_proven can be claimed."
+      ],
+      "next_action": "Require migration receipts for live cards before calling a product board compliant."
     },
     {
       "claim_id": "V2-P0-004-operating-systems-are-complete-and-addressable",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_OPERATING_SYSTEMS_ALIGNMENT_STUDY_2026-06-26.md",
       "claim": "The factory operating-system registry must model all seventeen V2 operating systems, with owner, contracts, validations and public issue mapping.",
+      "claim_boundary": "Public kernel proof covers the registry and scorecard. It does not prove every OS has complete runtime automation.",
       "schema_refs": [
         "schemas/factory-operating-system-registry.schema.json"
       ],
@@ -114,13 +131,18 @@
       "negative_fixture_refs": [
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Some operating systems remain contract-governed rather than end-to-end runtime automated."
+      ],
+      "next_action": "Use the OS scorecard to drive each runtime automation gap to its own implementation proof."
     },
     {
       "claim_id": "V2-P0-005-agent-process-authority-is-forbidden",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_AGENT_CONFIG_PROCESS_EXTRACTION_STUDY_2026-06-26.md",
       "claim": "Worker profiles must not encode route choice, phase choice, gate approval or state mutation as agent identity or memory.",
+      "claim_boundary": "Public kernel proof validates authority boundaries and profile leakage. It does not complete the nominal migration or alias/deprecation plan for every legacy worker id.",
       "schema_refs": [
         "schemas/worker-profile.schema.json",
         "schemas/worker-authority-contract.schema.json"
@@ -135,13 +157,18 @@
       "negative_fixture_refs": [
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Legacy-to-V2 profile compatibility aliases, expiry and deprecation receipts are still missing."
+      ],
+      "next_action": "Implement the profile compatibility alias ledger before claiming agent migration complete."
     },
     {
       "claim_id": "V2-P0-006-product-experience-is-a-control-plane",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_HERMES_USER_UX_STUDY_2026-06-26.md",
       "claim": "Product, design, frontend, brand and interface work must have explicit experience contracts and evidence instead of being treated as optional polish.",
+      "claim_boundary": "Public kernel proof covers the high-level Product Experience control plane. It does not yet provide every brand, identity, component, accessibility, visual regression and Storybook-equivalent contract.",
       "schema_refs": [
         "schemas/product-experience-control-plane.schema.json",
         "schemas/product-experience-plan.schema.json",
@@ -163,13 +190,18 @@
         "examples/cards/v35_invalid_product_face.md",
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Detailed brand strategy, identity system, component registry, accessibility report and visual regression artifacts remain obligations."
+      ],
+      "next_action": "Materialize the missing Product Experience evidence stack before claiming full design/frontend runtime maturity."
     },
     {
       "claim_id": "V2-P0-007-solana-ai-kit-is-first-class-domain-brain",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md",
       "claim": "Solana or onchain planning and execution must materialize Solana AI Kit as the official domain brain with usage receipts and signer boundaries.",
+      "claim_boundary": "Public kernel proof detects Solana/onchain routing gaps and requires receipts. It does not prove that a specific live Solana product board has used Solana AI Kit unless that board carries a usage receipt.",
       "schema_refs": [
         "schemas/solana-ai-kit-usage-receipt.schema.json",
         "schemas/onchain-work-package.schema.json",
@@ -187,13 +219,18 @@
         "fixtures/incidents/solana-f4-missing-provider.json",
         "examples/cards/v35_invalid_onchain_no_auditor.md"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "A live Solana product run must attach product-specific Solana AI Kit usage receipts before runtime_proven can be claimed."
+      ],
+      "next_action": "Block Solana product promotion unless the live board has a valid Solana AI Kit usage receipt."
     },
     {
       "claim_id": "V2-P0-008-security-is-born-in-architecture",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_FINAL_REVIEW_AND_HARDENING_2026-06-26.md",
       "claim": "Security must be represented as architecture, control, review and supply-chain contracts from planning, not only as a late scan.",
+      "claim_boundary": "Public kernel proof covers core security contracts and gate reports. It does not complete capability brokerage, leases, security profile matrix or every specialist runtime path.",
       "schema_refs": [
         "schemas/security-contract.schema.json",
         "schemas/security-architecture-plan.schema.json",
@@ -212,13 +249,18 @@
         "examples/cards/v35_invalid_security_no_scan.md",
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Security route contract, capability broker, capability leases and security profile artifacts are not fully materialized."
+      ],
+      "next_action": "Materialize the Security OS specialist matrix and runtime capability controls before claiming runtime_proven security architecture."
     },
     {
       "claim_id": "V2-P0-012-capability-acquisition-before-specialist-block",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md",
       "claim": "When a specialist or capability is missing, the factory must search existing packs and reference repositories, create or install a candidate capability, run smoke and eval, and block only if no safe candidate can be activated.",
+      "claim_boundary": "Public contract exists, but the full operational acquisition lane is not implemented end-to-end.",
       "schema_refs": [
         "schemas/capability-acquisition-contract.schema.json",
         "schemas/capability-pack-registry.schema.json",
@@ -235,13 +277,18 @@
       "negative_fixture_refs": [
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "contract_only",
+      "known_gaps": [
+        "The factory does not yet have a complete automated lane that searches references, creates or installs a capability, smokes it and activates it before blocking."
+      ],
+      "next_action": "Build the capability acquisition lane and only then promote this claim to kernel_implemented or runtime_integrated."
     },
     {
       "claim_id": "V2-P0-009-human-gates-require-delivered-decision-packets",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_HERMES_USER_UX_STUDY_2026-06-26.md",
       "claim": "A human gate must deliver structured material before asking for a decision, with language, channel, package, receipt and bounded authority.",
+      "claim_boundary": "Public kernel proof covers human gate packets and decision outbox behavior. It does not yet include the full channel delivery, notification and attachment receipt OS for every operator interface.",
       "schema_refs": [
         "schemas/human-gate-packet.schema.json",
         "schemas/operator-briefing-package.schema.json",
@@ -259,13 +306,18 @@
         "fixtures/incidents/text-only-human-gate.json",
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Operator delivery receipts, notification policy and channel pack contracts are still missing."
+      ],
+      "next_action": "Add delivery receipts and channel policy before claiming human-gate UX is runtime_proven."
     },
     {
       "claim_id": "V2-P0-010-reference-superiority-claims-need-proof",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_REFERENCE_COMPARISON_FINAL_STUDY_2026-06-26.md",
       "claim": "The factory may claim superiority over reference repositories only when the claim links to schema, reducer or validator, test and negative fixture proof.",
+      "claim_boundary": "The claim schema exists, but there is no full reference-derived fixture corpus and runner that proves superiority across the studied references.",
       "schema_refs": [
         "schemas/reference-superiority-claim.schema.json",
         "schemas/v2-study-traceability.schema.json"
@@ -281,13 +333,18 @@
         "fixtures/v2/phase-jump-blocked-by-earlier-phase.json",
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "contract_only",
+      "known_gaps": [
+        "Reference-derived negative fixture schema, corpus and superiority runner are not implemented."
+      ],
+      "next_action": "Build the reference superiority harness before making broad public superiority claims."
     },
     {
       "claim_id": "V2-P0-011-readiness-claims-use-truth-levels",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_FINAL_REVIEW_AND_HARDENING_2026-06-26.md",
       "claim": "The factory must not report product-run or production readiness from repo-only, static or bounded evidence; readiness must be classified by explicit truth levels.",
+      "claim_boundary": "Public kernel proof covers readiness truth levels and tests. It does not make any specific product run or production release ready by itself.",
       "schema_refs": [
         "schemas/factory-v2-readiness-claim.schema.json",
         "schemas/readiness-truth-ledger.schema.json",
@@ -304,13 +361,18 @@
       "negative_fixture_refs": [
         "fixtures/v2/v2-p0-negative-fixtures.json"
       ],
-      "status": "implemented"
+      "status": "kernel_implemented",
+      "known_gaps": [
+        "Runtime and production readiness require separate Hermes/product/release evidence."
+      ],
+      "next_action": "Keep product and production claims below runtime_proven unless specific evidence is attached."
     }
   ],
   "closure_policy": {
-    "p0_doc_only_forbidden": true,
-    "p0_contract_only_forbidden": true,
-    "runtime_or_test_required_for_every_p0": true,
-    "negative_fixture_required_for_every_p0": true
+    "implemented_status_forbidden": true,
+    "partial_status_requires_known_gaps": true,
+    "truth_level_must_match_evidence": true,
+    "runtime_or_production_claim_requires_runtime_proof": true,
+    "negative_fixture_required_for_kernel_or_stronger_p0": true
   }
 }

--- a/tests/test_factory_v2_kernel.py
+++ b/tests/test_factory_v2_kernel.py
@@ -226,10 +226,18 @@ class FactoryV2KernelTests(unittest.TestCase):
         self.assertEqual(plan["phases"][0]["next_phase_id"], "F1")
         self.assertIn("F27", {phase["phase_id"] for phase in plan["phases"]})
 
-    def test_v2_study_traceability_closes_p0_with_runtime_tests_and_negative_fixtures(self) -> None:
+    def test_v2_study_traceability_uses_bounded_truth_levels(self) -> None:
         packet = json.loads((ROOT / "templates" / "v2-study-traceability.json").read_text(encoding="utf-8"))
 
         self.assertEqual(factoryctl.validate_v2_study_traceability(packet), [])
+        statuses = {claim["status"] for claim in packet["claims"]}
+        self.assertNotIn("implemented", statuses)
+        self.assertIn("kernel_implemented", statuses)
+        self.assertIn("contract_only", statuses)
+        for claim in packet["claims"]:
+            self.assertIn("claim_boundary", claim)
+            self.assertGreater(len(claim["known_gaps"]), 0)
+            self.assertGreater(len(claim["next_action"]), 10)
         self.assertEqual(
             factoryctl.main_with_args_for_test(
                 ["validate-v2-study-traceability", "templates/v2-study-traceability.json"]
@@ -237,19 +245,72 @@ class FactoryV2KernelTests(unittest.TestCase):
             0,
         )
 
-    def test_v2_study_traceability_rejects_doc_only_p0_closure(self) -> None:
+    def test_v2_study_traceability_rejects_broad_implemented_status(self) -> None:
         packet = json.loads((ROOT / "templates" / "v2-study-traceability.json").read_text(encoding="utf-8"))
-        packet["claims"][0]["schema_refs"] = []
-        packet["claims"][0]["runtime_refs"] = []
-        packet["claims"][0]["test_refs"] = []
-        packet["claims"][0]["negative_fixture_refs"] = []
+        packet["claims"][0]["status"] = "implemented"
 
         errors = factoryctl.validate_v2_study_traceability(packet)
 
-        self.assertTrue(any("P0 requires schema_refs" in error for error in errors), errors)
-        self.assertTrue(any("P0 requires runtime_refs" in error for error in errors), errors)
-        self.assertTrue(any("P0 requires test_refs" in error for error in errors), errors)
-        self.assertTrue(any("P0 requires negative_fixture_refs" in error for error in errors), errors)
+        self.assertTrue(any("status 'implemented' is forbidden" in error for error in errors), errors)
+
+    def test_v2_study_traceability_rejects_kernel_claim_without_tests_or_fixtures(self) -> None:
+        packet = json.loads((ROOT / "templates" / "v2-study-traceability.json").read_text(encoding="utf-8"))
+        packet["claims"][0]["test_refs"] = []
+        packet["claims"][0]["negative_fixture_refs"] = []
+        packet["claims"][0]["status"] = "kernel_implemented"
+
+        errors = factoryctl.validate_v2_study_traceability(packet)
+
+        self.assertTrue(any("kernel_implemented P0 claim requires test_refs" in error for error in errors), errors)
+        self.assertTrue(
+            any("kernel_implemented P0 claim requires negative_fixture_refs" in error for error in errors),
+            errors,
+        )
+
+    def test_v2_study_traceability_rejects_runtime_proven_without_runtime_evidence(self) -> None:
+        packet = json.loads((ROOT / "templates" / "v2-study-traceability.json").read_text(encoding="utf-8"))
+        packet["claims"][0]["status"] = "runtime_proven"
+        packet["claims"][0]["known_gaps"] = []
+        packet["claims"][0]["runtime_refs"] = ["scripts/factoryctl.py"]
+        packet["claims"][0]["test_refs"] = ["tests/test_factory_v2_kernel.py"]
+
+        errors = factoryctl.validate_v2_study_traceability(packet)
+
+        self.assertTrue(any("runtime_proven requires runtime proof refs" in error for error in errors), errors)
+
+    def test_v2_doc_implementation_obligations_validate_and_cross_check_traceability(self) -> None:
+        packet = json.loads(
+            (ROOT / "templates" / "v2-doc-implementation-obligations.json").read_text(encoding="utf-8")
+        )
+        traceability = json.loads((ROOT / "templates" / "v2-study-traceability.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(factoryctl.validate_v2_doc_implementation_obligations(packet, traceability), [])
+        self.assertEqual(
+            factoryctl.main_with_args_for_test(
+                [
+                    "validate-v2-doc-implementation-obligations",
+                    "templates/v2-doc-implementation-obligations.json",
+                    "--traceability",
+                    "templates/v2-study-traceability.json",
+                ]
+            ),
+            0,
+        )
+
+    def test_v2_doc_implementation_obligations_reject_overclaim_without_artifacts(self) -> None:
+        packet = json.loads(
+            (ROOT / "templates" / "v2-doc-implementation-obligations.json").read_text(encoding="utf-8")
+        )
+        packet["obligations"][0]["current_truth_level"] = "kernel_implemented"
+        packet["obligations"][0]["implemented_artifact_refs"] = []
+        packet["obligations"][0]["validation_refs"] = []
+        packet["obligations"][0]["negative_fixture_refs"] = []
+
+        errors = factoryctl.validate_v2_doc_implementation_obligations(packet)
+
+        self.assertTrue(any("kernel_implemented requires implemented_artifact_refs" in error for error in errors), errors)
+        self.assertTrue(any("kernel_implemented requires validation_refs" in error for error in errors), errors)
+        self.assertTrue(any("kernel_implemented requires negative_fixture_refs" in error for error in errors), errors)
 
     def test_product_experience_control_plane_is_validated_by_cli(self) -> None:
         self.assertEqual(

--- a/tests/test_secret_safety_scan.py
+++ b/tests/test_secret_safety_scan.py
@@ -51,6 +51,26 @@ class SecretSafetyScanTest(unittest.TestCase):
 
         self.assertEqual([], findings)
 
+    def test_ignored_tmp_reference_repos_are_not_scanned(self):
+        scanner = load_scanner()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ignored = root / ".tmp" / "reference-repos" / "sample.env"
+            ignored.parent.mkdir(parents=True)
+            ignored.write_text("tok" + "en: " + "abcdefghijklmnopqrstuvwxyz123456\n", encoding="utf-8")
+            clean = root / "README.md"
+            clean.write_text("public docs only\n", encoding="utf-8")
+
+            original_root = scanner.ROOT
+            scanner.ROOT = root
+            try:
+                findings = scanner.scan()
+            finally:
+                scanner.ROOT = original_root
+
+        self.assertEqual([], findings)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- replace broad V2 study `implemented` status with explicit truth levels and required claim boundaries/gaps
- add `v2-doc-implementation-obligations` schema/template to track documented V2 obligations that are missing, contract-only, kernel-level, or runtime-proven
- add `factoryctl validate-v2-doc-implementation-obligations` and regression tests for overclaim failures
- update README/docs/CLI/skill references so the new gate is part of normal public validation
- align `secret_safety_scan.py` with the public scanner by skipping ignored runtime/cache folders such as `.tmp/`

Closes #450.

## Validation

- `python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json`
- `python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/validate_worker_profiles.py`
- `python scripts/validate_promise_implementation_map.py`
- `python scripts/validate_planning_bundles.py`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
- `python -m unittest discover -s tests -q` (1036 tests)