### PR TITLE
Repair missing declared Hermes artifacts

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1394,9 +1394,75 @@ def enrich_no_idle_rows(
             merged["parents"] = task_readback_parents(shown)
             merged["comments"] = task_readback_comments(shown)[-3:]
             merged["events"] = task_readback_events(shown)[-5:]
+            if status == "done":
+                runs = task_run_records(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+                if runs:
+                    merged["runs"] = runs[-3:]
+                missing = missing_declared_local_artifacts(merged)
+                if missing:
+                    merged["missing_declared_artifacts"] = missing
             next_items.append(merged)
         enriched[status] = next_items
     return enriched
+
+
+def declared_artifact_refs_from_mapping(mapping: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for key in ("artifacts", "artifact_paths", "artifact_refs", "evidence_refs"):
+        value = mapping.get(key)
+        if isinstance(value, list):
+            refs.extend(str(item).strip() for item in value if str(item or "").strip())
+        elif isinstance(value, str) and value.strip():
+            refs.append(value.strip())
+    for key in ("artifact_file", "review_packet_file", "source_file", "output_file"):
+        value = str(mapping.get(key) or "").strip()
+        if value:
+            refs.append(value)
+    for value in mapping.values():
+        if isinstance(value, dict):
+            refs.extend(declared_artifact_refs_from_mapping(value))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    refs.extend(declared_artifact_refs_from_mapping(item))
+    return refs
+
+
+def declared_artifact_refs_from_task_record(record: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for event in record.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        payload = event.get("payload")
+        payload_obj = parse_json_object(payload)
+        if payload_obj:
+            refs.extend(declared_artifact_refs_from_mapping(payload_obj))
+    for run in record.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        refs.extend(declared_artifact_refs_from_mapping(run))
+        metadata_obj = parse_json_object(run.get("metadata"))
+        if metadata_obj:
+            refs.extend(declared_artifact_refs_from_mapping(metadata_obj))
+    return sorted(set(refs))
+
+
+def missing_declared_local_artifacts(record: dict[str, Any]) -> list[dict[str, Any]]:
+    missing: list[dict[str, Any]] = []
+    for ref in declared_artifact_refs_from_task_record(record):
+        path = Path(ref)
+        if not path.is_absolute():
+            continue
+        if path.exists():
+            continue
+        missing.append(
+            {
+                "artifact_name": path.name or "declared-artifact",
+                "artifact_ref": "local-absolute-path:redacted",
+                "reason": "worker declared a local artifact path but the file is absent from the Hermes runtime",
+            }
+        )
+    return missing
 
 
 def summarize_no_idle_rows(rows: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
@@ -7718,6 +7784,7 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
         return public_envelope
     reducer_preempts_legacy_classifier = bool(rows.get("ready")) or reconcile_plan.get("plan_action") in {
         "repair_domain_brain_route",
+        "repair_declared_artifacts",
         "repair_human_gate_packet",
         "create_next_artifact_task",
         "request_operator_input",

--- a/schemas/factory-board-reconcile-plan.schema.json
+++ b/schemas/factory-board-reconcile-plan.schema.json
@@ -47,6 +47,7 @@
         "dispatch_ready",
         "no_unfinished_work",
         "repair_board_contract",
+        "repair_declared_artifacts",
         "create_next_artifact_task",
         "repair_domain_brain_route",
         "repair_human_gate_packet",

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18147,6 +18147,7 @@ def build_factory_help(
 TERMINAL_BOARD_STATUSES = {"done", "complete", "completed", "archived", "cancelled", "canceled"}
 BOARD_RECONCILE_CREATE_ACTIONS = {
     "repair_board_contract",
+    "repair_declared_artifacts",
     "create_next_artifact_task",
     "repair_domain_brain_route",
     "repair_human_gate_packet",
@@ -18325,6 +18326,36 @@ def board_reconcile_ready_dispatch_blockers(
     return sorted(set(blockers)), selected_repair_card, selected_repair_ref, selected_repair_action
 
 
+def board_reconcile_missing_declared_artifact_blockers(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[list[str], dict[str, Any] | None]:
+    blockers: list[str] = []
+    selected_ref: dict[str, Any] | None = None
+    for task in rows.get("done", []):
+        missing = task.get("missing_declared_artifacts")
+        if not isinstance(missing, list) or not missing:
+            continue
+        names = sorted(
+            {
+                str(item.get("artifact_name") or "declared-artifact").strip()
+                for item in missing
+                if isinstance(item, dict)
+            }
+        )
+        names = [name for name in names if name]
+        task_ref = _task_public_ref(task)
+        blockers.append(
+            "done task "
+            + task_ref
+            + " declared local artifacts that are absent from the Hermes runtime"
+            + (": " + ", ".join(names[:8]) if names else "")
+        )
+        if selected_ref is None:
+            selected_ref = board_reconcile_task_ref(task, status="done")
+            selected_ref["selection_reason"] = "terminal task selected because declared artifacts are missing at runtime"
+    return sorted(set(blockers)), selected_ref
+
+
 def board_rows_from_snapshot(snapshot: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     rows: dict[str, list[dict[str, Any]]] = {status: [] for status in ("ready", "running", "todo", "blocked", "done")}
     raw_rows = snapshot.get("rows") if isinstance(snapshot.get("rows"), dict) else snapshot.get("tasks_by_status")
@@ -18427,11 +18458,14 @@ def _board_reconcile_task_contract(
     card_id = str((selected_card or {}).get("card_id") or "board").strip() or "board"
     title_action = {
         "repair_board_contract": "Materialize canonical factory card",
+        "repair_declared_artifacts": "Repair missing declared artifacts",
         "create_next_artifact_task": f"Materialize {next_artifact}",
         "repair_domain_brain_route": "Materialize Solana AI Kit route",
         "repair_human_gate_packet": "Repair human gate decision package",
         "request_operator_input": "Prepare bounded operator input request",
     }.get(plan_action, "Reconcile factory board")
+    if plan_action == "repair_declared_artifacts":
+        next_artifact = "declared_artifact_readback_repair"
     return {
         "title": f"{title_action} for {card_id}",
         "assignee": assignee,
@@ -18506,6 +18540,7 @@ def build_board_reconcile_plan(
         ready_repair_ref,
         ready_repair_action,
     ) = board_reconcile_ready_dispatch_blockers(rows)
+    missing_artifact_blockers, missing_artifact_ref = board_reconcile_missing_declared_artifact_blockers(rows)
 
     if active_phase_blockers:
         plan_action = "block_invariant_violation"
@@ -18538,6 +18573,21 @@ def build_board_reconcile_plan(
             assignee="factory-orchestrator",
         )
         native_dispatch_required_next = False
+    elif missing_artifact_blockers:
+        selected_ref = missing_artifact_ref
+        plan_action = "repair_declared_artifacts"
+        reason = "completed Hermes work declared local artifacts that are missing from the runtime"
+        blocked_reasons.extend(missing_artifact_blockers)
+        create_task_contract = _board_reconcile_task_contract(
+            plan_action=plan_action,
+            board=board,
+            selected_card=None,
+            phase_engine=None,
+            factory_help=None,
+            reason=reason,
+            assignee="factory-orchestrator",
+        )
+        native_dispatch_required_next = True
     elif running:
         plan_action = "observe_running"
         reason = "running Hermes work exists; no reconcile task is allowed"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4152,6 +4152,56 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(replacement_body["supersedes_runtime_task_refs"], [stale_id])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_repairs_done_task_with_missing_declared_artifacts(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "done0001"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "product-sot-result.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "product-sot-planner",
+                "title": "F5 - Product SOT candidate",
+                "body": json.dumps({"objective": "prepare Product SOT"}),
+                "events": [
+                    {
+                        "type": "completed",
+                        "payload": {
+                            "summary": "declared artifact but did not persist it",
+                            "artifacts": [str(missing_artifact)],
+                        },
+                    }
+                ],
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["status"], "remediation_required")
+        self.assertEqual(state["classification"], "repair_declared_artifacts")
+        self.assertTrue(state["remediation_task_created"])
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "repair_declared_artifacts")
+        self.assertTrue(any("product-sot-result.json" in reason for reason in state["blocked_reasons"]))
+        created_task = next(
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("plan_action") == "repair_declared_artifacts"
+        )
+        self.assertEqual(created_task["status"], "ready")
+        body = adapter.parse_json_object(str(created_task.get("body") or "{}"))
+        self.assertEqual(body["required_output"], "declared_artifact_readback_repair")
+        self.assertFalse(body["agent_may_choose_phase"])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_reconciles_declared_f9_to_f5_owner_package_before_gate(self) -> None:
         fake = FakeHermes()
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")


### PR DESCRIPTION
## Summary\n- enrich no-idle inspection of done tasks with recent run metadata\n- detect local artifact paths declared by completed tasks but missing from the Hermes runtime\n- add deterministic repair_declared_artifacts board reconcile action and schema coverage\n- add regression coverage for the Todo test failure mode\n\nFixes #463\n\n## Tests\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/validate_public_json_artifacts.py schemas/factory-board-reconcile-plan.schema.json