### PR TITLE
Reconstruct architecture Markdown from metadata maps

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -1699,6 +1699,10 @@ def metadata_markdown_payload_for_declared_artifact(record: dict[str, Any], arti
                 for ref_key in ("artifact_paths", "artifacts", "artifact_files")
                 for item in (value.get(ref_key) if isinstance(value.get(ref_key), list) else [])
             ]
+            for ref_key in ("artifacts", "artifact_files"):
+                ref_map = value.get(ref_key)
+                if isinstance(ref_map, dict):
+                    refs.extend(str(item) for item in ref_map.values() if isinstance(item, str))
             names = {Path(ref).name for ref in refs}
             key_token = normalized_artifact_token(key)
             if artifact_name not in names and not (
@@ -1731,6 +1735,8 @@ def metadata_markdown_payload_for_declared_artifact(record: dict[str, Any], arti
                 lines.extend(f"- `{k}`: `{v}`" for k, v in sorted(validation.items()))
                 lines.append("")
             hashes = value.get("artifact_sha256")
+            if not isinstance(hashes, dict):
+                hashes = value.get("sha256")
             if isinstance(hashes, dict) and hashes:
                 lines.extend(["## Artifact Hashes", ""])
                 lines.extend(f"- `{k}`: `{v}`" for k, v in sorted(hashes.items()))

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4842,6 +4842,65 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                 "task_runs.metadata_markdown",
             )
 
+    def test_no_idle_reconstructs_architecture_markdown_from_artifacts_dict_metadata(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "arch0004"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            missing_artifact = workspace / f"ARCHITECTURE_PACKET_Todo_Web_Local.{done_id}.md"
+            json_artifact = workspace / f"architecture_packet.{done_id}.json"
+            manifest_artifact = workspace / f"architecture_packet_manifest.{done_id}.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "product-architect",
+                "title": "Materialize architecture_packet",
+                "body": "{}",
+                "events": [{"type": "completed", "payload": {"artifacts": [str(missing_artifact)]}}],
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "architecture_result": {
+                                    "status": "candidate_architecture_packet_ready_for_independent_review_not_closed",
+                                    "task_id": done_id,
+                                    "artifacts": {
+                                        "json": str(json_artifact),
+                                        "markdown": str(missing_artifact),
+                                        "manifest": str(manifest_artifact),
+                                    },
+                                    "sha256": {
+                                        json_artifact.name: "a" * 64,
+                                        missing_artifact.name: "b" * 64,
+                                        manifest_artifact.name: "c" * 64,
+                                    },
+                                    "validation": {"missing_required_markdown_sections": []},
+                                    "candidate_decisions": ["local-first browser Todo"],
+                                    "review_requirements": ["independent architecture review rerun"],
+                                    "downstream_frozen": ["implementation", "decomposition"],
+                                },
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+            recovered = missing_artifact.read_text(encoding="utf-8")
+            self.assertIn("Reconstructed Markdown readback", recovered)
+            self.assertIn("local-first browser Todo", recovered)
+            self.assertIn(missing_artifact.name, recovered)
+            self.assertIn("b" * 64, recovered)
+            self.assertEqual(result["artifact_materialization"][0]["materialized"], True)
+            self.assertEqual(result["artifact_materialization"][0]["recovery_source"], "task_runs.metadata_markdown")
+
     def test_no_idle_reconciles_declared_f9_to_f5_owner_package_before_gate(self) -> None:
         fake = FakeHermes()
         card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")


### PR DESCRIPTION
## Summary
- Teaches missing-artifact materialization to read artifact references from metadata maps such as `architecture_result.artifacts`.
- Uses `sha256` maps when reconstructing Markdown readback from structured metadata.
- Adds regression coverage for architecture Markdown reconstruction from the live Todo metadata shape.

Fixes #500.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_reconstructs_missing_markdown_from_structured_metadata tests.test_hermes_live_kanban_adapter.HermesLiveKanbanAdapterTest.test_no_idle_reconstructs_architecture_markdown_from_artifacts_dict_metadata`
- `python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience tests.test_factory_board_reconciler`
- `python scripts/public_safety_scan.py`