### PR TITLE
Continue terminal planning to architecture

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18183,6 +18183,55 @@ def _json_object_from_possible_string(value: Any) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
+def _task_search_text(task: dict[str, Any]) -> str:
+    values: list[str] = []
+    for key in ("title", "name", "summary", "latest_summary", "body", "result"):
+        value = task.get(key)
+        if isinstance(value, str):
+            values.append(value)
+        elif isinstance(value, dict):
+            values.append(json.dumps(value, sort_keys=True))
+    for comment in task.get("comments") or []:
+        if isinstance(comment, dict) and isinstance(comment.get("body"), str):
+            values.append(comment["body"])
+    for event in task.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        payload = event.get("payload")
+        if isinstance(payload, dict):
+            values.append(json.dumps(payload, sort_keys=True))
+        elif isinstance(payload, str):
+            values.append(payload)
+    for run in task.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        for key in ("summary", "metadata"):
+            value = run.get(key)
+            if isinstance(value, str):
+                values.append(value)
+            elif isinstance(value, dict):
+                values.append(json.dumps(value, sort_keys=True))
+    return "\n".join(values).lower()
+
+
+def _task_has_approved_product_sot_gate(task: dict[str, Any]) -> bool:
+    text = _task_search_text(task)
+    if "approve_product_sot" in text or ("approved" in text and "product sot" in text):
+        return True
+    for run in task.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = _json_object_from_possible_string(run.get("metadata"))
+        if not isinstance(metadata, dict):
+            continue
+        decision = metadata.get("decision")
+        if isinstance(decision, dict) and decision.get("value") == "approved":
+            code = str(decision.get("code") or "").strip().upper()
+            if code == "APPROVE_PRODUCT_SOT" or "product sot" in text:
+                return True
+    return False
+
+
 def _factory_card_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     if str(payload.get("factory_method_version") or "").strip() or str(payload.get("record_type") or "") == "factory_card":
         return copy.deepcopy(payload)
