### PR TITLE
Preserve workspace path for artifact readback

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1458,7 +1458,18 @@ def enrich_no_idle_rows(
             shown = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
             task = task_readback_task(shown)
             merged = dict(item)
-            for key in ("id", "task_id", "title", "body", "assignee", "status", "priority", "result", "summary"):
+            for key in (
+                "id",
+                "task_id",
+                "title",
+                "body",
+                "assignee",
+                "status",
+                "priority",
+                "result",
+                "summary",
+                "workspace_path",
+            ):
                 if task.get(key) is not None and merged.get(key) is None:
                     merged[key] = task.get(key)
             if shown.get("latest_summary") is not None:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4290,6 +4290,43 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         self.assertEqual(missing, [])
 
+    def test_no_idle_does_not_repair_declared_artifact_present_in_decision_package(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "donepkg2"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            declared_root_path = workspace / "VALIDATION_RECEIPT.final.json"
+            actual_package_path = workspace / "decision-package" / "VALIDATION_RECEIPT.final.json"
+            actual_package_path.parent.mkdir(parents=True, exist_ok=True)
+            actual_package_path.write_text(json.dumps({"status": "valid"}), encoding="utf-8")
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "human-gate-clerk",
+                "title": "Prepare Product SOT owner decision package",
+                "body": "{}",
+                "workspace_path": str(workspace),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(declared_root_path)]}),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertNotEqual(state["classification"], "repair_declared_artifacts")
+        self.assertFalse(any(
+            adapter.parse_json_object(str(task.get("body") or "{}")).get("plan_action") == "repair_declared_artifacts"
+            for task in fake.tasks.values()
+        ))
+
     def test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "done0002"


### PR DESCRIPTION
Follow-up to #473/#474.\n\nThe live Todo board still reproduced the false repair_declared_artifacts classification because the enriched Hermes task record did not preserve workspace_path before checking declared artifacts. This patch carries workspace_path through enrichment and adds a no-idle end-to-end unit test showing that a declared root-level artifact path is accepted when the actual file exists under decision-package/.\n\nValidation:\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_missing_declared_artifacts_accepts_decision_package_basename_match tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_does_not_repair_declared_artifact_present_in_decision_package tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_repairs_done_task_with_missing_declared_artifacts\n- python scripts/public_safety_scan.py\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience