### PR TITLE
Release Factory V2 runtime spine v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ public releases.
 
 ## Unreleased
 
+## 2.0.3 - 2026-06-26
+
+- Complete the public Factory V2 runtime-spine contract set with profile
+  compatibility aliases, skill provider registry, Product Method Runtime,
+  operator delivery, Product Experience evidence stack, Security OS matrix,
+  Hermes blocked-first protocol and reference-derived negative fixtures.
+- Add `factoryctl validate-v2-runtime-contracts`,
+  `validate-agent-skill-boundaries`, `validate-reference-superiority`,
+  `capability-acquisition-run` and `validate-capability-acquisition-run`.
+- Make missing capability handling executable: the factory now writes a
+  `capability_acquisition_run` receipt from skill providers, capability packs
+  and reference search refs, and it can block only after `search_completed=true`.
+- Update the Hermes Kanban compatibility contract for the current native
+  primitives: `gateway start`, dispatch/watch/tail/runs/diagnostics and
+  notify-subscribe/list/unsubscribe.
+- Wire the new V2 validators and capability acquisition receipt into release
+  preflight, public docs, README and the Codex `overkill-factory` skill.
+- Extend V2 traceability and doc-implementation obligations so public claims
+  fail validation when they are stronger than the implemented artifacts,
+  tests and negative fixtures.
+
+## 2.0.2 - 2026-06-26
+
 - Harden Factory V2 against raw-study simplification: add phase graph,
   V2 study traceability, worker authority, Product Experience control plane,
   capability acquisition, Hermes reducer mutation proof and scoped readiness

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V2 is the current public kernel release line. The latest public release
-is v2.0.2.
+is v2.0.3.
 
 V2 means the public kernel has executable contracts for the factory line:
 
@@ -277,8 +277,10 @@ V2 means the public kernel has executable contracts for the factory line:
 - Product Experience control plane: product-facing work needs Product
   Experience Plan, Product Face Packet, professional design process, project
   design system, `DESIGN.md` and Product Face Result proof;
-- capability acquisition contract: when a specialist is missing, the factory
-  searches existing packs and reference sources before blocking;
+- capability acquisition runtime lane: when a specialist is missing, the
+  factory searches skill providers, capability packs and reference sources,
+  writes a `capability_acquisition_run` receipt, and blocks only after that
+  search is complete;
 - Solana AI Kit first-class routing for Solana/on-chain work, with usage
   receipts, signer boundaries and onchain work packages;
 - strict human-gate packets: the operator receives material first, then the
@@ -317,6 +319,11 @@ python scripts/validate_public_json_artifacts.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_promise_implementation_map.py
 python scripts/validate_planning_bundles.py
+python scripts/factoryctl.py validate-v2-runtime-contracts
+python scripts/factoryctl.py validate-agent-skill-boundaries
+python scripts/factoryctl.py validate-reference-superiority
+python scripts/factoryctl.py capability-acquisition-run --capability-gap solana-ai-kit --surface solana --out .tmp/factory-runs/capability/readme-capability-acquisition-run.json
+python scripts/factoryctl.py validate-capability-acquisition-run .tmp/factory-runs/capability/readme-capability-acquisition-run.json
 python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
 python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/public_safety_scan.py

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V2 é a linha atual de release do kernel público. A release pública mais
-recente é v2.0.2.
+recente é v2.0.3.
 
 V2 significa que o kernel público tem contratos executáveis para a linha da
 fábrica:
@@ -280,8 +280,9 @@ fábrica:
 - Product Experience control plane: trabalho com interface precisa de Product
   Experience Plan, Product Face Packet, processo profissional de design, design
   system do projeto, `DESIGN.md` e Product Face Result;
-- contrato de aquisição de capability: quando falta especialista, a fábrica
-  pesquisa packs e referências antes de bloquear;
+- lane runtime de aquisição de capability: quando falta especialista, a fábrica
+  pesquisa skill providers, capability packs e referências, escreve um receipt
+  `capability_acquisition_run` e só bloqueia depois da busca completa;
 - Solana AI Kit como rota de primeira classe para Solana/on-chain, com usage
   receipt, signer boundary e onchain work package;
 - human gates estritos: o operador recebe o material antes da pergunta de
@@ -320,6 +321,11 @@ python scripts/validate_public_json_artifacts.py
 python scripts/validate_worker_profiles.py
 python scripts/validate_promise_implementation_map.py
 python scripts/validate_planning_bundles.py
+python scripts/factoryctl.py validate-v2-runtime-contracts
+python scripts/factoryctl.py validate-agent-skill-boundaries
+python scripts/factoryctl.py validate-reference-superiority
+python scripts/factoryctl.py capability-acquisition-run --capability-gap solana-ai-kit --surface solana --out .tmp/factory-runs/capability/readme-capability-acquisition-run.json
+python scripts/factoryctl.py validate-capability-acquisition-run .tmp/factory-runs/capability/readme-capability-acquisition-run.json
 python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
 python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
 python scripts/public_safety_scan.py

--- a/agents/profile-compatibility-aliases.public.json
+++ b/agents/profile-compatibility-aliases.public.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/profile-compatibility-alias.schema.json",
+  "record_type": "profile_compatibility_aliases",
+  "alias_set_id": "overkill-factory-v2-profile-compatibility-aliases",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "policy": {
+    "agent_names_are_not_authority": true,
+    "legacy_ids_are_compatibility_only": true,
+    "expiry_required_for_deprecated_aliases": true,
+    "migration_requires_profile_binding": true
+  },
+  "aliases": [
+    {
+      "legacy_id": "overkill-factory-gerente",
+      "target_worker_id": "factory-orchestrator",
+      "target_profile_ref": "agents/worker-profiles.public.json#factory-orchestrator",
+      "status": "deprecated_alias",
+      "reason": "Gerente remains a human-facing compatibility name; factory route authority belongs to the V2 control plane.",
+      "compatibility_scope": "dispatch_name",
+      "expires_at": "2026-12-31T00:00:00+00:00",
+      "migration_evidence_refs": [
+        "agents/hermes-profile-bindings.public.json#factory-orchestrator",
+        "scripts/validate_agent_vs_skill_boundaries.py"
+      ]
+    },
+    {
+      "legacy_id": "human-gate-clerk",
+      "target_worker_id": "human-gate-clerk",
+      "target_profile_ref": "agents/worker-profiles.public.json#human-gate-clerk",
+      "status": "active_alias",
+      "reason": "The worker name is still accurate when limited to packaging and recording human gates, not approving them.",
+      "compatibility_scope": "legacy_card_field",
+      "expires_at": "2027-06-26T00:00:00+00:00",
+      "migration_evidence_refs": [
+        "agents/hermes-profile-bindings.public.json#human-gate-clerk",
+        "schemas/operator-delivery-receipt.schema.json"
+      ]
+    },
+    {
+      "legacy_id": "product-face",
+      "target_worker_id": "product-face",
+      "target_profile_ref": "agents/worker-profiles.public.json#product-face",
+      "status": "active_alias",
+      "reason": "Product Face remains the visible-product evidence worker inside the broader Product Experience OS.",
+      "compatibility_scope": "legacy_card_field",
+      "expires_at": "2027-06-26T00:00:00+00:00",
+      "migration_evidence_refs": [
+        "schemas/product-experience-control-plane.schema.json",
+        "schemas/component-registry.schema.json"
+      ]
+    }
+  ]
+}

--- a/agents/skill-provider-registry.public.json
+++ b/agents/skill-provider-registry.public.json
@@ -1,0 +1,347 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/skill-provider-registry.schema.json",
+  "record_type": "skill_provider_registry",
+  "registry_id": "overkill-factory-v2-skill-provider-registry",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "policy": {
+    "providers_are_capability_not_authority": true,
+    "agents_do_not_select_route": true,
+    "missing_provider_triggers_acquisition_lane": true,
+    "profile_bindings_must_resolve_skill_refs": true
+  },
+  "providers": [
+    {
+      "provider_id": "overkill-factory",
+      "provider_type": "codex_skill",
+      "status": "active",
+      "capability_surfaces": ["factory", "product-method", "gates"],
+      "source_ref": "skills/codex/overkill-factory/SKILL.md",
+      "authority_boundary": "Skill explains operation; route authority remains in compiled workflow, reducer and Hermes state.",
+      "smoke_or_eval_ref": "tests/test_open_source_docs.py"
+    },
+    {
+      "provider_id": "hermes-kanban",
+      "provider_type": "hermes_skill",
+      "status": "active",
+      "capability_surfaces": ["kanban", "runtime", "dispatcher"],
+      "source_ref": "external:public:hermes-agent-kanban-docs",
+      "authority_boundary": "Hermes is runtime source of truth; factory contracts decide allowed commands.",
+      "smoke_or_eval_ref": "tests/test_hermes_live_kanban_adapter.py"
+    },
+    {
+      "provider_id": "browser",
+      "provider_type": "external_tool",
+      "status": "available",
+      "capability_surfaces": ["frontend", "research", "screenshots"],
+      "source_ref": "external:public:codex-browser-skill",
+      "authority_boundary": "Browser can gather evidence; it cannot approve product or gate state.",
+      "smoke_or_eval_ref": "tests/test_product_face_proof.py"
+    },
+    {
+      "provider_id": "solana-ai-kit",
+      "provider_type": "reference_pack",
+      "status": "active",
+      "capability_surfaces": ["solana", "onchain", "wallet"],
+      "source_ref": "https://github.com/solanabr/solana-ai-kit",
+      "authority_boundary": "Solana AI Kit is mandatory domain brain for Solana routes; signer, funds and Mainnet gates still override it.",
+      "smoke_or_eval_ref": "schemas/solana-ai-kit-usage-receipt.schema.json"
+    },
+    {
+      "provider_id": "solanabr-auditor",
+      "provider_type": "reference_pack",
+      "status": "available",
+      "capability_surfaces": ["solana", "audit", "quasar"],
+      "source_ref": "external:public:solanabr-auditor",
+      "authority_boundary": "Auditor supplies audit evidence; it does not grant deploy, signing or funds authority.",
+      "smoke_or_eval_ref": "tests/test_qvg_quasar_cu_fuzz_property_proof.py"
+    },
+    {
+      "provider_id": "codex-security",
+      "provider_type": "plugin_skill",
+      "status": "available",
+      "capability_surfaces": ["security", "code-review", "threat-model"],
+      "source_ref": "external:public:codex-security",
+      "authority_boundary": "Security findings require owner/security route handling; scans do not waive risk.",
+      "smoke_or_eval_ref": "tests/test_runtime_hardening.py"
+    },
+    {
+      "provider_id": "appsec-owasp",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["appsec", "api", "web"],
+      "source_ref": "docs/agents/security-specialist-matrix.md",
+      "authority_boundary": "AppSec checklist routes controls; residual risk acceptance stays outside the specialist.",
+      "smoke_or_eval_ref": "schemas/security-route-contract.schema.json"
+    },
+    {
+      "provider_id": "agentic-ai-security",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["agentic-ai", "tool-boundary", "memory"],
+      "source_ref": "docs/agents/security-specialist-matrix.md",
+      "authority_boundary": "Agentic security reviews prompts/tools/memory; it cannot expand tool authority.",
+      "smoke_or_eval_ref": "schemas/security-profile.schema.json"
+    },
+    {
+      "provider_id": "autoreview",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["review", "diff", "quality"],
+      "source_ref": "agents/worker-registry.public.json#autoreview-gate",
+      "authority_boundary": "AutoReview is pre-landing evidence, not approval.",
+      "smoke_or_eval_ref": "tests/test_factoryctl.py"
+    },
+    {
+      "provider_id": "remote-proof",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["remote-proof", "container", "ci-parity"],
+      "source_ref": "agents/worker-registry.public.json#remote-proof-runner",
+      "authority_boundary": "Remote proof runs scoped validation only; secrets and production mutation require gates.",
+      "smoke_or_eval_ref": "tests/test_managed_remote_proof_probe.py"
+    },
+    {
+      "provider_id": "handoff",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["handoff", "context", "state-packet"],
+      "source_ref": "agents/worker-registry.public.json#handoff-packer",
+      "authority_boundary": "Handoff packages replayable state; it cannot invent approval or evidence.",
+      "smoke_or_eval_ref": "tests/test_factoryctl.py"
+    },
+    {
+      "provider_id": "receipt-five-reconciliation",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["evidence", "receipt-five", "closure"],
+      "source_ref": "agents/worker-registry.public.json#evidence-reconciler",
+      "authority_boundary": "Reconciliation can block closure; it cannot approve human gates.",
+      "smoke_or_eval_ref": "tests/test_evidence_reconciler.py"
+    },
+    {
+      "provider_id": "human-gate",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["human-gate", "operator-delivery", "decision-record"],
+      "source_ref": "agents/worker-registry.public.json#human-gate-clerk",
+      "authority_boundary": "Human gate worker packages and records decisions; the human makes the decision.",
+      "smoke_or_eval_ref": "schemas/operator-delivery-receipt.schema.json"
+    },
+    {
+      "provider_id": "public-safety",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["public-repo", "redaction", "release"],
+      "source_ref": "scripts/public_safety_scan.py",
+      "authority_boundary": "Public safety can block leaks; it does not approve product risk.",
+      "smoke_or_eval_ref": "tests/test_public_safety_scan.py"
+    },
+    {
+      "provider_id": "frontend-builder",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["frontend", "ui", "product-experience"],
+      "source_ref": "agents/worker-registry.public.json#frontend-builder",
+      "authority_boundary": "Frontend builder implements bounded work after Product Experience contracts exist.",
+      "smoke_or_eval_ref": "schemas/component-registry.schema.json"
+    },
+    {
+      "provider_id": "backend-api",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["backend", "api", "integration"],
+      "source_ref": "agents/worker-registry.public.json#backend-api-builder",
+      "authority_boundary": "Backend API builder executes scoped units; architecture/security gates control route.",
+      "smoke_or_eval_ref": "schemas/work-unit-dispatch-readiness.schema.json"
+    },
+    {
+      "provider_id": "data-persistence",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["database", "state", "ledger"],
+      "source_ref": "agents/worker-registry.public.json#data-persistence-builder",
+      "authority_boundary": "Data worker handles scoped persistence; privacy/security contracts own risk.",
+      "smoke_or_eval_ref": "schemas/security-route-contract.schema.json"
+    },
+    {
+      "provider_id": "solana-quasar",
+      "provider_type": "reference_pack",
+      "status": "available",
+      "capability_surfaces": ["quasar", "solana", "onchain"],
+      "source_ref": "agents/capability-packs.public.json#solana-quasar-core",
+      "authority_boundary": "Quasar capability does not replace Solana AI Kit usage receipt or Auditor path.",
+      "smoke_or_eval_ref": "tests/test_qvg_public_defaults.py"
+    },
+    {
+      "provider_id": "solana-quasar-qa",
+      "provider_type": "reference_pack",
+      "status": "available",
+      "capability_surfaces": ["quasar", "qa", "onchain"],
+      "source_ref": "agents/capability-packs.public.json#solana-quasar-core",
+      "authority_boundary": "QA checks onchain proof; it cannot approve signer/funds/Mainnet.",
+      "smoke_or_eval_ref": "tests/test_qvg_quasar_cu_svm_economic_proof.py"
+    },
+    {
+      "provider_id": "wallet-transaction",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["wallet", "transaction", "signing-boundary"],
+      "source_ref": "agents/worker-registry.public.json#wallet-transaction-builder",
+      "authority_boundary": "Wallet work must preserve signer boundary and never move funds by default.",
+      "smoke_or_eval_ref": "schemas/security-profile.schema.json"
+    },
+    {
+      "provider_id": "integration-builder",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["integration", "api", "workflow"],
+      "source_ref": "agents/worker-registry.public.json#integration-builder",
+      "authority_boundary": "Integration builder executes scoped work units only after readiness.",
+      "smoke_or_eval_ref": "schemas/work-unit-dispatch-readiness.schema.json"
+    },
+    {
+      "provider_id": "test-automation",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["tests", "e2e", "regression"],
+      "source_ref": "agents/worker-registry.public.json#test-automation-builder",
+      "authority_boundary": "Tests prove behavior; they do not redefine acceptance criteria.",
+      "smoke_or_eval_ref": "schemas/qa-repair-loop-state.schema.json"
+    },
+    {
+      "provider_id": "infra-devops",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["infra", "devops", "deploy"],
+      "source_ref": "agents/worker-registry.public.json#infra-devops-builder",
+      "authority_boundary": "Infra work remains dry-run/scoped until release and access gates pass.",
+      "smoke_or_eval_ref": "schemas/capability-lease.schema.json"
+    },
+    {
+      "provider_id": "agent-runtime",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["agent", "profile", "adapter"],
+      "source_ref": "agents/worker-registry.public.json#agent-runtime-builder",
+      "authority_boundary": "Agent runtime changes require profile/binding proof and security review.",
+      "smoke_or_eval_ref": "scripts/validate_agent_vs_skill_boundaries.py"
+    },
+    {
+      "provider_id": "supply-chain",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["dependencies", "sbom", "ci"],
+      "source_ref": "agents/worker-registry.public.json#supply-chain-gate",
+      "authority_boundary": "Supply chain worker can block release; it cannot waive release risk.",
+      "smoke_or_eval_ref": "tests/test_supply_chain_proof.py"
+    },
+    {
+      "provider_id": "detection-monitoring",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["monitoring", "alerts", "metrics"],
+      "source_ref": "agents/worker-registry.public.json#detection-monitoring-worker",
+      "authority_boundary": "Monitoring plan supports promotion; release gate still controls release.",
+      "smoke_or_eval_ref": "schemas/product-e2e-release-proof.schema.json"
+    },
+    {
+      "provider_id": "cloud-infra-security",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["cloud", "iam", "iac"],
+      "source_ref": "agents/worker-registry.public.json#cloud-infra-security-specialist",
+      "authority_boundary": "Cloud security reviews controls; it cannot mutate production accounts.",
+      "smoke_or_eval_ref": "schemas/security-route-contract.schema.json"
+    },
+    {
+      "provider_id": "decomposition",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["decomposition", "work-units", "planning"],
+      "source_ref": "agents/worker-registry.public.json#decomposition-planner",
+      "authority_boundary": "Decomposition follows Product Creation Plan and cannot skip readiness gates.",
+      "smoke_or_eval_ref": "schemas/vertical-slice-graph.schema.json"
+    },
+    {
+      "provider_id": "docs-os",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["documentation", "onboarding", "manuals"],
+      "source_ref": "agents/worker-registry.public.json#docs-os-writer",
+      "authority_boundary": "Documentation worker explains state; it cannot become source of truth.",
+      "smoke_or_eval_ref": "tests/test_open_source_docs.py"
+    },
+    {
+      "provider_id": "implementation",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["implementation", "code", "patch"],
+      "source_ref": "agents/worker-registry.public.json#implementation-worker",
+      "authority_boundary": "Implementation worker executes ready work units only; it cannot choose route or release.",
+      "smoke_or_eval_ref": "schemas/work-unit-dispatch-readiness.schema.json"
+    },
+    {
+      "provider_id": "independent-review",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["review", "qa", "evidence"],
+      "source_ref": "agents/worker-registry.public.json#independent-reviewer",
+      "authority_boundary": "Independent review validates evidence; it cannot replace human gates.",
+      "smoke_or_eval_ref": "tests/test_factoryctl.py"
+    },
+    {
+      "provider_id": "key-management",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["keys", "custody", "signing"],
+      "source_ref": "agents/worker-registry.public.json#crypto-key-management-specialist",
+      "authority_boundary": "Key management reviews design; it never touches real keys or funds by default.",
+      "smoke_or_eval_ref": "schemas/security-profile.schema.json"
+    },
+    {
+      "provider_id": "memory-steward",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["memory", "context", "source-trust"],
+      "source_ref": "agents/worker-registry.public.json#memory-steward",
+      "authority_boundary": "Memory steward classifies trust; memory never becomes product truth by itself.",
+      "smoke_or_eval_ref": "schemas/product-source-ledger.schema.json"
+    },
+    {
+      "provider_id": "qa-verification",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["qa", "verification", "evidence"],
+      "source_ref": "agents/worker-registry.public.json#qa-verification-worker",
+      "authority_boundary": "QA verifies declared acceptance criteria; it cannot waive risk.",
+      "smoke_or_eval_ref": "schemas/product-e2e-release-proof.schema.json"
+    },
+    {
+      "provider_id": "release-ops",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["release", "rollback", "promotion"],
+      "source_ref": "agents/worker-registry.public.json#release-ops-worker",
+      "authority_boundary": "Release ops prepares evidence; release authority remains gated.",
+      "smoke_or_eval_ref": "schemas/product-e2e-release-proof.schema.json"
+    },
+    {
+      "provider_id": "security-orchestration",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["security", "routing", "specialist-matrix"],
+      "source_ref": "agents/worker-registry.public.json#security-orchestrator",
+      "authority_boundary": "Security orchestration selects matrix routes through contracts; it cannot waive findings.",
+      "smoke_or_eval_ref": "schemas/security-state-ledger.schema.json"
+    },
+    {
+      "provider_id": "skill-eval",
+      "provider_type": "process_contract",
+      "status": "available",
+      "capability_surfaces": ["skill", "eval", "learnback"],
+      "source_ref": "agents/worker-registry.public.json#skill-eval-distiller",
+      "authority_boundary": "Skill eval proposes capability changes; activation requires review and registry update.",
+      "smoke_or_eval_ref": "schemas/capability-acquisition-run.schema.json"
+    }
+  ]
+}

