### PR TITLE
Recover idempotent create replays with empty output

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -359,6 +359,69 @@ def parse_task_id(output: str) -> str:
     raise RuntimeError(f"could not parse Hermes task id from output: {text!r}")
 
 
+def find_task_id_by_idempotency_key(
+    *,
+    hermes_bin: str,
+    board: str,
+    idempotency_key: str,
+    runner: Runner = default_runner,
+) -> str | None:
+    key = str(idempotency_key or "").strip()
+    if not key:
+        return None
+    db_path = local_kanban_db_path(board)
+    if db_path is not None and db_path.exists():
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cols = {
+                str(row[1])
+                for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+                if len(row) > 1
+            }
+            if "idempotency_key" in cols:
+                row = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? ORDER BY created_at DESC LIMIT 1",
+                    (key,),
+                ).fetchone()
+                if row and row[0]:
+                    return str(row[0])
+        finally:
+            conn.close()
+    for status in ("ready", "running", "todo", "blocked", "triage", "done", "archived"):
+        try:
+            rows = list_tasks_by_status(hermes_bin=hermes_bin, board=board, status=status, runner=runner)
+        except RuntimeError:
+            continue
+        for task in rows:
+            if str(task.get("idempotency_key") or "").strip() == key:
+                task_id = str(task.get("id") or task.get("task_id") or "").strip()
+                if task_id:
+                    return task_id
+    return None
+
+
+def parse_task_id_or_find_idempotent(
+    *,
+    output: str,
+    hermes_bin: str,
+    board: str,
+    idempotency_key: str,
+    runner: Runner = default_runner,
+) -> str:
+    try:
+        return parse_task_id(output)
+    except RuntimeError:
+        task_id = find_task_id_by_idempotency_key(
+            hermes_bin=hermes_bin,
+            board=board,
+            idempotency_key=idempotency_key,
+            runner=runner,
+        )
+        if task_id:
+            return task_id
+        raise
+
+
 def hermes_kanban(hermes_bin: str, board: str, *args: str) -> list[str]:
     return [hermes_bin, "kanban", "--board", board, *args]
 
@@ -3619,7 +3682,13 @@ def create_task(
         workspace,
         "--json",
     )
-    task_id = parse_task_id(run_checked(args, runner).stdout)
+    task_id = parse_task_id_or_find_idempotent(
+        output=run_checked(args, runner).stdout,
+        hermes_bin=hermes_bin,
+        board=board,
+        idempotency_key=idempotency_key,
+        runner=runner,
+    )
     apply_native_workflow_state(
         board=board,
         task_id=task_id,
@@ -3645,8 +3714,8 @@ def create_blocked_task_before_assignment(
     runner: Runner = default_runner,
 ) -> str:
     ensure_non_empty_body(body)
-    task_id = parse_task_id(
-        run_checked(
+    task_id = parse_task_id_or_find_idempotent(
+        output=run_checked(
             hermes_kanban(
                 hermes_bin,
                 board,
@@ -3663,7 +3732,11 @@ def create_blocked_task_before_assignment(
                 "--json",
             ),
             runner,
-        ).stdout
+        ).stdout,
+        hermes_bin=hermes_bin,
+        board=board,
+        idempotency_key=idempotency_key,
+        runner=runner,
     )
     apply_native_workflow_state(
         board=board,

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18447,6 +18447,32 @@ def structured_phase_id_from_task(task: dict[str, Any]) -> str:
     return ""
 
 
+def task_has_structured_runtime_contract(task: dict[str, Any]) -> bool:
+    if structured_phase_id_from_task(task):
+        return True
+    body = _json_object_from_possible_string(task.get("body"))
+    if isinstance(body, dict):
+        binding = body.get("kanban_workflow_binding")
+        if isinstance(binding, dict) and binding.get("runtime_field_required") is True:
+            return True
+        if body.get("agent_may_choose_phase") is False and body.get("plan_action"):
+            return True
+    return False
+
+
+def board_reconcile_active_contract_blockers(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
+    blockers: list[str] = []
+    for status in ("running", "in_progress", "doing"):
+        for task in rows.get(status, []):
+            if task_has_structured_runtime_contract(task):
+                continue
+            task_ref = _task_public_ref(task)
+            blockers.append(
+                f"active {status} task {task_ref} cannot proceed without deterministic runtime contract"
+            )
+    return sorted(set(blockers))
+
+
 def board_reconcile_active_phase_blockers(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
     active: list[tuple[str, dict[str, Any], str, int]] = []
     for status in ("running", "in_progress", "doing", "ready"):
@@ -18939,6 +18965,7 @@ def build_board_reconcile_plan(
     human_gate_required = False
     operator_input_required = False
     create_task_contract: dict[str, Any] | None = None
+    active_contract_blockers = board_reconcile_active_contract_blockers(rows)
     active_phase_blockers = board_reconcile_active_phase_blockers(rows)
     (
         ready_dispatch_blockers,
@@ -18948,7 +18975,12 @@ def build_board_reconcile_plan(
     ) = board_reconcile_ready_dispatch_blockers(rows)
     missing_artifact_blockers, missing_artifact_ref = board_reconcile_missing_declared_artifact_blockers(rows)
 
-    if active_phase_blockers:
+    if active_contract_blockers:
+        plan_action = "block_invariant_violation"
+        reason = "active Hermes work is missing deterministic runtime contract"
+        blocked_reasons.extend(active_contract_blockers)
+        native_dispatch_required_next = False
+    elif active_phase_blockers:
         plan_action = "block_invariant_violation"
         reason = "active future-phase Hermes work is blocked by an earlier unresolved factory phase"
         blocked_reasons.extend(active_phase_blockers)

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -172,7 +172,14 @@ class FakeHermes:
             body = argv[argv.index("--body") + 1] if "--body" in argv else "{}"
             assignee = argv[argv.index("--assignee") + 1] if "--assignee" in argv else None
             workspace_ref = argv[argv.index("--workspace") + 1] if "--workspace" in argv else "scratch"
-            task = {"id": task_id, "status": initial_status, "events": [], "body": body, "assignee": assignee}
+            task = {
+                "id": task_id,
+                "status": initial_status,
+                "events": [],
+                "body": body,
+                "assignee": assignee,
+                "idempotency_key": idempotency_key,
+            }
             if workspace_ref.startswith("dir:"):
                 task["workspace_kind"] = "dir"
                 task["workspace_path"] = workspace_ref[4:]
@@ -309,6 +316,20 @@ class UnsafePromotionHermes(FakeHermes):
             task.setdefault("events", []).append({"kind": "promoted"})
             task.setdefault("events", []).append({"kind": "claimed"})
             return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(task), stderr="")
+        return super().__call__(argv)
+
+
+class EmptyStdoutIdempotentHermes(FakeHermes):
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "create":
+            idempotency_key = argv[argv.index("--idempotency-key") + 1] if "--idempotency-key" in argv else ""
+            if idempotency_key and idempotency_key in self.idempotent_task_ids:
+                task_id = self.idempotent_task_ids[idempotency_key]
+                self.tasks.setdefault(
+                    task_id,
+                    {"id": task_id, "status": "done", "events": [], "idempotency_key": idempotency_key},
+                )
+                return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
         return super().__call__(argv)
 
 
@@ -4386,6 +4407,71 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(len(replacements), 1)
         replacement_body = adapter.parse_json_object(str(replacements[0].get("body") or "{}"))
         self.assertEqual(replacement_body["plan_action"], "repair_declared_artifacts")
+
+    def test_no_idle_recovers_empty_stdout_idempotency_replay_before_replacement(self) -> None:
+        fake = EmptyStdoutIdempotentHermes()
+        done_id = "t_" + "doneart2"
+        stale_id = "t_" + "5a1eaa12"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "ARCHITECTURE_PACKET.example.md"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "product-architect",
+                "title": "Materialize architecture_packet for board",
+                "body": "{}",
+                "workspace_path": str(Path(tmpdir)),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                    }
+                ],
+            }
+            rows = {
+                "ready": [],
+                "running": [],
+                "todo": [],
+                "blocked": [],
+                "triage": [],
+                "done": [{"id": done_id, **fake.tasks[done_id]}],
+            }
+            rows = adapter.enrich_no_idle_rows(hermes_bin="hermes", board=TEST_BOARD, rows=rows, runner=fake)
+            plan = adapter.build_board_reconcile_plan_from_rows(board=TEST_BOARD, rows=rows)
+            body = adapter.deterministic_reconcile_task_body(plan=plan)
+            self.assertIsNotNone(body)
+            digest = adapter.idempotency_digest_fragment(adapter.contract_digest(body))
+            replay_key = f"overkill:reconcile:{adapter.public_safe_slug(TEST_BOARD, fallback='board')}:{digest}"
+            fake.idempotent_task_ids[replay_key] = stale_id
+            fake.tasks[stale_id] = {
+                "id": stale_id,
+                "status": "done",
+                "assignee": "factory-orchestrator",
+                "title": "Repair missing declared artifacts for board",
+                "body": json.dumps(body),
+                "idempotency_key": replay_key,
+                "events": [{"type": "completed"}],
+            }
+            fake.calls.clear()
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(
+            state["classification"],
+            "deterministic_board_reconcile_task_created_after_stale_terminal_replacement",
+        )
+        self.assertEqual(state["stale_remediation_task_refs"], ["kanban:<redacted>"])
+        replacements = [
+            task for task in fake.tasks.values()
+            if task.get("status") == "ready"
+            and adapter.parse_json_object(str(task.get("body") or "{}")).get("stale_terminal_remediation_replacement") is True
+        ]
+        self.assertEqual(len(replacements), 1)
 
     def test_missing_declared_artifacts_accepts_decision_package_basename_match(self) -> None:
         done_id = "t_" + "donepkg1"

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5206,6 +5206,40 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIsNone(result["remediation_task_id"])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_blocks_active_task_without_deterministic_runtime_contract(self) -> None:
+        fake = FakeHermes()
+        fake.tasks["t_" + "freef10"] = {
+            "id": "t_" + "freef10",
+            "status": "running",
+            "assignee": "product-architect",
+            "title": "F10 repair/rerun architecture_packet artifacts for Todo Web Local",
+            "body": (
+                "Factory bounded repair route. Phase: F10 architecture. "
+                "Required output: repaired architecture_packet."
+            ),
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["status"], "blocked")
+        self.assertEqual(state["classification"], "factory_phase_invariant_violation")
+        self.assertFalse(state["native_dispatch_required_next"])
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "block_invariant_violation")
+        self.assertEqual(
+            result["board_reconcile_plan"]["reason"],
+            "active Hermes work is missing deterministic runtime contract",
+        )
+        self.assertTrue(
+            any(
+                "cannot proceed without deterministic runtime contract" in reason
+                for reason in result["board_reconcile_plan"]["blocked_reasons"]
+            )
+        )
+        self.assertIsNone(result["remediation_task_id"])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_treats_delivered_product_sot_package_as_human_gate(self) -> None:
         fake = FakeHermes()
         failed_review_id = "t_" + "review01"


### PR DESCRIPTION
Closes #506.\n\n## What changed\n- Recovers task ids by idempotency key when Hermes create returns empty stdout.\n- Checks the local Hermes Kanban SQLite DB first, then falls back to status-list lookup.\n- Applies recovery to normal and blocked create paths.\n- Adds a regression test for empty-stdout idempotency replay before stale-terminal replacement.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter\n- python scripts/public_safety_scan.py\n- python scripts/secret_safety_scan.py