### PR TITLE
[codex] Fix no-idle Hermes block-loop triage handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ public releases.
 
 ## Unreleased
 
+## 2.0.5 - 2026-06-26
+
+- Fix no-idle typed block loop handling against the real Hermes #52848 runtime:
+  `block_loop_detected` cards move to `triage`, so no-idle now queries and
+  enriches `triage` before classifying loop-breaker state.
+- Add regression coverage for the real Hermes event shape
+  `events[].kind = block_loop_detected` with `payload.kind = transient`, and
+  surface `triage` counts in watchdog loop reports.
+
 ## 2.0.4 - 2026-06-26
 
 - Adapt Factory V2 to Hermes Kanban typed block reasons from upstream #52848:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V2 is the current public kernel release line. The latest public release
-is v2.0.4.
+is v2.0.5.
 
 V2 means the public kernel has executable contracts for the factory line:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V2 é a linha atual de release do kernel público. A release pública mais
-recente é v2.0.4.
+recente é v2.0.5.
 
 V2 significa que o kernel público tem contratos executáveis para a linha da
 fábrica:

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1376,7 +1376,7 @@ def enrich_no_idle_rows(
     enriched: dict[str, list[dict[str, Any]]] = {status: list(items) for status, items in rows.items()}
     if rows.get("ready") or rows.get("running"):
         return enriched
-    for status in ("todo", "blocked", "done"):
+    for status in ("todo", "blocked", "triage", "done"):
         next_items: list[dict[str, Any]] = []
         for item in rows.get(status, []):
             task_id = task_record_id(item)
@@ -7613,7 +7613,7 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
             status=status,
             runner=runner,
         )
-        for status in ("ready", "running", "todo", "blocked", "done")
+        for status in ("ready", "running", "todo", "blocked", "triage", "done")
     }
     rows = enrich_no_idle_rows(hermes_bin=args.hermes_bin, board=args.board, rows=rows, runner=runner)
     reconcile_plan: dict[str, Any] | None = build_board_reconcile_plan_from_rows(board=args.board, rows=rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "2.0.4"
+version = "2.0.5"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/factory_no_idle_watchdog.py
+++ b/scripts/factory_no_idle_watchdog.py
@@ -240,7 +240,7 @@ def no_idle_signature(no_idle_result: dict[str, Any], dispatch_result: dict[str,
         "counts": {
             key: value.get("count")
             for key, value in counts.items()
-            if isinstance(value, dict) and key in {"ready", "running", "todo", "blocked"}
+            if isinstance(value, dict) and key in {"ready", "running", "todo", "blocked", "triage"}
         },
         "remediation_strategy": state.get("remediation_strategy"),
         "remediation_task_created": remediation_created,
@@ -296,7 +296,7 @@ def summarize_board(board: str, signature: dict[str, Any]) -> str:
             return (
                 f"[Overkill Factory] {board}: Hermes detectou loop de bloqueio repetido; "
                 f"triagem determinística de causa criada/necessária. todo={counts.get('todo', 0)} "
-                f"blocked={counts.get('blocked', 0)}."
+                f"blocked={counts.get('blocked', 0)} triage={counts.get('triage', 0)}."
             )
         if "post_review_owner_gate" in classification:
             if signature.get("remediation_task_created") is True:

--- a/tests/test_factory_no_idle_watchdog.py
+++ b/tests/test_factory_no_idle_watchdog.py
@@ -335,7 +335,7 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
                 "typed_block_kind": "transient",
                 "block_loop_detected": True,
                 "block_loop_task_refs": ["kanban:redacted-loop"],
-                "state": {"blocked": {"count": 1}, "todo": {"count": 0}},
+                "state": {"blocked": {"count": 0}, "todo": {"count": 0}, "triage": {"count": 1}},
             },
         }
         with tempfile.TemporaryDirectory() as tmp:
@@ -355,6 +355,7 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
                 )
 
         self.assertIn("loop de bloqueio", buffer.getvalue())
+        self.assertIn("triage=1", buffer.getvalue())
         emit_call = next(call for call in fake.calls if len(call) > 2 and call[2] == "emit-event")
         self.assertIn("block_loop_detected", emit_call)
         self.assertNotIn("--requires-user", emit_call)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3857,6 +3857,32 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(result["no_idle_state"]["native_dispatch_required_next"])
         self.assertIsNone(result["remediation_task_id"])
 
+    def test_no_idle_reads_hermes_triage_block_loop_detected(self) -> None:
+        fake = FakeHermes()
+        fake.tasks[MAIN_TASK_ID] = {
+            "id": MAIN_TASK_ID,
+            "status": "triage",
+            "assignee": None,
+            "body": "{}",
+            "events": [
+                {"kind": "block_loop_detected", "payload": {"kind": "transient", "recurrences": 2}},
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        queried_statuses = [
+            call[call.index("--status") + 1]
+            for call in fake.calls
+            if len(call) >= 5 and call[4] == "list" and "--status" in call
+        ]
+        self.assertIn("triage", queried_statuses)
+        self.assertEqual(result["mode"], "no-idle")
+        self.assertEqual(result["no_idle_state"]["classification"], "hermes_typed_block_loop_detected")
+        self.assertTrue(result["no_idle_state"]["block_loop_detected"])
+        self.assertFalse(result["no_idle_state"]["human_gate_required"])
+
     def test_native_workflow_state_updates_hermes_sqlite_columns(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
@@ -5717,11 +5743,12 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         state = adapter.classify_no_idle_state(
             {
                 "todo": [],
-                "blocked": [
+                "blocked": [],
+                "triage": [
                     {
                         "id": "t_loop",
-                        "status": "blocked",
-                        "events": [{"type": "block_loop_detected", "payload": {"kind": "transient", "recurrences": 2}}],
+                        "status": "triage",
+                        "events": [{"kind": "block_loop_detected", "payload": {"kind": "transient", "recurrences": 2}}],
                     }
                 ],
                 "ready": [],


### PR DESCRIPTION
## Summary
- Fixes the no-idle adapter to query and enrich Hermes `triage` tasks.
- Covers the real Hermes #52848 loop-breaker shape: `events[].kind = block_loop_detected` with `payload.kind = transient`.
- Surfaces `triage` counts in watchdog loop reports and bumps the release to v2.0.5.

## Why
Real VM smoke showed repeated same-cause blocks move to `triage`, not `blocked`. v2.0.4 handled the event shape but no-idle did not query `triage`, so it could miss real Hermes loop-breaker state.

## Validation
- `python -m unittest discover -s tests -p "test_*.py" -q` — 1053 tests OK.
- Public/governance/safety validator chain OK.
- V2 factoryctl validator chain OK.
- Real VM smoke showed Hermes emits `block_loop_detected` in `triage` with `recurrences: 2`.