### PR TITLE
Route terminal architecture to review

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18232,6 +18232,28 @@ def _task_has_approved_product_sot_gate(task: dict[str, Any]) -> bool:
     return False
 
 
+def _task_has_architecture_candidate(task: dict[str, Any]) -> bool:
+    text = _task_search_text(task)
+    if "architecture_result" in text or "architecture_packet" in text:
+        if "candidate_architecture" in text or "architecture packet" in text:
+            return True
+    for run in task.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = _json_object_from_possible_string(run.get("metadata"))
+        if isinstance(metadata, dict) and isinstance(metadata.get("architecture_result"), dict):
+            return True
+    return False
+
+
+def _task_has_architecture_review(task: dict[str, Any]) -> bool:
+    text = _task_search_text(task)
+    assignee = str(task.get("assignee") or "").strip().lower()
+    return "independent-reviewer" in assignee and "architecture" in text and (
+        "pass" in text or "fail" in text or "review" in text
+    )
+
+
 def _factory_card_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     if str(payload.get("factory_method_version") or "").strip() or str(payload.get("record_type") or "") == "factory_card":
         return copy.deepcopy(payload)
@@ -18495,6 +18517,8 @@ def board_reconcile_terminal_planning_continuation(
     done = rows.get("done", [])
     if not done:
         return None, []
+    if any(_task_has_architecture_candidate(task) for task in done):
+        return None, []
 
     gate_refs: list[str] = []
     method_refs: list[str] = []
@@ -18536,6 +18560,42 @@ def board_reconcile_terminal_planning_continuation(
         "factory_next_action": {
             "artifact": FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"],
             "owner": "product-architect",
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
+def board_reconcile_terminal_architecture_review_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    done = rows.get("done", [])
+    architecture_refs = [_task_public_ref(task) for task in done if _task_has_architecture_candidate(task)]
+    if not architecture_refs:
+        return None, []
+    if any(_task_has_architecture_review(task) for task in done):
+        return None, []
+    phase_engine = {
+        "computed_frontier": "architecture",
+        "computed_phase_id": FACTORY_PHASE_ENGINE_PHASE_BY_FRONTIER["architecture"],
+        "next_required_artifact": "architecture_review_packet",
+        "decision_basis": (
+            "Architecture candidate exists and has not received independent architecture review; "
+            "the next deterministic frontier is architecture review."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(architecture_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": "architecture_review_packet",
+            "owner": "independent-reviewer",
             "why": phase_engine["decision_basis"],
             "evidence_refs": evidence_refs,
         }
@@ -18704,20 +18764,27 @@ def build_board_reconcile_plan(
         reason = "ready Hermes work exists; native Hermes dispatch is the next action"
         native_dispatch_required_next = True
     elif not unfinished:
-        terminal_continuation, terminal_continuation_errors = board_reconcile_terminal_planning_continuation(rows)
+        terminal_continuation, terminal_continuation_errors = (
+            board_reconcile_terminal_architecture_review_continuation(rows)
+        )
+        if terminal_continuation is None:
+            terminal_continuation, terminal_continuation_errors = board_reconcile_terminal_planning_continuation(rows)
         blocked_reasons.extend(terminal_continuation_errors)
         if terminal_continuation is not None:
             phase_engine = terminal_continuation["phase_engine"]
             factory_help = terminal_continuation["factory_help"]
+            next_action = factory_help.get("factory_next_action") if isinstance(factory_help, dict) else {}
+            next_owner = str((next_action or {}).get("owner") or "product-architect")
+            next_artifact = str((next_action or {}).get("artifact") or FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"])
             selected_ref = {
                 "task_ref": "board:terminal-planning-frontier",
                 "status": "done",
-                "title": "Terminal planning frontier selected from completed Product SOT/Method/Product Face review",
-                "assignee": "product-architect",
-                "selection_reason": "all prerequisites for architecture frontier are terminal and no non-terminal work exists",
+                "title": "Terminal factory frontier selected from completed prerequisite artifacts",
+                "assignee": next_owner,
+                "selection_reason": f"all prerequisites for {next_artifact} are terminal and no non-terminal work exists",
             }
             plan_action = "create_next_artifact_task"
-            reason = str((factory_help.get("factory_next_action") or {}).get("why"))
+            reason = str((next_action or {}).get("why"))
             create_task_contract = _board_reconcile_task_contract(
                 plan_action=plan_action,
                 board=board,
@@ -18725,7 +18792,7 @@ def build_board_reconcile_plan(
                 phase_engine=phase_engine,
                 factory_help=factory_help,
                 reason=reason,
-                assignee="product-architect",
+                assignee=next_owner,
             )
             if isinstance(create_task_contract.get("body"), dict):
                 create_task_contract["body"]["forbidden_actions"].extend(

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5375,6 +5375,52 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["phase_engine"]["human_gate_allowed"])
         self.assertTrue(state["native_dispatch_required_next"])
 
+    def test_no_idle_continues_from_terminal_architecture_to_review(self) -> None:
+        fake = FakeHermes()
+        arch_id = "t_" + "arch0002"
+        fake.tasks[arch_id] = {
+            "id": arch_id,
+            "status": "done",
+            "assignee": "product-architect",
+            "title": "Materialize architecture_packet for board",
+            "latest_summary": "Architecture candidate packet is ready for independent review.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "architecture_result": {
+                                "status": "candidate_architecture_packet_ready_for_independent_review_not_closed",
+                                "task_id": arch_id,
+                                "review_requirements": ["independent architecture review"],
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "create_next_artifact_task")
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        created_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_review_packet"
+        ]
+        self.assertEqual(len(created_tasks), 1)
+        created = created_tasks[0]
+        body = adapter.parse_json_object(str(created["body"]))
+        self.assertEqual(created["assignee"], "independent-reviewer")
+        self.assertEqual(created["status"], "ready")
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F10-architecture")
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+        self.assertTrue(state["native_dispatch_required_next"])
+
     def test_no_idle_does_not_treat_text_only_human_gate_as_decision_ready(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0001"


### PR DESCRIPTION
Closes #490.\n\n## Summary\n- Detect completed architecture candidates in terminal board state.\n- Route architecture candidates to rchitecture_review_packet assigned to independent-reviewer.\n- Prevent terminal planning continuation from creating duplicate architecture once an architecture candidate exists.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_continues_from_terminal_architecture_to_review tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_continues_from_terminal_planning_to_architecture\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/public_safety_scan.py