### PR TITLE
Scope declared artifact repair idempotency

### DIFF
--- a/schemas/factory-board-reconcile-plan.schema.json
+++ b/schemas/factory-board-reconcile-plan.schema.json
@@ -66,7 +66,12 @@
         "status": { "type": "string", "minLength": 1 },
         "title": { "type": "string", "minLength": 1 },
         "assignee": { "type": "string" },
-        "selection_reason": { "type": "string", "minLength": 1 }
+        "selection_reason": { "type": "string", "minLength": 1 },
+        "target_fingerprint": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "missing_artifact_names": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
       },
       "additionalProperties": false
     },
@@ -127,6 +132,45 @@
             "factory_next_action": { "type": ["object", "null"] },
             "required_output": { "type": "string", "minLength": 1 },
             "reason": { "type": "string", "minLength": 1 },
+            "repair_target": {
+              "type": ["object", "null"],
+              "required": ["task_ref", "status", "title", "assignee", "selection_reason"],
+              "properties": {
+                "task_ref": { "type": "string", "minLength": 1 },
+                "status": { "type": "string", "minLength": 1 },
+                "title": { "type": "string", "minLength": 1 },
+                "assignee": { "type": "string" },
+                "selection_reason": { "type": "string", "minLength": 1 },
+                "target_fingerprint": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                "missing_artifact_names": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              },
+              "additionalProperties": false
+            },
+            "repair_blocked_reasons": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "idempotency_scope": {
+              "type": "object",
+              "required": ["scope_type", "target_task_ref", "target_fingerprint", "missing_artifact_names", "blocked_reasons"],
+              "properties": {
+                "scope_type": { "const": "declared_artifact_readback_repair_target" },
+                "target_task_ref": { "type": ["string", "null"] },
+                "target_fingerprint": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
+                "missing_artifact_names": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                },
+                "blocked_reasons": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              },
+              "additionalProperties": false
+            },
             "runtime_authority": { "const": "hermes_kanban" },
             "local_state_authority": { "const": false },
             "agent_may_choose_phase": { "const": false },

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18422,6 +18422,15 @@ def board_reconcile_missing_declared_artifact_blockers(
         missing = task.get("missing_declared_artifacts")
         if not isinstance(missing, list) or not missing:
             continue
+        fingerprint_payload = {
+            "task_id": task.get("id"),
+            "title": _task_public_title(task),
+            "assignee": str(task.get("assignee") or task.get("owner") or "").strip(),
+            "missing_declared_artifacts": missing,
+        }
+        target_fingerprint = hashlib.sha256(
+            json.dumps(fingerprint_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
         names = sorted(
             {
                 str(item.get("artifact_name") or "declared-artifact").strip()
@@ -18440,6 +18449,8 @@ def board_reconcile_missing_declared_artifact_blockers(
         if selected_ref is None:
             selected_ref = board_reconcile_task_ref(task, status="done")
             selected_ref["selection_reason"] = "terminal task selected because declared artifacts are missing at runtime"
+            selected_ref["target_fingerprint"] = target_fingerprint
+            selected_ref["missing_artifact_names"] = names
     return sorted(set(blockers)), selected_ref
 
 
@@ -18770,6 +18781,16 @@ def build_board_reconcile_plan(
             reason=reason,
             assignee="factory-orchestrator",
         )
+        if isinstance(create_task_contract.get("body"), dict):
+            create_task_contract["body"]["repair_target"] = selected_ref
+            create_task_contract["body"]["repair_blocked_reasons"] = list(missing_artifact_blockers)
+            create_task_contract["body"]["idempotency_scope"] = {
+                "scope_type": "declared_artifact_readback_repair_target",
+                "target_task_ref": (selected_ref or {}).get("task_ref") if isinstance(selected_ref, dict) else None,
+                "target_fingerprint": (selected_ref or {}).get("target_fingerprint") if isinstance(selected_ref, dict) else None,
+                "missing_artifact_names": (selected_ref or {}).get("missing_artifact_names") if isinstance(selected_ref, dict) else [],
+                "blocked_reasons": list(missing_artifact_blockers),
+            }
         native_dispatch_required_next = True
     elif running:
         plan_action = "observe_running"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4262,8 +4262,63 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(created_task["status"], "ready")
         body = adapter.parse_json_object(str(created_task.get("body") or "{}"))
         self.assertEqual(body["required_output"], "declared_artifact_readback_repair")
+        self.assertEqual(body["repair_target"]["task_ref"], "kanban:<redacted>")
+        self.assertRegex(body["repair_target"]["target_fingerprint"], r"^[0-9a-f]{64}$")
+        self.assertTrue(any("product-sot-result.json" in reason for reason in body["repair_blocked_reasons"]))
+        self.assertEqual(body["idempotency_scope"]["scope_type"], "declared_artifact_readback_repair_target")
+        self.assertEqual(
+            body["idempotency_scope"]["target_fingerprint"],
+            body["repair_target"]["target_fingerprint"],
+        )
         self.assertFalse(body["agent_may_choose_phase"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
+    def test_declared_artifact_repair_idempotency_is_scoped_to_missing_target(self) -> None:
+        def plan_for_missing(task_id: str, artifact_name: str) -> dict[str, Any]:
+            fake = FakeHermes()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                missing_artifact = Path(tmpdir) / artifact_name
+                fake.tasks[task_id] = {
+                    "id": task_id,
+                    "status": "done",
+                    "assignee": "independent-reviewer",
+                    "title": "Materialize architecture_review_packet for board",
+                    "body": "{}",
+                    "workspace_path": str(Path(tmpdir)),
+                    "runs": [
+                        {
+                            "status": "done",
+                            "outcome": "completed",
+                            "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                        }
+                    ],
+                }
+                rows = {
+                    "ready": [],
+                    "running": [],
+                    "todo": [],
+                    "blocked": [],
+                    "triage": [],
+                    "done": [{"id": task_id, **fake.tasks[task_id]}],
+                }
+                rows = adapter.enrich_no_idle_rows(hermes_bin="hermes", board=TEST_BOARD, rows=rows, runner=fake)
+                return adapter.build_board_reconcile_plan_from_rows(board=TEST_BOARD, rows=rows)
+
+        first = plan_for_missing("t_" + "archrev1", "architecture_review_packet.first.json")
+        second = plan_for_missing("t_" + "archrev2", "architecture_review_packet.second.json")
+
+        first_body = adapter.deterministic_reconcile_task_body(plan=first)
+        second_body = adapter.deterministic_reconcile_task_body(plan=second)
+
+        self.assertIsNotNone(first_body)
+        self.assertIsNotNone(second_body)
+        self.assertNotEqual(adapter.contract_digest(first_body), adapter.contract_digest(second_body))
+        self.assertNotEqual(
+            first_body["idempotency_scope"]["target_fingerprint"],
+            second_body["idempotency_scope"]["target_fingerprint"],
+        )
+        self.assertIn("architecture_review_packet", first_body["repair_blocked_reasons"][0])
+        self.assertIn("architecture_review_packet", second_body["repair_blocked_reasons"][0])
 
     def test_no_idle_replaces_stale_declared_artifact_repair_task(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary
- Scopes `repair_declared_artifacts` reconcile contracts to the selected missing-artifact target using a safe fingerprint.
- Adds target metadata to the board reconcile schema instead of relying on generic repair bodies.
- Adds regression coverage proving different missing artifact incidents produce different reconcile task digests.

Fixes #496.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_repairs_done_task_with_missing_declared_artifacts tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_declared_artifact_repair_idempotency_is_scoped_to_missing_target tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_replaces_stale_declared_artifact_repair_task`
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience tests.test_factory_board_reconciler`
- `python scripts/public_safety_scan.py`