### PR TITLE
[codex] Clarify Hermes dependency wait semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ public releases.
 
 ## Unreleased
 
+## 2.0.7 - 2026-06-26
+
+- Clarify and test the real Hermes dependency semantics proven by live smoke:
+  durable dependency waiting comes from parent edges or current `todo`
+  `dependency_wait` state; a no-parent `dependency` block can recompute to
+  `ready` and must remain dispatchable instead of becoming a fake wait.
+- Add regression coverage so a `ready` task with historical `dependency_wait`
+  event history is not mistaken for a current native dependency wait; normal
+  ready/reconcile rules still decide the next action.
+
 ## 2.0.6 - 2026-06-26
 
 - Preserve native Hermes `dependency_wait` before phase-engine repair planning:
-  external dependency waits and parent dependency waits now stay in the Hermes
-  dependency lane instead of becoming generic factory remediation.
+  current `todo` dependency waits stay in the Hermes dependency lane instead
+  of becoming generic factory remediation.
 - Add regressions proving typed Hermes dependency/loop events win over the
   board reconciler unless an earlier deterministic phase invariant already
   blocks execution.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V2 is the current public kernel release line. The latest public release
-is v2.0.6.
+is v2.0.7.
 
 V2 means the public kernel has executable contracts for the factory line:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -267,7 +267,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V2 é a linha atual de release do kernel público. A release pública mais
-recente é v2.0.6.
+recente é v2.0.7.
 
 V2 significa que o kernel público tem contratos executáveis para a linha da
 fábrica:

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -7675,7 +7675,7 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
                 "dispatch_called_by_this_command": False,
                 "reporting_policy": (
                     "No-idle preserved native Hermes typed block state before phase-engine "
-                    "repair planning; dependency_wait waits natively and block_loop_detected "
+                    "repair planning; current dependency_wait states stay native and block_loop_detected "
                     "routes deterministic triage without a generic human gate."
                 ),
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "2.0.6"
+version = "2.0.7"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3883,7 +3883,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertTrue(result["no_idle_state"]["block_loop_detected"])
         self.assertFalse(result["no_idle_state"]["human_gate_required"])
 
-    def test_no_idle_preserves_dependency_wait_before_phase_reconcile(self) -> None:
+    def test_no_idle_preserves_todo_dependency_wait_before_phase_reconcile(self) -> None:
         fake = FakeHermes()
         fake.tasks[MAIN_TASK_ID] = {
             "id": MAIN_TASK_ID,
@@ -3913,6 +3913,25 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(result["no_idle_state"]["human_gate_required"])
         self.assertFalse(result["no_idle_state"]["operator_input_required"])
         self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+
+    def test_no_idle_ready_dependency_wait_history_is_not_current_dependency_wait(self) -> None:
+        fake = FakeHermes()
+        fake.tasks[MAIN_TASK_ID] = {
+            "id": MAIN_TASK_ID,
+            "status": "ready",
+            "assignee": "factory-orchestrator",
+            "body": "{}",
+            "events": [
+                {"kind": "dependency_wait", "payload": {"kind": "dependency"}},
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["mode"], "no-idle")
+        self.assertNotEqual(result["no_idle_state"]["classification"], "hermes_native_dependency_wait")
+        self.assertFalse(result["no_idle_state"]["human_gate_required"])
 
     def test_no_idle_preserves_block_loop_before_phase_reconcile(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary
- clarify the real Hermes dependency semantics discovered during disposable-board smoke testing
- distinguish current `todo` dependency waits from historical `dependency_wait` event history on `ready` work
- bump the public release line to v2.0.7 and add a regression that stale dependency history cannot hide ready/reconcile behavior

## Root cause
A live smoke showed that `block --kind dependency` without a parent edge can recompute to `ready` in Hermes. The v2.0.6 wording over-described that shape as a durable external dependency wait. The implementation remains conservative, but the public contract needed the exact Hermes behavior recorded.

## Validation
- `python -m unittest discover -s tests -p "test_*.py" -q` (1056 tests)
- public/governance/safety validator chain
- Factory V2 `factoryctl` validator chain
- focused Hermes no-idle regressions for todo dependency wait, ready dependency history, and loop triage