### PR TITLE
Continue readiness to ready gate

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -7829,6 +7829,7 @@ DEFAULT_ARTIFACT_REFS = {
     "method_contract": "templates/method-contract.json",
     "product_creation_plan": "templates/product-creation-plan.json",
     "product_implementation_readiness": "templates/product-implementation-readiness.json",
+    "gate_report": "factoryctl:gate-report",
     "sdlc_feedback_loop": "templates/factory-sdlc-feedback-loop.json",
     "specialist_research_plan": "templates/specialist-research-plan.json",
     "specialist_decision_packet": "templates/specialist-decision-packet.json",
@@ -7856,6 +7857,7 @@ DEFAULT_ARTIFACT_OWNERS = {
     "method_contract": "factory-orchestrator",
     "product_creation_plan": "decomposition-planner",
     "product_implementation_readiness": "factory-orchestrator",
+    "gate_report": "factory-orchestrator",
     "sdlc_feedback_loop": "skill-eval-distiller",
     "specialist_research_plan": "source-ledger-worker",
     "specialist_decision_packet": "product-architect",
@@ -7886,6 +7888,7 @@ ARTIFACT_REQUIRED_BEFORE = {
     "method_contract": "ready_gate",
     "product_creation_plan": "ready_gate",
     "product_implementation_readiness": "execution",
+    "gate_report": "execution",
     "sdlc_feedback_loop": "execution",
     "specialist_research_plan": "method_contract",
     "specialist_decision_packet": "method_contract",
@@ -18385,6 +18388,25 @@ def _task_has_product_implementation_readiness(task: dict[str, Any]) -> bool:
     return False
 
 
+def _task_has_gate_report(task: dict[str, Any]) -> bool:
+    title_text = " ".join(
+        str(task.get(key) or "")
+        for key in ("title", "name")
+        if isinstance(task.get(key), str)
+    ).lower()
+    assignee = str(task.get("assignee") or "").strip().lower()
+    if "factory-orchestrator" in assignee and ("gate_report" in title_text or "gate report" in title_text):
+        return True
+    for payload in _task_payload_objects(task):
+        if payload.get("record_type") == "gate_report":
+            return True
+        if str(payload.get("required_output") or payload.get("artifact") or "").strip() == "gate_report":
+            return True
+        if isinstance(payload.get("gate_report"), dict):
+            return True
+    return False
+
+
 def _task_payload_objects(task: dict[str, Any]) -> list[dict[str, Any]]:
     payloads: list[dict[str, Any]] = []
     for key in ("metadata", "body", "description", "result"):
@@ -18991,6 +19013,42 @@ def board_reconcile_terminal_product_creation_plan_continuation(
     }, []
 
 
+def board_reconcile_terminal_product_readiness_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    done = rows.get("done", [])
+    readiness_refs = [_task_public_ref(task) for task in done if _task_has_product_implementation_readiness(task)]
+    if not readiness_refs:
+        return None, []
+    if any(_task_has_gate_report(task) for task in done):
+        return None, []
+    phase_engine = {
+        "computed_frontier": "ready_gate",
+        "computed_phase_id": "F13",
+        "next_required_artifact": "gate_report",
+        "decision_basis": (
+            "Product Implementation Readiness exists; the next deterministic frontier is "
+            "Ready Gate before work units or implementation."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(readiness_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": "gate_report",
+            "owner": DEFAULT_ARTIFACT_OWNERS["gate_report"],
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
 def board_reconcile_terminal_blocked_artifact_readback_continuation(
     rows: dict[str, list[dict[str, Any]]],
 ) -> tuple[dict[str, Any] | None, list[str]]:
@@ -19256,6 +19314,10 @@ def build_board_reconcile_plan(
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (
                 board_reconcile_terminal_product_creation_plan_continuation(rows)
+            )
+        if terminal_continuation is None:
+            terminal_continuation, terminal_continuation_errors = (
+                board_reconcile_terminal_product_readiness_continuation(rows)
             )
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -6041,6 +6041,57 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(body["phase_engine"]["computed_phase_id"], "F12")
         self.assertFalse(body["phase_engine"]["human_gate_allowed"])
 
+    def test_no_idle_routes_implementation_readiness_to_ready_gate_report(self) -> None:
+        fake = FakeHermes()
+        readiness_id = "t_" + "ready001"
+        fake.tasks[readiness_id] = {
+            "id": readiness_id,
+            "status": "done",
+            "assignee": "factory-orchestrator",
+            "title": "Materialize product_implementation_readiness for board",
+            "latest_summary": "Product Implementation Readiness exists; Ready Gate is required next.",
+            "runs": [
+                {
+                    "status": "done",
+                    "outcome": "completed",
+                    "metadata": json.dumps(
+                        {
+                            "product_implementation_readiness": {
+                                "record_type": "product_implementation_readiness",
+                                "readiness_id": "todo-web-local-readiness",
+                                "handoff": {
+                                    "factory_owned_next_step": True,
+                                    "next_artifact": "gate_report",
+                                    "next_worker": "factory-orchestrator",
+                                },
+                            }
+                        }
+                    ),
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(
+            result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"],
+            "gate_report",
+        )
+        created_gate_reports = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "gate_report"
+        ]
+        self.assertEqual(len(created_gate_reports), 1)
+        created = created_gate_reports[0]
+        self.assertEqual(created["assignee"], "factory-orchestrator")
+        body = adapter.parse_json_object(str(created.get("body") or "{}"))
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F13-ready-gate")
+        self.assertEqual(body["phase_engine"]["computed_phase_id"], "F13")
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+
     def test_no_idle_keeps_newer_failed_architecture_review_active_after_older_pass(self) -> None:
         fake = FakeHermes()
         arch_id = "t_" + "archfix2"


### PR DESCRIPTION
## Summary
- add gate_report to artifact defaults/owners
- add strict gate_report detection so next_artifact references are not treated as materialized reports
- route terminal product_implementation_readiness to F13 gate_report through no-idle

## Validation
- python -m unittest tests.test_hermes_live_kanban_adapter
- python scripts/public_safety_scan.py
- python scripts/secret_safety_scan.py

Fixes #516