### PR TITLE
[codex] Preserve Hermes dependency waits before phase repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ public releases.
 
 ## Unreleased
 
+## 2.0.6 - 2026-06-26
+
+- Preserve native Hermes `dependency_wait` before phase-engine repair planning:
+  external dependency waits and parent dependency waits now stay in the Hermes
+  dependency lane instead of becoming generic factory remediation.
+- Add regressions proving typed Hermes dependency/loop events win over the
+  board reconciler unless an earlier deterministic phase invariant already
+  blocks execution.
+
 ## 2.0.5 - 2026-06-26
 
 - Fix no-idle typed block loop handling against the real Hermes #52848 runtime:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V2 is the current public kernel release line. The latest public release
-is v2.0.5.
+is v2.0.6.
 
 V2 means the public kernel has executable contracts for the factory line:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V2 é a linha atual de release do kernel público. A release pública mais
-recente é v2.0.5.
+recente é v2.0.6.
 
 V2 significa que o kernel público tem contratos executáveis para a linha da
 fábrica:

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1350,7 +1350,7 @@ def native_dependency_wait_todo_blockers(
             for parent_id in parent_map.get(task_id, [])
             if status_by_id.get(parent_id) not in {None, "", "done"}
         )
-        if blockers:
+        if task_block_event_kind(item) == "dependency":
             blockers_by_todo[task_id] = blockers
     return blockers_by_todo
 
@@ -1639,7 +1639,7 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             "human_gate_task_refs": human_gate_refs,
             "dependency_gated_task_refs": sorted(native_dependency_blockers),
             "dependency_blocker_task_refs": sorted({ref for refs in native_dependency_blockers.values() for ref in refs}),
-            "next_action": "wait for Hermes native dependency auto-resume when parent work completes; do not page the operator",
+            "next_action": "wait for Hermes native dependency handling or parent auto-resume; do not page the operator",
             "state": state,
         }
     identified_todo = [item for item in todo if task_record_id(item)]
@@ -7655,6 +7655,35 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
             write_json(args.out, public_envelope)
         return public_envelope
     legacy_classification = classify_no_idle_state(rows)
+    if legacy_classification.get("classification") in {
+        "hermes_native_dependency_wait",
+        "hermes_typed_block_loop_detected",
+    }:
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "no-idle",
+            "board": args.board,
+            "blocked": bool(legacy_classification.get("blocked")),
+            "no_idle_state": legacy_classification,
+            "board_reconcile_plan": reconcile_plan,
+            "targeted_remediation_plan": None,
+            "remediation_task_id": None,
+            "hook": {
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "no_shadow_dispatcher": True,
+                "dispatch_called_by_this_command": False,
+                "reporting_policy": (
+                    "No-idle preserved native Hermes typed block state before phase-engine "
+                    "repair planning; dependency_wait waits natively and block_loop_detected "
+                    "routes deterministic triage without a generic human gate."
+                ),
+            },
+        }
+        public_envelope = sanitize_public_refs(envelope)
+        if args.out:
+            write_json(args.out, public_envelope)
+        return public_envelope
     if (
         legacy_classification.get("remediation_required") is not True
         and (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "2.0.5"
+version = "2.0.6"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3883,6 +3883,68 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertTrue(result["no_idle_state"]["block_loop_detected"])
         self.assertFalse(result["no_idle_state"]["human_gate_required"])
 
+    def test_no_idle_preserves_dependency_wait_before_phase_reconcile(self) -> None:
+        fake = FakeHermes()
+        fake.tasks[MAIN_TASK_ID] = {
+            "id": MAIN_TASK_ID,
+            "status": "todo",
+            "assignee": "factory-orchestrator",
+            "current_step_key": "F13-runtime-execution",
+            "body": json.dumps(
+                {
+                    "factory_method_version": "OVERKILL_VFINAL",
+                    "card_id": "KFP-DEP-WAIT",
+                    "phase": "F13",
+                    "risk_effective": "R2",
+                    "surfaces": ["backend"],
+                }
+            ),
+            "events": [
+                {"kind": "dependency_wait", "payload": {"kind": "dependency"}},
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["mode"], "no-idle")
+        self.assertEqual(result["no_idle_state"]["classification"], "hermes_native_dependency_wait")
+        self.assertEqual(result["no_idle_state"]["typed_block_kind"], "dependency")
+        self.assertFalse(result["no_idle_state"]["human_gate_required"])
+        self.assertFalse(result["no_idle_state"]["operator_input_required"])
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+
+    def test_no_idle_preserves_block_loop_before_phase_reconcile(self) -> None:
+        fake = FakeHermes()
+        fake.tasks[MAIN_TASK_ID] = {
+            "id": MAIN_TASK_ID,
+            "status": "triage",
+            "assignee": "factory-orchestrator",
+            "current_step_key": "F13-runtime-execution",
+            "body": json.dumps(
+                {
+                    "factory_method_version": "OVERKILL_VFINAL",
+                    "card_id": "KFP-BLOCK-LOOP",
+                    "phase": "F13",
+                    "risk_effective": "R2",
+                    "surfaces": ["backend"],
+                }
+            ),
+            "events": [
+                {"kind": "block_loop_detected", "payload": {"kind": "transient", "recurrences": 2}},
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["mode"], "no-idle")
+        self.assertEqual(result["no_idle_state"]["classification"], "hermes_typed_block_loop_detected")
+        self.assertTrue(result["no_idle_state"]["block_loop_detected"])
+        self.assertFalse(result["no_idle_state"]["human_gate_required"])
+        self.assertFalse(result["no_idle_state"]["operator_input_required"])
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+
     def test_native_workflow_state_updates_hermes_sqlite_columns(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)


### PR DESCRIPTION
## Summary
- preserve native Hermes `dependency_wait` and `block_loop_detected` classifications before the factory phase reconciler can create generic remediation
- allow external dependency waits with no parent blockers to remain in the Hermes dependency lane
- bump the public release line to v2.0.6 and add regressions proving typed Hermes state wins over phase repair

## Root cause
The v2.0.5 integration handled Hermes typed block loop triage, but a real VM smoke exposed a second preemption path: a `dependency_wait` task with no parent blocker could fall through to the factory board reconciler and become generic remediation. That defeated Hermes #52848's native dependency behavior.

## Validation
- `python -m unittest discover -s tests -p "test_*.py" -q` (1055 tests)
- public/governance/safety validator chain
- Factory V2 `factoryctl` validator chain