### PR TITLE
Fix stale architecture review reconciliation

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -4977,6 +4977,12 @@ def factory_phase_engine_state(
 
 def factory_workflow_step_key(phase_engine: dict[str, Any] | None) -> str:
     if isinstance(phase_engine, dict):
+        phase_id = str(phase_engine.get("computed_phase_id") or "").strip().upper()
+        next_artifact = str(phase_engine.get("next_required_artifact") or "").strip()
+        if phase_id == "F11" or next_artifact == "product_creation_plan":
+            return "F11-product-creation-plan"
+        if phase_id == "F12" or next_artifact == "product_implementation_readiness":
+            return "F12-product-implementation-readiness"
         frontier = str(phase_engine.get("computed_frontier") or "").strip()
         if frontier in FACTORY_WORKFLOW_STEP_KEY_BY_FRONTIER:
             return FACTORY_WORKFLOW_STEP_KEY_BY_FRONTIER[frontier]
@@ -18252,6 +18258,13 @@ def _task_has_architecture_review(task: dict[str, Any]) -> bool:
         return False
     if "architecture_review_packet" in text or "architecture review packet" in text:
         return True
+    if ("architecture_review" in text or "architecture review" in text) and (
+        "pass_for_architecture" in text
+        or "blocking fail" in text
+        or "not reviewable" in text
+        or "repair/rerun architecture" in text
+    ):
+        return True
     if "architecture candidate" in text and ("pass" in text or "fail" in text or "review" in text):
         return True
     if "architecture_result" in text and ("review" in text or "pass" in text or "fail" in text):
@@ -18275,6 +18288,96 @@ def _task_has_failed_architecture_review(task: dict[str, Any]) -> bool:
         return False
     text = _task_search_text(task)
     return "fail" in text or "blocking fail" in text or "not reviewable" in text
+
+
+def _task_has_passed_architecture_review(task: dict[str, Any]) -> bool:
+    if not _task_has_architecture_review(task):
+        return False
+    text = _task_search_text(task)
+    explicit_pass_markers = (
+        "pass_for_architecture_review",
+        "pass for architecture review",
+        "architecture review: pass",
+        "architecture_review_result pass",
+        "architecture_review_result: pass",
+    )
+    if any(marker in text for marker in explicit_pass_markers):
+        return True
+    for run in task.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        metadata = _json_object_from_possible_string(run.get("metadata"))
+        if not isinstance(metadata, dict):
+            continue
+        result = metadata.get("architecture_review_result")
+        if not isinstance(result, dict):
+            continue
+        result_text = json.dumps(result, sort_keys=True, default=str).lower()
+        if any(marker in result_text for marker in explicit_pass_markers):
+            return True
+        status = str(
+            result.get("status")
+            or result.get("result")
+            or result.get("decision")
+            or result.get("verdict")
+            or ""
+        ).strip().lower()
+        if status == "pass" or status.startswith("pass_for_architecture_review"):
+            return True
+    return False
+
+
+def _task_has_product_creation_plan(task: dict[str, Any]) -> bool:
+    text = _task_search_text(task)
+    assignee = str(task.get("assignee") or "").strip().lower()
+    if "decomposition-planner" in assignee and (
+        "product_creation_plan" in text or "product creation plan" in text
+    ):
+        return True
+    payloads: list[dict[str, Any]] = []
+    for key in ("metadata", "body", "description", "result"):
+        payload = _json_object_from_possible_string(task.get(key))
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    for run in task.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        payload = _json_object_from_possible_string(run.get("metadata"))
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    for payload in payloads:
+        if payload.get("record_type") == "product_creation_plan":
+            return True
+        if str(payload.get("required_output") or payload.get("artifact") or "").strip() == "product_creation_plan":
+            return True
+        if isinstance(payload.get("product_creation_plan"), dict):
+            return True
+    return False
+
+
+def _task_temporal_key(task: dict[str, Any], index: int) -> tuple[int, float, int]:
+    for key in ("completed_at", "updated_at", "created_at", "time", "timestamp"):
+        value = str(task.get(key) or "").strip()
+        if not value:
+            continue
+        try:
+            normalized = value.replace("Z", "+00:00")
+            return (1, datetime.fromisoformat(normalized).timestamp(), index)
+        except ValueError:
+            continue
+    for event in task.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        for key in ("at", "time", "timestamp", "created_at"):
+            value = str(event.get(key) or "").strip()
+            if not value:
+                continue
+            try:
+                normalized = value.replace("Z", "+00:00")
+                return (1, datetime.fromisoformat(normalized).timestamp(), index)
+            except ValueError:
+                continue
+    return (0, 0.0, index)
 
 
 def _factory_card_from_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -18647,9 +18750,21 @@ def board_reconcile_terminal_failed_architecture_review_continuation(
     rows: dict[str, list[dict[str, Any]]],
 ) -> tuple[dict[str, Any] | None, list[str]]:
     done = rows.get("done", [])
-    failed_review_refs = [_task_public_ref(task) for task in done if _task_has_failed_architecture_review(task)]
-    if not failed_review_refs:
+    passed_review_keys = [
+        _task_temporal_key(task, index)
+        for index, task in enumerate(done)
+        if _task_has_passed_architecture_review(task)
+    ]
+    latest_pass_key = max(passed_review_keys) if passed_review_keys else None
+    active_failed_reviews = [
+        task
+        for index, task in enumerate(done)
+        if _task_has_failed_architecture_review(task)
+        and (latest_pass_key is None or _task_temporal_key(task, index) > latest_pass_key)
+    ]
+    if not active_failed_reviews:
         return None, []
+    failed_review_refs = [_task_public_ref(task) for task in active_failed_reviews]
     phase_engine = {
         "computed_frontier": "architecture",
         "computed_phase_id": FACTORY_PHASE_ENGINE_PHASE_BY_FRONTIER["architecture"],
@@ -18666,6 +18781,60 @@ def board_reconcile_terminal_failed_architecture_review_continuation(
         "factory_next_action": {
             "artifact": FACTORY_PHASE_LOCK_NEXT_ARTIFACTS["architecture"],
             "owner": "product-architect",
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
+def board_reconcile_terminal_passed_architecture_review_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    done = rows.get("done", [])
+    architecture_refs = [_task_public_ref(task) for task in done if _task_has_architecture_candidate(task)]
+    passed_reviews = [
+        (index, task)
+        for index, task in enumerate(done)
+        if _task_has_passed_architecture_review(task)
+    ]
+    failed_reviews = [
+        (index, task)
+        for index, task in enumerate(done)
+        if _task_has_failed_architecture_review(task)
+    ]
+    if not architecture_refs or not passed_reviews:
+        return None, []
+    latest_pass = max((_task_temporal_key(task, index), task) for index, task in passed_reviews)
+    latest_fail_key = max(
+        (_task_temporal_key(task, index) for index, task in failed_reviews),
+        default=None,
+    )
+    if latest_fail_key is not None and latest_fail_key > latest_pass[0]:
+        return None, []
+    passed_review_refs = [_task_public_ref(latest_pass[1])]
+    if any(_task_has_product_creation_plan(task) for task in done):
+        return None, []
+    phase_engine = {
+        "computed_frontier": "architecture",
+        "computed_phase_id": "F11",
+        "next_required_artifact": "product_creation_plan",
+        "decision_basis": (
+            "Architecture candidate has an explicit independent PASS; the next deterministic "
+            "frontier is Product Creation Plan before work units, ready gate or implementation."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(architecture_refs + passed_review_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": "product_creation_plan",
+            "owner": DEFAULT_ARTIFACT_OWNERS["product_creation_plan"],
             "why": phase_engine["decision_basis"],
             "evidence_refs": evidence_refs,
         }
@@ -18847,6 +19016,10 @@ def build_board_reconcile_plan(
         terminal_continuation, terminal_continuation_errors = (
             board_reconcile_terminal_failed_architecture_review_continuation(rows)
         )
+        if terminal_continuation is None:
+            terminal_continuation, terminal_continuation_errors = (
+                board_reconcile_terminal_passed_architecture_review_continuation(rows)
+            )
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (
                 board_reconcile_terminal_architecture_review_continuation(rows)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5598,6 +5598,158 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["phase_engine"]["human_gate_allowed"])
         self.assertIn("blocking FAIL", body["reason"])
 
+    def test_no_idle_supersedes_old_failed_architecture_review_after_pass_rerun(self) -> None:
+        fake = FakeHermes()
+        arch_id = "t_" + "archfix1"
+        failed_review_id = "t_" + "archfail"
+        passed_review_id = "t_" + "archpass"
+        fake.tasks[arch_id] = {
+            "id": arch_id,
+            "status": "done",
+            "assignee": "product-architect",
+            "title": "Materialize architecture_packet for board",
+            "latest_summary": "Repaired architecture candidate packet is ready for independent review.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "architecture_result": {
+                                "status": "candidate_architecture_packet_ready_for_independent_review_not_closed",
+                                "task_id": arch_id,
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        fake.tasks[failed_review_id] = {
+            "id": failed_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Materialize architecture_review_packet for board",
+            "completed_at": "2026-06-27T01:00:00+00:00",
+            "latest_summary": (
+                "Blocking FAIL: original architecture candidate is not reviewable; "
+                "repair/rerun architecture_packet is required before decomposition."
+            ),
+        }
+        fake.tasks[passed_review_id] = {
+            "id": passed_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Independent architecture review rerun",
+            "completed_at": "2026-06-27T01:05:00+00:00",
+            "latest_summary": (
+                "PASS_FOR_ARCHITECTURE_REVIEW_RERUN: repaired architecture candidate "
+                "is reviewable for Product Creation Plan planning."
+            ),
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "architecture_review_result": {
+                                "status": "PASS_FOR_ARCHITECTURE_REVIEW_RERUN",
+                                "target_task_id": arch_id,
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(
+            result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"],
+            "product_creation_plan",
+        )
+        created_architecture_repairs = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_packet"
+        ]
+        self.assertEqual(created_architecture_repairs, [])
+        created_product_plans = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "product_creation_plan"
+        ]
+        self.assertEqual(len(created_product_plans), 1)
+        body = adapter.parse_json_object(str(created_product_plans[0].get("body") or "{}"))
+        self.assertEqual(created_product_plans[0]["assignee"], "decomposition-planner")
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F11-product-creation-plan")
+        self.assertEqual(body["phase_engine"]["computed_phase_id"], "F11")
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+        self.assertIn("Product Creation Plan", body["reason"])
+
+    def test_no_idle_keeps_newer_failed_architecture_review_active_after_older_pass(self) -> None:
+        fake = FakeHermes()
+        arch_id = "t_" + "archfix2"
+        passed_review_id = "t_" + "archpass"
+        failed_review_id = "t_" + "archfail"
+        fake.tasks[arch_id] = {
+            "id": arch_id,
+            "status": "done",
+            "assignee": "product-architect",
+            "title": "Materialize architecture_packet for board",
+            "latest_summary": "Architecture candidate packet is ready for independent review.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "architecture_result": {
+                                "status": "candidate_architecture_packet_ready_for_independent_review_not_closed",
+                                "task_id": arch_id,
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        fake.tasks[passed_review_id] = {
+            "id": passed_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Independent architecture review",
+            "completed_at": "2026-06-27T01:00:00+00:00",
+            "latest_summary": "PASS_FOR_ARCHITECTURE_REVIEW: architecture candidate was reviewable.",
+        }
+        fake.tasks[failed_review_id] = {
+            "id": failed_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Independent architecture review rerun",
+            "completed_at": "2026-06-27T01:10:00+00:00",
+            "latest_summary": (
+                "Blocking FAIL: later architecture review found the packet is not reviewable; "
+                "repair/rerun architecture_packet is required."
+            ),
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(
+            result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"],
+            "architecture_packet",
+        )
+        created_architecture_repairs = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "architecture_packet"
+        ]
+        self.assertEqual(len(created_architecture_repairs), 1)
+        self.assertEqual(created_architecture_repairs[0]["assignee"], "product-architect")
+
     def test_no_idle_does_not_mistake_planning_review_for_architecture_review(self) -> None:
         fake = FakeHermes()
         gate_id = "t_" + "gate0003"


### PR DESCRIPTION
## Summary
- supersede stale failed architecture reviews when a newer/equivalent independent architecture PASS exists
- keep newer failed reviews active after older PASS reviews
- continue terminal architecture PASS state to F11 product_creation_plan instead of falling through to no work
- emit F11/F12 workflow step keys for product creation/readiness tasks

Closes #502.

## Tests
- python -m unittest tests.test_hermes_live_kanban_adapter tests.test_operator_experience tests.test_factory_board_reconciler
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py