### PR TITLE
Skip stale architecture readback loops

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18269,6 +18269,12 @@ def _task_has_architecture_review(task: dict[str, Any]) -> bool:
         return True
     if "architecture_result" in text and ("review" in text or "pass" in text or "fail" in text):
         return True
+    if (
+        "independent_review_result" in text
+        and ("architecture_packet" in text or "architecture packet" in text)
+        and ("reviewed_task_id" in text or "reviewed task" in text or "reviewed_task" in text)
+    ):
+        return True
     for run in task.get("runs") or []:
         if not isinstance(run, dict):
             continue
@@ -18277,6 +18283,11 @@ def _task_has_architecture_review(task: dict[str, Any]) -> bool:
             continue
         if isinstance(metadata.get("architecture_review_result"), dict):
             return True
+        result = metadata.get("independent_review_result")
+        if isinstance(result, dict):
+            result_text = json.dumps(result, sort_keys=True, default=str).lower()
+            if "architecture_packet" in result_text or "architecture packet" in result_text:
+                return True
         packet = str(metadata.get("required_output") or metadata.get("artifact") or "").strip().lower()
         if packet == "architecture_review_packet":
             return True
@@ -18296,7 +18307,9 @@ def _task_has_passed_architecture_review(task: dict[str, Any]) -> bool:
     text = _task_search_text(task)
     explicit_pass_markers = (
         "pass_for_architecture_review",
+        "pass_for_review_input_readiness_only",
         "pass for architecture review",
+        "pass for review input readiness",
         "architecture review: pass",
         "architecture_review_result pass",
         "architecture_review_result: pass",
@@ -18598,8 +18611,17 @@ def board_reconcile_missing_declared_artifact_blockers(
 ) -> tuple[list[str], dict[str, Any] | None]:
     blockers: list[str] = []
     selected_ref: dict[str, Any] | None = None
-    for task in rows.get("done", []):
+    done = rows.get("done", [])
+    architecture_review_keys = [
+        _task_temporal_key(review_task, review_index)
+        for review_index, review_task in enumerate(done)
+        if _task_has_architecture_review(review_task)
+    ]
+    for task_index, task in enumerate(done):
         if _task_has_failed_architecture_review(task):
+            continue
+        task_key = _task_temporal_key(task, task_index)
+        if _task_has_architecture_candidate(task) and any(key > task_key for key in architecture_review_keys):
             continue
         missing = task.get("missing_declared_artifacts")
         if not isinstance(missing, list) or not missing:

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5911,6 +5911,85 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(body["phase_engine"]["human_gate_allowed"])
         self.assertIn("Product Creation Plan", body["reason"])
 
+    def test_no_idle_does_not_repair_architecture_artifact_after_newer_independent_pass(self) -> None:
+        fake = FakeHermes()
+        arch_id = "t_" + "archpasssrc"
+        passed_review_id = "t_" + "archinputpass"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_artifact = Path(tmpdir) / f"ARCHITECTURE_PACKET_Todo_Web_Local.{arch_id}.md"
+            fake.tasks[arch_id] = {
+                "id": arch_id,
+                "status": "done",
+                "assignee": "product-architect",
+                "title": "Materialize architecture_packet for board",
+                "created_at": "2026-06-27T10:00:00+00:00",
+                "latest_summary": "Architecture candidate packet is ready for independent review.",
+                "workspace_path": str(Path(tmpdir)),
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "architecture_result": {
+                                    "status": "candidate_architecture_packet_ready_for_independent_review_not_closed",
+                                    "task_id": arch_id,
+                                    "artifact_paths": [str(missing_artifact)],
+                                },
+                                "artifacts": [str(missing_artifact)],
+                            }
+                        ),
+                    }
+                ],
+            }
+            fake.tasks[passed_review_id] = {
+                "id": passed_review_id,
+                "status": "done",
+                "assignee": "independent-reviewer",
+                "title": "Independent review — repaired architecture_packet for Todo Web Local",
+                "completed_at": "2026-06-27T10:05:00+00:00",
+                "latest_summary": "PASS_FOR_REVIEW_INPUT_READINESS_ONLY_NOT_ARCHITECTURE_CLOSURE.",
+                "runs": [
+                    {
+                        "status": "done",
+                        "outcome": "completed",
+                        "metadata": json.dumps(
+                            {
+                                "independent_review_result": {
+                                    "verdict": "PASS_FOR_REVIEW_INPUT_READINESS_ONLY_NOT_ARCHITECTURE_CLOSURE",
+                                    "reviewed_task_id": arch_id,
+                                    "reviewed_artifact_type": "architecture_packet",
+                                    "blocking_findings": [],
+                                }
+                            }
+                        ),
+                    }
+                ],
+            }
+            args = adapter.build_parser().parse_args(
+                ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+            )
+
+            result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(
+            result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"],
+            "product_creation_plan",
+        )
+        created_repairs = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("plan_action")
+            == "repair_declared_artifacts"
+        ]
+        self.assertEqual(created_repairs, [])
+        created_product_plans = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "product_creation_plan"
+        ]
+        self.assertEqual(len(created_product_plans), 1)
+
     def test_no_idle_keeps_newer_failed_architecture_review_active_after_older_pass(self) -> None:
         fake = FakeHermes()
         arch_id = "t_" + "archfix2"


### PR DESCRIPTION
## Summary
- recognize independent_review_result as architecture review evidence when it reviews architecture_packet
- treat review input readiness PASS as a deterministic architecture review pass for next-input progression
- skip stale missing declared-artifact repair when a newer architecture review exists

## Validation
- python -m unittest tests.test_hermes_live_kanban_adapter
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py

Fixes #512