### PR TITLE
Create owner gate after SOT candidate review requirement

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1040,9 +1040,66 @@ def done_review_targets_product_sot_candidate(record: dict[str, Any]) -> bool:
     return any(marker in text for marker in product_sot_artifact_markers)
 
 
+def done_product_sot_candidate_requires_owner_review(record: dict[str, Any]) -> bool:
+    if str(record.get("status") or "").strip().lower() not in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES:
+        return False
+    texts = [task_record_text(record)]
+    for run in record.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = parse_json_object(run.get("metadata"))
+        if metadata:
+            texts.append(json.dumps(metadata, sort_keys=True, ensure_ascii=False).lower())
+        if run.get("summary") is not None:
+            texts.append(str(run.get("summary")).lower())
+    haystack = " ".join(texts)
+    non_product_sot_markers = (
+        "not a reviewed product sot candidate",
+        "not product sot owner-review material",
+        "not product sot owner review material",
+        "runtime/code patch only",
+        "factory runtime code patch",
+        "factory no-idle runtime",
+        "no-idle runtime classifier patch",
+        "live_kanban_adapter.py",
+        "classify_no_idle_state",
+        "done_review_requires_owner_product_sot_gate",
+    )
+    if any(marker in haystack for marker in non_product_sot_markers):
+        return False
+    product_sot_markers = (
+        "product_sot_result",
+        "product_sot_candidate",
+        "product sot candidate",
+        "f5",
+    )
+    review_required_markers = (
+        "candidate_owner_review_required_not_approved",
+        "owner review required",
+        "product sot owner review",
+        "next required gate",
+        "before method contract",
+        "before method-contract",
+    )
+    approved_markers = (
+        "owner approved product sot",
+        "operator approved product sot",
+        "product sot approved",
+        '"decision": "approved',
+        "decision: approved",
+    )
+    if any(marker in haystack for marker in approved_markers):
+        return False
+    return any(marker in haystack for marker in product_sot_markers) and any(
+        marker in haystack for marker in review_required_markers
+    )
+
+
 def done_review_requires_owner_product_sot_gate(record: dict[str, Any]) -> bool:
     if str(record.get("status") or "").strip().lower() not in READY_WORK_UNIT_DEPENDENCY_SATISFIED_STATUSES:
         return False
+    if done_product_sot_candidate_requires_owner_review(record):
+        return True
     text = task_record_text(record)
     review_pass = any(
         marker in text
@@ -1714,7 +1771,7 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             "ignored_superseded_blocked_task_refs": ignored_superseded_blocked_refs,
             "remediation_strategy": "create_post_review_owner_gate_package_task",
             "remediation_reason": (
-                "A repaired independent review passed and requires owner/Product SOT approval "
+                "A completed Product SOT candidate or Product SOT review requires owner approval "
                 "or rebaseline before method-contract planning, but no live gate package task exists. "
                 "The factory must prepare and deliver the decision package before asking the operator."
             ),

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -3841,6 +3841,66 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
 
+    def test_no_idle_creates_owner_gate_package_after_product_sot_candidate_done(self) -> None:
+        fake = FakeHermes()
+        sot_task_id = "t_" + "sotdone1"
+        fake.tasks[sot_task_id] = {
+            "id": sot_task_id,
+            "title": "F5 - Prepare Product SOT candidate",
+            "status": "done",
+            "body": "Product SOT candidate only; no owner approval recorded.",
+            "latest_summary": (
+                "Prepared the Product SOT candidate and named Product SOT owner review "
+                "as the next required gate before Method Contract."
+            ),
+            "events": [{"kind": "completed"}],
+            "runs": [
+                {
+                    "status": "done",
+                    "summary": "Prepared Product SOT candidate; downstream frozen.",
+                    "metadata": {
+                        "product_sot_result": {
+                            "artifact_file": "product-sot-result.json",
+                            "review_packet_file": "product-sot-candidate.md",
+                            "status": "candidate_owner_review_required_not_approved",
+                            "next_required_gate": (
+                                "Product SOT owner review before Method Contract / "
+                                "Product Experience / architecture / implementation routing"
+                            ),
+                            "downstream_frozen": [
+                                "Method Contract",
+                                "Product Experience/Product Face",
+                                "architecture",
+                                "implementation",
+                            ],
+                        }
+                    },
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(
+            state["classification"],
+            "deterministic_post_review_owner_gate_package_task_created",
+        )
+        self.assertTrue(state["remediation_required"])
+        self.assertTrue(state["native_dispatch_required_next"])
+        self.assertEqual(state["post_review_task_refs"], ["kanban:<redacted>"])
+        created_tasks = [
+            task
+            for task_id, task in fake.tasks.items()
+            if task_id != sot_task_id and task.get("assignee") == "human-gate-clerk"
+        ]
+        self.assertEqual(len(created_tasks), 1)
+        created_body = json.loads(str(created_tasks[0]["body"]))
+        self.assertEqual(created_body["marker"], adapter.NO_IDLE_POST_REVIEW_GATE_MARKER)
+        self.assertIn("markdown/PDF", " ".join(created_body["required_actions"]))
+        self.assertIn("rich cards", " ".join(created_body["forbidden_actions"]))
+
     def test_no_idle_blocks_ready_work_without_structured_phase_binding(self) -> None:
         fake = FakeHermes()
         fake.tasks[READY_TASK_ID] = {
@@ -4252,7 +4312,11 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 "candidate_owner_review_required_not_approved",
             )
             self.assertEqual(result["board_reconcile_plan"]["plan_action"], "no_unfinished_work")
-            self.assertIsNone(result["remediation_task_id"])
+            self.assertIsNotNone(result["remediation_task_id"])
+            self.assertEqual(
+                result["no_idle_state"]["classification"],
+                "deterministic_post_review_owner_gate_package_task_created",
+            )
             self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
             self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "task_runs.metadata")
             self.assertFalse(
@@ -4376,7 +4440,11 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 "Next gate: Product SOT owner review.\n",
             )
             self.assertEqual(result["board_reconcile_plan"]["plan_action"], "no_unfinished_work")
-            self.assertIsNone(result["remediation_task_id"])
+            self.assertIsNotNone(result["remediation_task_id"])
+            self.assertEqual(
+                result["no_idle_state"]["classification"],
+                "deterministic_post_review_owner_gate_package_task_created",
+            )
             self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
             self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "worker_log_diff")
 


### PR DESCRIPTION
Closes #471.

This fixes the no-idle gap where a terminal Product SOT candidate with candidate_owner_review_required_not_approved left the board looking complete instead of creating the Product SOT owner decision package task. It also keeps Telegram decision-package requirements in the covered path: markdown/PDF attachments, no rich cards.

Validation:
- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_creates_owner_gate_package_after_product_sot_candidate_done tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_ignores_factory_runtime_code_review_pass_that_mentions_product_sot_gate
- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience