### PR TITLE
Prefer worker log diffs for artifact recovery

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1567,22 +1567,20 @@ def materialize_missing_declared_artifacts(
                 continue
             if path.exists():
                 continue
-            source = "task_runs.metadata"
-            payload = (
-                metadata_payload_for_declared_artifact(task, artifact_name)
-                if declared_artifact_prefers_metadata(artifact_name)
-                else None
-            )
-            if payload is None:
+            source = "worker_log_diff"
+            if task_id not in log_cache:
+                log_cache[task_id] = task_log_text(
+                    hermes_bin=hermes_bin,
+                    board=board,
+                    task_id=task_id,
+                    runner=runner,
+                )
+            payload = log_diff_payload_for_declared_artifact(log_cache[task_id], artifact_name)
+            if payload is None and declared_artifact_prefers_metadata(artifact_name):
+                source = "task_runs.metadata"
+                payload = metadata_payload_for_declared_artifact(task, artifact_name)
+            elif payload is None:
                 source = "worker_log_diff"
-                if task_id not in log_cache:
-                    log_cache[task_id] = task_log_text(
-                        hermes_bin=hermes_bin,
-                        board=board,
-                        task_id=task_id,
-                        runner=runner,
-                    )
-                payload = log_diff_payload_for_declared_artifact(log_cache[task_id], artifact_name)
             if payload is None:
                 records.append(
                     {

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4263,6 +4263,60 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 )
             )
 
+    def test_no_idle_prefers_worker_log_diff_over_summary_metadata_for_json(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "done0004"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "source-ledger-result.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "source-ledger-worker",
+                "title": "F2 - Source ledger",
+                "body": "{}",
+                "events": [{"type": "completed", "payload": {"artifacts": [str(missing_artifact)]}}],
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "source_ledger_result": {
+                                    "artifact_file": "source-ledger-result.json",
+                                    "summary_only": True,
+                                },
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
+                    }
+                ],
+            }
+            fake.logs[done_id] = "\n".join(
+                [
+                    "  ┊ review diff",
+                    "a/source-ledger-result.json -> b/source-ledger-result.json",
+                    "@@ -0,0 +1,7 @@",
+                    "+{",
+                    "+  \"source_ledger_result\": {",
+                    "+    \"artifact_file\": \"source-ledger-result.json\",",
+                    "+    \"full_payload_from_log\": true",
+                    "+  }",
+                    "+}",
+                    "  ┊ ⚡ kanban_complete",
+                ]
+            )
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+            recovered = json.loads(missing_artifact.read_text(encoding="utf-8"))
+            self.assertTrue(recovered["source_ledger_result"]["full_payload_from_log"])
+            self.assertNotIn("summary_only", recovered["source_ledger_result"])
+            self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
+            self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "worker_log_diff")
+
     def test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "done0003"


### PR DESCRIPTION
## Summary

Fixes the log-vs-metadata recovery priority for missing declared artifacts.

The materializer now:

- recovers from worker log diff first for every artifact type;
- falls back to `task_runs.metadata` only for JSON artifacts when no diff exists;
- keeps Markdown/text artifacts tied to actual text from log diffs;
- preserves the unrecoverable fallback path.

## Tests

- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_repairs_done_task_with_missing_declared_artifacts tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_prefers_worker_log_diff_over_summary_metadata_for_json tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair`
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience`