### PR TITLE
Continue product plans to implementation readiness

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -18368,6 +18368,23 @@ def _task_has_product_creation_plan(task: dict[str, Any]) -> bool:
     return False
 
 
+def _task_has_product_implementation_readiness(task: dict[str, Any]) -> bool:
+    text = _task_search_text(task)
+    assignee = str(task.get("assignee") or "").strip().lower()
+    if "factory-orchestrator" in assignee and (
+        "product_implementation_readiness" in text or "product implementation readiness" in text
+    ):
+        return True
+    for payload in _task_payload_objects(task):
+        if payload.get("record_type") == "product_implementation_readiness":
+            return True
+        if str(payload.get("required_output") or payload.get("artifact") or "").strip() == "product_implementation_readiness":
+            return True
+        if isinstance(payload.get("product_implementation_readiness"), dict):
+            return True
+    return False
+
+
 def _task_payload_objects(task: dict[str, Any]) -> list[dict[str, Any]]:
     payloads: list[dict[str, Any]] = []
     for key in ("metadata", "body", "description", "result"):
@@ -18938,6 +18955,42 @@ def board_reconcile_terminal_passed_architecture_review_continuation(
     }, []
 
 
+def board_reconcile_terminal_product_creation_plan_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    done = rows.get("done", [])
+    product_creation_refs = [_task_public_ref(task) for task in done if _task_has_product_creation_plan(task)]
+    if not product_creation_refs:
+        return None, []
+    if any(_task_has_product_implementation_readiness(task) for task in done):
+        return None, []
+    phase_engine = {
+        "computed_frontier": "ready_gate",
+        "computed_phase_id": "F12",
+        "next_required_artifact": "product_implementation_readiness",
+        "decision_basis": (
+            "Product Creation Plan exists; the next deterministic frontier is Product "
+            "Implementation Readiness before ready gate, work units or implementation."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(product_creation_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": "product_implementation_readiness",
+            "owner": DEFAULT_ARTIFACT_OWNERS["product_implementation_readiness"],
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
 def board_reconcile_terminal_blocked_artifact_readback_continuation(
     rows: dict[str, list[dict[str, Any]]],
 ) -> tuple[dict[str, Any] | None, list[str]]:
@@ -19199,6 +19252,10 @@ def build_board_reconcile_plan(
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (
                 board_reconcile_terminal_passed_architecture_review_continuation(rows)
+            )
+        if terminal_continuation is None:
+            terminal_continuation, terminal_continuation_errors = (
+                board_reconcile_terminal_product_creation_plan_continuation(rows)
             )
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -5990,6 +5990,57 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         ]
         self.assertEqual(len(created_product_plans), 1)
 
+    def test_no_idle_routes_product_creation_plan_to_implementation_readiness(self) -> None:
+        fake = FakeHermes()
+        product_plan_id = "t_" + "prodplan1"
+        fake.tasks[product_plan_id] = {
+            "id": product_plan_id,
+            "status": "done",
+            "assignee": "decomposition-planner",
+            "title": "Materialize product_creation_plan for board",
+            "latest_summary": "Product Creation Plan created; implementation readiness is required next.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "product_creation_plan": {
+                                "record_type": "product_creation_plan",
+                                "plan_id": "todo-web-local-product-creation-plan",
+                                "handoff": {
+                                    "factory_owned_next_step": True,
+                                    "next_artifact": "product_implementation_readiness",
+                                    "next_worker": "factory-orchestrator",
+                                },
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(
+            result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"],
+            "product_implementation_readiness",
+        )
+        created_readiness_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "product_implementation_readiness"
+        ]
+        self.assertEqual(len(created_readiness_tasks), 1)
+        created = created_readiness_tasks[0]
+        self.assertEqual(created["assignee"], "factory-orchestrator")
+        body = adapter.parse_json_object(str(created.get("body") or "{}"))
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F12-product-implementation-readiness")
+        self.assertEqual(body["phase_engine"]["computed_phase_id"], "F12")
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+
     def test_no_idle_keeps_newer_failed_architecture_review_active_after_older_pass(self) -> None:
         fake = FakeHermes()
         arch_id = "t_" + "archfix2"


### PR DESCRIPTION
## Summary
- add product_implementation_readiness terminal detection
- route terminal product_creation_plan to product_implementation_readiness through the deterministic reconciler
- cover the F11 -> F12 continuation with a no-idle regression test

## Validation
- python -m unittest tests.test_hermes_live_kanban_adapter
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py

Fixes #514