### PR TITLE
Detect architecture candidates from list titles

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18234,9 +18234,8 @@ def _task_has_approved_product_sot_gate(task: dict[str, Any]) -> bool:
 
 def _task_has_architecture_candidate(task: dict[str, Any]) -> bool:
     text = _task_search_text(task)
-    if "architecture_result" in text or "architecture_packet" in text:
-        if "candidate_architecture" in text or "architecture packet" in text:
-            return True
+    if "architecture_result" in text or "architecture_packet" in text or "architecture packet" in text:
+        return True
     for run in task.get("runs") or []:
         if not isinstance(run, dict):
             continue

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5421,6 +5421,29 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["phase_engine"]["human_gate_allowed"])
         self.assertTrue(state["native_dispatch_required_next"])
 
+    def test_no_idle_detects_terminal_architecture_from_hermes_list_title(self) -> None:
+        fake = FakeHermes()
+        arch_id = "t_" + "arch0003"
+        fake.tasks[arch_id] = {
+            "id": arch_id,
+            "status": "done",
+            "assignee": "product-architect",
+            "title": "Materialize architecture_packet for board",
+            "body": "{}",
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        created_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_review_packet"
+        ]
+        self.assertEqual(len(created_tasks), 1)
+        self.assertEqual(created_tasks[0]["assignee"], "independent-reviewer")
+
     def test_no_idle_does_not_treat_text_only_human_gate_as_decision_ready(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0001"


### PR DESCRIPTION
Closes #492.\n\n## Summary\n- Treat reduced Hermes list rows containing rchitecture_packet as terminal architecture candidates.\n- Preserve architecture -> review routing even when run metadata is unavailable in board list output.\n- Add regression coverage for list-style terminal architecture rows.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_detects_terminal_architecture_from_hermes_list_title tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_continues_from_terminal_architecture_to_review\n- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience\n- python scripts/public_safety_scan.py