### PR TITLE
Resolve declared artifacts inside task packages

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1525,7 +1525,7 @@ def missing_declared_local_artifacts(record: dict[str, Any]) -> list[dict[str, A
         path = Path(ref)
         if not path.is_absolute():
             continue
-        if path.exists():
+        if declared_local_artifact_exists(record, path):
             continue
         missing.append(
             {
@@ -1537,6 +1537,30 @@ def missing_declared_local_artifacts(record: dict[str, Any]) -> list[dict[str, A
             }
         )
     return missing
+
+
+def declared_local_artifact_exists(record: dict[str, Any], path: Path) -> bool:
+    if path.exists():
+        return True
+    if not path.name:
+        return False
+    workspace = Path(str(record.get("workspace_path") or ""))
+    if not workspace.is_absolute() or not workspace.exists():
+        return False
+    candidates = [
+        workspace / path.name,
+        workspace / "decision-package" / path.name,
+        workspace / "artifacts" / path.name,
+        workspace / "artifact" / path.name,
+        workspace / "outputs" / path.name,
+        workspace / "output" / path.name,
+    ]
+    if any(candidate.exists() for candidate in candidates):
+        return True
+    try:
+        return any(candidate.is_file() for candidate in workspace.rglob(path.name))
+    except OSError:
+        return False
 
 
 def metadata_payload_for_declared_artifact(record: dict[str, Any], artifact_name: str) -> str | None:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4265,6 +4265,31 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["agent_may_choose_phase"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_missing_declared_artifacts_accepts_decision_package_basename_match(self) -> None:
+        done_id = "t_" + "donepkg1"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            declared_root_path = workspace / "HUMAN_GATE_RECORD.approved.json"
+            actual_package_path = workspace / "decision-package" / "HUMAN_GATE_RECORD.approved.json"
+            actual_package_path.parent.mkdir(parents=True, exist_ok=True)
+            actual_package_path.write_text(json.dumps({"decision": "approved"}), encoding="utf-8")
+            record = {
+                "id": done_id,
+                "status": "done",
+                "workspace_path": str(workspace),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(declared_root_path)]}),
+                    }
+                ],
+            }
+
+            missing = adapter.missing_declared_local_artifacts(record)
+
+        self.assertEqual(missing, [])
+
     def test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "done0002"


### PR DESCRIPTION
Fixes #473.\n\nThis fixes a live end-to-end factory stall where no-idle reported human gate decision artifacts as missing even though they existed under the task workspace decision-package/ directory. The declared-artifact check now resolves absolute missing paths against the task workspace and canonical package/artifact subdirectories before classifying the board as needing repair.\n\nValidation:\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_missing_declared_artifacts_accepts_decision_package_basename_match tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_repairs_done_task_with_missing_declared_artifacts tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair\n- python scripts/public_safety_scan.py\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience