### PR TITLE
Normalize Hermes workspace arguments

### DIFF
--- a/adapters/hermes/live_kanban_adapter.py
+++ b/adapters/hermes/live_kanban_adapter.py
@@ -438,6 +438,18 @@ def public_safe_workspace_ref(value: Any) -> str:
     return text
 
 
+def hermes_workspace_arg(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "scratch"
+    normalized = text.replace("\\", "/")
+    if normalized in {"scratch", "worktree"} or normalized.startswith(("dir:", "worktree:")):
+        return text
+    if re.match(r"^[A-Za-z]:/", normalized) or normalized.startswith("/"):
+        return "dir:" + text
+    return text
+
+
 def normalize_task_record(record: dict[str, Any]) -> dict[str, Any]:
     task_id = str(record.get("task_id") or record.get("id") or "")
     normalized: dict[str, Any] = {"task_id": task_id}
@@ -3665,6 +3677,7 @@ def create_task(
             current_step_key=current_step_key,
             runner=runner,
         )
+    workspace_arg = hermes_workspace_arg(workspace)
     args = hermes_kanban(
         hermes_bin,
         board,
@@ -3679,7 +3692,7 @@ def create_task(
         "--created-by",
         created_by,
         "--workspace",
-        workspace,
+        workspace_arg,
         "--json",
     )
     task_id = parse_task_id_or_find_idempotent(
@@ -3728,7 +3741,7 @@ def create_blocked_task_before_assignment(
                 "--created-by",
                 created_by,
                 "--workspace",
-                workspace,
+                hermes_workspace_arg(workspace),
                 "--json",
             ),
             runner,

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4341,6 +4341,46 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIn("architecture_review_packet", first_body["repair_blocked_reasons"][0])
         self.assertIn("architecture_review_packet", second_body["repair_blocked_reasons"][0])
 
+    def test_no_idle_normalizes_absolute_workspace_for_remediation_create(self) -> None:
+        fake = FakeHermes()
+        done_id = "t_" + "doneabs1"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / "VALIDATION_RECEIPT.final.json"
+            fake.tasks[done_id] = {
+                "id": done_id,
+                "status": "done",
+                "assignee": "factory-orchestrator",
+                "title": "Prepare validation receipt",
+                "body": "{}",
+                "workspace_path": str(Path(tmpdir)),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps({"artifacts": [str(missing_artifact)]}),
+                    }
+                ],
+            }
+            absolute_workspace = str(Path(tmpdir) / "no-idle-workspace")
+            args = adapter.build_parser().parse_args(
+                [
+                    "no-idle",
+                    "--board",
+                    TEST_BOARD,
+                    "--create-remediation",
+                    "--workspace",
+                    absolute_workspace,
+                ]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        self.assertIsNotNone(result["remediation_task_id"])
+        create_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "create"]
+        self.assertTrue(create_calls)
+        workspace_value = create_calls[-1][create_calls[-1].index("--workspace") + 1]
+        self.assertTrue(workspace_value.startswith("dir:"))
+
     def test_no_idle_replaces_stale_declared_artifact_repair_task(self) -> None:
         fake = FakeHermes()
         done_id = "t_" + "doneart1"


### PR DESCRIPTION
Closes #508.\n\n## What changed\n- Adds hermes_workspace_arg to normalize adapter workspace values before hermes kanban create.\n- Converts absolute POSIX/Windows paths to dir:<path>, preserving valid Hermes workspace modes.\n- Applies normalization to normal and blocked create paths.\n- Adds no-idle regression coverage for absolute workspace remediation creation.\n\n## Validation\n- python -m unittest tests.test_hermes_live_kanban_adapter\n- python scripts/public_safety_scan.py\n- python scripts/secret_safety_scan.py