### PR TITLE
Reject invalid recovered artifact JSON

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1658,6 +1658,16 @@ def declared_artifact_prefers_metadata(artifact_name: str) -> bool:
     return Path(artifact_name).suffix.lower() == ".json"
 
 
+def artifact_payload_is_valid(artifact_name: str, payload: str) -> bool:
+    if Path(artifact_name).suffix.lower() != ".json":
+        return True
+    try:
+        json.loads(payload)
+    except json.JSONDecodeError:
+        return False
+    return True
+
+
 def log_diff_payload_for_declared_artifact(log_text: str, artifact_name: str) -> str | None:
     lines = log_text.splitlines()
     candidates = [
@@ -1732,9 +1742,13 @@ def materialize_missing_declared_artifacts(
                     runner=runner,
                 )
             payload = log_diff_payload_for_declared_artifact(log_cache[task_id], artifact_name)
+            if payload is not None and not artifact_payload_is_valid(artifact_name, payload):
+                payload = None
             if payload is None and declared_artifact_prefers_metadata(artifact_name):
                 source = "task_runs.metadata"
                 payload = metadata_payload_for_declared_artifact(task, artifact_name)
+                if payload is not None and not artifact_payload_is_valid(artifact_name, payload):
+                    payload = None
             elif payload is None:
                 source = "worker_log_diff"
             if payload is None:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4567,6 +4567,56 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
             self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "worker_log_diff")
 
+    def test_no_idle_rejects_invalid_log_diff_json_and_falls_back_to_metadata(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "done0005"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "source-ledger-result.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "source-ledger-worker",
+                "title": "F2 - Source ledger",
+                "body": "{}",
+                "events": [{"type": "completed", "payload": {"artifacts": [str(missing_artifact)]}}],
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "source_ledger_result": {
+                                    "artifact_file": "source-ledger-result.json",
+                                    "valid_payload_from_metadata": True,
+                                },
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
+                    }
+                ],
+            }
+            fake.logs[done_id] = "\n".join(
+                [
+                    "  ┊ review diff",
+                    "a/source-ledger-result.json -> b/source-ledger-result.json",
+                    "@@ -0,0 +1,5 @@",
+                    "+{",
+                    "+  \"source_ledger_result\": {",
+                    "+    \"broken\": true",
+                    "  ┊ ⚡ kanban_complete",
+                ]
+            )
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+            recovered = json.loads(missing_artifact.read_text(encoding="utf-8"))
+            self.assertTrue(recovered["source_ledger_result"]["valid_payload_from_metadata"])
+            self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
+            self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "task_runs.metadata")
+
     def test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "done0003"


### PR DESCRIPTION
Closes #482.\n\n## Summary\n- Validate recovered artifact payloads before writing JSON artifacts.\n- Ignore invalid JSON recovered from worker diffs and fall back to structured task metadata.\n- Add regression coverage for invalid diff JSON fallback while preserving valid diff preference.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_rejects_invalid_log_diff_json_and_falls_back_to_metadata tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_prefers_worker_log_diff_over_summary_metadata_for_json tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_invalid_declared_json_from_metadata\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/public_safety_scan.py