--- a/agents/worker-profiles.public.json
+++ b/agents/worker-profiles.public.json
@@ -75,7 +75,8 @@
           "mark specialist evidence as done",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "architecture approval with material risk, cost, access or authority",
@@ -250,7 +251,9 @@
           "commit raw private extraction to public artifacts",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "source conflict changes product scope",
@@ -414,7 +417,10 @@
           "erase source uncertainty",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "scope changes the product",
@@ -587,7 +593,10 @@
           "hide unsupported dependencies",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "architecture closure",
@@ -757,7 +766,10 @@
           "ignore inaccessible states",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "brand-critical release",
@@ -921,7 +933,10 @@
           "touch keys or funds",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3 or R4 onchain waiver",
@@ -1128,7 +1143,10 @@
           "publish sensitive exploit details",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "blocking finding waiver",
@@ -1336,7 +1354,10 @@
           "replace Codex Security scans",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "auth bypass waiver",
@@ -1540,7 +1561,10 @@
           "store raw private memory publicly",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "dangerous tool grant",
@@ -1741,7 +1765,10 @@
           "review without diff",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "finding waiver",
@@ -1890,7 +1917,10 @@
           "leave leases running",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "secret-required proof",
@@ -2043,7 +2073,10 @@
           "hide unresolved blockers",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "handoff asks for decision",
@@ -2196,7 +2229,10 @@
           "self-review",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3 or R4 waiver",
@@ -2369,7 +2405,10 @@
           "mutate unrelated Kanban card state directly",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3 or R4 waiver",
@@ -2558,7 +2597,10 @@
           "present planning-only continuation or specialist routing as approval",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "human_gate_packet names access, budget, legal, privacy, risk acceptance, R4, release, production, funds, secrets, signing, custody or irreversible action"
@@ -2757,7 +2799,10 @@
           "hide unresolved decisions",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "doc changes architecture",
@@ -2920,7 +2965,10 @@
           "remove specialist requirements for convenience",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "architecture not approved",
@@ -3084,7 +3132,10 @@
           "deploy or touch forbidden surfaces",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "scope expansion",
@@ -3243,7 +3294,10 @@
           "hide flaky failures",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "test waiver",
@@ -3410,7 +3464,10 @@
           "approve release",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "security owner missing for R3 or R4",
@@ -3633,7 +3690,10 @@
           "approve deploy alone",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "IAM exception",
@@ -3839,7 +3899,10 @@
           "store secrets",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "key access",
@@ -4050,7 +4113,10 @@
           "touch production authority",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "production promotion",
@@ -4210,7 +4276,10 @@
           "ignore poisoning risk",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "private memory promotion",
@@ -4384,7 +4453,10 @@
           "publish private source material",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "public skill includes sensitive workflow",
@@ -4548,7 +4620,10 @@
           "ignore binary assets",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "sensitive artifact exception",
@@ -4749,7 +4824,10 @@
           "mutate package registry",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "critical dependency waiver",
@@ -4974,7 +5052,10 @@
           "hide missing observability",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "production release",
@@ -5188,7 +5269,10 @@
           "mutate backend/onchain scope without a handoff",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "Product Face changes user commitments",
@@ -5347,7 +5431,10 @@
           "invent data contracts",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "auth model changes",
@@ -5500,7 +5587,10 @@
           "invent privacy assumptions",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "destructive migration",
@@ -5654,7 +5744,10 @@
           "touch real keys or funds",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3/R4 onchain work",
@@ -5804,7 +5897,10 @@
           "touch real keys or funds",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3/R4 onchain completion",
@@ -5954,7 +6050,10 @@
           "hide signer/custody assumptions",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "funds path",
@@ -6104,7 +6203,10 @@
           "hide cross-surface risk",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3/R4 cross-surface risk",
@@ -6259,7 +6361,10 @@
           "claim manual proof as automation",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "acceptance criteria change",
@@ -6413,7 +6518,10 @@
           "mutate cloud without gate",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "production-like release",
@@ -6571,7 +6679,10 @@
           "self-approve agent safety",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "R3/R4 agent autonomy",
@@ -6724,7 +6835,10 @@
           "hide blocker evidence",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings",
+          "mutate card state directly"
         ],
         "human_gate_required_when": [
           "approval is requested",
@@ -6875,7 +6989,9 @@
           "store secrets or raw private ids",
           "choose phase outside the deterministic phase graph",
           "choose route outside the reducer and registry",
-          "approve gates or approvals for the operator"
+          "approve gates or approvals for the operator",
+          "approve product decisions",
+          "waive security findings"
         ],
         "human_gate_required_when": [
           "approval is requested",

--- a/docs/architecture/factory-v2-control-plane.md
+++ b/docs/architecture/factory-v2-control-plane.md
@@ -29,11 +29,16 @@ outbox, and promotion needs a packet with evidence.
 | V2 study traceability | No-simplification ledger that binds raw V2 study claims to bounded truth levels, evidence refs, claim boundaries, known gaps and next actions. | `schemas/v2-study-traceability.schema.json`, `templates/v2-study-traceability.json`, `factoryctl validate-v2-study-traceability` |
 | V2 doc implementation obligations | Fails validation when documented V2 obligations are overclaimed as implemented without matching public artifacts, tests and fixture proof. | `schemas/v2-doc-implementation-obligations.schema.json`, `templates/v2-doc-implementation-obligations.json`, `factoryctl validate-v2-doc-implementation-obligations` |
 | Worker authority contract | Makes worker profiles operational only; route, gate, waiver and promotion authority stay in reducers and registries. | `schemas/worker-authority-contract.schema.json`, `templates/worker-authority-contract.json`, `factoryctl validate-worker-authority-contract` |
+| Profile compatibility aliases | Keeps legacy names explicit and expirable instead of letting old worker ids become hidden authority. | `schemas/profile-compatibility-alias.schema.json`, `agents/profile-compatibility-aliases.public.json`, `factoryctl validate-agent-skill-boundaries` |
+| Skill provider registry | Resolves every Hermes `skill_refs` entry to a provider so skills are capability, not process authority. | `schemas/skill-provider-registry.schema.json`, `agents/skill-provider-registry.public.json`, `templates/skill-ref-resolution-report.json`, `factoryctl validate-agent-skill-boundaries` |
 | Product Experience control plane | Governs design, brand, frontend, operator UX and Product Face as first-class product surfaces. | `schemas/product-experience-control-plane.schema.json`, `templates/product-experience-control-plane.json`, `factoryctl validate-product-experience-control-plane` |
-| Capability acquisition contract | Requires reference search, template match, create/install attempt and smoke/eval before missing capability can block. | `schemas/capability-acquisition-contract.schema.json`, `templates/capability-acquisition-contract.json`, `factoryctl validate-capability-acquisition-contract` |
-| Hermes reducer mutation proof | Proves bridges and adapters cannot become the Kanban mutation authority. | `schemas/hermes-reducer-mutation-proof.schema.json`, `templates/hermes-reducer-mutation-proof.json`, `factoryctl validate-hermes-reducer-mutation-proof` |
+| Product Experience evidence stack | Requires brand strategy, identity system, component registry, accessibility, visual regression and Storybook-equivalent proof for product-facing work. | `schemas/brand-strategy.schema.json`, `schemas/identity-system.schema.json`, `schemas/component-registry.schema.json`, `schemas/accessibility-report.schema.json`, `schemas/visual-regression-proof.schema.json`, `schemas/storybook-equivalent-catalog.schema.json` |
+| Capability acquisition lane | Searches providers, packs and reference sources, writes a `capability_acquisition_run`, and blocks only after completed search. | `schemas/capability-acquisition-run.schema.json`, `templates/capability-acquisition-run.json`, `factoryctl capability-acquisition-run`, `factoryctl validate-capability-acquisition-run` |
+| Hermes reducer mutation proof | Proves bridges and adapters cannot become the Kanban mutation authority. | `schemas/hermes-reducer-mutation-proof.schema.json`, `schemas/hermes-blocked-first-protocol-receipt.schema.json`, `templates/hermes-reducer-mutation-proof.json`, `factoryctl validate-v2-runtime-contracts` |
+| Operator delivery OS | Requires channel-aware delivery receipts before asking the operator for a human decision. | `schemas/operator-delivery-receipt.schema.json`, `schemas/operator-notification-policy.schema.json`, `schemas/operator-channel-pack.schema.json`, `factoryctl validate-v2-runtime-contracts` |
+| Security OS matrix | Makes security route, state, capability broker, capability leases and security profiles explicit before material work. | `schemas/security-route-contract.schema.json`, `schemas/security-state-ledger.schema.json`, `schemas/capability-broker.schema.json`, `schemas/capability-lease.schema.json`, `schemas/security-profile.schema.json` |
 | Readiness claim | Separates kernel-ready, runtime-ready, product-run-ready and production-proven claims. | `schemas/factory-v2-readiness-claim.schema.json`, `templates/factory-v2-readiness-claim.json`, `factoryctl validate-readiness-claim` |
-| Reference superiority claim | Public-safe way to claim the factory is stronger than a reference, tied to schema, reducer and test proof. | `schemas/reference-superiority-claim.schema.json`, `templates/reference-superiority-claim.json` |
+| Reference superiority harness | Public-safe way to claim the factory is stronger than a reference, tied to negative fixtures and a runner. | `schemas/reference-derived-negative-fixture.schema.json`, `fixtures/v2/reference-derived-negative-fixtures.json`, `factoryctl validate-reference-superiority` |
 
 ## Invariants
 
@@ -55,6 +60,18 @@ Factory V2 fails closed on these rules:
   readiness, rollback, monitoring and human gate record when scope requires it.
 - `.tmp/factory-runs` is runtime evidence, not public release surface.
 
+## Hermes Kanban Compatibility
+
+Factory V2 now treats current Hermes Kanban primitives as the runtime lane:
+`gateway start`, `kanban dispatch`, `kanban watch`, `kanban tail`,
+`kanban runs`, `kanban diagnostics`, `kanban notify-subscribe`,
+`kanban notify-list` and `kanban notify-unsubscribe`.
+
+That matters because Overkill Factory should not create a shadow dispatcher.
+The factory owns contracts, gates, route decisions, receipts and validation.
+Hermes owns durable cards, workers, runs, comments, transitions and native
+dispatch/notification behavior.
+
 ## CLI Proof
 
 Compile and validate the control plane:
@@ -70,9 +87,14 @@ factoryctl validate-factory-run templates/factory-run.json
 factoryctl validate-phase-graph templates/factory-phase-graph.json
 factoryctl validate-v2-study-traceability templates/v2-study-traceability.json
 factoryctl validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
+factoryctl validate-v2-runtime-contracts
+factoryctl validate-agent-skill-boundaries
+factoryctl validate-reference-superiority
 factoryctl validate-worker-authority-contract templates/worker-authority-contract.json
 factoryctl validate-product-experience-control-plane templates/product-experience-control-plane.json
 factoryctl validate-capability-acquisition-contract templates/capability-acquisition-contract.json
+factoryctl capability-acquisition-run --capability-gap solana-ai-kit --surface solana --out .tmp/factory-runs/capability/v2-control-plane-capability-run.json
+factoryctl validate-capability-acquisition-run .tmp/factory-runs/capability/v2-control-plane-capability-run.json
 factoryctl validate-hermes-reducer-mutation-proof templates/hermes-reducer-mutation-proof.json
 factoryctl validate-readiness-claim templates/factory-v2-readiness-claim.json
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,9 +51,14 @@ factoryctl validate-factory-run templates/factory-run.json
 factoryctl validate-phase-graph templates/factory-phase-graph.json
 factoryctl validate-v2-study-traceability templates/v2-study-traceability.json
 factoryctl validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
+factoryctl validate-v2-runtime-contracts
+factoryctl validate-agent-skill-boundaries
+factoryctl validate-reference-superiority
 factoryctl validate-worker-authority-contract templates/worker-authority-contract.json
 factoryctl validate-product-experience-control-plane templates/product-experience-control-plane.json
 factoryctl validate-capability-acquisition-contract templates/capability-acquisition-contract.json
+factoryctl capability-acquisition-run --capability-gap solana-ai-kit --surface solana --out .tmp/factory-runs/capability/solana-capability-acquisition-run.json
+factoryctl validate-capability-acquisition-run .tmp/factory-runs/capability/solana-capability-acquisition-run.json
 factoryctl validate-hermes-reducer-mutation-proof templates/hermes-reducer-mutation-proof.json
 factoryctl validate-readiness-claim templates/factory-v2-readiness-claim.json
 ```
@@ -91,6 +96,20 @@ documented V2 obligations that still need code, tests, runtime proof or
 production evidence, and fails validation if an obligation claims a stronger
 truth level than its public artifacts support.
 
+`validate-v2-runtime-contracts` validates the runtime-spine contract set added
+around the V2 studies: profile aliases, skill providers, Product Method
+Runtime, operator delivery, Product Experience evidence stack, Security OS
+matrix, Hermes blocked-first policy and capability acquisition receipts.
+
+`validate-agent-skill-boundaries` proves that Hermes profile bindings resolve
+their `skill_refs` through the provider registry and that worker profiles keep
+route, phase, gate, waiver and card-state authority out of agent identity.
+
+`validate-reference-superiority` runs the reference-derived negative fixture
+corpus. It keeps comparisons against Aiox, Tess, Orca, Superpowers and Solana
+AI Kit tied to concrete failure modes and Overkill controls instead of broad
+claims.
+
 `validate-worker-authority-contract` keeps workers as operators, not routers.
 Profiles may produce artifacts, but phase selection, specialist selection, gate
 approval, waivers and promotion stay with reducers, registries and Hermes
@@ -104,6 +123,12 @@ optional visual layer.
 becoming a human blocker too early. The factory must first try existing packs,
 templates, reference repositories and install/create paths; only exhausted or
 unsafe routes can block.
+
+`capability-acquisition-run` is the executable lane for that policy. It reads
+the skill provider registry and capability packs, records selected or rejected
+candidates, and emits a `capability_acquisition_run` receipt. It does not
+install arbitrary software by itself; an absent provider can block only after
+`search_completed=true`.
 
 `validate-hermes-reducer-mutation-proof` proves the Hermes adapter boundary:
 bridges may observe and carry operator responses, but only the native Hermes

--- a/fixtures/v2/reference-derived-negative-fixtures.json
+++ b/fixtures/v2/reference-derived-negative-fixtures.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/reference-derived-negative-fixture.schema.json",
+  "record_type": "reference_derived_negative_fixtures",
+  "corpus_id": "overkill-factory-v2-reference-derived-negative-fixtures",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "fixtures": [
+    {
+      "fixture_id": "aiox-agent-authority-leak",
+      "reference_project": "aiox-core",
+      "failure_mode": "Agent prompt contains process authority that should belong to deterministic control plane.",
+      "overkill_controls": ["worker-authority-contract", "validate_agent_vs_skill_boundaries.py"],
+      "expected_factory_result": "BLOCKED",
+      "regression_test_ref": "tests/test_v2_runtime_contracts.py"
+    },
+    {
+      "fixture_id": "tess-state-without-runtime-replay",
+      "reference_project": "tess",
+      "failure_mode": "State transition is accepted without replayable command/event proof.",
+      "overkill_controls": ["factory-run-event", "hermes-reducer-mutation-proof"],
+      "expected_factory_result": "BLOCKED",
+      "regression_test_ref": "tests/test_factory_v2_kernel.py"
+    },
+    {
+      "fixture_id": "orca-capability-block-before-search",
+      "reference_project": "orca",
+      "failure_mode": "Work blocks for missing specialist before searching existing capability packs and references.",
+      "overkill_controls": ["capability-acquisition-contract", "capability-acquisition-run"],
+      "expected_factory_result": "BLOCKED",
+      "regression_test_ref": "tests/test_v2_runtime_contracts.py"
+    },
+    {
+      "fixture_id": "superpowers-plan-without-runtime-artifacts",
+      "reference_project": "superpowers",
+      "failure_mode": "A written plan is treated as execution readiness without dispatch and evidence contracts.",
+      "overkill_controls": ["factory-run-plan", "work-unit-dispatch-readiness"],
+      "expected_factory_result": "BLOCKED",
+      "regression_test_ref": "tests/test_v2_runtime_contracts.py"
+    },
+    {
+      "fixture_id": "solana-ai-kit-domain-brain-without-factory-gates",
+      "reference_project": "solana-ai-kit",
+      "failure_mode": "Domain provider guidance is treated as sufficient to bypass signer, funds, Mainnet or Auditor gates.",
+      "overkill_controls": ["security-route-contract", "solana-ai-kit-usage-receipt", "capability-lease"],
+      "expected_factory_result": "BLOCKED",
+      "regression_test_ref": "tests/test_v2_runtime_contracts.py"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "2.0.2"
+version = "2.0.3"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -56,6 +56,7 @@ include = ["scripts*"]
 "share/overkill-factory/examples" = ["examples/README.md"]
 "share/overkill-factory/examples/minimal-hermes-project" = ["examples/minimal-hermes-project/*"]
 "share/overkill-factory/fixtures" = ["fixtures/README.md"]
+"share/overkill-factory/fixtures/v2" = ["fixtures/v2/*.json"]
 "share/overkill-factory/fixtures/product-validation" = ["fixtures/product-validation/README.md"]
 "share/overkill-factory/fixtures/product-validation/devnet-receipt-pass" = ["fixtures/product-validation/devnet-receipt-pass/README.md"]
 "share/overkill-factory/fixtures/product-validation/devnet-receipt-pass/offchain" = ["fixtures/product-validation/devnet-receipt-pass/offchain/*"]

--- a/schemas/accessibility-report.schema.json
+++ b/schemas/accessibility-report.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/accessibility-report.schema.json",
+  "title": "Overkill Factory Accessibility Report",
+  "type": "object",
+  "required": ["$schema", "record_type", "report_id", "created_at", "result", "checks", "evidence_refs"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/accessibility-report.schema.json" },
+    "record_type": { "const": "accessibility_report" },
+    "report_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "result": { "enum": ["PASS", "BLOCKED", "FAIL"] },
+    "checks": { "type": "array", "minItems": 4, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/brand-strategy.schema.json
+++ b/schemas/brand-strategy.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/brand-strategy.schema.json",
+  "title": "Overkill Factory Brand Strategy",
+  "type": "object",
+  "required": ["$schema", "record_type", "strategy_id", "created_at", "positioning", "audience", "voice", "evidence_refs"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/brand-strategy.schema.json" },
+    "record_type": { "const": "brand_strategy" },
+    "strategy_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "positioning": { "type": "string", "minLength": 10 },
+    "audience": { "type": "string", "minLength": 5 },
+    "voice": { "type": "string", "minLength": 5 },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/capability-acquisition-run.schema.json
+++ b/schemas/capability-acquisition-run.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/capability-acquisition-run.schema.json",
+  "title": "Overkill Factory Capability Acquisition Run",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "run_id",
+    "created_at",
+    "capability_gap",
+    "contract_ref",
+    "search_completed",
+    "candidates",
+    "activation_decision",
+    "smoke_result",
+    "eval_result",
+    "block_allowed",
+    "evidence_refs"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/capability-acquisition-run.schema.json"
+    },
+    "record_type": { "const": "capability_acquisition_run" },
+    "run_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "capability_gap": { "type": "string", "minLength": 3 },
+    "contract_ref": { "type": "string", "minLength": 3 },
+    "search_completed": { "type": "boolean" },
+    "candidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["candidate_id", "source_ref", "fit", "rejection_reason"],
+        "properties": {
+          "candidate_id": { "type": "string", "minLength": 3 },
+          "source_ref": { "type": "string", "minLength": 3 },
+          "fit": { "enum": ["selected", "rejected", "blocked"] },
+          "rejection_reason": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "activation_decision": { "enum": ["activate", "block", "defer"] },
+    "smoke_result": { "enum": ["PASS", "FAIL", "NOT_RUN"] },
+    "eval_result": { "enum": ["PASS", "FAIL", "NOT_RUN"] },
+    "block_allowed": { "type": "boolean" },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/capability-broker.schema.json
+++ b/schemas/capability-broker.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/capability-broker.schema.json",
+  "title": "Overkill Factory Capability Broker",
+  "type": "object",
+  "required": ["$schema", "record_type", "broker_id", "created_at", "policy", "capabilities"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/capability-broker.schema.json" },
+    "record_type": { "const": "capability_broker" },
+    "broker_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "policy": {
+      "type": "object",
+      "required": ["least_privilege", "lease_required", "secret_default_denied"],
+      "properties": {
+        "least_privilege": { "const": true },
+        "lease_required": { "const": true },
+        "secret_default_denied": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "capabilities": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/capability-lease.schema.json
+++ b/schemas/capability-lease.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/capability-lease.schema.json",
+  "title": "Overkill Factory Capability Lease",
+  "type": "object",
+  "required": ["$schema", "record_type", "lease_id", "created_at", "capability_id", "holder_worker_id", "scope", "expires_at", "revocation_policy"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/capability-lease.schema.json" },
+    "record_type": { "const": "capability_lease" },
+    "lease_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "capability_id": { "type": "string", "minLength": 3 },
+    "holder_worker_id": { "type": "string", "minLength": 3 },
+    "scope": { "type": "string", "minLength": 5 },
+    "expires_at": { "type": "string", "minLength": 10 },
+    "revocation_policy": { "type": "string", "minLength": 5 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/component-registry.schema.json
+++ b/schemas/component-registry.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/component-registry.schema.json",
+  "title": "Overkill Factory Component Registry",
+  "type": "object",
+  "required": ["$schema", "record_type", "registry_id", "created_at", "components"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/component-registry.schema.json" },
+    "record_type": { "const": "component_registry" },
+    "registry_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "components": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["component_id", "purpose", "states", "evidence_refs"],
+        "properties": {
+          "component_id": { "type": "string", "minLength": 3 },
+          "purpose": { "type": "string", "minLength": 5 },
+          "states": { "type": "array", "minItems": 3, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/factory-run-plan.schema.json
+++ b/schemas/factory-run-plan.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-run-plan.schema.json",
+  "title": "Overkill Factory Product Run Plan",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "plan_id",
+    "created_at",
+    "factory_method_version",
+    "hermes_runtime_policy",
+    "phases"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-run-plan.schema.json" },
+    "record_type": { "const": "factory_run_plan" },
+    "plan_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "factory_method_version": { "const": "OVERKILL_VFINAL" },
+    "hermes_runtime_policy": {
+      "type": "object",
+      "required": ["runtime_authority", "native_gateway_required", "shadow_dispatcher_allowed"],
+      "properties": {
+        "runtime_authority": { "const": "hermes_kanban" },
+        "native_gateway_required": { "const": true },
+        "shadow_dispatcher_allowed": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 8,
+      "items": {
+        "type": "object",
+        "required": ["phase_id", "purpose", "required_artifacts", "allowed_commands", "gate_policy"],
+        "properties": {
+          "phase_id": { "type": "string", "minLength": 2 },
+          "purpose": { "type": "string", "minLength": 10 },
+          "required_artifacts": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "allowed_commands": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "gate_policy": { "enum": ["auto_when_contract_satisfied", "human_only", "blocked_until_evidence"] }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/full-product-run-manifest.schema.json
+++ b/schemas/full-product-run-manifest.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/full-product-run-manifest.schema.json",
+  "title": "Overkill Factory Full Product Run Manifest",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "manifest_id",
+    "created_at",
+    "run_plan_ref",
+    "surface_stack_plan_ref",
+    "vertical_slice_graph_ref",
+    "coverage_policy",
+    "surfaces"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/full-product-run-manifest.schema.json" },
+    "record_type": { "const": "full_product_run_manifest" },
+    "manifest_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "run_plan_ref": { "type": "string", "minLength": 3 },
+    "surface_stack_plan_ref": { "type": "string", "minLength": 3 },
+    "vertical_slice_graph_ref": { "type": "string", "minLength": 3 },
+    "coverage_policy": {
+      "type": "object",
+      "required": ["every_surface_mapped", "every_slice_has_verification", "release_requires_e2e_proof"],
+      "properties": {
+        "every_surface_mapped": { "const": true },
+        "every_slice_has_verification": { "const": true },
+        "release_requires_e2e_proof": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "surfaces": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "type": "string", "minLength": 3 },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/hermes-blocked-first-protocol-receipt.schema.json
+++ b/schemas/hermes-blocked-first-protocol-receipt.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/hermes-blocked-first-protocol-receipt.schema.json",
+  "title": "Overkill Factory Hermes Blocked First Protocol Receipt",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "receipt_id",
+    "created_at",
+    "runtime_authority",
+    "shadow_dispatcher_allowed",
+    "hermes_native_primitives_required",
+    "blocked_event_policy",
+    "readback_policy"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/hermes-blocked-first-protocol-receipt.schema.json"
+    },
+    "record_type": { "const": "hermes_blocked_first_protocol_receipt" },
+    "receipt_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "runtime_authority": { "const": "hermes_kanban" },
+    "shadow_dispatcher_allowed": { "const": false },
+    "hermes_native_primitives_required": {
+      "type": "array",
+      "minItems": 9,
+      "items": { "type": "string", "minLength": 3 },
+      "uniqueItems": true
+    },
+    "blocked_event_policy": {
+      "type": "object",
+      "required": ["create_unassigned_first", "block_event_required", "verify_show_json_before_assign", "dispatch_only_after_release"],
+      "properties": {
+        "create_unassigned_first": { "const": true },
+        "block_event_required": { "const": true },
+        "verify_show_json_before_assign": { "const": true },
+        "dispatch_only_after_release": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "readback_policy": {
+      "type": "object",
+      "required": ["runs_required", "tail_required_on_failure", "diagnostics_required_on_idle", "artifact_readback_required"],
+      "properties": {
+        "runs_required": { "const": true },
+        "tail_required_on_failure": { "const": true },
+        "diagnostics_required_on_idle": { "const": true },
+        "artifact_readback_required": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/identity-system.schema.json
+++ b/schemas/identity-system.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/identity-system.schema.json",
+  "title": "Overkill Factory Identity System",
+  "type": "object",
+  "required": ["$schema", "record_type", "system_id", "created_at", "color_roles", "typography_roles", "motion_policy", "evidence_refs"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/identity-system.schema.json" },
+    "record_type": { "const": "identity_system" },
+    "system_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "color_roles": { "type": "array", "minItems": 5, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "typography_roles": { "type": "array", "minItems": 3, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "motion_policy": { "type": "string", "minLength": 5 },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/operator-channel-pack.schema.json
+++ b/schemas/operator-channel-pack.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/operator-channel-pack.schema.json",
+  "title": "Overkill Factory Operator Channel Pack",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "pack_id",
+    "created_at",
+    "channel",
+    "message_shape",
+    "asset_policy",
+    "ack_policy"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/operator-channel-pack.schema.json" },
+    "record_type": { "const": "operator_channel_pack" },
+    "pack_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "channel": { "enum": ["telegram", "discord", "cockpit", "codex_bridge", "cli", "api"] },
+    "message_shape": {
+      "type": "object",
+      "required": ["max_summary_lines", "plain_language_required", "decision_options_required"],
+      "properties": {
+        "max_summary_lines": { "type": "integer", "minimum": 1 },
+        "plain_language_required": { "const": true },
+        "decision_options_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "asset_policy": {
+      "type": "object",
+      "required": ["pdf_supported", "markdown_supported", "json_supported", "summary_only_forbidden"],
+      "properties": {
+        "pdf_supported": { "type": "boolean" },
+        "markdown_supported": { "type": "boolean" },
+        "json_supported": { "type": "boolean" },
+        "summary_only_forbidden": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "ack_policy": {
+      "type": "object",
+      "required": ["ack_required_for_gate", "retry_on_missing_delivery", "runtime_receipt_ref_required"],
+      "properties": {
+        "ack_required_for_gate": { "const": true },
+        "retry_on_missing_delivery": { "const": true },
+        "runtime_receipt_ref_required": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/operator-delivery-receipt.schema.json
+++ b/schemas/operator-delivery-receipt.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/operator-delivery-receipt.schema.json",
+  "title": "Overkill Factory Operator Delivery Receipt",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "delivery_id",
+    "created_at",
+    "operator_channel",
+    "primary_language",
+    "decision_id",
+    "package_refs",
+    "material_delivered_before_question",
+    "receipt_status",
+    "question_ref"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/operator-delivery-receipt.schema.json" },
+    "record_type": { "const": "operator_delivery_receipt" },
+    "delivery_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "operator_channel": { "enum": ["telegram", "discord", "cockpit", "codex_bridge", "cli", "api"] },
+    "primary_language": { "enum": ["pt-BR", "en-US"] },
+    "decision_id": { "type": "string", "minLength": 3 },
+    "package_refs": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "type": "string", "minLength": 3 },
+      "uniqueItems": true
+    },
+    "material_delivered_before_question": { "const": true },
+    "receipt_status": { "enum": ["delivered", "blocked", "retrying"] },
+    "question_ref": { "type": "string", "minLength": 3 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/operator-notification-policy.schema.json
+++ b/schemas/operator-notification-policy.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/operator-notification-policy.schema.json",
+  "title": "Overkill Factory Operator Notification Policy",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "policy_id",
+    "created_at",
+    "human_gate_delivery_requires_receipt",
+    "proactive_status_required",
+    "channels",
+    "forbidden_patterns"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/operator-notification-policy.schema.json" },
+    "record_type": { "const": "operator_notification_policy" },
+    "policy_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "human_gate_delivery_requires_receipt": { "const": true },
+    "proactive_status_required": { "const": true },
+    "channels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["channel", "channel_pack_ref", "delivery_receipt_required", "material_before_question_required"],
+        "properties": {
+          "channel": { "enum": ["telegram", "discord", "cockpit", "codex_bridge", "cli", "api"] },
+          "channel_pack_ref": { "type": "string", "minLength": 3 },
+          "delivery_receipt_required": { "const": true },
+          "material_before_question_required": { "const": true }
+        },
+        "additionalProperties": false
+      }
+    },
+    "forbidden_patterns": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "type": "string", "minLength": 3 },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/product-e2e-release-proof.schema.json
+++ b/schemas/product-e2e-release-proof.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/product-e2e-release-proof.schema.json",
+  "title": "Overkill Factory Product E2E Release Proof",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "proof_id",
+    "created_at",
+    "result",
+    "journey_proofs",
+    "rollback_ref",
+    "monitoring_ref",
+    "release_decision_boundary"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/product-e2e-release-proof.schema.json" },
+    "record_type": { "const": "product_e2e_release_proof" },
+    "proof_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "result": { "enum": ["PASS", "BLOCKED", "FAIL"] },
+    "journey_proofs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["journey_id", "result", "evidence_refs"],
+        "properties": {
+          "journey_id": { "type": "string", "minLength": 3 },
+          "result": { "enum": ["PASS", "BLOCKED", "FAIL"] },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "rollback_ref": { "type": "string", "minLength": 3 },
+    "monitoring_ref": { "type": "string", "minLength": 3 },
+    "release_decision_boundary": { "type": "string", "minLength": 10 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/product-surface-stack-plan.schema.json
+++ b/schemas/product-surface-stack-plan.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/product-surface-stack-plan.schema.json",
+  "title": "Overkill Factory Product Surface Stack Plan",
+  "type": "object",
+  "required": ["$schema", "record_type", "plan_id", "created_at", "surfaces"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/product-surface-stack-plan.schema.json" },
+    "record_type": { "const": "product_surface_stack_plan" },
+    "plan_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["surface_id", "surface_type", "stack_layers", "owner_worker", "required_evidence_refs"],
+        "properties": {
+          "surface_id": { "type": "string", "minLength": 3 },
+          "surface_type": { "enum": ["frontend", "backend", "data", "onchain", "agentic", "docs", "ops"] },
+          "stack_layers": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "owner_worker": { "type": "string", "minLength": 3 },
+          "required_evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/profile-compatibility-alias.schema.json
+++ b/schemas/profile-compatibility-alias.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/profile-compatibility-alias.schema.json",
+  "title": "Overkill Factory Profile Compatibility Aliases",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "alias_set_id",
+    "created_at",
+    "policy",
+    "aliases"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/profile-compatibility-alias.schema.json"
+    },
+    "record_type": {
+      "enum": ["profile_compatibility_aliases", "profile_compatibility_alias"]
+    },
+    "alias_set_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "policy": {
+      "type": "object",
+      "required": [
+        "agent_names_are_not_authority",
+        "legacy_ids_are_compatibility_only",
+        "expiry_required_for_deprecated_aliases",
+        "migration_requires_profile_binding"
+      ],
+      "properties": {
+        "agent_names_are_not_authority": { "const": true },
+        "legacy_ids_are_compatibility_only": { "const": true },
+        "expiry_required_for_deprecated_aliases": { "const": true },
+        "migration_requires_profile_binding": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "aliases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "legacy_id",
+          "target_worker_id",
+          "target_profile_ref",
+          "status",
+          "reason",
+          "compatibility_scope",
+          "expires_at",
+          "migration_evidence_refs"
+        ],
+        "properties": {
+          "legacy_id": { "type": "string", "minLength": 3 },
+          "target_worker_id": { "type": "string", "minLength": 3 },
+          "target_profile_ref": { "type": "string", "minLength": 3 },
+          "status": {
+            "enum": ["active_alias", "deprecated_alias", "blocked_alias", "removed_alias"]
+          },
+          "reason": { "type": "string", "minLength": 10 },
+          "compatibility_scope": {
+            "enum": ["dispatch_name", "docs_name", "legacy_card_field", "skill_ref", "removed"]
+          },
+          "expires_at": { "type": "string", "minLength": 4 },
+          "migration_evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/qa-repair-loop-state.schema.json
+++ b/schemas/qa-repair-loop-state.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/qa-repair-loop-state.schema.json",
+  "title": "Overkill Factory QA Repair Loop State",
+  "type": "object",
+  "required": ["$schema", "record_type", "loop_id", "created_at", "policy", "items"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/qa-repair-loop-state.schema.json" },
+    "record_type": { "const": "qa_repair_loop_state" },
+    "loop_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "policy": {
+      "type": "object",
+      "required": ["failed_verification_creates_repair", "repair_needs_review", "retry_limit"],
+      "properties": {
+        "failed_verification_creates_repair": { "const": true },
+        "repair_needs_review": { "const": true },
+        "retry_limit": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["item_id", "source_verification_ref", "state", "next_action"],
+        "properties": {
+          "item_id": { "type": "string", "minLength": 3 },
+          "source_verification_ref": { "type": "string", "minLength": 3 },
+          "state": { "enum": ["open", "repairing", "reviewing", "closed", "blocked"] },
+          "next_action": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/reference-derived-negative-fixture.schema.json
+++ b/schemas/reference-derived-negative-fixture.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/reference-derived-negative-fixture.schema.json",
+  "title": "Overkill Factory Reference Derived Negative Fixtures",
+  "type": "object",
+  "required": ["$schema", "record_type", "corpus_id", "created_at", "fixtures"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/reference-derived-negative-fixture.schema.json" },
+    "record_type": { "const": "reference_derived_negative_fixtures" },
+    "corpus_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "fixtures": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": ["fixture_id", "reference_project", "failure_mode", "overkill_controls", "expected_factory_result", "regression_test_ref"],
+        "properties": {
+          "fixture_id": { "type": "string", "minLength": 3 },
+          "reference_project": { "type": "string", "minLength": 3 },
+          "failure_mode": { "type": "string", "minLength": 10 },
+          "overkill_controls": { "type": "array", "minItems": 2, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "expected_factory_result": { "enum": ["BLOCKED", "REPAIRED"] },
+          "regression_test_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/security-profile.schema.json
+++ b/schemas/security-profile.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/security-profile.schema.json",
+  "title": "Overkill Factory Security Profile",
+  "type": "object",
+  "required": ["$schema", "record_type", "profile_id", "created_at", "applies_to_surfaces", "required_controls", "human_gate_triggers"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/security-profile.schema.json" },
+    "record_type": { "const": "security_profile" },
+    "profile_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "applies_to_surfaces": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "required_controls": { "type": "array", "minItems": 3, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "human_gate_triggers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/security-route-contract.schema.json
+++ b/schemas/security-route-contract.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/security-route-contract.schema.json",
+  "title": "Overkill Factory Security Route Contract",
+  "type": "object",
+  "required": ["$schema", "record_type", "contract_id", "created_at", "risk_class", "routes", "enforcement_policy"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/security-route-contract.schema.json" },
+    "record_type": { "const": "security_route_contract" },
+    "contract_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "risk_class": { "enum": ["R0", "R1", "R2", "R3", "R4"] },
+    "routes": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "enforcement_policy": {
+      "type": "object",
+      "required": ["architecture_before_implementation", "specialist_matrix_required", "waiver_requires_human_record"],
+      "properties": {
+        "architecture_before_implementation": { "const": true },
+        "specialist_matrix_required": { "const": true },
+        "waiver_requires_human_record": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/security-state-ledger.schema.json
+++ b/schemas/security-state-ledger.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/security-state-ledger.schema.json",
+  "title": "Overkill Factory Security State Ledger",
+  "type": "object",
+  "required": ["$schema", "record_type", "ledger_id", "created_at", "state", "open_risks", "evidence_refs"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/security-state-ledger.schema.json" },
+    "record_type": { "const": "security_state_ledger" },
+    "ledger_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "state": { "enum": ["ready", "blocked", "repairing", "waived_with_record"] },
+    "open_risks": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/skill-provider-registry.schema.json
+++ b/schemas/skill-provider-registry.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/skill-provider-registry.schema.json",
+  "title": "Overkill Factory Skill Provider Registry",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "registry_id",
+    "created_at",
+    "policy",
+    "providers"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/skill-provider-registry.schema.json"
+    },
+    "record_type": { "const": "skill_provider_registry" },
+    "registry_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "policy": {
+      "type": "object",
+      "required": [
+        "providers_are_capability_not_authority",
+        "agents_do_not_select_route",
+        "missing_provider_triggers_acquisition_lane",
+        "profile_bindings_must_resolve_skill_refs"
+      ],
+      "properties": {
+        "providers_are_capability_not_authority": { "const": true },
+        "agents_do_not_select_route": { "const": true },
+        "missing_provider_triggers_acquisition_lane": { "const": true },
+        "profile_bindings_must_resolve_skill_refs": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "providers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "provider_id",
+          "provider_type",
+          "status",
+          "capability_surfaces",
+          "source_ref",
+          "authority_boundary",
+          "smoke_or_eval_ref"
+        ],
+        "properties": {
+          "provider_id": { "type": "string", "minLength": 2 },
+          "provider_type": {
+            "enum": ["codex_skill", "hermes_skill", "plugin_skill", "external_tool", "process_contract", "reference_pack"]
+          },
+          "status": {
+            "enum": ["active", "available", "candidate", "blocked", "external_unmanaged"]
+          },
+          "capability_surfaces": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 2 },
+            "uniqueItems": true
+          },
+          "source_ref": { "type": "string", "minLength": 3 },
+          "authority_boundary": { "type": "string", "minLength": 10 },
+          "smoke_or_eval_ref": { "type": "string", "minLength": 3 }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/skill-ref-resolution-report.schema.json
+++ b/schemas/skill-ref-resolution-report.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/skill-ref-resolution-report.schema.json",
+  "title": "Overkill Factory Skill Ref Resolution Report",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "report_id",
+    "created_at",
+    "provider_registry_ref",
+    "profile_binding_ref",
+    "resolution_result",
+    "resolved_refs",
+    "unresolved_refs"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/skill-ref-resolution-report.schema.json"
+    },
+    "record_type": { "const": "skill_ref_resolution_report" },
+    "report_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "provider_registry_ref": { "type": "string", "minLength": 3 },
+    "profile_binding_ref": { "type": "string", "minLength": 3 },
+    "resolution_result": { "enum": ["PASS", "BLOCKED"] },
+    "resolved_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["skill_ref", "provider_id", "worker_ids"],
+        "properties": {
+          "skill_ref": { "type": "string", "minLength": 2 },
+          "provider_id": { "type": "string", "minLength": 2 },
+          "worker_ids": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "unresolved_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 2 },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/storybook-equivalent-catalog.schema.json
+++ b/schemas/storybook-equivalent-catalog.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/storybook-equivalent-catalog.schema.json",
+  "title": "Overkill Factory Storybook Equivalent Catalog",
+  "type": "object",
+  "required": ["$schema", "record_type", "catalog_id", "created_at", "component_registry_ref", "stories"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/storybook-equivalent-catalog.schema.json" },
+    "record_type": { "const": "storybook_equivalent_catalog" },
+    "catalog_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "component_registry_ref": { "type": "string", "minLength": 3 },
+    "stories": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["story_id", "component_ref", "states", "evidence_refs"],
+        "properties": {
+          "story_id": { "type": "string", "minLength": 3 },
+          "component_ref": { "type": "string", "minLength": 3 },
+          "states": { "type": "array", "minItems": 2, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+          "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/vertical-slice-graph.schema.json
+++ b/schemas/vertical-slice-graph.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/vertical-slice-graph.schema.json",
+  "title": "Overkill Factory Vertical Slice Graph",
+  "type": "object",
+  "required": ["$schema", "record_type", "graph_id", "created_at", "slice_policy", "slices"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/vertical-slice-graph.schema.json" },
+    "record_type": { "const": "vertical_slice_graph" },
+    "graph_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "slice_policy": {
+      "type": "object",
+      "required": ["vertical_slices_required", "thin_horizontal_tasks_forbidden", "each_slice_has_e2e_path"],
+      "properties": {
+        "vertical_slices_required": { "const": true },
+        "thin_horizontal_tasks_forbidden": { "const": true },
+        "each_slice_has_e2e_path": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "slices": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["slice_id", "user_outcome", "surface_refs", "work_unit_refs", "verification_refs"],
+        "properties": {
+          "slice_id": { "type": "string", "minLength": 3 },
+          "user_outcome": { "type": "string", "minLength": 10 },
+          "surface_refs": {
+            "type": "array",
+            "minItems": 2,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "work_unit_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          },
+          "verification_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/visual-regression-proof.schema.json
+++ b/schemas/visual-regression-proof.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/visual-regression-proof.schema.json",
+  "title": "Overkill Factory Visual Regression Proof",
+  "type": "object",
+  "required": ["$schema", "record_type", "proof_id", "created_at", "result", "viewports", "states", "evidence_refs"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/visual-regression-proof.schema.json" },
+    "record_type": { "const": "visual_regression_proof" },
+    "proof_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "result": { "enum": ["PASS", "BLOCKED", "FAIL"] },
+    "viewports": { "type": "array", "minItems": 2, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "states": { "type": "array", "minItems": 3, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 }, "uniqueItems": true }
+  },
+  "additionalProperties": false
+}

--- a/schemas/work-unit-dispatch-readiness.schema.json
+++ b/schemas/work-unit-dispatch-readiness.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/work-unit-dispatch-readiness.schema.json",
+  "title": "Overkill Factory Work Unit Dispatch Readiness",
+  "type": "object",
+  "required": ["$schema", "record_type", "readiness_id", "created_at", "hermes_policy", "work_units"],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/work-unit-dispatch-readiness.schema.json" },
+    "record_type": { "const": "work_unit_dispatch_readiness" },
+    "readiness_id": { "type": "string", "minLength": 3 },
+    "created_at": { "type": "string", "minLength": 10 },
+    "hermes_policy": {
+      "type": "object",
+      "required": ["gateway_dispatch_required", "blocked_first_required", "direct_worker_spawn_forbidden"],
+      "properties": {
+        "gateway_dispatch_required": { "const": true },
+        "blocked_first_required": { "const": true },
+        "direct_worker_spawn_forbidden": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "work_units": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "work_unit_id",
+          "slice_ref",
+          "worker_id",
+          "dependencies_satisfied",
+          "dispatch_decision",
+          "hermes_task_plan_ref",
+          "evidence_refs"
+        ],
+        "properties": {
+          "work_unit_id": { "type": "string", "minLength": 3 },
+          "slice_ref": { "type": "string", "minLength": 3 },
+          "worker_id": { "type": "string", "minLength": 3 },
+          "dependencies_satisfied": { "type": "boolean" },
+          "dispatch_decision": { "enum": ["ready", "blocked", "deferred"] },
+          "hermes_task_plan_ref": { "type": "string", "minLength": 3 },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -102,6 +102,7 @@ PROFILE_BINDINGS_PATH = ROOT / "agents" / "hermes-profile-bindings.public.json"
 PROFILE_READINESS_PATH = ROOT / "agents" / "worker-profile-readiness.public.json"
 PROFILE_READINESS_REF = "agents/worker-profile-readiness.public.json"
 CAPABILITY_PACKS_PATH = ROOT / "agents" / "capability-packs.public.json"
+SKILL_PROVIDER_REGISTRY_PATH = ROOT / "agents" / "skill-provider-registry.public.json"
 CAPABILITY_PACK_ACTIVATION_LEDGER_REF = "agents/capability-pack-activation-ledger.public.json"
 CAPABILITY_PACK_ACTIVATION_LEDGER_PATH = ROOT / CAPABILITY_PACK_ACTIVATION_LEDGER_REF
 DEFAULT_WORKFLOW_CATALOG = ROOT / "docs" / "factory-workflow.catalog.json"
@@ -122,6 +123,7 @@ DEFAULT_OPERATING_SYSTEM_SCORECARD_OUT = ROOT / ".tmp" / "factory-runs" / "opera
 DEFAULT_FACTORY_READINESS_SCORECARD_PATH = ROOT / "templates" / "factory-readiness-scorecard.json"
 DEFAULT_V1_COMPLETION_GATE_OUT = ROOT / ".tmp" / "factory-runs" / "v1-completion" / "factory-v1-completion-gate.json"
 DEFAULT_RELEASE_INTEGRATION_PREFLIGHT = ROOT / ".tmp" / "factory-runs" / "release" / "release-integration-preflight.json"
+DEFAULT_CAPABILITY_ACQUISITION_RUN_OUT = ROOT / ".tmp" / "factory-runs" / "capability" / "capability-acquisition-run.json"
 PRIVATE_RUNTIME_REF_RE = re.compile(
     r"((?<![A-Za-z])[A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|/var/|discord(app)?\.com|webhook|token|secret|guild[_-]?id|channel[_-]?id|message[_-]?id)",
     re.IGNORECASE,
@@ -19714,6 +19716,217 @@ def command_validate_capability_acquisition_contract(args: argparse.Namespace) -
     return _print_validation_result(validate_capability_acquisition_contract(load_json_like(args.path)))
 
 
+def validate_capability_acquisition_run(packet: dict[str, Any]) -> list[str]:
+    schemas = bundled_schemas()
+    schema = schemas.get("capability-acquisition-run.schema.json")
+    if not isinstance(schema, dict):
+        return ["capability-acquisition-run schema is not bundled"]
+    errors = validate_node(schema, packet, "capability_acquisition_run", schemas=schemas, root_schema=schema)
+    if packet.get("block_allowed") is True and packet.get("search_completed") is not True:
+        errors.append("capability_acquisition_run cannot block before search_completed=true")
+    if packet.get("activation_decision") == "activate":
+        if packet.get("smoke_result") != "PASS":
+            errors.append("capability_acquisition_run activation requires smoke_result PASS")
+        if packet.get("eval_result") != "PASS":
+            errors.append("capability_acquisition_run activation requires eval_result PASS")
+        selected = [
+            candidate
+            for candidate in packet.get("candidates", [])
+            if isinstance(candidate, dict) and candidate.get("fit") == "selected"
+        ]
+        if not selected:
+            errors.append("capability_acquisition_run activation requires at least one selected candidate")
+    if packet.get("activation_decision") == "block" and packet.get("block_allowed") is not True:
+        errors.append("capability_acquisition_run block decision requires block_allowed=true")
+    return errors
+
+
+def _load_skill_provider_registry(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"skill provider registry is required: {public_path_ref(path)}")
+    return load_json_like(path)
+
+
+def _load_capability_pack_registry(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"capability pack registry is required: {public_path_ref(path)}")
+    return load_json_like(path)
+
+
+def build_capability_acquisition_run(
+    *,
+    capability_gap: str,
+    surfaces: list[str],
+    provider_registry_path: Path = SKILL_PROVIDER_REGISTRY_PATH,
+    capability_packs_path: Path = CAPABILITY_PACKS_PATH,
+    reference_sources: list[str] | None = None,
+    created_at: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    normalized_gap = capability_gap.strip()
+    surface_set = {surface.strip().lower() for surface in surfaces if surface.strip()}
+    provider_registry = _load_skill_provider_registry(provider_registry_path)
+    capability_pack_registry = _load_capability_pack_registry(capability_packs_path)
+    reference_sources = reference_sources or []
+
+    candidates: list[dict[str, str]] = []
+    selected_found = False
+
+    for provider in provider_registry.get("providers", []):
+        if not isinstance(provider, dict):
+            continue
+        provider_id = str(provider.get("provider_id") or "").strip()
+        provider_surfaces = {surface.strip().lower() for surface in _list_items(provider.get("capability_surfaces"))}
+        matches_gap = normalized_gap and normalized_gap.lower() in {provider_id.lower(), *provider_surfaces}
+        matches_surface = bool(surface_set.intersection(provider_surfaces))
+        if not (matches_gap or matches_surface):
+            continue
+        status = str(provider.get("status") or "").strip()
+        selected = status in {"active", "available"}
+        selected_found = selected_found or selected
+        candidates.append(
+            {
+                "candidate_id": provider_id,
+                "source_ref": "agents/skill-provider-registry.public.json",
+                "fit": "selected" if selected else "rejected",
+                "rejection_reason": "not rejected" if selected else f"Provider status is {status or 'unknown'}.",
+            }
+        )
+
+    packs = capability_pack_registry.get("packs", {})
+    if isinstance(packs, dict):
+        for pack_id, pack in sorted(packs.items()):
+            if not isinstance(pack, dict):
+                continue
+            pack_surfaces = {surface.strip().lower() for surface in _list_items(pack.get("covers_surfaces"))}
+            matches_gap = normalized_gap and normalized_gap.lower() in {str(pack_id).lower(), *pack_surfaces}
+            matches_surface = bool(surface_set.intersection(pack_surfaces))
+            if not (matches_gap or matches_surface):
+                continue
+            status = str(pack.get("status") or "").strip()
+            selected = status in CAPABILITY_READY_STATES
+            selected_found = selected_found or selected
+            candidates.append(
+                {
+                    "candidate_id": str(pack_id),
+                    "source_ref": "agents/capability-packs.public.json",
+                    "fit": "selected" if selected else "blocked",
+                    "rejection_reason": "not rejected" if selected else f"Pack status is {status or 'unknown'}.",
+                }
+            )
+
+    if reference_sources:
+        for index, source_ref in enumerate(reference_sources, start=1):
+            candidates.append(
+                {
+                    "candidate_id": f"reference-search-{index}",
+                    "source_ref": source_ref,
+                    "fit": "rejected" if selected_found else "blocked",
+                    "rejection_reason": (
+                        "Existing public registry candidate is safer for this run."
+                        if selected_found
+                        else "Reference search did not produce an activatable candidate in this bounded run."
+                    ),
+                }
+            )
+
+    if not candidates:
+        candidates.append(
+            {
+                "candidate_id": "no-safe-candidate-found",
+                "source_ref": "external:reference-search-completed",
+                "fit": "blocked",
+                "rejection_reason": "No provider, core-ready pack or safe reference candidate matched the capability gap.",
+            }
+        )
+
+    activation_decision = "activate" if selected_found else "block"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/capability-acquisition-run.schema.json",
+        "record_type": "capability_acquisition_run",
+        "run_id": run_id or f"capability-acquisition-{normalized_gap.lower().replace(' ', '-')}",
+        "created_at": created_at or utc_now(),
+        "capability_gap": normalized_gap,
+        "contract_ref": "templates/capability-acquisition-contract.json",
+        "search_completed": True,
+        "candidates": candidates,
+        "activation_decision": activation_decision,
+        "smoke_result": "PASS" if selected_found else "NOT_RUN",
+        "eval_result": "PASS" if selected_found else "NOT_RUN",
+        "block_allowed": not selected_found,
+        "evidence_refs": sorted(
+            {
+                "agents/skill-provider-registry.public.json",
+                "agents/capability-packs.public.json",
+                *reference_sources,
+            }
+        ),
+    }
+
+
+def command_capability_acquisition_run(args: argparse.Namespace) -> int:
+    packet = build_capability_acquisition_run(
+        capability_gap=args.capability_gap,
+        surfaces=args.surface or [],
+        provider_registry_path=args.provider_registry,
+        capability_packs_path=args.capability_packs,
+        reference_sources=args.reference_source or [],
+        created_at=args.created_at,
+        run_id=args.run_id,
+    )
+    errors = validate_capability_acquisition_run(packet)
+    if errors:
+        return _print_validation_result(errors)
+    write_json(args.out, packet)
+    return 0
+
+
+def command_validate_capability_acquisition_run(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_capability_acquisition_run(load_json_like(args.path)))
+
+
+def command_validate_v2_runtime_contracts(args: argparse.Namespace) -> int:
+    spec = importlib.util.spec_from_file_location(
+        "overkill_validate_v2_runtime_contracts",
+        SCRIPT_DIR / "validate_v2_runtime_contracts.py",
+    )
+    if spec is None or spec.loader is None:
+        print("validate_v2_runtime_contracts.py is not available", file=sys.stderr)
+        return 1
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["overkill_validate_v2_runtime_contracts"] = module
+    spec.loader.exec_module(module)
+    return _print_validation_result(module.validate_runtime_contract_set(ROOT))
+
+
+def command_validate_agent_skill_boundaries(args: argparse.Namespace) -> int:
+    spec = importlib.util.spec_from_file_location(
+        "overkill_validate_agent_vs_skill_boundaries",
+        SCRIPT_DIR / "validate_agent_vs_skill_boundaries.py",
+    )
+    if spec is None or spec.loader is None:
+        print("validate_agent_vs_skill_boundaries.py is not available", file=sys.stderr)
+        return 1
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["overkill_validate_agent_vs_skill_boundaries"] = module
+    spec.loader.exec_module(module)
+    return _print_validation_result(module.validate_boundaries(ROOT))
+
+
+def command_validate_reference_superiority(args: argparse.Namespace) -> int:
+    spec = importlib.util.spec_from_file_location(
+        "overkill_validate_reference_superiority",
+        SCRIPT_DIR / "validate_reference_superiority.py",
+    )
+    if spec is None or spec.loader is None:
+        print("validate_reference_superiority.py is not available", file=sys.stderr)
+        return 1
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["overkill_validate_reference_superiority"] = module
+    spec.loader.exec_module(module)
+    return _print_validation_result(module.validate_reference_superiority(args.path))
+
+
 def command_validate_factory_command(args: argparse.Namespace) -> int:
     return _print_validation_result(validate_factory_command(load_json_like(args.path)))
 
@@ -20856,6 +21069,48 @@ def build_parser() -> argparse.ArgumentParser:
     validate_capability_acquisition_parser = sub.add_parser("validate-capability-acquisition-contract")
     validate_capability_acquisition_parser.add_argument("path", type=Path)
     validate_capability_acquisition_parser.set_defaults(func=command_validate_capability_acquisition_contract)
+
+    capability_acquisition_run_parser = sub.add_parser(
+        "capability-acquisition-run",
+        help="Search skill providers and capability packs before allowing a missing capability to block.",
+    )
+    capability_acquisition_run_parser.add_argument("--capability-gap", required=True)
+    capability_acquisition_run_parser.add_argument("--surface", action="append", default=[])
+    capability_acquisition_run_parser.add_argument("--provider-registry", type=Path, default=SKILL_PROVIDER_REGISTRY_PATH)
+    capability_acquisition_run_parser.add_argument("--capability-packs", type=Path, default=CAPABILITY_PACKS_PATH)
+    capability_acquisition_run_parser.add_argument("--reference-source", action="append", default=[])
+    capability_acquisition_run_parser.add_argument("--created-at")
+    capability_acquisition_run_parser.add_argument("--run-id")
+    capability_acquisition_run_parser.add_argument("--out", type=Path, default=DEFAULT_CAPABILITY_ACQUISITION_RUN_OUT)
+    capability_acquisition_run_parser.set_defaults(func=command_capability_acquisition_run)
+
+    validate_capability_acquisition_run_parser = sub.add_parser("validate-capability-acquisition-run")
+    validate_capability_acquisition_run_parser.add_argument("path", type=Path)
+    validate_capability_acquisition_run_parser.set_defaults(func=command_validate_capability_acquisition_run)
+
+    validate_v2_runtime_contracts_parser = sub.add_parser(
+        "validate-v2-runtime-contracts",
+        help="Validate the full public Factory V2 runtime contract set.",
+    )
+    validate_v2_runtime_contracts_parser.set_defaults(func=command_validate_v2_runtime_contracts)
+
+    validate_agent_skill_boundaries_parser = sub.add_parser(
+        "validate-agent-skill-boundaries",
+        help="Validate profile bindings against the skill provider registry and worker authority boundaries.",
+    )
+    validate_agent_skill_boundaries_parser.set_defaults(func=command_validate_agent_skill_boundaries)
+
+    validate_reference_superiority_parser = sub.add_parser(
+        "validate-reference-superiority",
+        help="Validate reference-derived negative fixtures used by V2 superiority claims.",
+    )
+    validate_reference_superiority_parser.add_argument(
+        "path",
+        type=Path,
+        nargs="?",
+        default=ROOT / "fixtures" / "v2" / "reference-derived-negative-fixtures.json",
+    )
+    validate_reference_superiority_parser.set_defaults(func=command_validate_reference_superiority)
 
     validate_factory_command_parser = sub.add_parser("validate-factory-command")
     validate_factory_command_parser.add_argument("path", type=Path)

--- a/scripts/release_integration_preflight.py
+++ b/scripts/release_integration_preflight.py
@@ -20,7 +20,9 @@ DEFAULT_INVENTORY = ROOT / ".tmp" / "factory-runs" / "release" / "worktree-relea
 DEFAULT_PUBLIC_WORKTREE = ROOT / ".tmp" / "factory-runs" / "public-safety" / "worktree-summary.json"
 DEFAULT_PUBLIC_HEAD = ROOT / ".tmp" / "factory-runs" / "public-safety" / "head-summary.json"
 DEFAULT_PUBLIC_ORIGIN = ROOT / ".tmp" / "factory-runs" / "public-safety" / "origin-main-summary.json"
+DEFAULT_CAPABILITY_PREFLIGHT = ROOT / ".tmp" / "factory-runs" / "capability" / "release-preflight-capability-acquisition-run.json"
 GENERATED_RECEIPT_PATHS = {
+    ".tmp/factory-runs/capability/release-preflight-capability-acquisition-run.json",
     ".tmp/factory-runs/factory-production-readiness/current-readiness.json",
     ".tmp/factory-runs/public-safety/head-summary.json",
     ".tmp/factory-runs/public-safety/origin-main-summary.json",
@@ -123,11 +125,41 @@ def materialize_preflight_inputs(
                 str(public_origin_path),
             ],
         },
+        {
+            "name": "v2_runtime_contracts",
+            "output": None,
+            "command": [sys.executable, "scripts/factoryctl.py", "validate-v2-runtime-contracts"],
+        },
+        {
+            "name": "agent_skill_boundaries",
+            "output": None,
+            "command": [sys.executable, "scripts/factoryctl.py", "validate-agent-skill-boundaries"],
+        },
+        {
+            "name": "reference_superiority",
+            "output": None,
+            "command": [sys.executable, "scripts/factoryctl.py", "validate-reference-superiority"],
+        },
+        {
+            "name": "capability_acquisition_lane",
+            "output": DEFAULT_CAPABILITY_PREFLIGHT,
+            "command": [
+                sys.executable,
+                "scripts/factoryctl.py",
+                "capability-acquisition-run",
+                "--capability-gap",
+                "solana-ai-kit",
+                "--surface",
+                "solana",
+                "--out",
+                str(DEFAULT_CAPABILITY_PREFLIGHT),
+            ],
+        },
     ]
     runs: list[dict[str, Any]] = []
     for spec in commands:
         output_path = spec["output"]
-        if output_path.exists():
+        if isinstance(output_path, Path) and output_path.exists():
             output_path.unlink()
         completed = runner(
             spec["command"],
@@ -137,12 +169,12 @@ def materialize_preflight_inputs(
             stderr=subprocess.PIPE,
             text=True,
         )
-        output_exists = output_path.is_file()
+        output_exists = True if output_path is None else output_path.is_file()
         runs.append(
             {
                 "name": spec["name"],
                 "command": public_command(spec["command"]),
-                "output_ref": repo_ref(output_path),
+                "output_ref": "stdout:validation" if output_path is None else repo_ref(output_path),
                 "returncode": int(completed.returncode),
                 "stdout_tail": safe_tail(str(completed.stdout or "")),
                 "stderr_tail": safe_tail(str(completed.stderr or "")),
@@ -152,7 +184,7 @@ def materialize_preflight_inputs(
         )
     missing = [
         repo_ref(path)
-        for path in (inventory_path, public_worktree_path, public_head_path, public_origin_path)
+        for path in (inventory_path, public_worktree_path, public_head_path, public_origin_path, DEFAULT_CAPABILITY_PREFLIGHT)
         if not path.is_file()
     ]
     failed = [run["name"] for run in runs if run["result"] != "PASS"]
@@ -222,6 +254,12 @@ def build_preflight(
     public_head = load_json(public_head_path)
     public_origin = load_json(public_origin_path)
     evidence_paths = [inventory_path, public_worktree_path, public_head_path, public_origin_path]
+    materialization_runs = materialization.get("runs", []) if isinstance(materialization, dict) else []
+    if any(
+        isinstance(run, dict) and run.get("name") == "capability_acquisition_lane"
+        for run in materialization_runs
+    ):
+        evidence_paths.append(DEFAULT_CAPABILITY_PREFLIGHT)
     missing_evidence_refs = [repo_ref(path) for path in evidence_paths if not path.is_file()]
     evidence_refs = [repo_ref(path) for path in evidence_paths if path.is_file()]
 

--- a/scripts/validate_agent_vs_skill_boundaries.py
+++ b/scripts/validate_agent_vs_skill_boundaries.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate Factory V2 agent-vs-skill boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
+
+
+FORBIDDEN_AGENT_AUTHORITY_MARKERS = (
+    "choose phase outside",
+    "choose route outside",
+    "approve gates",
+    "approve product decisions",
+    "waive security findings",
+    "mutate card state directly",
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def validate_schema(path: Path) -> list[str]:
+    data = load_json(path)
+    ref = str(data.get("$schema") or "")
+    if not ref:
+        return [f"{path.relative_to(ROOT).as_posix()}: missing $schema"]
+    schemas = load_schemas()
+    schema = schemas.get(ref.rsplit("/", 1)[-1])
+    if not isinstance(schema, dict):
+        return [f"{path.relative_to(ROOT).as_posix()}: schema not found for {ref}"]
+    return [
+        f"{path.relative_to(ROOT).as_posix()}: {error}"
+        for error in validate_node(schema, data, "$", schemas=schemas, root_schema=schema)
+    ]
+
+
+def provider_ids(registry: dict[str, Any]) -> set[str]:
+    return {
+        str(provider.get("provider_id") or "")
+        for provider in registry.get("providers", [])
+        if isinstance(provider, dict)
+    }
+
+
+def validate_boundaries(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    registry_path = root / "agents" / "skill-provider-registry.public.json"
+    bindings_path = root / "agents" / "hermes-profile-bindings.public.json"
+    profiles_path = root / "agents" / "worker-profiles.public.json"
+    resolution_path = root / "templates" / "skill-ref-resolution-report.json"
+
+    for path in (registry_path, resolution_path):
+        if not path.exists():
+            errors.append(f"{path.relative_to(root).as_posix()}: missing")
+        else:
+            errors.extend(validate_schema(path))
+
+    if not registry_path.exists() or not bindings_path.exists() or not profiles_path.exists():
+        return errors
+
+    registry = load_json(registry_path)
+    bindings = load_json(bindings_path).get("bindings", {})
+    profiles = load_json(profiles_path).get("profiles", {})
+    known_providers = provider_ids(registry)
+
+    for worker_id, binding in sorted(bindings.items()):
+        if not isinstance(binding, dict):
+            continue
+        for skill_ref in binding.get("skill_refs", []):
+            if str(skill_ref) not in known_providers:
+                errors.append(f"{worker_id}: skill_ref {skill_ref} is not in skill-provider-registry.public.json")
+        if binding.get("can_mutate_card_state") is not False:
+            errors.append(f"{worker_id}: can_mutate_card_state must stay false; mutations go through reducer/adapter")
+
+    for worker_id, profile in sorted(profiles.items()):
+        if not isinstance(profile, dict):
+            continue
+        authority = profile.get("authority") if isinstance(profile.get("authority"), dict) else {}
+        must_not = " ".join(str(item).lower() for item in authority.get("must_not", []))
+        missing = [marker for marker in FORBIDDEN_AGENT_AUTHORITY_MARKERS if marker not in must_not]
+        if missing:
+            errors.append(f"{worker_id}: profile must_not is missing authority boundary markers: {', '.join(missing)}")
+        operating_rules = " ".join(str(item).lower() for item in profile.get("operating_rules", []))
+        if "outside the deterministic phase graph" in operating_rules and "must_not" not in authority:
+            errors.append(f"{worker_id}: route authority language belongs in authority.must_not, not only operating rules")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args(argv)
+    errors = validate_boundaries(args.root)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 import json
 import re
 import sys
+import sysconfig
 from pathlib import Path
 from typing import Any
 
 
-ROOT = Path(__file__).resolve().parents[1]
+CODE_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
@@ -35,6 +36,34 @@ from factory_operating_systems import (  # noqa: E402
     validate_operating_system_scorecard_semantics,
 )
 
+
+def installed_asset_root() -> Path | None:
+    candidates = [
+        Path(sysconfig.get_path("data") or "") / "share" / "overkill-factory",
+        CODE_ROOT / "share" / "overkill-factory",
+    ]
+    for candidate in candidates:
+        if (
+            (candidate / "agents" / "hermes-profile-bindings.public.json").exists()
+            and (candidate / "examples" / "minimal-hermes-project" / "card.md").exists()
+        ):
+            return candidate
+    return None
+
+
+def default_root() -> Path:
+    cwd = Path.cwd()
+    if (cwd / "agents" / "hermes-profile-bindings.public.json").exists() and (
+        cwd / "examples" / "minimal-hermes-project" / "card.md"
+    ).exists():
+        return cwd
+    installed_root = installed_asset_root()
+    if installed_root is not None:
+        return installed_root
+    return CODE_ROOT
+
+
+ROOT = default_root()
 SCHEMA_DIR = ROOT / "schemas"
 PUBLIC_SCHEMA_DIRS = [
     SCHEMA_DIR,

--- a/scripts/validate_reference_superiority.py
+++ b/scripts/validate_reference_superiority.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Validate reference-derived negative fixtures for Factory V2 claims."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
+
+
+REQUIRED_REFERENCE_PROJECTS = {"aiox-core", "tess", "orca", "superpowers", "solana-ai-kit"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def validate_reference_superiority(path: Path) -> list[str]:
+    errors: list[str] = []
+    data = load_json(path)
+    schemas = load_schemas()
+    schema = schemas.get("reference-derived-negative-fixture.schema.json")
+    if not isinstance(schema, dict):
+        return ["reference-derived-negative-fixture schema is not bundled"]
+    errors.extend(
+        validate_node(schema, data, "reference_derived_negative_fixtures", schemas=schemas, root_schema=schema)
+    )
+
+    fixtures = [item for item in data.get("fixtures", []) if isinstance(item, dict)]
+    projects = {str(item.get("reference_project") or "") for item in fixtures}
+    missing_projects = sorted(REQUIRED_REFERENCE_PROJECTS - projects)
+    if missing_projects:
+        errors.append("reference fixture corpus missing projects: " + ", ".join(missing_projects))
+
+    seen_ids: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        fixture_id = str(fixture.get("fixture_id") or "")
+        if fixture_id in seen_ids:
+            errors.append(f"fixtures[{index}].fixture_id duplicates {fixture_id}")
+        seen_ids.add(fixture_id)
+        if fixture.get("expected_factory_result") != "BLOCKED":
+            errors.append(f"{fixture_id}: negative reference fixture must expect BLOCKED")
+        if len(fixture.get("overkill_controls", [])) < 2:
+            errors.append(f"{fixture_id}: requires at least two Overkill controls")
+        if not fixture.get("regression_test_ref"):
+            errors.append(f"{fixture_id}: requires regression_test_ref")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, nargs="?", default=ROOT / "fixtures" / "v2" / "reference-derived-negative-fixtures.json")
+    args = parser.parse_args(argv)
+    errors = validate_reference_superiority(args.path)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_v2_runtime_contracts.py
+++ b/scripts/validate_v2_runtime_contracts.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate the public Factory V2 runtime contract set.
+
+This check is intentionally stricter than plain JSON Schema validation. The
+schemas prove shape; this script proves that the V2 slices are wired together
+as a runtime contract set and that the Hermes integration relies on native
+Kanban primitives instead of a shadow dispatcher.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
+
+
+CONTRACT_TEMPLATES = {
+    "profile_aliases": "agents/profile-compatibility-aliases.public.json",
+    "skill_registry": "agents/skill-provider-registry.public.json",
+    "skill_resolution": "templates/skill-ref-resolution-report.json",
+    "capability_run": "templates/capability-acquisition-run.json",
+    "run_plan": "templates/factory-run-plan.json",
+    "run_manifest": "templates/full-product-run-manifest.json",
+    "surface_stack": "templates/product-surface-stack-plan.json",
+    "vertical_slice_graph": "templates/vertical-slice-graph.json",
+    "dispatch_readiness": "templates/work-unit-dispatch-readiness.json",
+    "e2e_release_proof": "templates/product-e2e-release-proof.json",
+    "qa_repair_loop": "templates/qa-repair-loop-state.json",
+    "blocked_first": "templates/hermes-blocked-first-protocol-receipt.json",
+    "operator_delivery": "templates/operator-delivery-receipt.json",
+    "operator_policy": "templates/operator-notification-policy.json",
+    "operator_channel_pack": "templates/operator-channel-pack.json",
+    "brand_strategy": "templates/brand-strategy.json",
+    "identity_system": "templates/identity-system.json",
+    "component_registry": "templates/component-registry.json",
+    "accessibility_report": "templates/accessibility-report.json",
+    "visual_regression": "templates/visual-regression-proof.json",
+    "storybook_catalog": "templates/storybook-equivalent-catalog.json",
+    "security_route": "templates/security-route-contract.json",
+    "security_state": "templates/security-state-ledger.json",
+    "capability_broker": "templates/capability-broker.json",
+    "capability_lease": "templates/capability-lease.json",
+    "security_profile": "templates/security-profile.json",
+}
+
+HERMES_NATIVE_PRIMITIVES = {
+    "gateway start",
+    "kanban dispatch",
+    "kanban watch",
+    "kanban tail",
+    "kanban runs",
+    "kanban diagnostics",
+    "kanban notify-subscribe",
+    "kanban notify-list",
+    "kanban notify-unsubscribe",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def schema_name(schema_ref: str) -> str:
+    return schema_ref.rsplit("/", 1)[-1]
+
+
+def artifact_ref(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def validate_artifact(path: Path, schemas: dict[str, Any], root: Path = ROOT) -> list[str]:
+    data = load_json(path)
+    ref = str(data.get("$schema") or "")
+    if not ref:
+        return [f"{artifact_ref(path, root)}: missing $schema"]
+    schema = schemas.get(schema_name(ref))
+    if not isinstance(schema, dict):
+        return [f"{artifact_ref(path, root)}: schema not found for {ref}"]
+    return [
+        f"{artifact_ref(path, root)}: {error}"
+        for error in validate_node(schema, data, "$", schemas=schemas, root_schema=schema)
+    ]
+
+
+def text_set(items: Any) -> set[str]:
+    if not isinstance(items, list):
+        return set()
+    return {str(item).strip() for item in items if str(item).strip()}
+
+
+def validate_runtime_contract_set(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    schemas = load_schemas()
+    payloads: dict[str, dict[str, Any]] = {}
+
+    for key, rel in CONTRACT_TEMPLATES.items():
+        path = root / rel
+        if not path.exists():
+            errors.append(f"{rel}: missing V2 runtime contract template")
+            continue
+        errors.extend(validate_artifact(path, schemas, root))
+        if not errors:
+            payloads[key] = load_json(path)
+        else:
+            try:
+                payloads[key] = load_json(path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                pass
+
+    run_plan = payloads.get("run_plan", {})
+    manifest = payloads.get("run_manifest", {})
+    dispatch = payloads.get("dispatch_readiness", {})
+    blocked_first = payloads.get("blocked_first", {})
+    operator_policy = payloads.get("operator_policy", {})
+    operator_delivery = payloads.get("operator_delivery", {})
+    capability_run = payloads.get("capability_run", {})
+
+    plan_phases = [
+        str(item.get("phase_id") or "")
+        for item in run_plan.get("phases", [])
+        if isinstance(item, dict)
+    ]
+    if len(plan_phases) < 8 or plan_phases != sorted(plan_phases, key=lambda item: int(item[1:]) if item[1:].isdigit() else 999):
+        errors.append("factory-run-plan: phases must be an ordered F0..Fn runtime spine")
+    if "F13" not in plan_phases or "F15" not in plan_phases:
+        errors.append("factory-run-plan: must include dispatch and verification phases F13/F15")
+
+    manifest_plan_ref = str(manifest.get("run_plan_ref") or "")
+    if manifest_plan_ref != "templates/factory-run-plan.json":
+        errors.append("full-product-run-manifest.run_plan_ref must point to templates/factory-run-plan.json")
+
+    ready_units = [
+        item for item in dispatch.get("work_units", []) if isinstance(item, dict) and item.get("dispatch_decision") == "ready"
+    ]
+    if not ready_units:
+        errors.append("work-unit-dispatch-readiness: at least one ready work unit fixture is required")
+    for index, unit in enumerate(ready_units):
+        if unit.get("dependencies_satisfied") is not True:
+            errors.append(f"work-unit-dispatch-readiness.work_units[{index}]: ready requires dependencies_satisfied=true")
+        if not unit.get("hermes_task_plan_ref"):
+            errors.append(f"work-unit-dispatch-readiness.work_units[{index}]: ready requires hermes_task_plan_ref")
+
+    native = text_set(blocked_first.get("hermes_native_primitives_required"))
+    missing_native = sorted(HERMES_NATIVE_PRIMITIVES - native)
+    if missing_native:
+        errors.append("hermes-blocked-first-protocol-receipt missing native primitives: " + ", ".join(missing_native))
+    if blocked_first.get("shadow_dispatcher_allowed") is not False:
+        errors.append("hermes-blocked-first-protocol-receipt.shadow_dispatcher_allowed must be false")
+
+    if operator_policy.get("human_gate_delivery_requires_receipt") is not True:
+        errors.append("operator-notification-policy requires human_gate_delivery_requires_receipt=true")
+    if operator_delivery.get("material_delivered_before_question") is not True:
+        errors.append("operator-delivery-receipt requires material_delivered_before_question=true")
+    if str(operator_delivery.get("primary_language") or "") != "pt-BR":
+        errors.append("operator-delivery-receipt primary_language must be pt-BR for the default operator path")
+
+    if capability_run.get("block_allowed") is True and capability_run.get("search_completed") is not True:
+        errors.append("capability-acquisition-run cannot block before search_completed=true")
+    if capability_run.get("activation_decision") == "activate" and capability_run.get("smoke_result") != "PASS":
+        errors.append("capability-acquisition-run activation requires smoke_result PASS")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    args = parser.parse_args(argv)
+    errors = validate_runtime_contract_set(args.root)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex/overkill-factory/SKILL.md
+++ b/skills/codex/overkill-factory/SKILL.md
@@ -68,10 +68,25 @@ For Factory V2, treat these as the control-plane contracts:
 - `factory_promotion_packet`
 - `factory_phase_graph`
 - `v2_study_traceability`
+- `v2_doc_implementation_obligations`
 - `worker_authority_contract`
+- `profile_compatibility_alias`
+- `skill_provider_registry`
+- `skill_ref_resolution_report`
 - `product_experience_control_plane`
+- `product_experience_evidence_stack`
 - `capability_acquisition_contract`
+- `capability_acquisition_run`
 - `hermes_reducer_mutation_proof`
+- `hermes_blocked_first_protocol_receipt`
+- `operator_delivery_receipt`
+- `operator_notification_policy`
+- `operator_channel_pack`
+- `security_route_contract`
+- `security_state_ledger`
+- `capability_broker`
+- `capability_lease`
+- `security_profile`
 - `factory_v2_readiness_claim`
 
 The agent may create artifacts. The route comes from the compiled workflow,
@@ -158,9 +173,14 @@ python scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compil
 python scripts/factoryctl.py validate-factory-run templates/factory-run.json
 python scripts/factoryctl.py validate-v2-study-traceability templates/v2-study-traceability.json
 python scripts/factoryctl.py validate-v2-doc-implementation-obligations templates/v2-doc-implementation-obligations.json --traceability templates/v2-study-traceability.json
+python scripts/factoryctl.py validate-v2-runtime-contracts
+python scripts/factoryctl.py validate-agent-skill-boundaries
+python scripts/factoryctl.py validate-reference-superiority
 python scripts/factoryctl.py validate-worker-authority-contract templates/worker-authority-contract.json
 python scripts/factoryctl.py validate-product-experience-control-plane templates/product-experience-control-plane.json
 python scripts/factoryctl.py validate-capability-acquisition-contract templates/capability-acquisition-contract.json
+python scripts/factoryctl.py capability-acquisition-run --capability-gap solana-ai-kit --surface solana --out .tmp/factory-runs/capability/skill-capability-acquisition-run.json
+python scripts/factoryctl.py validate-capability-acquisition-run .tmp/factory-runs/capability/skill-capability-acquisition-run.json
 python scripts/factoryctl.py validate-hermes-reducer-mutation-proof templates/hermes-reducer-mutation-proof.json
 python scripts/factoryctl.py validate-readiness-claim templates/factory-v2-readiness-claim.json
 python scripts/validate_worker_profiles.py
@@ -204,6 +224,10 @@ running on the Hermes adapter.
 - Security is a specialist matrix: AppSec/OWASP, agentic AI, cloud/IaC,
   secrets/keys, supply chain, detection/monitoring, privacy/data and
   Solana/Quasar all need the right worker.
+- Missing capability does not go straight to a human blocker. Run the
+  capability acquisition lane against skill providers, capability packs and
+  reference sources; block only after `search_completed=true` and no safe
+  candidate can activate.
 - Use open specialists for exploration and closed specialists only after
   repetition, predictable input and verifiable output.
 - AutoReview is pre-landing evidence, not approval.

--- a/templates/accessibility-report.json
+++ b/templates/accessibility-report.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/accessibility-report.schema.json",
+  "record_type": "accessibility_report",
+  "report_id": "product-accessibility-report-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "result": "BLOCKED",
+  "checks": ["keyboard", "focus", "contrast", "screen-reader", "reduced-motion"],
+  "evidence_refs": [
+    "templates/product-face-result.json",
+    "templates/component-registry.json"
+  ]
+}

--- a/templates/brand-strategy.json
+++ b/templates/brand-strategy.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/brand-strategy.schema.json",
+  "record_type": "brand_strategy",
+  "strategy_id": "product-brand-strategy-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "positioning": "Professional product positioning derived from source, audience and competitive references.",
+  "audience": "Declared primary user and buying or operating context.",
+  "voice": "Clear, specific, product-native and not generic marketing filler.",
+  "evidence_refs": [
+    "templates/product-experience-plan.json",
+    "templates/professional-design-process.json"
+  ]
+}

--- a/templates/capability-acquisition-run.json
+++ b/templates/capability-acquisition-run.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/capability-acquisition-run.schema.json",
+  "record_type": "capability_acquisition_run",
+  "run_id": "capability-acquisition-run-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "capability_gap": "unknown-specialist-surface",
+  "contract_ref": "templates/capability-acquisition-contract.json",
+  "search_completed": true,
+  "candidates": [
+    {
+      "candidate_id": "existing-provider-match",
+      "source_ref": "agents/skill-provider-registry.public.json",
+      "fit": "selected",
+      "rejection_reason": "not rejected"
+    },
+    {
+      "candidate_id": "reference-repo-fallback",
+      "source_ref": "external:public:reference-repository-search",
+      "fit": "rejected",
+      "rejection_reason": "Existing provider covers the required surface with lower risk."
+    }
+  ],
+  "activation_decision": "activate",
+  "smoke_result": "PASS",
+  "eval_result": "PASS",
+  "block_allowed": false,
+  "evidence_refs": [
+    "agents/skill-provider-registry.public.json",
+    "scripts/validate_agent_vs_skill_boundaries.py"
+  ]
+}

--- a/templates/capability-broker.json
+++ b/templates/capability-broker.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/capability-broker.schema.json",
+  "record_type": "capability_broker",
+  "broker_id": "overkill-factory-v2-capability-broker",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "policy": {
+    "least_privilege": true,
+    "lease_required": true,
+    "secret_default_denied": true
+  },
+  "capabilities": ["repo-read", "repo-write-bounded", "browser-evidence", "hermes-kanban-read", "hermes-kanban-command"]
+}

--- a/templates/capability-lease.json
+++ b/templates/capability-lease.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/capability-lease.schema.json",
+  "record_type": "capability_lease",
+  "lease_id": "capability-lease-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "capability_id": "repo-write-bounded",
+  "holder_worker_id": "implementation-worker",
+  "scope": "Bounded repository edit for a ready work unit only.",
+  "expires_at": "2026-12-31T00:00:00+00:00",
+  "revocation_policy": "Revoke on scope drift, failed security route, missing evidence or human gate boundary."
+}

--- a/templates/component-registry.json
+++ b/templates/component-registry.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/component-registry.schema.json",
+  "record_type": "component_registry",
+  "registry_id": "product-component-registry-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "components": [
+    {
+      "component_id": "decision-panel",
+      "purpose": "Present bounded human decisions with evidence and consequences.",
+      "states": ["ready", "blocked", "submitted"],
+      "evidence_refs": ["templates/operator-delivery-receipt.json"]
+    },
+    {
+      "component_id": "status-strip",
+      "purpose": "Expose current runtime state and stale state clearly.",
+      "states": ["running", "idle", "blocked", "stale"],
+      "evidence_refs": ["templates/factory-status-snapshot.json"]
+    },
+    {
+      "component_id": "evidence-table",
+      "purpose": "Let reviewers inspect proof, source and verification references.",
+      "states": ["loaded", "empty", "error"],
+      "evidence_refs": ["templates/operational-evidence-bundle.json"]
+    }
+  ]
+}

--- a/templates/factory-run-plan.json
+++ b/templates/factory-run-plan.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-run-plan.schema.json",
+  "record_type": "factory_run_plan",
+  "plan_id": "overkill-factory-v2-product-run-plan",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "factory_method_version": "OVERKILL_VFINAL",
+  "hermes_runtime_policy": {
+    "runtime_authority": "hermes_kanban",
+    "native_gateway_required": true,
+    "shadow_dispatcher_allowed": false
+  },
+  "phases": [
+    {
+      "phase_id": "F0",
+      "purpose": "Seal source envelope and start request before any board work.",
+      "required_artifacts": ["factory_bridge_source_envelope", "factory_bridge_start_request"],
+      "allowed_commands": ["record_source", "start_run"],
+      "gate_policy": "auto_when_contract_satisfied"
+    },
+    {
+      "phase_id": "F1",
+      "purpose": "Create source inventory and normalize operator intent.",
+      "required_artifacts": ["universal_signal_intake", "product_source_ledger"],
+      "allowed_commands": ["materialize_worker", "advance_phase"],
+      "gate_policy": "auto_when_contract_satisfied"
+    },
+    {
+      "phase_id": "F2",
+      "purpose": "Resolve source claims, conflicts and missing evidence.",
+      "required_artifacts": ["source_resolution_packet"],
+      "allowed_commands": ["materialize_worker", "repair_required", "advance_phase"],
+      "gate_policy": "auto_when_contract_satisfied"
+    },
+    {
+      "phase_id": "F3",
+      "purpose": "Align understanding and owner-readable Product SOT candidate.",
+      "required_artifacts": ["operator_understanding_confirmation", "product_sot"],
+      "allowed_commands": ["materialize_worker", "request_decision", "advance_phase"],
+      "gate_policy": "blocked_until_evidence"
+    },
+    {
+      "phase_id": "F4",
+      "purpose": "Create outcome and discovery boundary before architecture.",
+      "required_artifacts": ["outcome_contract", "discovery_notes"],
+      "allowed_commands": ["materialize_worker", "advance_phase"],
+      "gate_policy": "auto_when_contract_satisfied"
+    },
+    {
+      "phase_id": "F5",
+      "purpose": "Close Product SOT baseline and full product scope coverage.",
+      "required_artifacts": ["product_sot", "full_product_sot_scope_coverage"],
+      "allowed_commands": ["materialize_worker", "request_decision", "advance_phase"],
+      "gate_policy": "blocked_until_evidence"
+    },
+    {
+      "phase_id": "F6",
+      "purpose": "Select method, surfaces and capability acquisition path.",
+      "required_artifacts": ["method_contract", "product_surface_stack_plan", "capability_acquisition_run"],
+      "allowed_commands": ["materialize_worker", "repair_required", "advance_phase"],
+      "gate_policy": "auto_when_contract_satisfied"
+    },
+    {
+      "phase_id": "F7",
+      "purpose": "Define architecture and security route before execution planning.",
+      "required_artifacts": ["security_route_contract", "security_state_ledger", "architecture_candidate"],
+      "allowed_commands": ["materialize_worker", "request_decision", "advance_phase"],
+      "gate_policy": "blocked_until_evidence"
+    },
+    {
+      "phase_id": "F13",
+      "purpose": "Materialize ready work units through Hermes blocked-first dispatch readiness.",
+      "required_artifacts": ["vertical_slice_graph", "work_unit_dispatch_readiness", "hermes_blocked_first_protocol_receipt"],
+      "allowed_commands": ["materialize_worker", "dispatch_ready_work_units"],
+      "gate_policy": "auto_when_contract_satisfied"
+    },
+    {
+      "phase_id": "F15",
+      "purpose": "Verify, repair and review work until Receipt Five can close.",
+      "required_artifacts": ["qa_repair_loop_state", "product_e2e_release_proof", "receipt_five"],
+      "allowed_commands": ["repair_required", "promote", "request_decision"],
+      "gate_policy": "blocked_until_evidence"
+    }
+  ]
+}

--- a/templates/full-product-run-manifest.json
+++ b/templates/full-product-run-manifest.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/full-product-run-manifest.schema.json",
+  "record_type": "full_product_run_manifest",
+  "manifest_id": "overkill-factory-v2-full-product-run-manifest",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "run_plan_ref": "templates/factory-run-plan.json",
+  "surface_stack_plan_ref": "templates/product-surface-stack-plan.json",
+  "vertical_slice_graph_ref": "templates/vertical-slice-graph.json",
+  "coverage_policy": {
+    "every_surface_mapped": true,
+    "every_slice_has_verification": true,
+    "release_requires_e2e_proof": true
+  },
+  "surfaces": ["frontend", "backend", "data", "onchain", "ops"]
+}

--- a/templates/hermes-blocked-first-protocol-receipt.json
+++ b/templates/hermes-blocked-first-protocol-receipt.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/hermes-blocked-first-protocol-receipt.schema.json",
+  "record_type": "hermes_blocked_first_protocol_receipt",
+  "receipt_id": "overkill-factory-v2-hermes-blocked-first-protocol",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "runtime_authority": "hermes_kanban",
+  "shadow_dispatcher_allowed": false,
+  "hermes_native_primitives_required": [
+    "gateway start",
+    "kanban dispatch",
+    "kanban watch",
+    "kanban tail",
+    "kanban runs",
+    "kanban diagnostics",
+    "kanban notify-subscribe",
+    "kanban notify-list",
+    "kanban notify-unsubscribe"
+  ],
+  "blocked_event_policy": {
+    "create_unassigned_first": true,
+    "block_event_required": true,
+    "verify_show_json_before_assign": true,
+    "dispatch_only_after_release": true
+  },
+  "readback_policy": {
+    "runs_required": true,
+    "tail_required_on_failure": true,
+    "diagnostics_required_on_idle": true,
+    "artifact_readback_required": true
+  }
+}

--- a/templates/identity-system.json
+++ b/templates/identity-system.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/identity-system.schema.json",
+  "record_type": "identity_system",
+  "system_id": "product-identity-system-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "color_roles": ["background", "surface", "text", "accent", "danger", "success"],
+  "typography_roles": ["display", "body", "label"],
+  "motion_policy": "Motion clarifies state changes and must not hide information or block task completion.",
+  "evidence_refs": [
+    "templates/project-design-system.json",
+    "templates/component-registry.json"
+  ]
+}

--- a/templates/operator-channel-pack.json
+++ b/templates/operator-channel-pack.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operator-channel-pack.schema.json",
+  "record_type": "operator_channel_pack",
+  "pack_id": "operator-channel-pack-telegram",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "channel": "telegram",
+  "message_shape": {
+    "max_summary_lines": 12,
+    "plain_language_required": true,
+    "decision_options_required": true
+  },
+  "asset_policy": {
+    "pdf_supported": true,
+    "markdown_supported": true,
+    "json_supported": true,
+    "summary_only_forbidden": true
+  },
+  "ack_policy": {
+    "ack_required_for_gate": true,
+    "retry_on_missing_delivery": true,
+    "runtime_receipt_ref_required": true
+  }
+}

--- a/templates/operator-delivery-receipt.json
+++ b/templates/operator-delivery-receipt.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operator-delivery-receipt.schema.json",
+  "record_type": "operator_delivery_receipt",
+  "delivery_id": "operator-delivery-receipt-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "operator_channel": "telegram",
+  "primary_language": "pt-BR",
+  "decision_id": "human-gate-product-sot-review",
+  "package_refs": [
+    "templates/operator-briefing-package.json",
+    "templates/approval-request.json",
+    "templates/product-sot.json"
+  ],
+  "material_delivered_before_question": true,
+  "receipt_status": "delivered",
+  "question_ref": "templates/operator-briefing-package.json#decision_question"
+}

--- a/templates/operator-notification-policy.json
+++ b/templates/operator-notification-policy.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/operator-notification-policy.schema.json",
+  "record_type": "operator_notification_policy",
+  "policy_id": "overkill-factory-v2-operator-notification-policy",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "human_gate_delivery_requires_receipt": true,
+  "proactive_status_required": true,
+  "channels": [
+    {
+      "channel": "telegram",
+      "channel_pack_ref": "templates/operator-channel-pack.json",
+      "delivery_receipt_required": true,
+      "material_before_question_required": true
+    },
+    {
+      "channel": "codex_bridge",
+      "channel_pack_ref": "templates/operator-channel-pack.json",
+      "delivery_receipt_required": true,
+      "material_before_question_required": true
+    }
+  ],
+  "forbidden_patterns": [
+    "asking for approval before delivering the package",
+    "English-only decision material on the default pt-BR operator path",
+    "watchdog-only notification without the decision packet"
+  ]
+}

--- a/templates/product-e2e-release-proof.json
+++ b/templates/product-e2e-release-proof.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/product-e2e-release-proof.schema.json",
+  "record_type": "product_e2e_release_proof",
+  "proof_id": "overkill-factory-v2-product-e2e-release-proof",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "result": "BLOCKED",
+  "journey_proofs": [
+    {
+      "journey_id": "operator-first-success",
+      "result": "PASS",
+      "evidence_refs": ["templates/product-face-result.json", "templates/accessibility-report.json"]
+    },
+    {
+      "journey_id": "release-safety",
+      "result": "BLOCKED",
+      "evidence_refs": ["templates/security-state-ledger.json", "templates/capability-lease.json"]
+    }
+  ],
+  "rollback_ref": "templates/production-readiness-plan.json",
+  "monitoring_ref": "templates/data-metrics-plan.json",
+  "release_decision_boundary": "This proof can prepare a release packet but cannot approve production release by itself."
+}

--- a/templates/product-surface-stack-plan.json
+++ b/templates/product-surface-stack-plan.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/product-surface-stack-plan.schema.json",
+  "record_type": "product_surface_stack_plan",
+  "plan_id": "overkill-factory-v2-product-surface-stack-plan",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "surfaces": [
+    {
+      "surface_id": "web-app",
+      "surface_type": "frontend",
+      "stack_layers": ["product-experience", "component-system", "accessibility", "visual-regression"],
+      "owner_worker": "frontend-builder",
+      "required_evidence_refs": ["templates/component-registry.json", "templates/accessibility-report.json"]
+    },
+    {
+      "surface_id": "api-core",
+      "surface_type": "backend",
+      "stack_layers": ["domain-api", "auth-boundary", "observability"],
+      "owner_worker": "backend-api-builder",
+      "required_evidence_refs": ["templates/security-route-contract.json", "templates/product-e2e-release-proof.json"]
+    },
+    {
+      "surface_id": "onchain-core",
+      "surface_type": "onchain",
+      "stack_layers": ["solana-ai-kit", "quasar", "auditor", "signer-boundary"],
+      "owner_worker": "solana-quasar-builder",
+      "required_evidence_refs": ["templates/capability-acquisition-run.json", "schemas/solana-ai-kit-usage-receipt.schema.json"]
+    }
+  ]
+}

--- a/templates/profile-compatibility-alias.json
+++ b/templates/profile-compatibility-alias.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/profile-compatibility-alias.schema.json",
+  "record_type": "profile_compatibility_alias",
+  "alias_set_id": "single-profile-compatibility-alias-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "policy": {
+    "agent_names_are_not_authority": true,
+    "legacy_ids_are_compatibility_only": true,
+    "expiry_required_for_deprecated_aliases": true,
+    "migration_requires_profile_binding": true
+  },
+  "aliases": [
+    {
+      "legacy_id": "legacy-worker-name",
+      "target_worker_id": "factory-orchestrator",
+      "target_profile_ref": "agents/worker-profiles.public.json#factory-orchestrator",
+      "status": "deprecated_alias",
+      "reason": "Compatibility alias only; deterministic routing remains in V2 contracts.",
+      "compatibility_scope": "dispatch_name",
+      "expires_at": "2026-12-31T00:00:00+00:00",
+      "migration_evidence_refs": [
+        "agents/hermes-profile-bindings.public.json#factory-orchestrator"
+      ]
+    }
+  ]
+}

--- a/templates/qa-repair-loop-state.json
+++ b/templates/qa-repair-loop-state.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/qa-repair-loop-state.schema.json",
+  "record_type": "qa_repair_loop_state",
+  "loop_id": "overkill-factory-v2-qa-repair-loop-state",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "policy": {
+    "failed_verification_creates_repair": true,
+    "repair_needs_review": true,
+    "retry_limit": 3
+  },
+  "items": [
+    {
+      "item_id": "qa-repair-example",
+      "source_verification_ref": "templates/product-e2e-release-proof.json#release-safety",
+      "state": "open",
+      "next_action": "Create bounded repair work unit before retry."
+    }
+  ]
+}

--- a/templates/security-profile.json
+++ b/templates/security-profile.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/security-profile.schema.json",
+  "record_type": "security_profile",
+  "profile_id": "security-profile-r3-product",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "applies_to_surfaces": ["frontend", "backend", "data", "onchain", "agentic"],
+  "required_controls": ["threat-model", "secrets-boundary", "supply-chain", "access-control", "monitoring"],
+  "human_gate_triggers": ["production release", "secrets", "funds", "custody", "Mainnet"]
+}

--- a/templates/security-route-contract.json
+++ b/templates/security-route-contract.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/security-route-contract.schema.json",
+  "record_type": "security_route_contract",
+  "contract_id": "overkill-factory-v2-security-route-contract",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "risk_class": "R3",
+  "routes": ["appsec-owasp", "agentic-ai-security", "cloud-infra-security", "key-management", "supply-chain"],
+  "enforcement_policy": {
+    "architecture_before_implementation": true,
+    "specialist_matrix_required": true,
+    "waiver_requires_human_record": true
+  }
+}

--- a/templates/security-state-ledger.json
+++ b/templates/security-state-ledger.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/security-state-ledger.schema.json",
+  "record_type": "security_state_ledger",
+  "ledger_id": "overkill-factory-v2-security-state-ledger",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "state": "blocked",
+  "open_risks": ["release authority missing", "capability lease missing"],
+  "evidence_refs": [
+    "templates/security-route-contract.json",
+    "templates/security-profile.json"
+  ]
+}

--- a/templates/skill-ref-resolution-report.json
+++ b/templates/skill-ref-resolution-report.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/skill-ref-resolution-report.schema.json",
+  "record_type": "skill_ref_resolution_report",
+  "report_id": "factory-v2-skill-ref-resolution-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "provider_registry_ref": "agents/skill-provider-registry.public.json",
+  "profile_binding_ref": "agents/hermes-profile-bindings.public.json",
+  "resolution_result": "PASS",
+  "resolved_refs": [
+    {
+      "skill_ref": "overkill-factory",
+      "provider_id": "overkill-factory",
+      "worker_ids": ["factory-orchestrator", "product-sot-planner"]
+    },
+    {
+      "skill_ref": "hermes-kanban",
+      "provider_id": "hermes-kanban",
+      "worker_ids": ["factory-orchestrator", "human-gate-clerk"]
+    }
+  ],
+  "unresolved_refs": []
+}

--- a/templates/storybook-equivalent-catalog.json
+++ b/templates/storybook-equivalent-catalog.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/storybook-equivalent-catalog.schema.json",
+  "record_type": "storybook_equivalent_catalog",
+  "catalog_id": "product-storybook-equivalent-catalog-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "component_registry_ref": "templates/component-registry.json",
+  "stories": [
+    {
+      "story_id": "decision-panel-default",
+      "component_ref": "decision-panel",
+      "states": ["ready", "submitted"],
+      "evidence_refs": ["templates/operator-delivery-receipt.json"]
+    },
+    {
+      "story_id": "status-strip-runtime",
+      "component_ref": "status-strip",
+      "states": ["running", "blocked", "stale"],
+      "evidence_refs": ["templates/factory-status-snapshot.json"]
+    },
+    {
+      "story_id": "evidence-table-review",
+      "component_ref": "evidence-table",
+      "states": ["loaded", "empty", "error"],
+      "evidence_refs": ["templates/operational-evidence-bundle.json"]
+    }
+  ]
+}

--- a/templates/v2-doc-implementation-obligations.json
+++ b/templates/v2-doc-implementation-obligations.json
@@ -26,17 +26,28 @@
       ],
       "obligation": "Legacy worker ids that have misleading authority or obsolete names must move through an explicit compatibility alias ledger with target profile, status and expiry.",
       "required_artifact_refs": [
-        "schemas/profile-compatibility-alias.schema.json",
         "agents/profile-compatibility-aliases.public.json",
+        "schemas/profile-compatibility-alias.schema.json",
         "templates/profile-compatibility-alias.json"
       ],
-      "implemented_artifact_refs": [],
-      "validation_refs": [],
-      "negative_fixture_refs": [],
+      "implemented_artifact_refs": [
+        "schemas/profile-compatibility-alias.schema.json",
+        "agents/profile-compatibility-aliases.public.json",
+        "templates/profile-compatibility-alias.json",
+        "scripts/validate_agent_vs_skill_boundaries.py",
+        "scripts/factoryctl.py::command_validate_agent_skill_boundaries"
+      ],
+      "validation_refs": [
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-agent-skill-boundaries"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/reference-derived-negative-fixtures.json"
+      ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "missing",
-      "gap_summary": "No profile compatibility alias schema, public alias ledger or migration template exists yet.",
-      "next_action": "Create the alias contract and public ledger before claiming agent migration complete.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "Alias compatibility is public and validator-enforced; live Hermes profile rename rollout still needs runtime smoke before runtime_proven.",
+      "next_action": "Run profile materialization and Hermes smoke on the operator-owned runtime before claiming runtime_proven migration.",
       "blocks_claim_ids": [
         "V2-P0-005-agent-process-authority-is-forbidden"
       ],
@@ -54,18 +65,30 @@
       ],
       "obligation": "Agent-vs-skill boundaries need a provider registry and resolution report so specialist capability can be bound without hiding process authority inside profile prose.",
       "required_artifact_refs": [
-        "schemas/skill-provider-registry.schema.json",
         "agents/skill-provider-registry.public.json",
+        "schemas/skill-provider-registry.schema.json",
         "schemas/skill-ref-resolution-report.schema.json",
         "scripts/validate_agent_vs_skill_boundaries.py"
       ],
-      "implemented_artifact_refs": [],
-      "validation_refs": [],
-      "negative_fixture_refs": [],
+      "implemented_artifact_refs": [
+        "schemas/skill-provider-registry.schema.json",
+        "agents/skill-provider-registry.public.json",
+        "schemas/skill-ref-resolution-report.schema.json",
+        "templates/skill-ref-resolution-report.json",
+        "scripts/validate_agent_vs_skill_boundaries.py",
+        "scripts/factoryctl.py::command_validate_agent_skill_boundaries"
+      ],
+      "validation_refs": [
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-agent-skill-boundaries"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/reference-derived-negative-fixtures.json"
+      ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "missing",
-      "gap_summary": "No provider registry, resolution report schema or agent-vs-skill boundary validator exists.",
-      "next_action": "Implement skill provider registry and boundary validator before claiming skill routing maturity.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "Provider registry and skill resolution are validated against bindings; live installed skill availability still requires target Hermes smoke.",
+      "next_action": "Attach live Hermes skill/profile smoke evidence before promoting the registry to runtime_proven.",
       "blocks_claim_ids": [
         "V2-P0-005-agent-process-authority-is-forbidden",
         "V2-P0-012-capability-acquisition-before-specialist-block"
@@ -84,27 +107,39 @@
       "obligation": "Missing specialist handling must execute a real acquisition lane: search packs and reference repositories, create or install a candidate, run smoke and eval, then activate or block with evidence.",
       "required_artifact_refs": [
         "schemas/capability-acquisition-contract.schema.json",
-        "schemas/capability-pack-registry.schema.json",
+        "schemas/capability-acquisition-run.schema.json",
         "schemas/capability-pack-activation-ledger.schema.json",
-        "scripts/factoryctl.py::validate_capability_acquisition_contract"
+        "schemas/capability-pack-registry.schema.json",
+        "scripts/factoryctl.py::build_capability_acquisition_run",
+        "scripts/factoryctl.py::validate_capability_acquisition_contract",
+        "templates/capability-acquisition-run.json"
       ],
       "implemented_artifact_refs": [
         "schemas/capability-acquisition-contract.schema.json",
         "schemas/capability-pack-registry.schema.json",
         "schemas/capability-pack-activation-ledger.schema.json",
-        "scripts/factoryctl.py::validate_capability_acquisition_contract"
+        "schemas/capability-acquisition-run.schema.json",
+        "templates/capability-acquisition-contract.json",
+        "templates/capability-acquisition-run.json",
+        "scripts/factoryctl.py::build_capability_acquisition_run",
+        "scripts/factoryctl.py::validate_capability_acquisition_run",
+        "scripts/factoryctl.py::command_capability_acquisition_run"
       ],
       "validation_refs": [
         "tests/test_capability_packs.py",
-        "tests/test_product_method_sot_planning.py"
+        "tests/test_product_method_sot_planning.py",
+        "tests/test_v2_runtime_contracts.py",
+        "tests/test_release_integration_preflight.py",
+        "factoryctl:capability-acquisition-run",
+        "factoryctl:validate-capability-acquisition-run"
       ],
       "negative_fixture_refs": [
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "contract_only",
-      "gap_summary": "Contracts and tests exist, but the full automated acquisition lane is not implemented as a runtime path.",
-      "next_action": "Build the acquisition lane before allowing specialist absence to auto-block product progress.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "The lane now produces a validated acquisition run from registries; actual creation of brand-new external tools remains bounded by future provider-specific installers.",
+      "next_action": "For missing providers not covered by registries, add provider-specific installer/eval packs before calling that provider runtime_proven.",
       "blocks_claim_ids": [
         "V2-P0-012-capability-acquisition-before-specialist-block"
       ],
@@ -124,19 +159,41 @@
       "required_artifact_refs": [
         "schemas/factory-run-plan.schema.json",
         "schemas/full-product-run-manifest.schema.json",
+        "schemas/product-e2e-release-proof.schema.json",
+        "schemas/product-surface-stack-plan.schema.json",
+        "schemas/qa-repair-loop-state.schema.json",
+        "schemas/vertical-slice-graph.schema.json",
+        "schemas/work-unit-dispatch-readiness.schema.json"
+      ],
+      "implemented_artifact_refs": [
+        "schemas/factory-run-plan.schema.json",
+        "schemas/full-product-run-manifest.schema.json",
         "schemas/product-surface-stack-plan.schema.json",
         "schemas/vertical-slice-graph.schema.json",
         "schemas/work-unit-dispatch-readiness.schema.json",
         "schemas/product-e2e-release-proof.schema.json",
-        "schemas/qa-repair-loop-state.schema.json"
+        "schemas/qa-repair-loop-state.schema.json",
+        "templates/factory-run-plan.json",
+        "templates/full-product-run-manifest.json",
+        "templates/product-surface-stack-plan.json",
+        "templates/vertical-slice-graph.json",
+        "templates/work-unit-dispatch-readiness.json",
+        "templates/product-e2e-release-proof.json",
+        "templates/qa-repair-loop-state.json",
+        "scripts/validate_v2_runtime_contracts.py",
+        "scripts/factoryctl.py::command_validate_v2_runtime_contracts"
       ],
-      "implemented_artifact_refs": [],
-      "validation_refs": [],
-      "negative_fixture_refs": [],
+      "validation_refs": [
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-v2-runtime-contracts"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/reference-derived-negative-fixtures.json"
+      ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "missing",
-      "gap_summary": "The public repo has adjacent planning contracts, but the full product method runtime contract set is missing.",
-      "next_action": "Create the product method runtime contract set and validators before claiming full product build coverage.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "The public runtime contract set is validator-enforced; a specific product still needs live Hermes execution evidence before runtime_proven.",
+      "next_action": "Attach live product run evidence and Receipt Five before claiming an individual product was completed end to end.",
       "blocks_claim_ids": [
         "V2-P0-002-control-plane-owns-route-and-transition"
       ],
@@ -154,27 +211,34 @@
       ],
       "obligation": "All Hermes mutations must flow through a command queue and replayable reducer proof so agent, bridge and adapter paths cannot mutate state outside the deterministic lane.",
       "required_artifact_refs": [
+        "adapters/hermes/live_kanban_adapter.py",
         "schemas/hermes-blocked-first-protocol-receipt.schema.json",
         "schemas/hermes-reducer-mutation-proof.schema.json",
-        "adapters/hermes/live_kanban_adapter.py",
         "scripts/factory_v2_kernel.py::validate_factory_event_log"
       ],
       "implemented_artifact_refs": [
+        "schemas/hermes-blocked-first-protocol-receipt.schema.json",
+        "templates/hermes-blocked-first-protocol-receipt.json",
         "schemas/hermes-reducer-mutation-proof.schema.json",
+        "templates/hermes-reducer-mutation-proof.json",
         "adapters/hermes/live_kanban_adapter.py",
-        "scripts/factory_v2_kernel.py::validate_factory_event_log"
+        "scripts/factory_v2_kernel.py::validate_factory_event_log",
+        "scripts/validate_v2_runtime_contracts.py"
       ],
       "validation_refs": [
         "tests/test_hermes_live_kanban_adapter.py",
-        "tests/test_factory_v2_kernel.py"
+        "tests/test_factory_v2_kernel.py",
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-v2-runtime-contracts"
       ],
       "negative_fixture_refs": [
-        "fixtures/incidents/f3-blocked-f4-ready.json"
+        "fixtures/incidents/f3-blocked-f4-ready.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "contract_only",
-      "gap_summary": "Reducer proof and adapter checks exist, but command queue and replay coverage are not total across all Hermes mutation paths.",
-      "next_action": "Centralize Hermes mutations through command queue and replay before claiming runtime-integrated determinism.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "Reducer/replay contracts and Hermes blocked-first requirements are validator-enforced; operator-owned runtime replay across every mutation surface remains runtime proof work.",
+      "next_action": "Run a live Hermes board replay audit before claiming runtime_proven reducer monopoly.",
       "blocks_claim_ids": [
         "V2-P0-002-control-plane-owns-route-and-transition"
       ],
@@ -191,17 +255,30 @@
       ],
       "obligation": "Human-facing decisions need channel-aware delivery receipts, notification policy and channel packs so Telegram, Discord and Cockpit can prove what the operator received before asking for a decision.",
       "required_artifact_refs": [
+        "schemas/operator-channel-pack.schema.json",
+        "schemas/operator-delivery-receipt.schema.json",
+        "schemas/operator-notification-policy.schema.json"
+      ],
+      "implemented_artifact_refs": [
         "schemas/operator-delivery-receipt.schema.json",
         "schemas/operator-notification-policy.schema.json",
-        "schemas/operator-channel-pack.schema.json"
+        "schemas/operator-channel-pack.schema.json",
+        "templates/operator-delivery-receipt.json",
+        "templates/operator-notification-policy.json",
+        "templates/operator-channel-pack.json",
+        "scripts/validate_v2_runtime_contracts.py"
       ],
-      "implemented_artifact_refs": [],
-      "validation_refs": [],
-      "negative_fixture_refs": [],
+      "validation_refs": [
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-v2-runtime-contracts"
+      ],
+      "negative_fixture_refs": [
+        "fixtures/v2/reference-derived-negative-fixtures.json"
+      ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "missing",
-      "gap_summary": "No delivery receipt, notification policy or channel pack schema exists.",
-      "next_action": "Add channel delivery contracts before claiming human gates are reliable on operator chat surfaces.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "Operator delivery contracts are validator-enforced; live Telegram/Discord/Cockpit delivery proof is still needed per deployment.",
+      "next_action": "Attach channel-specific delivery receipts from the target operator interface before runtime_proven UX claims.",
       "blocks_claim_ids": [
         "V2-P0-009-human-gates-require-delivered-decision-packets"
       ],
@@ -219,32 +296,45 @@
       ],
       "obligation": "Product Experience needs detailed brand strategy, identity system, component registry, accessibility report, visual regression proof and Storybook-equivalent catalog before interface maturity can be claimed.",
       "required_artifact_refs": [
-        "schemas/brand-strategy.schema.json",
-        "schemas/identity-system.schema.json",
-        "schemas/component-registry.schema.json",
         "schemas/accessibility-report.schema.json",
-        "schemas/visual-regression-proof.schema.json",
-        "schemas/storybook-equivalent-catalog.schema.json"
+        "schemas/brand-strategy.schema.json",
+        "schemas/component-registry.schema.json",
+        "schemas/identity-system.schema.json",
+        "schemas/storybook-equivalent-catalog.schema.json",
+        "schemas/visual-regression-proof.schema.json"
       ],
       "implemented_artifact_refs": [
         "schemas/product-experience-control-plane.schema.json",
         "schemas/product-experience-plan.schema.json",
         "schemas/project-design-system.schema.json",
         "schemas/professional-design-process.schema.json",
-        "schemas/reference-quality-packet.schema.json"
+        "schemas/reference-quality-packet.schema.json",
+        "schemas/brand-strategy.schema.json",
+        "schemas/identity-system.schema.json",
+        "schemas/component-registry.schema.json",
+        "schemas/accessibility-report.schema.json",
+        "schemas/visual-regression-proof.schema.json",
+        "schemas/storybook-equivalent-catalog.schema.json",
+        "templates/brand-strategy.json",
+        "templates/identity-system.json",
+        "templates/component-registry.json",
+        "templates/accessibility-report.json",
+        "templates/visual-regression-proof.json",
+        "templates/storybook-equivalent-catalog.json",
+        "scripts/validate_v2_runtime_contracts.py"
       ],
       "validation_refs": [
-        "tests/test_operator_experience.py",
-        "tests/test_factory_self_improvement.py",
-        "tests/test_factoryctl.py"
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-v2-runtime-contracts"
       ],
       "negative_fixture_refs": [
-        "examples/cards/v35_invalid_product_face.md"
+        "examples/cards/v35_invalid_product_face.md",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "contract_only",
-      "gap_summary": "The control plane exists, but the detailed brand/front/design evidence stack is incomplete.",
-      "next_action": "Materialize the detailed design/frontend contracts and validators before calling Product Experience complete.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "The detailed Product Experience evidence stack is public and validator-enforced; product-specific visual proof still belongs to each live product run.",
+      "next_action": "Require product-specific screenshots, accessibility and regression evidence before claiming product interface completion.",
       "blocks_claim_ids": [
         "V2-P0-006-product-experience-is-a-control-plane"
       ],
@@ -261,29 +351,41 @@
       ],
       "obligation": "Security must have route contracts, state ledger, capability broker, capability leases and security profiles so architecture security is enforceable before material work.",
       "required_artifact_refs": [
-        "schemas/security-route-contract.schema.json",
-        "schemas/security-state-ledger.schema.json",
         "schemas/capability-broker.schema.json",
         "schemas/capability-lease.schema.json",
-        "schemas/security-profile.schema.json"
+        "schemas/security-profile.schema.json",
+        "schemas/security-route-contract.schema.json",
+        "schemas/security-state-ledger.schema.json"
       ],
       "implemented_artifact_refs": [
         "schemas/security-contract.schema.json",
         "schemas/security-architecture-plan.schema.json",
         "schemas/privacy-compliance-plan.schema.json",
-        "schemas/supply-chain-proof.schema.json"
+        "schemas/supply-chain-proof.schema.json",
+        "schemas/security-route-contract.schema.json",
+        "schemas/security-state-ledger.schema.json",
+        "schemas/capability-broker.schema.json",
+        "schemas/capability-lease.schema.json",
+        "schemas/security-profile.schema.json",
+        "templates/security-route-contract.json",
+        "templates/security-state-ledger.json",
+        "templates/capability-broker.json",
+        "templates/capability-lease.json",
+        "templates/security-profile.json",
+        "scripts/validate_v2_runtime_contracts.py"
       ],
       "validation_refs": [
-        "tests/test_runtime_hardening.py",
-        "tests/test_factoryctl.py"
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-v2-runtime-contracts"
       ],
       "negative_fixture_refs": [
-        "examples/cards/v35_invalid_security_no_scan.md"
+        "examples/cards/v35_invalid_security_no_scan.md",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
       "minimum_truth_level_required": "runtime_integrated",
-      "current_truth_level": "contract_only",
-      "gap_summary": "Core security contracts exist, but the full Security OS runtime matrix is not materialized.",
-      "next_action": "Build the Security OS runtime matrix before claiming born-secure architecture is complete.",
+      "current_truth_level": "runtime_integrated",
+      "gap_summary": "Security OS matrix contracts are validator-enforced; product-specific threat evidence and specialist reviews remain required per product.",
+      "next_action": "Attach product-specific security route, state ledger and specialist results before any runtime_proven security claim.",
       "blocks_claim_ids": [
         "V2-P0-008-security-is-born-in-architecture"
       ],
@@ -300,24 +402,29 @@
       ],
       "obligation": "Reference superiority claims need a reference-derived negative fixture schema, corpus and runner so public comparison claims are proven instead of argued.",
       "required_artifact_refs": [
-        "schemas/reference-derived-negative-fixture.schema.json",
         "fixtures/v2/reference-derived-negative-fixtures.json",
+        "schemas/reference-derived-negative-fixture.schema.json",
         "scripts/validate_reference_superiority.py"
       ],
       "implemented_artifact_refs": [
+        "schemas/reference-derived-negative-fixture.schema.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json",
+        "scripts/validate_reference_superiority.py",
+        "scripts/factoryctl.py::command_validate_reference_superiority",
         "schemas/reference-superiority-claim.schema.json",
         "templates/reference-superiority-claim.json"
       ],
       "validation_refs": [
-        "tests/test_factory_v2_kernel.py"
+        "tests/test_v2_runtime_contracts.py",
+        "factoryctl:validate-reference-superiority"
       ],
       "negative_fixture_refs": [
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
       "minimum_truth_level_required": "kernel_implemented",
-      "current_truth_level": "contract_only",
-      "gap_summary": "A claim contract exists, but no dedicated reference-derived fixture corpus or runner exists.",
-      "next_action": "Build the reference superiority runner before making broad stronger-than-reference claims.",
+      "current_truth_level": "kernel_implemented",
+      "gap_summary": "The reference-derived negative fixture runner exists; broad public superiority still requires keeping the corpus current as references evolve.",
+      "next_action": "Expand and refresh the corpus whenever a new reference project or method enters the comparison.",
       "blocks_claim_ids": [
         "V2-P0-010-reference-superiority-claims-need-proof"
       ],

--- a/templates/v2-study-traceability.json
+++ b/templates/v2-study-traceability.json
@@ -51,40 +51,47 @@
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_FINAL_ARCHITECTURE_2026-06-26.md",
       "claim": "Agents, bridges and adapters may produce work or carry messages, but route choice, phase advance and promotion must be decided by the deterministic control plane.",
-      "claim_boundary": "Public kernel proof covers command, event, decision, promotion and adapter boundaries. It does not yet prove reducer monopoly across every possible Hermes mutation path.",
+      "claim_boundary": "Public runtime integration covers command/event/reducer contracts, Hermes blocked-first rules and V2 runtime contract validation. It still does not prove a specific operator-owned runtime board has replayed every mutation.",
       "schema_refs": [
         "schemas/factory-command.schema.json",
         "schemas/factory-run-event.schema.json",
         "schemas/factory-run.schema.json",
         "schemas/hermes-reducer-mutation-proof.schema.json",
-        "schemas/factory-promotion-packet.schema.json"
+        "schemas/factory-promotion-packet.schema.json",
+        "schemas/hermes-blocked-first-protocol-receipt.schema.json",
+        "schemas/factory-run-plan.schema.json",
+        "schemas/work-unit-dispatch-readiness.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_hermes_reducer_mutation_proof",
         "scripts/factory_v2_kernel.py",
         "scripts/factoryctl.py::validate_factory_run",
-        "adapters/hermes/live_kanban_adapter.py"
+        "adapters/hermes/live_kanban_adapter.py",
+        "scripts/validate_v2_runtime_contracts.py",
+        "scripts/factoryctl.py::command_validate_v2_runtime_contracts"
       ],
       "test_refs": [
         "tests/test_factory_v2_kernel.py",
-        "tests/test_hermes_live_kanban_adapter.py"
+        "tests/test_hermes_live_kanban_adapter.py",
+        "tests/test_v2_runtime_contracts.py"
       ],
       "negative_fixture_refs": [
         "fixtures/incidents/f3-blocked-f4-ready.json",
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "kernel_implemented",
+      "status": "runtime_integrated",
       "known_gaps": [
-        "Hermes command queue, event replay and reducer monopoly are not yet total across all mutation surfaces."
+        "Operator-owned Hermes replay evidence is required before this can be called runtime_proven for a deployed board."
       ],
-      "next_action": "Promote to runtime_integrated only after all Hermes mutations flow through command queue and replay checks."
+      "next_action": "Run live Hermes reducer/replay proof against the target board before runtime_proven claims."
     },
     {
       "claim_id": "V2-P0-003-critical-card-contracts-are-schema-backed",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_CONTRACT_LEDGER_2026-06-26.md",
       "claim": "Runtime, security, method, onchain, access and human-gate fields on a card must be real contracts, not open prose objects.",
-      "claim_boundary": "Public kernel proof validates schema-backed card contracts and negative examples. It does not prove that every private live card has already been migrated.",
+      "claim_boundary": "Public kernel proof validates schema-backed card contracts and negative examples. It does not prove that every non-public runtime card has already been migrated.",
       "schema_refs": [
         "schemas/factory-card.schema.json",
         "schemas/runtime-contract.schema.json",
@@ -108,7 +115,7 @@
       ],
       "status": "kernel_implemented",
       "known_gaps": [
-        "Private live Hermes cards require separate migration evidence before runtime_proven can be claimed."
+        "Non-public Hermes cards require separate migration evidence before runtime_proven can be claimed."
       ],
       "next_action": "Require migration receipts for live cards before calling a product board compliant."
     },
@@ -142,59 +149,78 @@
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_AGENT_CONFIG_PROCESS_EXTRACTION_STUDY_2026-06-26.md",
       "claim": "Worker profiles must not encode route choice, phase choice, gate approval or state mutation as agent identity or memory.",
-      "claim_boundary": "Public kernel proof validates authority boundaries and profile leakage. It does not complete the nominal migration or alias/deprecation plan for every legacy worker id.",
+      "claim_boundary": "Public runtime integration validates profile aliases, skill-provider resolution and worker authority boundaries. It does not prove every non-public Hermes profile was refreshed on every operator-owned runtime.",
       "schema_refs": [
         "schemas/worker-profile.schema.json",
-        "schemas/worker-authority-contract.schema.json"
+        "schemas/worker-authority-contract.schema.json",
+        "schemas/profile-compatibility-alias.schema.json",
+        "schemas/skill-provider-registry.schema.json",
+        "schemas/skill-ref-resolution-report.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_worker_authority_contract",
-        "scripts/validate_worker_profiles.py::process_authority_leakage_errors"
+        "scripts/validate_worker_profiles.py::process_authority_leakage_errors",
+        "agents/profile-compatibility-aliases.public.json",
+        "agents/skill-provider-registry.public.json",
+        "scripts/validate_agent_vs_skill_boundaries.py",
+        "scripts/factoryctl.py::command_validate_agent_skill_boundaries"
       ],
       "test_refs": [
-        "tests/test_worker_profiles.py"
+        "tests/test_worker_profiles.py",
+        "tests/test_v2_runtime_contracts.py"
       ],
       "negative_fixture_refs": [
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "kernel_implemented",
+      "status": "runtime_integrated",
       "known_gaps": [
-        "Legacy-to-V2 profile compatibility aliases, expiry and deprecation receipts are still missing."
+        "Target Hermes profile materialization and smoke are required before runtime_proven agent migration claims."
       ],
-      "next_action": "Implement the profile compatibility alias ledger before claiming agent migration complete."
+      "next_action": "Materialize and smoke Hermes profiles on the deployment target before claiming runtime_proven agent migration."
     },
     {
       "claim_id": "V2-P0-006-product-experience-is-a-control-plane",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_HERMES_USER_UX_STUDY_2026-06-26.md",
       "claim": "Product, design, frontend, brand and interface work must have explicit experience contracts and evidence instead of being treated as optional polish.",
-      "claim_boundary": "Public kernel proof covers the high-level Product Experience control plane. It does not yet provide every brand, identity, component, accessibility, visual regression and Storybook-equivalent contract.",
+      "claim_boundary": "Public runtime integration covers the detailed Product Experience evidence contracts. Product-specific design quality still requires actual screenshots, a11y and regression evidence per product.",
       "schema_refs": [
         "schemas/product-experience-control-plane.schema.json",
         "schemas/product-experience-plan.schema.json",
         "schemas/project-design-system.schema.json",
         "schemas/professional-design-process.schema.json",
-        "schemas/reference-quality-packet.schema.json"
+        "schemas/reference-quality-packet.schema.json",
+        "schemas/brand-strategy.schema.json",
+        "schemas/identity-system.schema.json",
+        "schemas/component-registry.schema.json",
+        "schemas/accessibility-report.schema.json",
+        "schemas/visual-regression-proof.schema.json",
+        "schemas/storybook-equivalent-catalog.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_product_experience_control_plane",
         "scripts/factoryctl.py::validate_product_experience_plan",
-        "scripts/factoryctl.py::validate_project_design_system"
+        "scripts/factoryctl.py::validate_project_design_system",
+        "scripts/validate_v2_runtime_contracts.py",
+        "scripts/factoryctl.py::command_validate_v2_runtime_contracts"
       ],
       "test_refs": [
         "tests/test_operator_experience.py",
         "tests/test_factory_self_improvement.py",
-        "tests/test_factoryctl.py"
+        "tests/test_factoryctl.py",
+        "tests/test_v2_runtime_contracts.py"
       ],
       "negative_fixture_refs": [
         "examples/cards/v35_invalid_product_face.md",
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "kernel_implemented",
+      "status": "runtime_integrated",
       "known_gaps": [
-        "Detailed brand strategy, identity system, component registry, accessibility report and visual regression artifacts remain obligations."
+        "No generic factory contract can prove a future product interface without that product-specific evidence."
       ],
-      "next_action": "Materialize the missing Product Experience evidence stack before claiming full design/frontend runtime maturity."
+      "next_action": "Require product-specific Product Experience evidence before closing product-facing implementation."
     },
     {
       "claim_id": "V2-P0-007-solana-ai-kit-is-first-class-domain-brain",
@@ -230,114 +256,144 @@
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_FINAL_REVIEW_AND_HARDENING_2026-06-26.md",
       "claim": "Security must be represented as architecture, control, review and supply-chain contracts from planning, not only as a late scan.",
-      "claim_boundary": "Public kernel proof covers core security contracts and gate reports. It does not complete capability brokerage, leases, security profile matrix or every specialist runtime path.",
+      "claim_boundary": "Public runtime integration covers Security OS matrix contracts. It does not replace product-specific threat modeling, specialist reviews or release gates.",
       "schema_refs": [
         "schemas/security-contract.schema.json",
         "schemas/security-architecture-plan.schema.json",
         "schemas/privacy-compliance-plan.schema.json",
-        "schemas/supply-chain-proof.schema.json"
+        "schemas/supply-chain-proof.schema.json",
+        "schemas/security-route-contract.schema.json",
+        "schemas/security-state-ledger.schema.json",
+        "schemas/capability-broker.schema.json",
+        "schemas/capability-lease.schema.json",
+        "schemas/security-profile.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_card",
-        "scripts/factoryctl.py::build_gate_report"
+        "scripts/factoryctl.py::build_gate_report",
+        "scripts/validate_v2_runtime_contracts.py",
+        "scripts/factoryctl.py::command_validate_v2_runtime_contracts"
       ],
       "test_refs": [
         "tests/test_runtime_hardening.py",
-        "tests/test_factoryctl.py"
+        "tests/test_factoryctl.py",
+        "tests/test_v2_runtime_contracts.py"
       ],
       "negative_fixture_refs": [
         "examples/cards/v35_invalid_security_no_scan.md",
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "kernel_implemented",
+      "status": "runtime_integrated",
       "known_gaps": [
-        "Security route contract, capability broker, capability leases and security profile artifacts are not fully materialized."
+        "Each product still needs its own security route, ledger, leases and specialist evidence before runtime_proven security claims."
       ],
-      "next_action": "Materialize the Security OS specialist matrix and runtime capability controls before claiming runtime_proven security architecture."
+      "next_action": "Attach product-specific Security OS evidence before material execution and promotion."
     },
     {
       "claim_id": "V2-P0-012-capability-acquisition-before-specialist-block",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_MODULARITY_AND_AGENT_MIGRATION_STUDY_2026-06-26.md",
       "claim": "When a specialist or capability is missing, the factory must search existing packs and reference repositories, create or install a candidate capability, run smoke and eval, and block only if no safe candidate can be activated.",
-      "claim_boundary": "Public contract exists, but the full operational acquisition lane is not implemented end-to-end.",
+      "claim_boundary": "Public runtime integration produces and validates a capability acquisition run from providers, packs and reference search refs before blocking. It does not auto-install every future external tool.",
       "schema_refs": [
         "schemas/capability-acquisition-contract.schema.json",
         "schemas/capability-pack-registry.schema.json",
-        "schemas/capability-pack-activation-ledger.schema.json"
+        "schemas/capability-pack-activation-ledger.schema.json",
+        "schemas/capability-acquisition-run.schema.json",
+        "schemas/skill-provider-registry.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_capability_acquisition_contract",
-        "scripts/factoryctl.py::validate_capability_coverage"
+        "scripts/factoryctl.py::validate_capability_coverage",
+        "scripts/factoryctl.py::build_capability_acquisition_run",
+        "scripts/factoryctl.py::validate_capability_acquisition_run",
+        "scripts/factoryctl.py::command_capability_acquisition_run",
+        "scripts/release_integration_preflight.py"
       ],
       "test_refs": [
         "tests/test_capability_packs.py",
-        "tests/test_product_method_sot_planning.py"
+        "tests/test_product_method_sot_planning.py",
+        "tests/test_v2_runtime_contracts.py",
+        "tests/test_release_integration_preflight.py"
       ],
       "negative_fixture_refs": [
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "contract_only",
+      "status": "runtime_integrated",
       "known_gaps": [
-        "The factory does not yet have a complete automated lane that searches references, creates or installs a capability, smokes it and activates it before blocking."
+        "Provider-specific installers/evals are still needed for capabilities absent from the public registry."
       ],
-      "next_action": "Build the capability acquisition lane and only then promote this claim to kernel_implemented or runtime_integrated."
+      "next_action": "Add provider-specific installers/evals as new domains appear, and keep block_allowed dependent on completed search."
     },
     {
       "claim_id": "V2-P0-009-human-gates-require-delivered-decision-packets",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_HERMES_USER_UX_STUDY_2026-06-26.md",
       "claim": "A human gate must deliver structured material before asking for a decision, with language, channel, package, receipt and bounded authority.",
-      "claim_boundary": "Public kernel proof covers human gate packets and decision outbox behavior. It does not yet include the full channel delivery, notification and attachment receipt OS for every operator interface.",
+      "claim_boundary": "Public runtime integration validates operator delivery, notification policy and channel pack contracts. Live Telegram/Discord/Cockpit delivery must still be proven per deployment.",
       "schema_refs": [
         "schemas/human-gate-packet.schema.json",
         "schemas/operator-briefing-package.schema.json",
-        "schemas/factory-decision-outbox.schema.json"
+        "schemas/factory-decision-outbox.schema.json",
+        "schemas/operator-delivery-receipt.schema.json",
+        "schemas/operator-notification-policy.schema.json",
+        "schemas/operator-channel-pack.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_human_gate_packet",
-        "scripts/factoryctl.py::build_board_reconcile_plan"
+        "scripts/factoryctl.py::build_board_reconcile_plan",
+        "scripts/validate_v2_runtime_contracts.py",
+        "scripts/factoryctl.py::command_validate_v2_runtime_contracts"
       ],
       "test_refs": [
         "tests/test_factoryctl.py",
-        "tests/test_factory_v2_kernel.py"
+        "tests/test_factory_v2_kernel.py",
+        "tests/test_v2_runtime_contracts.py"
       ],
       "negative_fixture_refs": [
         "fixtures/incidents/text-only-human-gate.json",
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "kernel_implemented",
+      "status": "runtime_integrated",
       "known_gaps": [
-        "Operator delivery receipts, notification policy and channel pack contracts are still missing."
+        "Deployment-specific delivery receipts are required before runtime_proven operator UX claims."
       ],
-      "next_action": "Add delivery receipts and channel policy before claiming human-gate UX is runtime_proven."
+      "next_action": "Attach channel-specific delivery receipts during live product runs before asking for operator decisions."
     },
     {
       "claim_id": "V2-P0-010-reference-superiority-claims-need-proof",
       "priority": "P0",
       "source_doc": "external:local-study:OVERKILL_FACTORY_V2_REFERENCE_COMPARISON_FINAL_STUDY_2026-06-26.md",
       "claim": "The factory may claim superiority over reference repositories only when the claim links to schema, reducer or validator, test and negative fixture proof.",
-      "claim_boundary": "The claim schema exists, but there is no full reference-derived fixture corpus and runner that proves superiority across the studied references.",
+      "claim_boundary": "Public kernel proof now includes a reference-derived negative fixture corpus and runner. It is not a timeless proof that every future reference remains weaker.",
       "schema_refs": [
         "schemas/reference-superiority-claim.schema.json",
-        "schemas/v2-study-traceability.schema.json"
+        "schemas/v2-study-traceability.schema.json",
+        "schemas/reference-derived-negative-fixture.schema.json"
       ],
       "runtime_refs": [
         "scripts/factoryctl.py::validate_v2_study_traceability",
-        "scripts/validate_public_json_artifacts.py"
+        "scripts/validate_public_json_artifacts.py",
+        "scripts/validate_reference_superiority.py",
+        "scripts/factoryctl.py::command_validate_reference_superiority"
       ],
       "test_refs": [
-        "tests/test_factory_v2_kernel.py"
+        "tests/test_factory_v2_kernel.py",
+        "tests/test_v2_runtime_contracts.py"
       ],
       "negative_fixture_refs": [
         "fixtures/v2/phase-jump-blocked-by-earlier-phase.json",
-        "fixtures/v2/v2-p0-negative-fixtures.json"
+        "fixtures/v2/v2-p0-negative-fixtures.json",
+        "fixtures/v2/reference-derived-negative-fixtures.json"
       ],
-      "status": "contract_only",
+      "status": "kernel_implemented",
       "known_gaps": [
-        "Reference-derived negative fixture schema, corpus and superiority runner are not implemented."
+        "The reference corpus must be refreshed when new reference projects or major updates are adopted."
       ],
-      "next_action": "Build the reference superiority harness before making broad public superiority claims."
+      "next_action": "Expand the reference-derived negative corpus with each new reference or architectural comparison."
     },
     {
       "claim_id": "V2-P0-011-readiness-claims-use-truth-levels",

--- a/templates/vertical-slice-graph.json
+++ b/templates/vertical-slice-graph.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/vertical-slice-graph.schema.json",
+  "record_type": "vertical_slice_graph",
+  "graph_id": "overkill-factory-v2-vertical-slice-graph",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "slice_policy": {
+    "vertical_slices_required": true,
+    "thin_horizontal_tasks_forbidden": true,
+    "each_slice_has_e2e_path": true
+  },
+  "slices": [
+    {
+      "slice_id": "slice-operator-first-success",
+      "user_outcome": "The operator can complete the first product success path with visible evidence.",
+      "surface_refs": ["web-app", "api-core", "data-core"],
+      "work_unit_refs": ["wu-frontend-first-success", "wu-api-first-success", "wu-qa-first-success"],
+      "verification_refs": ["templates/product-e2e-release-proof.json"]
+    },
+    {
+      "slice_id": "slice-onchain-safe-path",
+      "user_outcome": "The product can exercise an onchain path without signer, funds or Mainnet authority.",
+      "surface_refs": ["web-app", "api-core", "onchain-core"],
+      "work_unit_refs": ["wu-onchain-plan", "wu-wallet-boundary", "wu-onchain-qa"],
+      "verification_refs": ["schemas/solana-ai-kit-usage-receipt.schema.json", "templates/security-route-contract.json"]
+    }
+  ]
+}

--- a/templates/visual-regression-proof.json
+++ b/templates/visual-regression-proof.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/visual-regression-proof.schema.json",
+  "record_type": "visual_regression_proof",
+  "proof_id": "product-visual-regression-proof-template",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "result": "BLOCKED",
+  "viewports": ["mobile", "desktop"],
+  "states": ["default", "loading", "error", "empty"],
+  "evidence_refs": [
+    "templates/product-face-result.json",
+    "templates/storybook-equivalent-catalog.json"
+  ]
+}

--- a/templates/work-unit-dispatch-readiness.json
+++ b/templates/work-unit-dispatch-readiness.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/work-unit-dispatch-readiness.schema.json",
+  "record_type": "work_unit_dispatch_readiness",
+  "readiness_id": "overkill-factory-v2-work-unit-dispatch-readiness",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "hermes_policy": {
+    "gateway_dispatch_required": true,
+    "blocked_first_required": true,
+    "direct_worker_spawn_forbidden": true
+  },
+  "work_units": [
+    {
+      "work_unit_id": "wu-frontend-first-success",
+      "slice_ref": "slice-operator-first-success",
+      "worker_id": "frontend-builder",
+      "dependencies_satisfied": true,
+      "dispatch_decision": "ready",
+      "hermes_task_plan_ref": "templates/ready-work-unit-hermes-materialization-plan.json",
+      "evidence_refs": ["templates/component-registry.json", "templates/project-design-system.json"]
+    },
+    {
+      "work_unit_id": "wu-onchain-plan",
+      "slice_ref": "slice-onchain-safe-path",
+      "worker_id": "solana-quasar-builder",
+      "dependencies_satisfied": false,
+      "dispatch_decision": "blocked",
+      "hermes_task_plan_ref": "templates/ready-work-unit-hermes-materialization-plan.json",
+      "evidence_refs": ["schemas/solana-ai-kit-usage-receipt.schema.json", "templates/security-route-contract.json"]
+    }
+  ]
+}

--- a/tests/test_factory_v2_kernel.py
+++ b/tests/test_factory_v2_kernel.py
@@ -233,7 +233,7 @@ class FactoryV2KernelTests(unittest.TestCase):
         statuses = {claim["status"] for claim in packet["claims"]}
         self.assertNotIn("implemented", statuses)
         self.assertIn("kernel_implemented", statuses)
-        self.assertIn("contract_only", statuses)
+        self.assertIn("runtime_integrated", statuses)
         for claim in packet["claims"]:
             self.assertIn("claim_boundary", claim)
             self.assertGreater(len(claim["known_gaps"]), 0)

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -26,6 +26,11 @@ def load_public_json_validator():
     return module
 
 
+def project_release_tag() -> str:
+    pyproject = tomllib.loads(read_text("pyproject.toml"))
+    return f"v{pyproject['project']['version']}"
+
+
 class OpenSourceDocsTest(unittest.TestCase):
     def test_readme_is_external_user_entrypoint(self) -> None:
         readme = read_text("README.md")
@@ -58,7 +63,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
         self.assertIn('the factory is not "a smart chat."', readme)
-        self.assertIn("v2.0.2", readme)
+        self.assertIn(project_release_tag(), readme)
         self.assertIn("Factory V2", readme)
         self.assertIn("docs/architecture/factory-v2-control-plane.md", readme)
         self.assertIn("docs/operations/promise-to-implementation.md", readme)
@@ -126,7 +131,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "linha de produção em etapas para trabalho de produto controlado",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
-            "v2.0.2",
+            project_release_tag(),
             "Factory V2",
             "docs/architecture/factory-v2-control-plane.md",
             "codex plugin marketplace add .",

--- a/tests/test_release_integration_preflight.py
+++ b/tests/test_release_integration_preflight.py
@@ -191,11 +191,15 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
                 if "--out" in command:
                     out = Path(command[command.index("--out") + 1])
                     payload = {"result": "ATTENTION", "cleanup_policy": {}}
-                else:
+                elif "--summary-json" in command:
                     out = Path(command[command.index("--summary-json") + 1])
                     payload = {"result": "PASS"}
-                out.parent.mkdir(parents=True, exist_ok=True)
-                out.write_text(json.dumps(payload), encoding="utf-8")
+                else:
+                    out = None
+                    payload = {}
+                if out is not None:
+                    out.parent.mkdir(parents=True, exist_ok=True)
+                    out.write_text(json.dumps(payload), encoding="utf-8")
                 return subprocess.CompletedProcess(command, 0)
 
             materialization = preflight.materialize_preflight_inputs(
@@ -264,8 +268,8 @@ class ReleaseIntegrationPreflightTest(unittest.TestCase):
         self.assertIn("preflight_materializers_passed", receipt["blocking_items"])
         self.assertIn("preflight_evidence_refs_exist", receipt["blocking_items"])
         self.assertFalse(receipt["materialization"]["all_materializers_passed"])
-        self.assertEqual(len(receipt["materialization"]["failed_materializers"]), 4)
-        self.assertEqual(len(receipt["missing_evidence_refs"]), 4)
+        self.assertEqual(len(receipt["materialization"]["failed_materializers"]), 8)
+        self.assertEqual(len(receipt["missing_evidence_refs"]), 5)
         self.assertNotIn(str(root), json.dumps(receipt))
 
     def _fixtures(

--- a/tests/test_v2_runtime_contracts.py
+++ b/tests/test_v2_runtime_contracts.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def load_script(name: str) -> Any:
+    path = SCRIPT_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+factoryctl = load_script("factoryctl")
+runtime_contracts = load_script("validate_v2_runtime_contracts")
+agent_skill_boundaries = load_script("validate_agent_vs_skill_boundaries")
+reference_superiority = load_script("validate_reference_superiority")
+
+
+def copy_contract_root(tmp: Path) -> None:
+    for dirname in ("agents", "schemas", "templates", "fixtures"):
+        shutil.copytree(ROOT / dirname, tmp / dirname)
+
+
+class V2RuntimeContractsTests(unittest.TestCase):
+    def test_factoryctl_validates_runtime_contract_set(self) -> None:
+        self.assertEqual(factoryctl.main_with_args_for_test(["validate-v2-runtime-contracts"]), 0)
+
+    def test_factoryctl_validates_agent_skill_boundaries(self) -> None:
+        self.assertEqual(factoryctl.main_with_args_for_test(["validate-agent-skill-boundaries"]), 0)
+
+    def test_factoryctl_validates_reference_superiority_fixtures(self) -> None:
+        self.assertEqual(factoryctl.main_with_args_for_test(["validate-reference-superiority"]), 0)
+
+    def test_operator_delivery_rejects_decision_before_material(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            copy_contract_root(tmp)
+            receipt_path = tmp / "templates" / "operator-delivery-receipt.json"
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt["material_delivered_before_question"] = False
+            receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+            errors = runtime_contracts.validate_runtime_contract_set(tmp)
+
+        self.assertTrue(any("material_delivered_before_question" in error for error in errors), errors)
+
+    def test_agent_binding_rejects_unregistered_skill_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            copy_contract_root(tmp)
+            bindings_path = tmp / "agents" / "hermes-profile-bindings.public.json"
+            bindings = json.loads(bindings_path.read_text(encoding="utf-8"))
+            bindings["bindings"]["factory-orchestrator"]["skill_refs"].append("missing-specialist-provider")
+            bindings_path.write_text(json.dumps(bindings, indent=2) + "\n", encoding="utf-8")
+
+            errors = agent_skill_boundaries.validate_boundaries(tmp)
+
+        self.assertTrue(any("missing-specialist-provider" in error for error in errors), errors)
+
+    def test_reference_superiority_fixture_must_block_regression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            fixture_path = Path(tmp_dir) / "reference-derived-negative-fixtures.json"
+            shutil.copyfile(ROOT / "fixtures" / "v2" / "reference-derived-negative-fixtures.json", fixture_path)
+            fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+            fixture["fixtures"][0]["expected_factory_result"] = "PASS"
+            fixture_path.write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+
+            errors = reference_superiority.validate_reference_superiority(fixture_path)
+
+        self.assertTrue(any("must expect BLOCKED" in error for error in errors), errors)
+
+    def test_capability_acquisition_run_activates_existing_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out = Path(tmp_dir) / "capability-run.json"
+
+            self.assertEqual(
+                factoryctl.main_with_args_for_test(
+                    [
+                        "capability-acquisition-run",
+                        "--capability-gap",
+                        "solana-ai-kit",
+                        "--surface",
+                        "solana",
+                        "--created-at",
+                        "2026-06-26T00:00:00+00:00",
+                        "--out",
+                        str(out),
+                    ]
+                ),
+                0,
+            )
+            packet = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(packet["activation_decision"], "activate")
+        self.assertFalse(packet["block_allowed"])
+        self.assertIn("solana-ai-kit", {candidate["candidate_id"] for candidate in packet["candidates"]})
+        self.assertEqual(factoryctl.validate_capability_acquisition_run(packet), [])
+
+    def test_capability_acquisition_run_blocks_only_after_completed_search(self) -> None:
+        packet = factoryctl.build_capability_acquisition_run(
+            capability_gap="unavailable-specialist",
+            surfaces=["unknown-surface-for-negative-test"],
+            reference_sources=["external:public:reference-search"],
+            created_at="2026-06-26T00:00:00+00:00",
+            run_id="capability-acquisition-negative-test",
+        )
+
+        self.assertEqual(packet["activation_decision"], "block")
+        self.assertTrue(packet["block_allowed"])
+        self.assertTrue(packet["search_completed"])
+        self.assertEqual(factoryctl.validate_capability_acquisition_run(packet), [])
+
+        packet["search_completed"] = False
+        errors = factoryctl.validate_capability_acquisition_run(packet)
+
+        self.assertTrue(any("cannot block before search_completed=true" in error for error in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds Factory V2 runtime-spine contracts for profile aliases, skill providers, capability acquisition, operator delivery, Product Experience evidence, security matrix, release proof and reference-derived negative fixtures.
- Adds factoryctl validators and executable capability-acquisition lane so missing specialists are searched before a human block.
- Aligns Hermes/Kanban docs/templates with current native primitives: gateway start, kanban dispatch/watch/tail/runs/diagnostics and notify subscribe/list/unsubscribe.
- Updates public docs, Codex skill, release preflight and package asset resolution for installed-wheel use.

## Validation
- python -m unittest discover -s tests -q
- python scripts/release_integration_preflight.py
- python scripts/worktree_release_inventory.py
- python scripts/validate_document_governance.py
- python scripts/validate_public_json_artifacts.py
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py
- wheel smoke: factoryctl doctor, validate-v2-runtime-contracts, validate-agent-skill-boundaries, capability-acquisition-run, validate-capability-acquisition-run