### PR TITLE
Route failed architecture review to repair

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18270,6 +18270,13 @@ def _task_has_architecture_review(task: dict[str, Any]) -> bool:
     return False
 
 
+def _task_has_failed_architecture_review(task: dict[str, Any]) -> bool:
+    if not _task_has_architecture_review(task):
+        return False
+    text = _task_search_text(task)
+    return "fail" in text or "blocking fail" in text or "not reviewable" in text
+
+
 def _factory_card_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     if str(payload.get("factory_method_version") or "").strip() or str(payload.get("record_type") or "") == "factory_card":
         return copy.deepcopy(payload)
@@ -18419,6 +18426,8 @@ def board_reconcile_missing_declared_artifact_blockers(
     blockers: list[str] = []
     selected_ref: dict[str, Any] | None = None
     for task in rows.get("done", []):
+        if _task_has_failed_architecture_review(task):
+            continue
         missing = task.get("missing_declared_artifacts")
         if not isinstance(missing, list) or not missing:
             continue
@@ -18634,6 +18643,40 @@ def board_reconcile_terminal_architecture_review_continuation(
     }, []
 
 
+def board_reconcile_terminal_failed_architecture_review_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    done = rows.get("done", [])
+    failed_review_refs = [_task_public_ref(task) for task in done if _task_has_failed_architecture_review(task)]
+    if not failed_review_refs:
+        return None, []
+    phase_engine = {
+        "computed_frontier": "architecture",
+        "computed_phase_id": FACTORY_PHASE_ENGINE_PHASE_BY_FRONTIER["architecture"],
+        "next_required_artifact": FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"],
+        "decision_basis": (
+            "Independent architecture review recorded a blocking FAIL; the next deterministic "
+            "frontier is architecture repair/rerun, not human approval or downstream decomposition."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(failed_review_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"],
+            "owner": "product-architect",
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
 def _board_reconcile_task_contract(
     *,
     plan_action: str,
@@ -18802,8 +18845,12 @@ def build_board_reconcile_plan(
         native_dispatch_required_next = True
     elif not unfinished:
         terminal_continuation, terminal_continuation_errors = (
-            board_reconcile_terminal_architecture_review_continuation(rows)
+            board_reconcile_terminal_failed_architecture_review_continuation(rows)
         )
+        if terminal_continuation is None:
+            terminal_continuation, terminal_continuation_errors = (
+                board_reconcile_terminal_architecture_review_continuation(rows)
+            )
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = board_reconcile_terminal_planning_continuation(rows)
         blocked_reasons.extend(terminal_continuation_errors)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5499,6 +5499,46 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(len(created_tasks), 1)
         self.assertEqual(created_tasks[0]["assignee"], "independent-reviewer")
 
+    def test_no_idle_routes_failed_architecture_review_to_architecture_repair(self) -> None:
+        fake = FakeHermes()
+        review_id = "t_" + "archrev3"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "architecture_review_packet.final.json"
+            fake.tasks[review_id] = {
+                "id": review_id,
+                "status": "done",
+                "assignee": "independent-reviewer",
+                "title": "Materialize architecture_review_packet for board",
+                "latest_summary": (
+                    "Blocking FAIL: architecture candidate is not reviewable; "
+                    "repair/rerun architecture_packet is required before decomposition."
+                ),
+                "workspace_path": str(Path(tmpdir)),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+            result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"], "architecture_packet")
+        created_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_packet"
+        ]
+        self.assertEqual(len(created_tasks), 1)
+        self.assertEqual(created_tasks[0]["assignee"], "product-architect")
+        body = adapter.parse_json_object(str(created_tasks[0].get("body") or "{}"))
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+        self.assertIn("blocking FAIL", body["reason"])
+
     def test_no_idle_does_not_mistake_planning_review_for_architecture_review(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0003"


### PR DESCRIPTION
## Summary
- Adds deterministic routing for blocking FAIL architecture reviews back to `architecture_packet` repair/rerun.
- Prevents missing declared artifact repair from taking precedence over a failed architecture review when FAIL evidence is already available.
- Adds regression coverage for the live Todo failure mode.

Fixes #498.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_routes_failed_architecture_review_to_architecture_repair tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_does_not_mistake_planning_review_for_architecture_review tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_detects_terminal_architecture_from_hermes_list_title`
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience tests.test_factory_board_reconciler`
- `python scripts/public_safety_scan.py`