@@ -18440,6 +18489,64 @@ def select_canonical_board_card(rows: dict[str, list[dict[str, Any]]]) -> tuple[
     return card, selected, []
 
 
+def board_reconcile_terminal_planning_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    done = rows.get("done", [])
+    if not done:
+        return None, []
+
+    gate_refs: list[str] = []
+    method_refs: list[str] = []
+    product_face_refs: list[str] = []
+    review_refs: list[str] = []
+    for task in done:
+        text = _task_search_text(task)
+        task_ref = _task_public_ref(task)
+        assignee = str(task.get("assignee") or "").strip().lower()
+        if _task_has_approved_product_sot_gate(task):
+            gate_refs.append(task_ref)
+        if "method contract" in text or "method_contract" in text:
+            method_refs.append(task_ref)
+        if "product face" in text or "product_face" in text or "product experience" in text:
+            product_face_refs.append(task_ref)
+        if (
+            "independent-reviewer" in assignee
+            and ("pass" in text or "pass_for_planning" in text)
+            and ("method contract" in text or "product face" in text or "product experience" in text)
+        ):
+            review_refs.append(task_ref)
+
+    if not (gate_refs and method_refs and product_face_refs and review_refs):
+        return None, []
+
+    phase_engine = {
+        "computed_frontier": "architecture",
+        "computed_phase_id": FACTORY_PHASE_ENGINE_PHASE_BY_FRONTIER["architecture"],
+        "next_required_artifact": FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"],
+        "decision_basis": (
+            "Product SOT owner gate is closed and Method Contract/Product Experience planning "
+            "has independent review evidence; the next deterministic frontier is architecture."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(gate_refs + method_refs + product_face_refs + review_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"],
+            "owner": "product-architect",
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
 def _board_reconcile_task_contract(
     *,
     plan_action: str,
@@ -18597,9 +18704,41 @@ def build_board_reconcile_plan(
         reason = "ready Hermes work exists; native Hermes dispatch is the next action"
         native_dispatch_required_next = True
     elif not unfinished:
-        plan_action = "no_unfinished_work"
-        reason = "no non-terminal Hermes work was observed"
-        native_dispatch_required_next = False
+        terminal_continuation, terminal_continuation_errors = board_reconcile_terminal_planning_continuation(rows)
+        blocked_reasons.extend(terminal_continuation_errors)
+        if terminal_continuation is not None:
+            phase_engine = terminal_continuation["phase_engine"]
+            factory_help = terminal_continuation["factory_help"]
+            selected_ref = {
+                "task_ref": "board:terminal-planning-frontier",
+                "status": "done",
+                "title": "Terminal planning frontier selected from completed Product SOT/Method/Product Face review",
+                "assignee": "product-architect",
+                "selection_reason": "all prerequisites for architecture frontier are terminal and no non-terminal work exists",
+            }
+            plan_action = "create_next_artifact_task"
+            reason = str((factory_help.get("factory_next_action") or {}).get("why"))
+            create_task_contract = _board_reconcile_task_contract(
+                plan_action=plan_action,
+                board=board,
+                selected_card={"card_id": "board"},
+                phase_engine=phase_engine,
+                factory_help=factory_help,
+                reason=reason,
+                assignee="product-architect",
+            )
+            if isinstance(create_task_contract.get("body"), dict):
+                create_task_contract["body"]["forbidden_actions"].extend(
+                    [
+                        "treat Product SOT approval as architecture approval",
+                        "skip architecture evidence and jump directly to decomposition or implementation",
+                    ]
+                )
+            native_dispatch_required_next = True
+        else:
+            plan_action = "no_unfinished_work"
+            reason = "no non-terminal Hermes work was observed"
+            native_dispatch_required_next = False
     else:
         selected_card, selected_ref, selection_errors = select_canonical_board_card(rows)
         blocked_reasons.extend(selection_errors)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5252,6 +5252,79 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_continues_from_terminal_planning_to_architecture(self) -> None:
+        fake = FakeHermes()
+        gate_id = "t_" + "gate0002"
+        method_id = "t_" + "method01"
+        face_id = "t_" + "face0001"
+        review_id = "t_" + "review03"
+        fake.tasks[gate_id] = {
+            "id": gate_id,
+            "status": "done",
+            "assignee": "human-gate-clerk",
+            "title": "Prepare Product SOT owner decision package",
+            "body": json.dumps({"marker": "factory_no_idle_post_review_gate_package"}),
+            "latest_summary": "Owner decision recorded: approved Product SOT for method-contract planning only.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "decision": {
+                                "code": "APPROVE_PRODUCT_SOT",
+                                "value": "approved",
+                                "actor_role": "Factory Owner",
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        fake.tasks[method_id] = {
+            "id": method_id,
+            "status": "done",
+            "assignee": "product-architect",
+            "title": "F7 - Draft Method Contract planning packet",
+            "latest_summary": "Method Contract planning packet completed for architecture use.",
+        }
+        fake.tasks[face_id] = {
+            "id": face_id,
+            "status": "done",
+            "assignee": "product-face",
+            "title": "F8 - Draft Product Experience/Product Face planning packet",
+            "latest_summary": "Product Face and Product Experience planning packet completed for architecture use.",
+        }
+        fake.tasks[review_id] = {
+            "id": review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Review Method Contract and Product Face planning packets",
+            "latest_summary": "PASS_FOR_PLANNING_USE_ONLY: Method Contract and Product Face planning may proceed to architecture.",
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "create_next_artifact_task")
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertIsNotNone(result["remediation_task_id"])
+        created_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_packet"
+        ]
+        self.assertEqual(len(created_tasks), 1)
+        created = created_tasks[0]
+        body = adapter.parse_json_object(str(created["body"]))
+        self.assertEqual(created["assignee"], "product-architect")
+        self.assertEqual(created["status"], "ready")
+        self.assertEqual(body["required_output"], "architecture_packet")
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F10-architecture")
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+        self.assertTrue(state["native_dispatch_required_next"])
+
     def test_no_idle_does_not_treat_text_only_human_gate_as_decision_ready(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0001"


### PR DESCRIPTION
Closes #486.\n\n## Summary\n- Detect terminal boards where Product SOT owner approval, Method Contract planning, Product Face/Product Experience planning and independent review are complete.\n- Create the next deterministic architecture frontier task (rchitecture_packet) instead of reporting no unfinished work.\n- Keep the Product SOT gate from being duplicated and preserve human-gate boundaries.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_continues_from_terminal_planning_to_architecture tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_does_not_recreate_post_review_gate_after_owner_gate_closed\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/public_safety_scan.py