### PR TITLE
Reconstruct approved human gate records

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1632,6 +1632,30 @@ def metadata_payload_candidate_keys(metadata: dict[str, Any], artifact_name: str
     return list(dict.fromkeys(key for key in preferred_keys if key in metadata and isinstance(metadata.get(key), dict)))
 
 
+def human_gate_record_payload_for_declared_artifact(metadata: dict[str, Any], artifact_name: str) -> str | None:
+    artifact_token = normalized_artifact_token(artifact_name)
+    if "humangaterecord" not in artifact_token or "approved" not in artifact_token:
+        return None
+    decision = metadata.get("decision")
+    if not isinstance(decision, dict) or decision.get("value") != "approved":
+        return None
+    record = {
+        "artifact_file": artifact_name,
+        "record_type": "human_gate_record",
+        "decision_state": "approved",
+        "decision": decision,
+        "approval_scope": metadata.get("approval_scope") or [],
+        "forbidden_scope": metadata.get("forbidden_scope") or [],
+        "delivery_evidence": metadata.get("delivery_evidence") or [],
+        "validation": metadata.get("validation") or {},
+        "hashes": metadata.get("hashes") or {},
+        "next_child_task": metadata.get("next_child_task"),
+        "next_frontier": metadata.get("next_frontier") or [],
+        "reconstructed_from": "task_runs.metadata",
+    }
+    return json.dumps({"human_gate_record": record}, indent=2, ensure_ascii=False) + "\n"
+
+
 def metadata_payload_for_declared_artifact(record: dict[str, Any], artifact_name: str) -> str | None:
     for run in record.get("runs") or []:
         if not isinstance(run, dict):
@@ -1639,6 +1663,9 @@ def metadata_payload_for_declared_artifact(record: dict[str, Any], artifact_name
         metadata = parse_json_object(run.get("metadata"))
         if not isinstance(metadata, dict):
             continue
+        human_gate_payload = human_gate_record_payload_for_declared_artifact(metadata, artifact_name)
+        if human_gate_payload is not None:
+            return human_gate_payload
         for key, value in metadata.items():
             if not isinstance(value, dict):
                 continue

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4617,6 +4617,59 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
             self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "task_runs.metadata")
 
+    def test_no_idle_reconstructs_human_gate_record_from_run_metadata(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "gate0001"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "decision-package" / "HUMAN_GATE_RECORD.approved.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "human-gate-clerk",
+                "title": "Prepare Product SOT owner decision package",
+                "body": "{}",
+                "events": [{"type": "completed", "payload": {"artifacts": [str(missing_artifact)]}}],
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "decision": {
+                                    "actor_role": "Factory Owner",
+                                    "captured_at": "2026-06-27T04:21:22Z",
+                                    "code": "APPROVE_PRODUCT_SOT",
+                                    "recorded_at": "2026-06-27T04:23:36Z",
+                                    "value": "approved",
+                                },
+                                "approval_scope": ["Product SOT boundary only"],
+                                "forbidden_scope": ["implementation", "deployment"],
+                                "delivery_evidence": ["telegram_delivery:message_ref:1139"],
+                                "validation": {"json_valid": True},
+                                "hashes": {"HUMAN_GATE_RECORD.approved.md": "abc123"},
+                                "next_child_task": "task:next-planning",
+                                "next_frontier": ["Method Contract planning"],
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+            recovered = json.loads(missing_artifact.read_text(encoding="utf-8"))
+            record = recovered["human_gate_record"]
+            self.assertEqual(record["decision"]["code"], "APPROVE_PRODUCT_SOT")
+            self.assertEqual(record["decision_state"], "approved")
+            self.assertIn("Product SOT boundary only", record["approval_scope"])
+            self.assertEqual(record["reconstructed_from"], "task_runs.metadata")
+            self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
+            self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "task_runs.metadata")
+
     def test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "done0003"


### PR DESCRIPTION
Closes #484.\n\n## Summary\n- Reconstruct HUMAN_GATE_RECORD.approved.json from structured run metadata when the approved human decision is present.\n- Preserve approval scope, forbidden scope, delivery evidence, validation and hashes in the reconstructed readback artifact.\n- Keep approval strict: no reconstruction from prose-only evidence or non-approved decisions.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_reconstructs_human_gate_record_from_run_metadata tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_rejects_invalid_log_diff_json_and_falls_back_to_metadata tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_invalid_declared_json_from_metadata\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/public_safety_scan.py