### PR TITLE
Reconstruct missing markdown readbacks

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1681,6 +1681,72 @@ def metadata_payload_for_declared_artifact(record: dict[str, Any], artifact_name
     return None
 
 
+def metadata_markdown_payload_for_declared_artifact(record: dict[str, Any], artifact_name: str) -> str | None:
+    if Path(artifact_name).suffix.lower() not in {".md", ".markdown"}:
+        return None
+    artifact_token = normalized_artifact_token(artifact_name)
+    for run in record.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = parse_json_object(run.get("metadata"))
+        if not isinstance(metadata, dict):
+            continue
+        for key, value in metadata.items():
+            if not isinstance(value, dict):
+                continue
+            refs = [
+                str(item)
+                for ref_key in ("artifact_paths", "artifacts", "artifact_files")
+                for item in (value.get(ref_key) if isinstance(value.get(ref_key), list) else [])
+            ]
+            names = {Path(ref).name for ref in refs}
+            key_token = normalized_artifact_token(key)
+            if artifact_name not in names and not (
+                key_token and (key_token in artifact_token or artifact_token in key_token)
+            ):
+                continue
+            lines = [
+                f"# {artifact_name}",
+                "",
+                "Reconstructed Markdown readback from structured Hermes run metadata.",
+                "",
+                f"- Source metadata key: `{key}`",
+                f"- Source status: `{value.get('status') or 'unknown'}`",
+                f"- Source task: `{value.get('task_id') or task_record_id(record) or 'unknown'}`",
+                "",
+            ]
+            for section_key, title in (
+                ("candidate_decisions", "Candidate Decisions"),
+                ("review_requirements", "Review Requirements"),
+                ("downstream_frozen", "Downstream Frozen"),
+            ):
+                items = value.get(section_key)
+                if isinstance(items, list) and items:
+                    lines.extend([f"## {title}", ""])
+                    lines.extend(f"- {str(item)}" for item in items)
+                    lines.append("")
+            validation = value.get("validation")
+            if isinstance(validation, dict) and validation:
+                lines.extend(["## Validation", ""])
+                lines.extend(f"- `{k}`: `{v}`" for k, v in sorted(validation.items()))
+                lines.append("")
+            hashes = value.get("artifact_sha256")
+            if isinstance(hashes, dict) and hashes:
+                lines.extend(["## Artifact Hashes", ""])
+                lines.extend(f"- `{k}`: `{v}`" for k, v in sorted(hashes.items()))
+                lines.append("")
+            lines.extend(
+                [
+                    "## Boundary",
+                    "",
+                    "This reconstructed Markdown is a readback artifact. Hermes run metadata remains the structured source of truth.",
+                    "",
+                ]
+            )
+            return "\n".join(lines)
+    return None
+
+
 def declared_artifact_prefers_metadata(artifact_name: str) -> bool:
     return Path(artifact_name).suffix.lower() == ".json"
 
@@ -1777,7 +1843,10 @@ def materialize_missing_declared_artifacts(
                 if payload is not None and not artifact_payload_is_valid(artifact_name, payload):
                     payload = None
             elif payload is None:
-                source = "worker_log_diff"
+                source = "task_runs.metadata_markdown"
+                payload = metadata_markdown_payload_for_declared_artifact(task, artifact_name)
+                if payload is None:
+                    source = "worker_log_diff"
             if payload is None:
                 records.append(
                     {

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4737,6 +4737,56 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
             self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "worker_log_diff")
 
+    def test_no_idle_reconstructs_missing_markdown_from_structured_metadata(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "arch0001"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "ARCHITECTURE_PACKET_Todo_Web_Local.md"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "product-architect",
+                "title": "Materialize architecture_packet",
+                "body": "{}",
+                "events": [{"type": "completed", "payload": {"artifacts": [str(missing_artifact)]}}],
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "architecture_result": {
+                                    "status": "candidate_architecture_packet_ready_for_independent_review_not_closed",
+                                    "task_id": done_id,
+                                    "artifact_paths": [str(missing_artifact)],
+                                    "artifact_sha256": {"ARCHITECTURE_PACKET_Todo_Web_Local.md": "abc123"},
+                                    "validation": {"required_md_sections_missing": []},
+                                    "candidate_decisions": ["client-only local browser runtime"],
+                                    "review_requirements": ["independent architecture review"],
+                                    "downstream_frozen": ["implementation"],
+                                },
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+            recovered = missing_artifact.read_text(encoding="utf-8")
+            self.assertIn("Reconstructed Markdown readback", recovered)
+            self.assertIn("client-only local browser runtime", recovered)
+            self.assertIn("independent architecture review", recovered)
+            self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
+            self.assertEqual(
+                result["artifact_materialization"][0]["recovery_source"],
+                "task_runs.metadata_markdown",
+            )
+
     def test_no_idle_reconciles_declared_f9_to_f5_owner_package_before_gate(self) -> None:
         fake = FakeHermes()
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")


### PR DESCRIPTION
Closes #488.\n\n## Summary\n- Reconstruct missing Markdown readback artifacts from structured Hermes run metadata when worker log diffs are unavailable.\n- Preserve JSON strictness while adding a metadata Markdown fallback for architecture/readback artifacts.\n- Add regression coverage for missing architecture Markdown readback.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_reconstructs_missing_markdown_from_structured_metadata tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_materializes_missing_markdown_from_worker_log_diff_before_repair tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_reconstructs_human_gate_record_from_run_metadata\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/public_safety_scan.py