### PR TITLE
Flag active tasks without runtime contracts

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18447,6 +18447,32 @@ def structured_phase_id_from_task(task: dict[str, Any]) -> str:
     return ""
 
 
+def task_has_structured_runtime_contract(task: dict[str, Any]) -> bool:
+    if structured_phase_id_from_task(task):
+        return True
+    body = _json_object_from_possible_string(task.get("body"))
+    if isinstance(body, dict):
+        binding = body.get("kanban_workflow_binding")
+        if isinstance(binding, dict) and binding.get("runtime_field_required") is True:
+            return True
+        if body.get("agent_may_choose_phase") is False and body.get("plan_action"):
+            return True
+    return False
+
+
+def board_reconcile_active_contract_blockers(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
+    blockers: list[str] = []
+    for status in ("running", "in_progress", "doing"):
+        for task in rows.get(status, []):
+            if task_has_structured_runtime_contract(task):
+                continue
+            task_ref = _task_public_ref(task)
+            blockers.append(
+                f"active {status} task {task_ref} cannot proceed without deterministic runtime contract"
+            )
+    return sorted(set(blockers))
+
+
 def board_reconcile_active_phase_blockers(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
     active: list[tuple[str, dict[str, Any], str, int]] = []
     for status in ("running", "in_progress", "doing", "ready"):
@@ -18939,6 +18965,7 @@ def build_board_reconcile_plan(
     human_gate_required = False
     operator_input_required = False
     create_task_contract: dict[str, Any] | None = None
+    active_contract_blockers = board_reconcile_active_contract_blockers(rows)
     active_phase_blockers = board_reconcile_active_phase_blockers(rows)
     (
         ready_dispatch_blockers,
@@ -18948,7 +18975,12 @@ def build_board_reconcile_plan(
     ) = board_reconcile_ready_dispatch_blockers(rows)
     missing_artifact_blockers, missing_artifact_ref = board_reconcile_missing_declared_artifact_blockers(rows)
 
-    if active_phase_blockers:
+    if active_contract_blockers:
+        plan_action = "block_invariant_violation"
+        reason = "active Hermes work is missing deterministic runtime contract"
+        blocked_reasons.extend(active_contract_blockers)
+        native_dispatch_required_next = False
+    elif active_phase_blockers:
         plan_action = "block_invariant_violation"
         reason = "active future-phase Hermes work is blocked by an earlier unresolved factory phase"
         blocked_reasons.extend(active_phase_blockers)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5206,6 +5206,40 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIsNone(result["remediation_task_id"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_blocks_active_task_without_deterministic_runtime_contract(self) -> None:
+        fake = FakeHermes()
+        fake.tasks["t_" + "freef10"] = {
+            "id": "t_" + "freef10",
+            "status": "running",
+            "assignee": "product-architect",
+            "title": "F10 repair/rerun architecture_packet artifacts for Todo Web Local",
+            "body": (
+                "Factory bounded repair route. Phase: F10 architecture. "
+                "Required output: repaired architecture_packet."
+            ),
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["status"], "blocked")
+        self.assertEqual(state["classification"], "factory_phase_invariant_violation")
+        self.assertFalse(state["native_dispatch_required_next"])
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "block_invariant_violation")
+        self.assertEqual(
+            result["board_reconcile_plan"]["reason"],
+            "active Hermes work is missing deterministic runtime contract",
+        )
+        self.assertTrue(
+            any(
+                "cannot proceed without deterministic runtime contract" in reason
+                for reason in result["board_reconcile_plan"]["blocked_reasons"]
+            )
+        )
+        self.assertIsNone(result["remediation_task_id"])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_treats_delivered_product_sot_package_as_human_gate(self) -> None:
         fake = FakeHermes()
         failed_review_id = "t_" + "review01"


### PR DESCRIPTION
Closes #504.\n\n## What changed\n- Adds a deterministic reducer check for running/in-progress/doing Hermes tasks that lack a structured runtime contract.\n- Keeps existing ready-task repair behavior intact.\n- Adds a regression test for the exact freeform F10 repair card shape observed during the Telegram Todo Web Local factory test.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter\n- python scripts/public_safety_scan.py\n- python scripts/secret_safety_scan.py