### PR TITLE
Continue worker packets to ready work-unit cards

### DIFF
--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -7860,6 +7860,7 @@ DEFAULT_ARTIFACT_OWNERS = {
     "product_implementation_readiness": "factory-orchestrator",
     "gate_report": "factory-orchestrator",
     "worker_packet": "factory-orchestrator",
+    "ready_work_unit_hermes_materialization_plan": "factory-orchestrator",
     "sdlc_feedback_loop": "skill-eval-distiller",
     "specialist_research_plan": "source-ledger-worker",
     "specialist_decision_packet": "product-architect",
@@ -18446,6 +18447,39 @@ def _task_has_worker_packet(task: dict[str, Any]) -> bool:
     return False
 
 
+def _task_has_ready_work_unit_hermes_materialization_plan(task: dict[str, Any]) -> bool:
+    title_text = " ".join(
+        str(task.get(key) or "")
+        for key in ("title", "name")
+        if isinstance(task.get(key), str)
+    ).lower()
+    if "ready_work_unit_hermes_materialization_plan" in title_text:
+        return True
+    if "ready work-unit hermes materialization plan" in title_text:
+        return True
+    for payload in _task_payload_objects(task):
+        if payload.get("record_type") == "ready_work_unit_hermes_materialization_plan":
+            return True
+        if (
+            str(payload.get("required_output") or payload.get("artifact") or "").strip()
+            == "ready_work_unit_hermes_materialization_plan"
+        ):
+            return True
+        if isinstance(payload.get("ready_work_unit_hermes_materialization_plan"), dict):
+            return True
+    return False
+
+
+def _task_has_ready_work_unit_execution_request(task: dict[str, Any]) -> bool:
+    for payload in _task_payload_objects(task):
+        if payload.get("packet_type") == "ready_work_unit_execution_request":
+            return True
+        body_contract = payload.get("body_contract")
+        if isinstance(body_contract, dict) and body_contract.get("packet_type") == "ready_work_unit_execution_request":
+            return True
+    return False
+
+
 def _task_payload_objects(task: dict[str, Any]) -> list[dict[str, Any]]:
     payloads: list[dict[str, Any]] = []
     for key in ("metadata", "body", "description", "result"):
@@ -19124,6 +19158,50 @@ def board_reconcile_terminal_ready_gate_continuation(
     }, []
 
 
+def board_reconcile_terminal_worker_packet_continuation(
+    rows: dict[str, list[dict[str, Any]]],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    all_tasks = [
+        task
+        for items in rows.values()
+        for task in items
+    ]
+    done = rows.get("done", [])
+    worker_packet_refs = [_task_public_ref(task) for task in done if _task_has_worker_packet(task)]
+    if not worker_packet_refs:
+        return None, []
+    if any(_task_has_ready_work_unit_execution_request(task) for task in all_tasks):
+        return None, []
+    if any(_task_has_ready_work_unit_hermes_materialization_plan(task) for task in done):
+        return None, []
+    phase_engine = {
+        "computed_frontier": "execution",
+        "computed_phase_id": "F15",
+        "next_required_artifact": "ready_work_unit_hermes_materialization_plan",
+        "decision_basis": (
+            "Worker packets exist but no native Hermes ready work-unit execution cards exist; "
+            "the next deterministic frontier is the Hermes materialization plan that turns "
+            "validated packets into blocked-first Kanban execution cards."
+        ),
+        "human_gate_allowed": False,
+        "phase_mismatch": False,
+    }
+    evidence_refs = sorted(set(worker_packet_refs))
+    factory_help = {
+        "factory_next_action": {
+            "artifact": "ready_work_unit_hermes_materialization_plan",
+            "owner": DEFAULT_ARTIFACT_OWNERS["ready_work_unit_hermes_materialization_plan"],
+            "why": phase_engine["decision_basis"],
+            "evidence_refs": evidence_refs,
+        }
+    }
+    return {
+        "phase_engine": phase_engine,
+        "factory_help": factory_help,
+        "evidence_refs": evidence_refs,
+    }, []
+
+
 def board_reconcile_terminal_blocked_artifact_readback_continuation(
     rows: dict[str, list[dict[str, Any]]],
 ) -> tuple[dict[str, Any] | None, list[str]]:
@@ -19397,6 +19475,10 @@ def build_board_reconcile_plan(
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (
                 board_reconcile_terminal_ready_gate_continuation(rows)
+            )
+        if terminal_continuation is None:
+            terminal_continuation, terminal_continuation_errors = (
+                board_reconcile_terminal_worker_packet_continuation(rows)
             )
         if terminal_continuation is None:
             terminal_continuation, terminal_continuation_errors = (

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -6143,6 +6143,58 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(body["phase_engine"]["computed_phase_id"], "F15")
         self.assertFalse(body["phase_engine"]["human_gate_allowed"])
 
+    def test_no_idle_routes_worker_packet_to_ready_work_unit_hermes_plan(self) -> None:
+        fake = FakeHermes()
+        worker_packet_id = "t_" + "workerpkt"
+        fake.tasks[worker_packet_id] = {
+            "id": worker_packet_id,
+            "status": "done",
+            "assignee": "factory-orchestrator",
+            "title": "Materialize worker_packet for board",
+            "body": json.dumps(
+                {
+                    "packet_type": "factory_deterministic_reconcile_task",
+                    "required_output": "worker_packet",
+                    "kanban_workflow_binding": {
+                        "workflow_template_id": "overkill-vfinal",
+                        "current_step_key": "F15-execution",
+                        "runtime_field_required": True,
+                    },
+                    "phase_engine": {
+                        "computed_phase_id": "F15",
+                        "computed_frontier": "execution",
+                        "next_required_artifact": "worker_packet",
+                        "human_gate_allowed": False,
+                    },
+                }
+            ),
+            "latest_summary": (
+                "Validated worker_packet manifest exists; next step is Hermes ready work-unit materialization."
+            ),
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        self.assertEqual(result["board_reconcile_plan"]["plan_action"], "create_next_artifact_task")
+        self.assertEqual(
+            result["board_reconcile_plan"]["create_task_contract"]["body"]["required_output"],
+            "ready_work_unit_hermes_materialization_plan",
+        )
+        created_plans = [
+            task for task in fake.tasks.values()
+            if adapter.parse_json_object(str(task.get("body") or "{}")).get("required_output")
+            == "ready_work_unit_hermes_materialization_plan"
+        ]
+        self.assertEqual(len(created_plans), 1)
+        created = created_plans[0]
+        self.assertEqual(created["assignee"], "factory-orchestrator")
+        body = adapter.parse_json_object(str(created.get("body") or "{}"))
+        self.assertEqual(body["kanban_workflow_binding"]["current_step_key"], "F15-execution")
+        self.assertEqual(body["phase_engine"]["computed_phase_id"], "F15")
+        self.assertFalse(body["phase_engine"]["human_gate_allowed"])
+        self.assertIn("blocked-first Kanban execution cards", body["phase_engine"]["decision_basis"])
+
     def test_no_idle_keeps_newer_failed_architecture_review_active_after_older_pass(self) -> None:
         fake = FakeHermes()
         arch_id = "t_" + "archfix2"


### PR DESCRIPTION
Closes #520.

## What changed
- Adds a deterministic terminal continuation after F15 worker_packet completion.
- If no native Hermes ready work-unit execution cards exist yet, no-idle creates a F15 continuation for `ready_work_unit_hermes_materialization_plan`.
- Keeps human gates disabled for this internal execution-materialization step.
- Adds regression coverage for the live Todo board failure shape.

## Validation
- `python -m unittest tests.test_hermes_live_kanban_adapter`
- `python scripts/public_safety_scan.py`
- `python scripts/secret_safety_scan.py`
