### PR TITLE
Release v2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V2 is the current public kernel release line. The latest public release
-is v2.0.1.
+is v2.0.2.
 
 V2 means the public kernel has executable contracts for the factory line:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V2 é a linha atual de release do kernel público. A release pública mais
-recente é v2.0.1.
+recente é v2.0.2.
 
 V2 significa que o kernel público tem contratos executáveis para a linha da
 fábrica:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "2.0.1"
+version = "2.0.2"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -58,12 +58,13 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v2.0.1", readme)
+        self.assertIn("v2.0.2", readme)
         self.assertIn("Factory V2", readme)
         self.assertIn("docs/architecture/factory-v2-control-plane.md", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
         self.assertIn("docs/promise-implementation-map.public.json", readme)
         self.assertIn("templates/v2-study-traceability.json", readme)
+        self.assertIn("templates/v2-doc-implementation-obligations.json", readme)
         self.assertIn("templates/factory-v2-readiness-claim.json", readme)
         self.assertNotIn("Para você, como usuário leigo", readme)
         self.assertNotIn("## What It Does Not Do", readme)
@@ -81,6 +82,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "docs/operations/promise-to-implementation.md",
             "docs/promise-implementation-map.public.json",
             "templates/v2-study-traceability.json",
+            "templates/v2-doc-implementation-obligations.json",
             "templates/factory-v2-readiness-claim.json",
         ]:
             with self.subTest(link=rel):
@@ -124,7 +126,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "linha de produção em etapas para trabalho de produto controlado",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v2.0.1",
+            "v2.0.2",
             "Factory V2",
             "docs/architecture/factory-v2-control-plane.md",
             "codex plugin marketplace add .",
@@ -133,6 +135,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "docs/promise-implementation-map.public.json",
             "docs/operator/overkill-factory-bridge.md",
             "docs/operator/overkill-factory-bridge-plugin.md",
+            "templates/v2-doc-implementation-obligations.json",
             "fixtures/README.md",
             "https://storage.googleapis.com/overkill-factory-public-assets-20apy/overkill-factory-map-v1.0.1.html",
             "factoryctl run minimal",


### PR DESCRIPTION
## Summary

- bump package and public README release references to v2.0.2 after the V2 doc implementation overclaim gate landed
- update open-source doc tests to lock the new release string and the new obligations ledger link

## Validation

- `python -m unittest tests.test_open_source_docs tests.test_factory_v2_kernel tests.test_secret_safety_scan -q`
- `python scripts/validate_document_governance.py`
- `python scripts/validate_public_json_artifacts.py`
- `python scripts/secret_safety_scan.py`