### PR TITLE
Recover text artifacts from worker log diffs only

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1502,6 +1502,10 @@ def metadata_payload_for_declared_artifact(record: dict[str, Any], artifact_name
     return None
 
 
+def declared_artifact_prefers_metadata(artifact_name: str) -> bool:
+    return Path(artifact_name).suffix.lower() == ".json"
+
+
 def log_diff_payload_for_declared_artifact(log_text: str, artifact_name: str) -> str | None:
     lines = log_text.splitlines()
     candidates = [
@@ -1564,7 +1568,11 @@ def materialize_missing_declared_artifacts(
             if path.exists():
                 continue
             source = "task_runs.metadata"
-            payload = metadata_payload_for_declared_artifact(task, artifact_name)
+            payload = (
+                metadata_payload_for_declared_artifact(task, artifact_name)
+                if declared_artifact_prefers_metadata(artifact_name)
+                else None
+            )
             if payload is None:
                 source = "worker_log_diff"
                 if task_id not in log_cache:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4284,7 +4284,16 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     {
                         "status": "done",
                         "outcome": "completed",
-                        "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                        "metadata": json.dumps(
+                            {
+                                "product_sot_result": {
+                                    "artifact_file": "product-sot-result.json",
+                                    "review_packet_file": "product-sot-candidate.md",
+                                    "status": "candidate_owner_review_required_not_approved",
+                                },
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
                     }
                 ],
             }


### PR DESCRIPTION
## Summary

Fixes #467.

Follow-up to #466. The artifact materializer now treats metadata as a source only for JSON artifacts. Markdown/text artifacts are recovered from the worker log diff so a `review_packet_file` declared in JSON metadata cannot accidentally write JSON into a `.md` file.

## Tests

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_repairs_done_task_with_missing_declared_artifacts tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair`
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience`