### PR TITLE
Tighten architecture review detection

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18248,9 +18248,26 @@ def _task_has_architecture_candidate(task: dict[str, Any]) -> bool:
 def _task_has_architecture_review(task: dict[str, Any]) -> bool:
     text = _task_search_text(task)
     assignee = str(task.get("assignee") or "").strip().lower()
-    return "independent-reviewer" in assignee and "architecture" in text and (
-        "pass" in text or "fail" in text or "review" in text
-    )
+    if "independent-reviewer" not in assignee:
+        return False
+    if "architecture_review_packet" in text or "architecture review packet" in text:
+        return True
+    if "architecture candidate" in text and ("pass" in text or "fail" in text or "review" in text):
+        return True
+    if "architecture_result" in text and ("review" in text or "pass" in text or "fail" in text):
+        return True
+    for run in task.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = _json_object_from_possible_string(run.get("metadata"))
+        if not isinstance(metadata, dict):
+            continue
+        if isinstance(metadata.get("architecture_review_result"), dict):
+            return True
+        packet = str(metadata.get("required_output") or metadata.get("artifact") or "").strip().lower()
+        if packet == "architecture_review_packet":
+            return True
+    return False
 
 
 def _factory_card_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5444,6 +5444,66 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(len(created_tasks), 1)
         self.assertEqual(created_tasks[0]["assignee"], "independent-reviewer")
 
+    def test_no_idle_does_not_mistake_planning_review_for_architecture_review(self) -> None:
+        fake = FakeHermes()
+        gate_id = "t_" + "gate0003"
+        planning_review_id = "t_" + "review04"
+        arch_id = "t_" + "arch0004"
+        fake.tasks[gate_id] = {
+            "id": gate_id,
+            "status": "done",
+            "assignee": "human-gate-clerk",
+            "title": "Prepare Product SOT owner decision package",
+            "body": json.dumps({"marker": "factory_no_idle_post_review_gate_package"}),
+            "latest_summary": "Owner decision recorded: approved Product SOT for method-contract planning only.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "decision": {
+                                "code": "APPROVE_PRODUCT_SOT",
+                                "value": "approved",
+                                "actor_role": "Factory Owner",
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        fake.tasks[planning_review_id] = {
+            "id": planning_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Review Method Contract and Product Face planning packets",
+            "latest_summary": (
+                "PASS_FOR_PLANNING_USE_ONLY: Method Contract and Product Face planning "
+                "may proceed to architecture."
+            ),
+        }
+        fake.tasks[arch_id] = {
+            "id": arch_id,
+            "status": "done",
+            "assignee": "product-architect",
+            "title": "Materialize architecture_packet for board",
+            "body": "{}",
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "create_next_artifact_task")
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        created_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_review_packet"
+        ]
+        self.assertEqual(len(created_tasks), 1)
+        self.assertEqual(created_tasks[0]["assignee"], "independent-reviewer")
+
     def test_no_idle_does_not_treat_text_only_human_gate_as_decision_ready(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0001"


### PR DESCRIPTION
## Summary
- Tightens architecture review detection so a planning review that merely says work may proceed to architecture is not counted as an architecture review.
- Adds regression coverage for the live Todo board shape: Product SOT owner gate closed + planning review done + architecture packet done must create `architecture_review_packet`.

Fixes #494.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_does_not_mistake_planning_review_for_architecture_review tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_detects_terminal_architecture_from_hermes_list_title tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_continues_from_terminal_architecture_to_review`
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience`
- `python scripts/public_safety_scan.py`