### PR TITLE
Replace stale artifact repair tasks

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1458,7 +1458,18 @@ def enrich_no_idle_rows(
             shown = show_task(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
             task = task_readback_task(shown)
             merged = dict(item)
-            for key in ("id", "task_id", "title", "body", "assignee", "status", "priority", "result", "summary"):
+            for key in (
+                "id",
+                "task_id",
+                "title",
+                "body",
+                "assignee",
+                "status",
+                "priority",
+                "result",
+                "summary",
+                "workspace_path",
+            ):
                 if task.get(key) is not None and merged.get(key) is None:
                     merged[key] = task.get(key)
             if shown.get("latest_summary") is not None:

--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -8054,23 +8054,36 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
         remediation_task_id: str | None = None
         task_runtime: dict[str, Any] = {}
         create_allowed = reconcile_plan.get("create_task_allowed") is True
+        stale_remediation_task_refs: list[str] = []
+        remediation_replacement_attempts = 0
         if create_allowed and args.create_remediation:
-            remediation_task_id = create_deterministic_reconcile_task(
-                hermes_bin=args.hermes_bin,
-                board=args.board,
-                workspace=args.workspace,
-                plan=reconcile_plan,
-                runner=runner,
-            )
-            task_runtime = remediation_task_runtime_metadata(
-                hermes_bin=args.hermes_bin,
-                board=args.board,
-                task_id=remediation_task_id,
-                runner=runner,
-            )
+            for _attempt in range(3):
+                remediation_task_id = create_deterministic_reconcile_task(
+                    hermes_bin=args.hermes_bin,
+                    board=args.board,
+                    workspace=args.workspace,
+                    plan=reconcile_plan,
+                    runner=runner,
+                    stale_remediation_task_refs=stale_remediation_task_refs,
+                )
+                task_runtime = remediation_task_runtime_metadata(
+                    hermes_bin=args.hermes_bin,
+                    board=args.board,
+                    task_id=remediation_task_id,
+                    runner=runner,
+                )
+                if not (remediation_task_id and task_runtime.get("remediation_task_stale")):
+                    break
+                if remediation_task_id in stale_remediation_task_refs:
+                    break
+                stale_remediation_task_refs.append(remediation_task_id)
+                remediation_replacement_attempts += 1
+        classification_name = str(reconcile_plan.get("plan_action") or "board_reconcile_action_required")
+        if stale_remediation_task_refs and remediation_task_id and not task_runtime.get("remediation_task_stale"):
+            classification_name = "deterministic_board_reconcile_task_created_after_stale_terminal_replacement"
         classification = {
             "status": "remediation_required" if create_allowed else "blocked",
-            "classification": str(reconcile_plan.get("plan_action") or "board_reconcile_action_required"),
+            "classification": classification_name,
             "blocked": True,
             "remediation_required": create_allowed,
             "human_gate_required": reconcile_plan.get("human_gate_required") is True,
@@ -8086,6 +8099,12 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
             "next_action": reconcile_plan.get("reason"),
             "state": summarize_no_idle_rows(rows),
         }
+        if stale_remediation_task_refs:
+            classification["stale_remediation_task_refs"] = stale_remediation_task_refs
+            classification["remediation_replacement_attempts"] = remediation_replacement_attempts
+            classification["remediation_replacement_strategy"] = (
+                "create_fresh_reconcile_task_after_terminal_idempotency_replay"
+            )
         classification.update(task_runtime)
         envelope = {
             "$schema": LIVE_ADAPTER_SCHEMA,

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4265,6 +4265,73 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["agent_may_choose_phase"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_replaces_stale_declared_artifact_repair_task(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "doneart1"
+        stale_id = "t_" + "5a1eaa11"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "VALIDATION_RECEIPT.final.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "human-gate-clerk",
+                "title": "Prepare Product SOT owner decision package",
+                "body": "{}",
+                "workspace_path": str(Path(tmpdir)),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                    }
+                ],
+            }
+            fake.tasks[stale_id] = {
+                "id": stale_id,
+                "status": "done",
+                "assignee": "factory-orchestrator",
+                "title": "Repair missing declared artifacts for board",
+                "body": json.dumps({"marker": "factory_deterministic_reconcile"}),
+                "events": [{"type": "completed"}],
+            }
+            rows = {
+                "ready": [],
+                "running": [],
+                "todo": [],
+                "blocked": [],
+                "triage": [],
+                "done": [{"id": done_id, **fake.tasks[done_id]}, {"id": stale_id, **fake.tasks[stale_id]}],
+            }
+            rows = adapter.enrich_no_idle_rows(hermes_bin="hermes", board=TEST_BOARD, rows=rows, runner=fake)
+            plan = adapter.build_board_reconcile_plan_from_rows(board=TEST_BOARD, rows=rows)
+            body = adapter.deterministic_reconcile_task_body(plan=plan)
+            self.assertIsNotNone(body)
+            digest = adapter.idempotency_digest_fragment(adapter.contract_digest(body))
+            fake.idempotent_task_ids[f"overkill:reconcile:{adapter.public_safe_slug(TEST_BOARD, fallback='board')}:{digest}"] = stale_id
+            fake.calls.clear()
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(
+            state["classification"],
+            "deterministic_board_reconcile_task_created_after_stale_terminal_replacement",
+        )
+        self.assertEqual(state["stale_remediation_task_refs"], ["kanban:<redacted>"])
+        self.assertEqual(state["remediation_replacement_attempts"], 1)
+        self.assertTrue(state["native_dispatch_required_next"])
+        replacements = [
+            task for task in fake.tasks.values()
+            if task.get("status") == "ready"
+            and adapter.parse_json_object(str(task.get("body") or "{}")).get("stale_terminal_remediation_replacement") is True
+        ]
+        self.assertEqual(len(replacements), 1)
+        replacement_body = adapter.parse_json_object(str(replacements[0].get("body") or "{}"))
+        self.assertEqual(replacement_body["plan_action"], "repair_declared_artifacts")
+
     def test_missing_declared_artifacts_accepts_decision_package_basename_match(self) -> None:
         done_id = "t_" + "donepkg1"
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4290,6 +4290,43 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
         self.assertEqual(missing, [])
 
+    def test_no_idle_does_not_repair_declared_artifact_present_in_decision_package(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "donepkg2"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            declared_root_path = workspace / "VALIDATION_RECEIPT.final.json"
+            actual_package_path = workspace / "decision-package" / "VALIDATION_RECEIPT.final.json"
+            actual_package_path.parent.mkdir(parents=True, exist_ok=True)
+            actual_package_path.write_text(json.dumps({"status": "valid"}), encoding="utf-8")
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "human-gate-clerk",
+                "title": "Prepare Product SOT owner decision package",
+                "body": "{}",
+                "workspace_path": str(workspace),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(declared_root_path)]}),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertNotEqual(state["classification"], "repair_declared_artifacts")
+        self.assertFalse(any(
+            adapter.parse_json_object(str(task.get("body") or "{}")).get("plan_action") == "repair_declared_artifacts"
+            for task in fake.tasks.values()
+        ))
+
     def test_no_idle_materializes_missing_declared_json_from_run_metadata_before_repair(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "done0002"


### PR DESCRIPTION
Fixes #477.\n\nThe deterministic no-idle preemption path for repair_declared_artifacts created or replayed an idempotent repair task once, then returned even when that remediation task was already terminal/stale. This meant a real missing-artifact condition could stay blocked forever behind an old done repair task.\n\nThis applies the stale-terminal replacement loop to the deterministic reconciler preemption path and adds a dedicated test for stale repair_declared_artifacts replacement.\n\nValidation:\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_replaces_stale_declared_artifact_repair_task tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_creates_fresh_reconcile_card_when_idempotent_card_is_terminal_stale tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_repairs_done_task_with_missing_declared_artifacts\n- python scripts/public_safety_scan.py\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience