### PR TITLE
Disable rich Telegram decision packages

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1980,7 +1980,7 @@ def no_idle_post_review_gate_body(
             "keep APPROVAL_REQUEST, EVIDENCE_INDEX, OWNER_REVIEW, hashes, schemas and validation receipts as supporting evidence, not as the SOT body",
             "prepare the canonical Product SOT in markdown and PDF before asking for a decision",
             "attach or reference the canonical Product SOT markdown/PDF decision material available to the Telegram-facing manager",
-            "when a primary operator channel such as Telegram is configured, deliver a short decision message and the Product SOT PDF through the manager/operator-facing profile (for Hermes use `hermes send` with `MEDIA:<pdf>` from that profile)",
+            "when a primary operator channel such as Telegram is configured, deliver a short plain-text decision message and the Product SOT markdown/PDF as standard file attachments through the manager/operator-facing profile; do not use Telegram rich cards, rich drafts, media groups or table-rendered bot messages",
             "ask only the bounded Product SOT approve / rebaseline / request changes decision",
         ],
         "forbidden_actions": [
@@ -1989,6 +1989,7 @@ def no_idle_post_review_gate_body(
             "start architecture, implementation, repo cleanup, deployment, cloud mutation, DevNet/Mainnet material action, funds, custody, signing or release",
             "ask for a decision from a chat summary without the decision package material",
             "deliver an operational receipt, approval JSON, evidence index, hash list or worker log as if it were the Product SOT",
+            "send Telegram rich cards, rich drafts, media groups or table-rendered bot messages as the primary decision package",
             "deliver an English-only Product SOT when the operator-facing language is Portuguese",
             "treat a Kanban comment alone as delivered material when a primary operator channel is configured",
             "send the operator-facing gate from a non-manager profile when a manager/operator-facing profile is configured",

--- a/docs/concepts/factory-flow.md
+++ b/docs/concepts/factory-flow.md
@@ -11,7 +11,7 @@ from jumping straight from a vague request to a confident completion claim.
 | Operator interface profile | The selected human interface, such as Telegram, Discord or Cockpit, with proactive notification and attachment rules. |
 | Factory start conversation | The open conversational start that confirms the product understanding before a formal start request. |
 | Source resolution | The step that separates source facts, inference, decisions, conflicts and gaps. |
-| Operator briefing package | The deep review package for important decisions: short projection plus markdown/PDF attachments and optional explainers. |
+| Operator briefing package | The deep review package for important decisions: short plain-text projection plus markdown/PDF attachments and optional explainers. |
 | Product SOT | The source-of-truth candidate for the complete product scope, non-goals and acceptance criteria. |
 | Full Product SOT scope coverage | The map that prevents a first slice from silently becoming the whole product. |
 | Specialist research decision | A public-safe research result that changes SOT, architecture, method, gate, worker, proof or blocker state. |
@@ -121,6 +121,11 @@ For Telegram-first operation, important decisions should not be made from a
 short chat summary alone. The operator should receive a briefing package with a
 deep document and PDF attachment, and the bot should proactively push meaningful
 state changes instead of waiting for the operator to poll.
+
+Telegram delivery is plain-text first. Markdown/PDF are ordinary file
+attachments; Telegram rich cards, rich drafts, media groups and table-rendered
+bot messages are not the primary decision package because Telegram Desktop may
+render them as unsupported messages.
 
 ## What Blocks A Card
 

--- a/docs/getting-started/install-in-hermes.md
+++ b/docs/getting-started/install-in-hermes.md
@@ -71,6 +71,20 @@ screenshots or runtime proof from your own Hermes instance.
 If the operator talks only to `overkill-factory-gerente` through Telegram, add a
 Hermes cron job for the no-idle watchdog after the adapter path is installed:
 
+Telegram Desktop should be treated as a plain-text channel. Decision messages
+must be short text plus ordinary markdown/PDF file attachments. Do not enable
+Hermes rich cards, rich drafts, media groups or table-rendered bot messages for
+this profile.
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      rich_messages: false
+      rich_drafts: false
+      plain_text_required_reason: Telegram Desktop does not render Bot API rich messages reliably for factory decision packets.
+```
+
 For a gateway launched with a dedicated profile, put the wrapper in that
 profile's script directory. For a default-profile gateway, `~/.hermes/scripts`
 is also valid.

--- a/schemas/operator-interface-profile.schema.json
+++ b/schemas/operator-interface-profile.schema.json
@@ -32,7 +32,10 @@
         "supports_push_notifications",
         "supports_threads",
         "supports_buttons",
-        "supported_attachment_formats"
+        "supported_attachment_formats",
+        "message_rendering_mode",
+        "rich_bot_messages_allowed",
+        "standard_file_attachments_only"
       ],
       "properties": {
         "max_short_message_chars": { "type": "integer", "minimum": 500, "maximum": 10000 },
@@ -46,7 +49,10 @@
           "items": {
             "enum": ["markdown", "pdf", "json", "diagram_png", "video_mp4", "audio_mp3", "html", "link"]
           }
-        }
+        },
+        "message_rendering_mode": { "enum": ["plain_text", "rich_supported"] },
+        "rich_bot_messages_allowed": { "type": "boolean" },
+        "standard_file_attachments_only": { "type": "boolean" }
       },
       "additionalProperties": false
     },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -8854,6 +8854,9 @@ def build_operator_interface_profile(
             "supports_threads": False,
             "supports_buttons": True,
             "supported_attachment_formats": ["markdown", "pdf", "json", "diagram_png", "video_mp4", "audio_mp3", "link"],
+            "message_rendering_mode": "plain_text",
+            "rich_bot_messages_allowed": False,
+            "standard_file_attachments_only": True,
         },
         "discord": {
             "max_short_message_chars": 1800,
@@ -8861,6 +8864,9 @@ def build_operator_interface_profile(
             "supports_threads": True,
             "supports_buttons": True,
             "supported_attachment_formats": ["markdown", "pdf", "json", "diagram_png", "video_mp4", "audio_mp3", "link"],
+            "message_rendering_mode": "rich_supported",
+            "rich_bot_messages_allowed": True,
+            "standard_file_attachments_only": False,
         },
         "cockpit": {
             "max_short_message_chars": 5000,
@@ -8868,6 +8874,9 @@ def build_operator_interface_profile(
             "supports_threads": True,
             "supports_buttons": True,
             "supported_attachment_formats": ["markdown", "pdf", "json", "diagram_png", "video_mp4", "audio_mp3", "html", "link"],
+            "message_rendering_mode": "rich_supported",
+            "rich_bot_messages_allowed": True,
+            "standard_file_attachments_only": False,
         },
         "codex_bridge": {
             "max_short_message_chars": 3500,
@@ -8875,6 +8884,9 @@ def build_operator_interface_profile(
             "supports_threads": True,
             "supports_buttons": False,
             "supported_attachment_formats": ["markdown", "pdf", "json", "link"],
+            "message_rendering_mode": "plain_text",
+            "rich_bot_messages_allowed": False,
+            "standard_file_attachments_only": True,
         },
         "cli": {
             "max_short_message_chars": 8000,
@@ -8882,6 +8894,9 @@ def build_operator_interface_profile(
             "supports_threads": False,
             "supports_buttons": False,
             "supported_attachment_formats": ["markdown", "json", "link"],
+            "message_rendering_mode": "plain_text",
+            "rich_bot_messages_allowed": False,
+            "standard_file_attachments_only": True,
         },
         "api": {
             "max_short_message_chars": 8000,
@@ -8889,6 +8904,9 @@ def build_operator_interface_profile(
             "supports_threads": False,
             "supports_buttons": False,
             "supported_attachment_formats": ["markdown", "pdf", "json", "html", "link"],
+            "message_rendering_mode": "plain_text",
+            "rich_bot_messages_allowed": False,
+            "standard_file_attachments_only": True,
         },
     }
     capabilities = channel_defaults[interface]
@@ -8976,6 +8994,12 @@ def validate_operator_interface_profile(profile: dict[str, Any]) -> list[str]:
         formats = set(_list_items(capabilities.get("supported_attachment_formats")))
         if not {"markdown", "pdf"}.issubset(formats):
             errors.append("operator_interface_profile.telegram must support markdown and pdf attachments")
+        if capabilities.get("message_rendering_mode") != "plain_text":
+            errors.append("operator_interface_profile.telegram must use plain_text message rendering")
+        if capabilities.get("rich_bot_messages_allowed") is not False:
+            errors.append("operator_interface_profile.telegram must disable rich bot messages")
+        if capabilities.get("standard_file_attachments_only") is not True:
+            errors.append("operator_interface_profile.telegram must use standard file attachments only")
     if capabilities.get("supports_push_notifications") is not True:
         errors.append("operator_interface_profile must support push/proactive notifications")
 

--- a/scripts/validate_public_json_artifacts.py
+++ b/scripts/validate_public_json_artifacts.py
@@ -1385,6 +1385,12 @@ def validate_domain_rules(data: dict[str, Any], at: str) -> list[str]:
             formats = set(text_items(capabilities.get("supported_attachment_formats")))
             if not {"markdown", "pdf"}.issubset(formats):
                 errors.append(f"{at}: telegram interface must support markdown and pdf attachments")
+            if capabilities.get("message_rendering_mode") != "plain_text":
+                errors.append(f"{at}: telegram interface must use plain_text message rendering")
+            if capabilities.get("rich_bot_messages_allowed") is not False:
+                errors.append(f"{at}: telegram interface must disable rich bot messages")
+            if capabilities.get("standard_file_attachments_only") is not True:
+                errors.append(f"{at}: telegram interface must use standard file attachments only")
         conversation = data.get("conversation_policy") if isinstance(data.get("conversation_policy"), dict) else {}
         if conversation.get("status_polling_required") is not False:
             errors.append(f"{at}: operator_interface_profile must not require status polling")

--- a/templates/operator-interface-profile.json
+++ b/templates/operator-interface-profile.json
@@ -11,7 +11,10 @@
     "supports_push_notifications": true,
     "supports_threads": false,
     "supports_buttons": true,
-    "supported_attachment_formats": ["markdown", "pdf", "json", "diagram_png", "video_mp4", "audio_mp3", "link"]
+    "supported_attachment_formats": ["markdown", "pdf", "json", "diagram_png", "video_mp4", "audio_mp3", "link"],
+    "message_rendering_mode": "plain_text",
+    "rich_bot_messages_allowed": false,
+    "standard_file_attachments_only": true
   },
   "conversation_policy": {
     "start_mode": "conversational_intake_before_factory_start",

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4387,12 +4387,16 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             body["required_actions"],
         )
         self.assertIn(
-            "when a primary operator channel such as Telegram is configured, deliver a short decision message and the Product SOT PDF through the manager/operator-facing profile (for Hermes use `hermes send` with `MEDIA:<pdf>` from that profile)",
+            "when a primary operator channel such as Telegram is configured, deliver a short plain-text decision message and the Product SOT markdown/PDF as standard file attachments through the manager/operator-facing profile; do not use Telegram rich cards, rich drafts, media groups or table-rendered bot messages",
             body["required_actions"],
         )
         self.assertIn("ask for a decision from a chat summary without the decision package material", body["forbidden_actions"])
         self.assertIn(
             "deliver an operational receipt, approval JSON, evidence index, hash list or worker log as if it were the Product SOT",
+            body["forbidden_actions"],
+        )
+        self.assertIn(
+            "send Telegram rich cards, rich drafts, media groups or table-rendered bot messages as the primary decision package",
             body["forbidden_actions"],
         )
         self.assertIn(

--- a/tests/test_operator_experience.py
+++ b/tests/test_operator_experience.py
@@ -160,6 +160,9 @@ class OperatorExperienceTest(unittest.TestCase):
             profile = json.loads(out.read_text(encoding="utf-8"))
 
         self.assertEqual(profile["primary_interface"], "telegram")
+        self.assertEqual(profile["interface_capabilities"]["message_rendering_mode"], "plain_text")
+        self.assertFalse(profile["interface_capabilities"]["rich_bot_messages_allowed"])
+        self.assertTrue(profile["interface_capabilities"]["standard_file_attachments_only"])
         self.assertFalse(profile["conversation_policy"]["status_polling_required"])
         self.assertTrue(profile["conversation_policy"]["operator_not_required_to_poll"])
         self.assertIn("decision_required", profile["proactive_notification_policy"]["notify_on"])


### PR DESCRIPTION
## Summary\n- force Telegram operator profiles to plain-text rendering with standard file attachments only\n- update factoryctl/public validation and no-idle Product SOT package instructions\n- document Telegram Desktop as plain-text first and add regression coverage\n\nFixes #461\n\n## Tests\n- python -m unittest tests.test_operator_experience tests.test_hermes_live_kanban_adapter\n- python scripts/factoryctl.py operator-interface --primary-interface telegram --out .tmp/operator-interface-telegram-check.json\n- python scripts/factoryctl.py validate-operator-interface .tmp/operator-interface-telegram-check.json\n- python scripts/validate_public_json_artifacts.py templates/operator-interface-profile.json