### PR TITLE
Add executable Swiss Watch reliability audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv/
 __pycache__/
 .pytest_cache/
 .tmp/
+.worktrees/
 *.egg-info/
 dist/
 build/

--- a/README.md
+++ b/README.md
@@ -89,9 +89,20 @@ your idea/material
 -> learnback to improve the factory
 ```
 
-The most important point: the factory is not "a smart chat." It is a system for
-preventing agents from skipping understanding, inventing scope, ignoring
-security or claiming work is done without proof.
+The most important point: the factory is not "a smart chat" and not a
+mini-Hermes. Hermes owns the native runtime floor: Kanban state, typed blocks,
+dependencies, dispatch and worker execution. Overkill Factory adds the product
+method, contracts and gates only where Hermes needs a factory-specific layer.
+
+The Swiss Watch reliability audit makes that rule executable:
+
+```bash
+python scripts/swiss_watch_audit.py --out .tmp/swiss-watch-audit.json --markdown .tmp/swiss-watch-audit.md
+```
+
+It checks that the production-line gears have contracts, Hermes-native
+authority, no-idle safeguards, operator UX rules, block classification,
+security boundaries, loop control and worker quality floors.
 
 ## Why This Exists
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -90,9 +90,22 @@ sua ideia/material
 -> aprendizados para melhorar a fábrica
 ```
 
-O ponto mais importante: a fábrica não é "um chat inteligente". Ela é um
-sistema para impedir que agentes pulem entendimento, inventem escopo, ignorem
-segurança ou digam que algo está pronto sem prova.
+O ponto mais importante: a fábrica não é "um chat inteligente" e não é um
+mini-Hermes. O Hermes é dono do chão de runtime nativo: Kanban, typed blocks,
+dependências, dispatch e execução dos workers. A Overkill Factory adiciona o
+método de produto, contratos e gates apenas onde o Hermes precisa de uma camada
+específica de fábrica.
+
+A auditoria Swiss Watch torna essa regra executável:
+
+```bash
+python scripts/swiss_watch_audit.py --out .tmp/swiss-watch-audit.json --markdown .tmp/swiss-watch-audit.md
+```
+
+Ela verifica se as engrenagens da linha de produção têm contrato, autoridade
+Hermes-native, proteção no-idle, regras de UX do operador, classificação de
+bloqueios, fronteiras de segurança, controle de loop e piso de qualidade dos
+workers.
 
 ## Por Que Existe
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,12 @@ Codex was closed.
 Use `maintenance/repo-surface.md` to decide whether a file belongs in the
 operator surface, maintainer internals or generated output.
 
+Use `maintenance/swiss-watch-reliability-program.md` when improving autonomy,
+operator experience, no-idle behavior, worker output quality, performance,
+security or Hermes-native runtime alignment without reducing factory stages.
+Use `maintenance/swiss-watch-gear-matrix.md` as the generated phase-by-phase
+baseline for gear input/output/authority/proof audits.
+
 Use `maintenance/self-improvement-loop.md` for learnback issue candidates,
 missing-capability completion plans, owner issue intake, reasoning policy,
 factory readiness scorecards, SDLC feedback loops, reference quality packets

--- a/docs/maintenance/swiss-watch-gear-matrix.md
+++ b/docs/maintenance/swiss-watch-gear-matrix.md
@@ -1,0 +1,726 @@
+# Swiss Watch Gear Matrix
+
+> Document status: GENERATED MAINTAINER BASELINE.
+> Source: `.tmp/swiss-watch/factory-workflow-compiled-plan.json`, `agents/worker-registry.public.json`, `templates/hermes-typed-block-policy.json`.
+> Runtime boundary: Hermes Kanban remains the runtime source of truth. This matrix is an audit view, not a parallel state store.
+
+## Purpose
+
+This matrix turns the Swiss Watch Reliability Program into a phase-by-phase audit baseline. It preserves every factory phase and asks whether each gear has enough explicit input, worker ownership, gates, proof and Hermes-native runtime authority to move the next gear without operator babysitting or shallow agent output.
+
+## Hermes-Native Runtime Rule
+
+- Use Hermes Kanban cards, parent dependencies, typed blocks, dispatch, comments, runs, logs and attachments whenever those primitives exist.
+- Factory code may validate contracts, route gates and produce proof requirements. It must not become a shadow dispatcher, shadow scheduler or mini-Hermes.
+- `dependency`, `needs_input`, `capability` and `transient` typed block semantics come from Hermes. Factory no-idle/watchdog logic audits and repairs; it does not own normal route authority.
+
+## Phase Gear Baseline
+
+### F0: Pre-Start / Sealed Source Envelope
+
+- Next gear: `F1`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `factory_bridge_source_envelope`
+  - `factory_bridge_start_request`
+- Required gates:
+  - `Start Boundary`
+- Workflow-required workers:
+  - `overkill-factory-gerente`
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `source-ledger-worker` -> `source_ledger_result`
+  - `memory-steward` -> `memory_steward_result`
+- Blocked actions:
+  - `summarize or reinterpret source material in the bridge`
+  - `create Hermes board/card directly from bridge`
+  - `start without explicit runtime target policy`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F1: Intake
+
+- Next gear: `F2`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `operator_interface_profile`
+  - `factory_start_conversation`
+  - `universal_signal_intake`
+  - `source_refs`
+  - `source_resolution_packet`
+- Required gates:
+  - `Source Gate`
+- Workflow-required workers:
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `source-ledger-worker` -> `source_ledger_result`
+  - `agentic-ai-security-specialist` -> `agentic_ai_security_result`
+  - `memory-steward` -> `memory_steward_result`
+- Blocked actions:
+  - `route implementation before source resolution`
+  - `create Product SOT from raw input`
+  - `require the operator to poll for status`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F2: Source Ledger
+
+- Next gear: `F3`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `source_refs`
+  - `product_source_ledger`
+  - `operator_understanding_confirmation`
+- Required gates:
+  - `Source Gate`
+- Workflow-required workers:
+  - `source-ledger-worker`
+- Registry workers with this phase:
+  - `source-ledger-worker` -> `source_ledger_result`
+  - `product-sot-planner` -> `product_sot_result`
+- Blocked actions:
+  - `ask user to reconcile internal source bookkeeping`
+  - `create outcome contract or Product SOT before understanding is confirmed`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F3: Source Resolution
+
+- Next gear: `F4`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `discovery_brief`
+- Required gates:
+  - `Discovery Gate`
+- Workflow-required workers:
+  - `source-ledger-worker`
+  - `product-sot-planner`
+- Registry workers with this phase:
+  - `source-ledger-worker` -> `source_ledger_result`
+  - `product-sot-planner` -> `product_sot_result`
+- Blocked actions:
+  - `turn unresolved gaps into execution scope`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F4: Product Outcome And Discovery
+
+- Next gear: `F5`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `operator_understanding_confirmation`
+  - `operator_briefing_package`
+  - `outcome_contract`
+  - `discovery_brief`
+- Required gates:
+  - `Outcome Gate`
+  - `Discovery Gate`
+- Workflow-required workers:
+  - `product-sot-planner`
+- Registry workers with this phase:
+  - `product-sot-planner` -> `product_sot_result`
+  - `product-architect` -> `architecture_result`
+  - `security-orchestrator` -> `security_orchestration_result`
+  - `detection-monitoring-worker` -> `detection_monitoring_result`
+- Blocked actions:
+  - `treat outcome candidate as approved Product SOT`
+  - `draft Product SOT before operator understanding confirmation`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F5: Product SOT
+
+- Next gear: `F6`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `product_sot`
+  - `operator_briefing_package`
+  - `full_product_sot_scope_coverage`
+  - `factory_phase_lock`
+- Required gates:
+  - `Product SOT Gate`
+- Workflow-required workers:
+  - `product-sot-planner`
+- Registry workers with this phase:
+  - `product-sot-planner` -> `product_sot_result`
+  - `product-face` -> `product_face_result`
+- Blocked actions:
+  - `execute from paper instead of Product SOT`
+  - `ask operator to approve Product SOT from a short chat summary only`
+  - `start architecture, repo cleanup, human gate or worker packet while Product SOT owner package is missing`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F6: Agentic Method Router
+
+- Next gear: `F7`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `factory_phase_lock`
+  - `method_contract`
+- Required gates:
+  - `Method Gate`
+- Workflow-required workers:
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `product-architect` -> `architecture_result`
+  - `security-orchestrator` -> `security_orchestration_result`
+- Blocked actions:
+  - `ask user to choose internal method machinery`
+  - `start architecture or repo cleanup before Method Contract`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F7: Method Contract
+
+- Next gear: `F8`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `factory_phase_lock`
+  - `method_contract`
+- Required gates:
+  - `Method Gate`
+- Workflow-required workers:
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `solana-quasar-auditor` -> `auditor_result`
+  - `appsec-owasp-specialist` -> `appsec_owasp_result`
+  - `agentic-ai-security-specialist` -> `agentic_ai_security_result`
+  - `security-orchestrator` -> `security_orchestration_result`
+  - `cloud-infra-security-specialist` -> `cloud_infra_security_result`
+  - `crypto-key-management-specialist` -> `crypto_key_management_result`
+- Blocked actions:
+  - `start implementation with undocumented process choices`
+  - `materialize future-phase cards while active frontier is still product_sot or method_contract`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F8: Pack And Product Experience Selection
+
+- Next gear: `F9`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `capability_pack_contract`
+  - `product_experience_plan`
+  - `product_face_packet`
+  - `project_design_system`
+  - `professional_design_process`
+  - `surface_evidence_profile`
+  - `product_delivery_quality_profile`
+- Required gates:
+  - `Pack Gate`
+  - `Product Experience Gate`
+  - `Surface Pack Gate`
+- Workflow-required workers:
+  - `product-face`
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `product-face` -> `product_face_result`
+  - `codex-security` -> `security_scan_result`
+  - `security-orchestrator` -> `security_orchestration_result`
+  - `skill-eval-distiller` -> `skill_eval_result`
+- Blocked actions:
+  - `activate a pack without proof or coverage`
+  - `start product-facing implementation before surface state coverage`
+  - `treat generic UI proof as Product Experience proof`
+  - `move to implementation with unnamed surface pack or proof profile`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F9: Risk And Authority Gates
+
+- Next gear: `F10`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `access_capability`
+  - `budget_contract`
+- Required gates:
+  - `Access Gate`
+  - `Budget Gate`
+  - `Human Gate when required`
+- Workflow-required workers:
+  - `human-gate-clerk`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `handoff-packer` -> `handoff_packet_result`
+  - `human-gate-clerk` -> `human_gate_record`
+- Blocked actions:
+  - `infer approval from silence`
+  - `ask for planning-only continuation approval`
+  - `ask for architecture or repo cleanup approval while downstream is frozen`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F10: Security Architecture
+
+- Next gear: `F11`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `factory_phase_lock`
+  - `security_architecture_plan`
+- Required gates:
+  - `Security Architecture Gate`
+- Workflow-required workers:
+  - `security-orchestrator`
+- Registry workers with this phase:
+  - `docs-os-worker` -> `documentation_os_result`
+  - `security-orchestrator` -> `security_orchestration_result`
+- Blocked actions:
+  - `build material risk before architecture`
+  - `start security architecture while Product SOT or Method Contract is still missing`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F11: Executable Plans
+
+- Next gear: `F12`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `software_development_plan`
+  - `spec_graph`
+  - `loop_plan`
+  - `product_creation_plan`
+- Required gates:
+  - `Ready Gate`
+- Workflow-required workers:
+  - `decomposition-planner`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `decomposition-planner` -> `decomposition_result`
+  - `supply-chain-gate` -> `supply_chain_result`
+- Blocked actions:
+  - `execute before plans, coverage review and stop criteria exist`
+  - `mark decomposition review as passed from the planner that created the decomposition`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F12: Autonomy Readiness
+
+- Next gear: `F13`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `decomposition_coverage_review`
+  - `product_implementation_readiness`
+  - `autonomy_readiness_packet`
+- Required gates:
+  - `Decomposition Coverage Gate`
+  - `Access & Capability Gate`
+- Workflow-required workers:
+  - `independent-reviewer`
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `agentic-ai-security-specialist` -> `agentic_ai_security_result`
+  - `independent-reviewer` -> `independent_review_result`
+  - `implementation-worker` -> `implementation_result`
+  - `frontend-builder` -> `frontend_build_result`
+  - `backend-api-builder` -> `backend_api_build_result`
+  - `data-persistence-builder` -> `data_persistence_result`
+  - `solana-quasar-builder` -> `solana_quasar_build_result`
+  - `wallet-transaction-builder` -> `wallet_transaction_result`
+  - `integration-builder` -> `integration_build_result`
+  - `test-automation-builder` -> `test_automation_result`
+  - `infra-devops-builder` -> `infra_devops_result`
+  - ... 1 more
+- Blocked actions:
+  - `start autonomous work with missing review, access or limits`
+  - `let a single reviewer approve the complete decomposition alone`
+  - `create Product Implementation Readiness from a failed or missing decomposition coverage review`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F13: Ready Gate
+
+- Next gear: `F15`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `gate_report`
+- Required gates:
+  - `Ready Gate`
+- Workflow-required workers:
+  - `factory-orchestrator`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `product-face` -> `product_face_result`
+  - `solana-quasar-auditor` -> `auditor_result`
+  - `codex-security` -> `security_scan_result`
+  - `remote-proof-runner` -> `remote_proof_result`
+  - `evidence-reconciler` -> `receipt_five_reconciliation_result`
+  - `frontend-builder` -> `frontend_build_result`
+  - `backend-api-builder` -> `backend_api_build_result`
+  - `data-persistence-builder` -> `data_persistence_result`
+  - `solana-quasar-builder` -> `solana_quasar_build_result`
+  - `solana-quasar-qa-engineer` -> `solana_quasar_qa_result`
+  - `wallet-transaction-builder` -> `wallet_transaction_result`
+  - ... 5 more
+- Blocked actions:
+  - `dispatch blocked workers`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F15: Runtime Execution
+
+- Next gear: `F16`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `worker_packets`
+- Required gates:
+  - `Runtime Gate`
+- Workflow-required workers:
+  - `implementation-worker`
+  - `qa-verification-worker`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `solana-quasar-auditor` -> `auditor_result`
+  - `appsec-owasp-specialist` -> `appsec_owasp_result`
+  - `autoreview-gate` -> `autoreview_result`
+  - `handoff-packer` -> `handoff_packet_result`
+  - `evidence-reconciler` -> `receipt_five_reconciliation_result`
+  - `human-gate-clerk` -> `human_gate_record`
+  - `implementation-worker` -> `implementation_result`
+  - `solana-quasar-qa-engineer` -> `solana_quasar_qa_result`
+  - `qa-verification-worker` -> `qa_verification_result`
+- Blocked actions:
+  - `spawn without route readiness`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F16: Worker Results
+
+- Next gear: `F17`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `worker_results`
+- Required gates:
+  - `Done Gate`
+- Workflow-required workers:
+  - `evidence-reconciler`
+- Registry workers with this phase:
+  - `remote-proof-runner` -> `remote_proof_result`
+  - `evidence-reconciler` -> `receipt_five_reconciliation_result`
+  - `human-gate-clerk` -> `human_gate_record`
+  - `infra-devops-builder` -> `infra_devops_result`
+  - `security-orchestrator` -> `security_orchestration_result`
+  - `cloud-infra-security-specialist` -> `cloud_infra_security_result`
+  - `crypto-key-management-specialist` -> `crypto_key_management_result`
+  - `release-ops-worker` -> `release_ops_result`
+  - `public-safety-gate` -> `public_safety_result`
+  - `supply-chain-gate` -> `supply_chain_result`
+  - `detection-monitoring-worker` -> `detection_monitoring_result`
+- Blocked actions:
+  - `treat packet existence as proof`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F17: Verification
+
+- Next gear: `F18`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `verification_plan`
+  - `verification_result`
+- Required gates:
+  - `Verification Gate`
+- Workflow-required workers:
+  - `qa-verification-worker`
+- Registry workers with this phase:
+  - `qa-verification-worker` -> `qa_verification_result`
+  - `release-ops-worker` -> `release_ops_result`
+  - `public-safety-gate` -> `public_safety_result`
+  - `detection-monitoring-worker` -> `detection_monitoring_result`
+- Blocked actions:
+  - `claim done without command evidence`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F18: Independent Review
+
+- Next gear: `F20`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `review_result`
+- Required gates:
+  - `Review Gate`
+- Workflow-required workers:
+  - `independent-reviewer`
+- Registry workers with this phase:
+  - `factory-orchestrator` -> `orchestration_result`
+  - `appsec-owasp-specialist` -> `appsec_owasp_result`
+  - `agentic-ai-security-specialist` -> `agentic_ai_security_result`
+  - `autoreview-gate` -> `autoreview_result`
+  - `independent-reviewer` -> `independent_review_result`
+  - `evidence-reconciler` -> `receipt_five_reconciliation_result`
+  - `test-automation-builder` -> `test_automation_result`
+  - `agent-runtime-builder` -> `agent_runtime_result`
+  - `memory-steward` -> `memory_steward_result`
+  - `skill-eval-distiller` -> `skill_eval_result`
+- Blocked actions:
+  - `allow executor to self-approve`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F20: Closure Summary
+
+- Next gear: `F21`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `closure_summary`
+- Required gates:
+  - `Closure Gate`
+- Workflow-required workers:
+  - `handoff-packer`
+- Registry workers with this phase:
+  - `handoff-packer` -> `handoff_packet_result`
+- Blocked actions:
+  - `hide unresolved blockers in prose`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F21: Receipt Five
+
+- Next gear: `F22`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `receipt_five`
+- Required gates:
+  - `Done Gate`
+- Workflow-required workers:
+  - `evidence-reconciler`
+- Registry workers with this phase:
+  - `evidence-reconciler` -> `receipt_five_reconciliation_result`
+- Blocked actions:
+  - `mark done without Receipt Five`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F22: Completion Audit
+
+- Next gear: `F23`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `completion_audit`
+- Required gates:
+  - `Completion Audit`
+- Workflow-required workers:
+  - `evidence-reconciler`
+- Registry workers with this phase:
+  - `evidence-reconciler` -> `receipt_five_reconciliation_result`
+- Blocked actions:
+  - `close skipped method or evidence requirements`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F23: Production Operations
+
+- Next gear: `F24`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `production_readiness_plan`
+- Required gates:
+  - `Release Gate`
+- Workflow-required workers:
+  - `release-ops-worker`
+- Registry workers with this phase:
+  - `release-ops-worker` -> `release_ops_result`
+- Blocked actions:
+  - `release without owner, rollback or approval`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F24: Release Or Block
+
+- Next gear: `F25`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `release_decision`
+- Required gates:
+  - `Release Gate`
+  - `Human Gate when required`
+- Workflow-required workers:
+  - `release-ops-worker`
+  - `human-gate-clerk`
+- Registry workers with this phase:
+  - `human-gate-clerk` -> `human_gate_record`
+  - `release-ops-worker` -> `release_ops_result`
+  - `discord-control-tower-bridge` -> `control_tower_bridge_result`
+- Blocked actions:
+  - `promote without production-strict evidence`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F25: Monitoring Support
+
+- Next gear: `F26`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `incident_support_plan`
+- Required gates:
+  - `Support Gate`
+- Workflow-required workers:
+  - `release-ops-worker`
+- Registry workers with this phase:
+  - `release-ops-worker` -> `release_ops_result`
+- Blocked actions:
+  - `ship without support owner when support is material`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F26: Learnback
+
+- Next gear: `F27`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `factory_learning_proposal`
+- Required gates:
+  - `Learning Gate`
+- Workflow-required workers:
+  - `skill-eval-distiller`
+- Registry workers with this phase:
+  - `skill-eval-distiller` -> `skill_eval_result`
+- Blocked actions:
+  - `auto-activate critical factory changes`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+### F27: Factory Maturity Audit
+
+- Next gear: `terminal`
+- Auto-pass allowed: `false`
+- Required artifacts:
+  - `factory_maturity_scorecard`
+- Required gates:
+  - `Maturity Gate`
+- Workflow-required workers:
+  - `skill-eval-distiller`
+- Registry workers with this phase:
+  - `skill-eval-distiller` -> `skill_eval_result`
+- Blocked actions:
+  - `commit raw study or private evidence`
+- Swiss Watch audit questions:
+  - Does Hermes native state already expose the current status/dependency for this gear?
+  - Is the next action derived from compiled workflow/phase graph/reducer state, not agent prose?
+  - Would an internal dependency/capability/transient block avoid paging the operator?
+  - Does every required worker output have product-specific evidence and a quality floor?
+  - Does the operator receive a clear package before any real human decision?
+
+## Typed Block Gear Baseline
+
+| Hermes typed block | Owner | Operator page? | Required behavior |
+| --- | --- | --- | --- |
+| `dependency` | Hermes Kanban dependency lane | No | Native wait in TODO; auto-resume from parent completion. |
+| `needs_input` | Operator delivery/human gate lane | Only after complete delivery package | Ask the operator only for real input/decision with material first. |
+| `capability` | Capability acquisition lane | No until search is complete and blocked | Search providers/packs/references, write receipt, then block if no safe candidate. |
+| `transient` | Runtime repair/retry lane | No | Retry or route repair; never become generic human approval. |
+
+## Immediate Gap Inventory Seeds
+
+- Add operator-experience regressions for every typed block and gate false-positive class.
+- Add worker quality-floor regressions for shallow Product SOT, shallow architecture, shallow Product Face proof, shallow review and weak Receipt Five.
+- Add no-idle regressions for terminal worker metadata, repaired review, duplicate remediation prevention and graph invariant violations.
+- Audit every scheduling/dispatch/reconcile path for Hermes-native replacement opportunities before adding factory-native runtime code.
+

--- a/docs/maintenance/swiss-watch-reliability-program.md
+++ b/docs/maintenance/swiss-watch-reliability-program.md
@@ -1,0 +1,385 @@
+# Swiss Watch Reliability Program
+
+> Document status: CURRENT MAINTAINER EXECUTION PLAN.
+> Current authority: Hermes native runtime state, `scripts/factoryctl.py`, adapters,
+> schemas, tests and live Hermes evidence.
+> Runtime boundary: This document is a reliability plan. It does not replace
+> Hermes Kanban, factory contracts, Receipt Five, human gate records or tests.
+
+## Mission
+
+Make Overkill Factory operate like a Swiss watch without reducing the factory.
+Every existing stage remains allowed to exist. The work is to make every gear
+mesh correctly: autonomous when safe, blocked when necessary, secure by default,
+fast enough to feel alive, and strict enough that shallow agent work cannot pass.
+
+The factory must not become a mini-Hermes. The default answer is to use Hermes
+native capability: Kanban graph state, parent dependencies, typed blocks,
+dispatch, comments, runs, logs, attachments, schedules, notifications and worker
+state. Overkill Factory adds native code only when Hermes has no suitable native
+primitive or when the factory needs a product-method contract above the runtime.
+
+## Non-Negotiables
+
+1. Do not remove stages to make the system look simpler.
+2. Do not let agents select route, phase, gate or promotion path from memory,
+   prose, enthusiasm, title text or chat context.
+3. Prefer Hermes-native graph/dependency/block/dispatch behavior over sidecar
+   loops and factory-owned shadow schedulers.
+4. Treat no-idle and watchdog code as integrity auditors and repair paths, not
+   normal route authority.
+5. A worker packet is assignment, not proof.
+6. A PASS requires product-specific evidence, not generic template-shaped prose.
+7. The operator is contacted only for real human decisions or missing operator
+   input, never for internal dependency, capability, retry or repair states.
+8. Public artifacts must stay public-safe. Runtime/private evidence stays in
+   `.tmp/`, private evidence storage or operator-owned Hermes.
+9. Every fix must produce a regression test or validator that catches the exact
+   failure class again.
+10. Before saying done, show evidence: command, result, changed files, remaining
+    risk and next safe action.
+
+## The Eight Workstreams
+
+### 1. Gear Audit
+
+Question for every phase: does this gear have explicit input, output, authority,
+quality floor, timeout/retry behavior, proof and next gear?
+
+Required gears:
+
+- F0 sealed/source envelope
+- F1 intake
+- F2 source ledger/source resolution
+- F3 understanding alignment
+- F4 outcome/discovery
+- F5 Product SOT
+- F6 full-scope coverage
+- F7 Method Contract
+- F8 Product Experience/capability selection
+- F9 architecture boundary
+- F10 security/access/budget
+- F11 Product Creation Plan
+- F12 Decomposition Coverage Review
+- F13 execution packets/work units
+- F15 verification/review
+- human gate event only when real decision is required
+- Receipt Five
+- release/block decision
+- operations/learnback
+
+Deliverables:
+
+- phase-by-phase gear matrix with input/output/authority/proof.
+- gap list: missing test, missing authority, missing proof, missing UX contract.
+- one regression or validator per critical missing gear behavior.
+
+### 2. Swiss Watch Scorecard
+
+Measure each gear against five dimensions:
+
+- Autonomy: advances safely without operator babysitting.
+- Performance: avoids idle loops, duplicate remediation and slow recomputation.
+- Security: fails closed, preserves boundaries and protects secrets/private refs.
+- Quality: rejects shallow, generic or template-only worker output.
+- UX: tells the operator exactly what matters, in the right language, only when
+  human input is truly required.
+
+Deliverables:
+
+- scorecard schema/template if no existing contract is enough.
+- `factoryctl` command only if this becomes a repeated operator/maintainer path.
+- tests that fail when a required dimension silently disappears.
+
+Hermes-native rule:
+
+- If Hermes already exposes state needed for a score, read Hermes state. Do not
+  create a parallel factory truth store.
+
+### 3. Real Operator Experience First
+
+Optimize the lived flow, not just the contract surface.
+
+Representative target flow:
+
+```text
+operator material
+-> understanding package
+-> operator confirms/corrects
+-> Product SOT with real depth
+-> coverage/method/architecture/security/product experience
+-> work units and worker execution
+-> review rejects shallow work
+-> repair stays on rails
+-> Receipt Five proves completion or block
+```
+
+Deliverables:
+
+- operator-experience regression scenarios for the above flow.
+- clear expected operator messages for real human gates.
+- tests proving dependency/capability/transient/review repair states do not page
+  the operator as generic human approval.
+
+### 4. Worker Quality Floors
+
+Agents must stop passing with simplistic work.
+
+Minimum rule:
+
+- Every critical worker must have a quality floor that is specific enough for a
+  reviewer or validator to reject shallow output.
+
+Priority workers:
+
+- product-sot-planner
+- source-ledger-worker
+- product-architect
+- product-face/frontend-builder
+- decomposition-planner
+- independent-reviewer
+- qa-verification-worker
+- evidence-reconciler
+- security-orchestrator and security specialists
+- handoff-packer
+- human-gate-clerk
+
+Deliverables:
+
+- quality-floor checklist per priority worker.
+- worker result acceptance tests for generic/shallow output rejection.
+- reviewer behavior that routes repair instead of accepting weak PASS.
+
+Hermes-native rule:
+
+- Use Hermes worker results, comments, attachments and task state as evidence.
+  Factory code validates quality; it does not become a second worker runtime.
+
+### 5. Stall Classification and No-Idle Reliability
+
+The factory must classify stalled states exactly.
+
+Critical states:
+
+- dependency wait
+- needs input
+- capability acquisition
+- transient retry/repair
+- review failed
+- repair completed but not reconciled
+- worker terminal metadata present
+- human gate required
+- ready frontier exists
+- graph invariant violation
+- board truly idle
+
+Deliverables:
+
+- state matrix mapping state -> owner -> next safe action -> operator contact?
+- regression tests for every state above.
+- no-idle behavior proves it audits/repairs but does not become route authority.
+
+Hermes-native rule:
+
+- Current Hermes typed block and dependency state wins over factory prose.
+- Parent edges and current status must beat historical event text when deciding
+  whether a task is actually waiting.
+
+### 6. Operator Experience Regression Suite
+
+Create tests for experience failures, not only schemas.
+
+Required scenario classes:
+
+- no operator page for internal dependency.
+- no operator page for capability search until search is complete and blocked.
+- no duplicate remediation after self-evidenced repair PASS.
+- no fake human gate from free-text gate wording.
+- decision package delivered before decision question.
+- Portuguese operator flow receives Portuguese owner-facing material.
+- shallow Product SOT or shallow worker result is rejected.
+- board with safe next action does not remain silently idle.
+- failed review routes targeted repair, then re-review, then human gate only if
+  real decision remains.
+
+Deliverables:
+
+- one test module or clearly named tests under existing test files.
+- fixtures kept public-safe and minimal.
+- tests run in CI without private runtime.
+
+### 7. Systematic Fix Discipline
+
+No patch roulette.
+
+For every bug:
+
+1. reproduce with a tight command.
+2. identify root cause.
+3. write or locate the red test.
+4. implement the smallest root-cause fix.
+5. run targeted test.
+6. run relevant integration tests.
+7. run public safety/secret safety when public surface or artifacts change.
+8. record remaining risk.
+
+Deliverables:
+
+- each code change tied to a failure class.
+- no broad refactor mixed with bug fix unless explicitly scoped.
+- every accepted fix leaves behind a guardrail.
+
+### 8. Factory Reliability Engineer Loop
+
+Make reliability a continuous operating mode.
+
+The loop:
+
+```text
+observe bad UX or runtime stall
+-> classify exact failure class
+-> reproduce locally or with public-safe fixture
+-> fix root cause using Hermes-native primitive when available
+-> add regression
+-> update docs/skill only if behavior/pitfall changed
+-> run validation battery
+-> keep release notes honest
+```
+
+Deliverables:
+
+- reliability backlog grouped by failure class, not vague complaints.
+- release audit showing which failure classes were reduced.
+- repeatable validation battery before claiming improvement.
+
+## Immediate Execution Plan
+
+### Phase A: Stabilize Current Main
+
+A1. Reproduce the current failing unit test in isolation.
+
+- Command: `python -m unittest tests.test_factory_concierge_discord_automation.FactoryConciergeDiscordAutomationTest.test_run_automation_empty_inboxes_posts_idle_health_receipt -q`
+- Expected now: FAIL until root cause is fixed.
+
+A2. Trace root cause through Discord automation channel/guild resolution.
+
+- Files: `scripts/factory_concierge_discord_automation.py`,
+  `scripts/factory_concierge_discord_bridge.py`,
+  `tests/test_factory_concierge_discord_automation.py`.
+
+A3. Fix only the root cause.
+
+- Must preserve Hermes/factory boundary.
+- Must not add a new runtime path or sidecar scheduler.
+
+A4. Verify.
+
+- targeted failing test passes.
+- full Discord automation/bridge tests pass.
+- full unittest suite passes or any remaining failure is documented with command
+  and root cause.
+
+### Phase B: Prevent Local Runtime Artifacts From Breaking Validation
+
+B1. Inspect why local `.worktrees/` appears in public safety scan.
+
+B2. Decide by repo rule:
+
+- if `.worktrees/` is a generated/transient local workspace, ignore or exclude it
+  from public-safety discovery.
+- if it contains material that belongs in public fixtures, move only the minimal
+  public-safe fixture.
+
+B3. Add a regression so local worktrees/private runtime materials do not cause a
+false public-surface failure, while tracked public files remain scanned.
+
+### Phase C: Build the Gear Matrix
+
+C1. Generate or write the first gear matrix from existing workflow/contracts.
+
+C2. Use existing sources first:
+
+- workflow compiled plan
+- phase graph contracts
+- worker registry/profile bindings
+- Hermes typed block policy
+- Product Experience control plane
+- security route contracts
+
+C3. Add tests for any critical missing state.
+
+### Phase D: Add Operator Experience Regression Cases
+
+D1. Inventory existing tests for no-idle, human gate, operator interface,
+Telegram/Discord, Product SOT and worker result acceptance.
+
+D2. Add missing tests in the smallest existing test module that owns the behavior.
+
+D3. Keep tests public-safe and deterministic.
+
+### Phase E: Add Worker Quality Floors
+
+E1. Start with Product SOT because shallow Product SOT poisons every downstream
+phase.
+
+E2. Define unacceptable shallow output patterns.
+
+E3. Add a failing test proving shallow output is rejected.
+
+E4. Add validator/worker acceptance logic only where existing contracts cannot
+already express the rule.
+
+E5. Repeat for architecture, Product Face, review and evidence reconciliation.
+
+### Phase F: Prove Hermes-Native Runtime Direction
+
+F1. Audit code paths that create scheduling, dependency, block, dispatch or
+state-reconciliation behavior.
+
+F2. For each path, answer:
+
+- is Hermes native capability available?
+- is factory code duplicating Hermes?
+- can this become a Hermes adapter call, validator or contract instead of a
+  parallel runtime behavior?
+
+F3. Convert duplication into Hermes-native use where safe, with tests.
+
+### Phase G: Validation Battery
+
+Required before claiming improvement:
+
+```bash
+python scripts/swiss_watch_audit.py --out .tmp/swiss-watch-audit.json --markdown .tmp/swiss-watch-audit.md
+python scripts/factoryctl.py doctor
+python scripts/factoryctl.py run minimal
+python scripts/validate_document_governance.py
+python scripts/generate_factory_reference_docs.py --check
+python scripts/validate_public_json_artifacts.py
+python scripts/validate_worker_profiles.py
+python scripts/validate_promise_implementation_map.py
+python scripts/factoryctl.py validate-v2-runtime-contracts
+python scripts/factoryctl.py validate-agent-skill-boundaries
+python scripts/factoryctl.py validate-reference-superiority
+python scripts/public_safety_scan.py
+python scripts/secret_safety_scan.py
+python -m unittest discover -s tests -q
+```
+
+If a validation is intentionally blocked by local runtime state, the blocker must
+be classified and either fixed or documented as non-public local state with a
+regression preventing false release failures.
+
+## First Success Criteria
+
+The first complete reliability pass is not done until:
+
+- current main has no unexplained test failure.
+- local public/secret scans are meaningful and not polluted by private transient
+  workspaces.
+- at least one operator-experience regression catches a previously plausible bad
+  UX path.
+- at least one worker quality-floor regression rejects shallow output.
+- the gear matrix exists and points to real contracts/tests, not prose-only
+  promises.
+- the plan remains Hermes-native: no new mini-Hermes runtime code is introduced.

--- a/docs/operations/validation-and-release.md
+++ b/docs/operations/validation-and-release.md
@@ -10,6 +10,7 @@ Use this before editing cards, docs or examples:
 ```bash
 factoryctl doctor
 factoryctl run minimal
+python scripts/swiss_watch_audit.py --out .tmp/swiss-watch-audit.json --markdown .tmp/swiss-watch-audit.md
 python -m unittest discover -s tests
 python scripts/validate_document_governance.py
 python scripts/generate_factory_reference_docs.py --check
@@ -148,6 +149,7 @@ For a stronger local pass:
 ```bash
 factoryctl doctor
 factoryctl run minimal
+python scripts/swiss_watch_audit.py --out .tmp/swiss-watch-audit.json --markdown .tmp/swiss-watch-audit.md
 python scripts/factory_battery.py
 python scripts/validate_document_governance.py
 python scripts/generate_factory_reference_docs.py --check

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,8 @@ nav:
       - Public Visual Surfaces: visuals/README.md
   - Maintainer Internals:
       - Repo Surface: maintenance/repo-surface.md
+      - Swiss Watch Reliability Program: maintenance/swiss-watch-reliability-program.md
+      - Swiss Watch Gear Matrix: maintenance/swiss-watch-gear-matrix.md
       - Factory Learning OS: maintenance/factory-learning-skill-evolution-os.md
       - Hermes Learn Integration: maintenance/hermes-learn-integration.md
       - Self Improvement Loop: maintenance/self-improvement-loop.md

--- a/schemas/worker-result.schema.json
+++ b/schemas/worker-result.schema.json
@@ -262,6 +262,24 @@
     "reusable_for_product": {
       "type": "boolean"
     },
+    "quality_floor": {
+      "type": "object",
+      "description": "Worker-specific quality floor proof for real reusable PASS results that must not be shallow or generic.",
+      "properties": {
+        "result": { "enum": ["PASS", "FAIL", "BLOCKED"] },
+        "anti_generic_checked": { "type": "boolean" },
+        "source_traceability_checked": { "type": "boolean" },
+        "requirement_graph_checked": { "type": "boolean" },
+        "operator_readability_checked": { "type": "boolean" },
+        "rejects_shallow_output": { "type": "boolean" },
+        "depth_dimensions": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "basis": { "type": "string", "minLength": 12 }
+      },
+      "additionalProperties": true
+    },
     "async_subagent": {
       "type": "object",
       "required": [

--- a/scripts/factoryctl.py
+++ b/scripts/factoryctl.py
@@ -17694,6 +17694,56 @@ def validate_worker_result_record(
     errors.extend(_record_specific_errors(data, evidence_kind))
     if record_type == "product_face_result" and card is not None:
         errors.extend(validate_product_face_result_against_card(data, card))
+    errors.extend(worker_quality_floor_errors(data, evidence_kind=evidence_kind))
+    return errors
+
+
+WORKER_QUALITY_FLOOR_REQUIRED_DIMENSIONS = {
+    "product_sot_result": {
+        "source_traceability",
+        "scope_boundaries",
+        "requirement_graph",
+        "risks",
+        "operations",
+        "metrics",
+        "open_decisions",
+    }
+}
+
+
+def worker_quality_floor_errors(data: dict[str, Any], *, evidence_kind: str) -> list[str]:
+    record_type = str(data.get("record_type") or "").strip()
+    if record_type not in WORKER_QUALITY_FLOOR_REQUIRED_DIMENSIONS:
+        return []
+    if str(data.get("result") or "").strip() != "PASS":
+        return []
+    if evidence_kind != "real" or data.get("reusable_for_product") is not True:
+        return []
+
+    errors: list[str] = []
+    floor = data.get("quality_floor")
+    if not isinstance(floor, dict):
+        return [f"{record_type} reusable PASS requires quality_floor"]
+    if str(floor.get("result") or "").strip() != "PASS":
+        errors.append("quality_floor.result must be PASS")
+    for field in (
+        "anti_generic_checked",
+        "source_traceability_checked",
+        "requirement_graph_checked",
+        "operator_readability_checked",
+        "rejects_shallow_output",
+    ):
+        if floor.get(field) is not True:
+            errors.append(f"quality_floor.{field} must be true")
+    dimensions = set(string_list(floor.get("depth_dimensions")))
+    missing_dimensions = sorted(WORKER_QUALITY_FLOOR_REQUIRED_DIMENSIONS[record_type] - dimensions)
+    if missing_dimensions:
+        errors.append("quality_floor.depth_dimensions missing: " + ", ".join(missing_dimensions))
+    if not _non_empty_text(floor.get("basis")):
+        errors.append("quality_floor.basis is required")
+    summary_words = str(data.get("findings_summary") or "").split()
+    if len(summary_words) < 12:
+        errors.append(f"{record_type}.findings_summary must describe product-specific evidence, not a shallow completion note")
     return errors
 
 
@@ -20557,7 +20607,7 @@ def _task_is_safe_canonical_frontier_resume_target(task: dict[str, Any], receipt
             '"human_gate_required": true',
             "human_gate_required=true",
             "needs_input",
-            "awaiting felipe",
+            "awaiting operator",
             "owner decision required",
             "decision package delivered",
         )

--- a/scripts/public_safety_scan.py
+++ b/scripts/public_safety_scan.py
@@ -26,7 +26,19 @@ from public_refs import (  # noqa: E402
 )
 
 SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico", ".pdf", ".tgz", ".zip"}
-SKIP_PARTS = {".git", ".tmp", ".pytest_cache", ".venv", "__pycache__", "build", "dist", "node_modules", "site", "venv"}
+SKIP_PARTS = {
+    ".git",
+    ".tmp",
+    ".pytest_cache",
+    ".venv",
+    ".worktrees",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "site",
+    "venv",
+}
 SKIP_PART_SUFFIXES = (".egg-info",)
 PUBLIC_REPO_URL = "https://github.com/felipegermano17/overkill-factory"
 

--- a/scripts/swiss_watch_audit.py
+++ b/scripts/swiss_watch_audit.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Swiss Watch reliability audit for Overkill Factory.
+
+This script is intentionally a validator, not a runtime. It reads the public
+Factory V2 contracts and checks that the factory remains Hermes-native instead
+of becoming a mini-Hermes sidecar runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import factoryctl  # noqa: E402
+
+PROGRAM_REF = "docs/maintenance/swiss-watch-reliability-program.md"
+GEAR_MATRIX_REF = "docs/maintenance/swiss-watch-gear-matrix.md"
+REQUIRED_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+MANAGER_WORKERS = {"overkill-factory-gerente"}
+DIMENSIONS = [
+    "gear_contract",
+    "hermes_native_authority",
+    "autonomy_no_idle",
+    "operator_experience",
+    "worker_quality_floor",
+    "block_classification",
+    "security_boundary",
+    "performance_loop_control",
+]
+
+
+def _items(value: Any) -> list[str]:
+    return factoryctl.string_list(value)
+
+
+def _worker_ids(registry: dict[str, Any]) -> set[str]:
+    workers = registry.get("workers") if isinstance(registry.get("workers"), list) else []
+    return {
+        str(worker.get("worker_id") or "").strip()
+        for worker in workers
+        if isinstance(worker, dict) and str(worker.get("worker_id") or "").strip()
+    }
+
+
+def check(name: str, passed: bool, evidence_refs: list[str], remediation: str = "") -> dict[str, Any]:
+    return {
+        "check": name,
+        "result": "PASS" if passed else "FAIL",
+        "evidence_refs": evidence_refs,
+        "remediation": remediation,
+    }
+
+
+def score(checks: list[dict[str, Any]]) -> int:
+    if not checks:
+        return 0
+    return round((sum(1 for item in checks if item.get("result") == "PASS") / len(checks)) * 100)
+
+
+def build_audit(
+    compiled_plan: dict[str, Any],
+    typed_block_policy: dict[str, Any],
+    worker_registry: dict[str, Any],
+    *,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    created = created_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    plan_errors = factoryctl.validate_factory_workflow_compiled_plan(compiled_plan)
+    worker_ids = _worker_ids(worker_registry)
+    phases = compiled_plan.get("phases") if isinstance(compiled_plan.get("phases"), list) else []
+    terminal_phase_id = str(phases[-1].get("phase_id") if phases and isinstance(phases[-1], dict) else "")
+    native_kinds = set(_items(typed_block_policy.get("native_block_kinds")))
+    policy_authority = str(typed_block_policy.get("runtime_authority") or "").strip()
+    policy_rules = typed_block_policy.get("kind_rules") if isinstance(typed_block_policy.get("kind_rules"), dict) else {}
+    loop_policy = typed_block_policy.get("same_cause_loop_policy") if isinstance(typed_block_policy.get("same_cause_loop_policy"), dict) else {}
+
+    gear_assessments: list[dict[str, Any]] = []
+    for phase in phases:
+        if not isinstance(phase, dict):
+            continue
+        phase_id = str(phase.get("phase_id") or "").strip()
+        required_workers = set(_items(phase.get("required_workers")))
+        missing_workers = sorted(required_workers - worker_ids - MANAGER_WORKERS)
+        checks = [
+            check(
+                "input_output_contract",
+                bool(_items(phase.get("required_artifacts"))) and bool(_items(phase.get("required_gates"))),
+                ["templates/factory-workflow-compiled-plan.json", GEAR_MATRIX_REF],
+                "Add required artifacts and gates to the compiled phase contract.",
+            ),
+            check(
+                "worker_authority_contract",
+                bool(required_workers) and not missing_workers,
+                ["agents/worker-registry.public.json", "agents/hermes-profile-bindings.public.json"],
+                "Register missing workers or explicitly classify manager-only operators: " + ", ".join(missing_workers),
+            ),
+            check(
+                "hermes_native_next_action",
+                "advance_phase" in _items(phase.get("allowed_commands")),
+                ["docs/architecture/factory-v2-control-plane.md", "templates/factory-workflow-compiled-plan.json"],
+                "Route the phase through Factory V2 commands/events instead of agent prose.",
+            ),
+            check(
+                "no_idle_operator_ux_guard",
+                bool(_items(phase.get("blocked_actions"))),
+                [PROGRAM_REF, "templates/hermes-typed-block-policy.json"],
+                "Declare blocked actions that prevent idle loops, false human pages or unsafe shortcuts.",
+            ),
+            check(
+                "handoff_chain",
+                bool(phase.get("next_phase_id")) or phase_id == terminal_phase_id,
+                ["docs/factory-workflow.catalog.json", "templates/factory-workflow-compiled-plan.json"],
+                "Declare next_phase_id or make the phase terminal.",
+            ),
+        ]
+        gear_assessments.append(
+            {
+                "phase_id": phase_id,
+                "phase_name": str(phase.get("phase_name") or "").strip(),
+                "score": score(checks),
+                "result": "PASS" if all(item["result"] == "PASS" for item in checks) else "FAIL",
+                "checks": checks,
+                "missing_worker_ids": missing_workers,
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+            }
+        )
+
+    dimensions = [
+        check(
+            "gear_contract",
+            not plan_errors and bool(gear_assessments) and all(item["score"] >= 80 for item in gear_assessments),
+            ["templates/factory-workflow-compiled-plan.json", GEAR_MATRIX_REF],
+            "; ".join(plan_errors) if plan_errors else "Fix phase gear checks below 80.",
+        ),
+        check(
+            "hermes_native_authority",
+            policy_authority == "hermes_kanban",
+            ["templates/hermes-typed-block-policy.json", "docs/architecture/factory-v2-control-plane.md"],
+            "Typed block policy must keep runtime_authority=hermes_kanban.",
+        ),
+        check(
+            "autonomy_no_idle",
+            "dependency" in native_kinds and bool(policy_rules.get("dependency", {}).get("auto_resume_expected")),
+            ["templates/hermes-typed-block-policy.json"],
+            "Dependency blocks must auto-resume through Hermes state, not operator nudges.",
+        ),
+        check(
+            "operator_experience",
+            bool(policy_rules.get("needs_input", {}).get("decision_package_required"))
+            and bool(policy_rules.get("needs_input", {}).get("delivery_receipt_required")),
+            ["templates/hermes-typed-block-policy.json", "templates/operator-delivery-receipt.json"],
+            "Human pages must include a decision package and delivery receipt.",
+        ),
+        check(
+            "worker_quality_floor",
+            "product_sot_result" in factoryctl.WORKER_QUALITY_FLOOR_REQUIRED_DIMENSIONS,
+            ["schemas/worker-result.schema.json", "scripts/factoryctl.py"],
+            "Real reusable Product SOT PASS must have a quality_floor.",
+        ),
+        check(
+            "block_classification",
+            REQUIRED_BLOCK_KINDS.issubset(native_kinds),
+            ["templates/hermes-typed-block-policy.json"],
+            "Typed block policy must cover dependency, needs_input, capability and transient.",
+        ),
+        check(
+            "security_boundary",
+            any("security" in worker for worker in worker_ids) and any("supply-chain" in worker for worker in worker_ids),
+            ["agents/worker-registry.public.json", "scripts/public_safety_scan.py", "scripts/secret_safety_scan.py"],
+            "Security and supply-chain workers must remain registered and scans must stay green.",
+        ),
+        check(
+            "performance_loop_control",
+            bool(loop_policy) and int(loop_policy.get("recurrence_limit") or 0) > 0 and bool(loop_policy.get("escalation_event")),
+            ["templates/hermes-typed-block-policy.json"],
+            "Same-cause loop handling must have a recurrence limit and escalation event.",
+        ),
+    ]
+    result = "PASS" if all(item["result"] == "PASS" for item in dimensions) and all(item["result"] == "PASS" for item in gear_assessments) else "FAIL"
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/swiss-watch-audit.schema.json",
+        "record_type": "swiss_watch_reliability_audit",
+        "created_at": created,
+        "result": result,
+        "score": score(dimensions),
+        "rule_zero": {
+            "factory_must_not_become_mini_hermes": True,
+            "prefer_hermes_native_primitives": ["kanban", "typed_blocks", "dependencies", "dispatch", "runtime_state"],
+            "factory_native_code_only_when_hermes_lacks_primitive": True,
+        },
+        "dimensions": dimensions,
+        "gear_assessments": gear_assessments,
+        "summary": {
+            "phase_count": len(gear_assessments),
+            "failing_phase_count": sum(1 for item in gear_assessments if item["result"] != "PASS"),
+            "native_block_kinds": sorted(native_kinds),
+            "runtime_authority": policy_authority,
+        },
+    }
+
+
+def validate_audit(audit: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if audit.get("record_type") != "swiss_watch_reliability_audit":
+        errors.append("record_type must be swiss_watch_reliability_audit")
+    if audit.get("result") not in {"PASS", "FAIL"}:
+        errors.append("result must be PASS or FAIL")
+    rule_zero = audit.get("rule_zero") if isinstance(audit.get("rule_zero"), dict) else {}
+    if rule_zero.get("factory_must_not_become_mini_hermes") is not True:
+        errors.append("rule_zero.factory_must_not_become_mini_hermes must be true")
+    if "kanban" not in _items(rule_zero.get("prefer_hermes_native_primitives")):
+        errors.append("rule_zero.prefer_hermes_native_primitives must include kanban")
+    dimensions = audit.get("dimensions") if isinstance(audit.get("dimensions"), list) else []
+    present = {str(item.get("check") or "") for item in dimensions if isinstance(item, dict)}
+    for dimension in DIMENSIONS:
+        if dimension not in present:
+            errors.append(f"dimensions missing {dimension}")
+    gears = audit.get("gear_assessments") if isinstance(audit.get("gear_assessments"), list) else []
+    if not gears:
+        errors.append("gear_assessments must be non-empty")
+    for index, gear in enumerate(gears):
+        if not isinstance(gear, dict):
+            errors.append(f"gear_assessments[{index}] must be an object")
+            continue
+        if gear.get("runtime_authority") != "hermes_kanban":
+            errors.append(f"gear_assessments[{index}].runtime_authority must be hermes_kanban")
+        if gear.get("local_state_authority") is not False:
+            errors.append(f"gear_assessments[{index}].local_state_authority must be false")
+    if audit.get("result") == "PASS":
+        bad_dimensions = [str(item.get("check")) for item in dimensions if isinstance(item, dict) and item.get("result") != "PASS"]
+        bad_gears = [str(item.get("phase_id")) for item in gears if isinstance(item, dict) and item.get("result") != "PASS"]
+        if bad_dimensions:
+            errors.append("PASS audit cannot contain failing dimensions: " + ", ".join(bad_dimensions))
+        if bad_gears:
+            errors.append("PASS audit cannot contain failing gears: " + ", ".join(bad_gears))
+    return errors
+
+
+def markdown(audit: dict[str, Any]) -> str:
+    lines = [
+        "# Swiss Watch Reliability Audit",
+        "",
+        f"Result: `{audit.get('result')}`",
+        f"Score: `{audit.get('score')}`",
+        f"Created at: `{audit.get('created_at')}`",
+        "",
+        "## Rule Zero",
+        "",
+        "The factory must not become a mini-Hermes. It uses Hermes-native Kanban, typed blocks, dependencies, dispatch and runtime state first; factory-native code exists only where Hermes lacks a primitive.",
+        "",
+        "## Dimensions",
+        "",
+    ]
+    for item in audit.get("dimensions", []):
+        if isinstance(item, dict):
+            lines.append(f"- `{item.get('result')}` {item.get('check')}: {', '.join(_items(item.get('evidence_refs')))}")
+    lines.extend(["", "## Gear Assessments", ""])
+    for gear in audit.get("gear_assessments", []):
+        if isinstance(gear, dict):
+            lines.append(f"- `{gear.get('result')}` {gear.get('phase_id')} {gear.get('phase_name')} - score `{gear.get('score')}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build the Swiss Watch reliability scorecard from Hermes-native factory contracts.")
+    parser.add_argument("--compiled-plan", type=Path, default=ROOT / "templates" / "factory-workflow-compiled-plan.json")
+    parser.add_argument("--typed-block-policy", type=Path, default=ROOT / "templates" / "hermes-typed-block-policy.json")
+    parser.add_argument("--worker-registry", type=Path, default=ROOT / "agents" / "worker-registry.public.json")
+    parser.add_argument("--created-at")
+    parser.add_argument("--out", type=Path, default=ROOT / ".tmp" / "swiss-watch-audit.json")
+    parser.add_argument("--markdown", type=Path)
+    args = parser.parse_args(argv)
+
+    audit = build_audit(
+        factoryctl.load_json_like(args.compiled_plan),
+        factoryctl.load_json_like(args.typed_block_policy),
+        factoryctl.load_json_like(args.worker_registry),
+        created_at=args.created_at,
+    )
+    errors = validate_audit(audit)
+    factoryctl.write_json(args.out, audit)
+    if args.markdown:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(markdown(audit), encoding="utf-8")
+        print(f"Wrote {factoryctl.public_path_ref(args.markdown)}")
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0 if audit["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_factory_board_reconciler.py
+++ b/tests/test_factory_board_reconciler.py
@@ -285,7 +285,7 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertFalse(plan["human_gate_required"])
 
     def test_reconciled_blocked_frontier_resumes_existing_task_instead_of_repairing_contract(self) -> None:
-        frontier_task_id = "t_f8canonical"
+        frontier_task_id = "fixture-frontier-canonical"
         snapshot = {
             "rows": {
                 "blocked": [
@@ -316,7 +316,7 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
                         ],
                     },
                     {
-                        "id": "t_oldf7",
+                        "id": "fixture-old-f7",
                         "status": "blocked",
                         "title": "F7 - superseded stale branch",
                         "current_step_key": "F7-method-contract",
@@ -337,7 +337,7 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
                                     "canonical_frontier_status": (
                                         "blocked_until_reducer_adapter_authorizes_resume_or_rerun"
                                     ),
-                                    "stale_non_consumable_tasks": ["t_oldf7"],
+                                    "stale_non_consumable_tasks": ["fixture-old-f7"],
                                 }
                             }
                         ),

--- a/tests/test_factory_concierge_discord_automation.py
+++ b/tests/test_factory_concierge_discord_automation.py
@@ -401,7 +401,10 @@ class FactoryConciergeDiscordAutomationTest(unittest.TestCase):
                 timeout=1.0,
                 apply=True,
             )
-            with patch.dict(automation.os.environ, {"DISCORD_BOT_TOKEN": "test-token"}), patch.object(
+            with patch.dict(
+                automation.os.environ,
+                {"DISCORD_BOT_TOKEN": "test-token", "DISCORD_GUILD_ID": ""},
+            ), patch.object(
                 automation.bridge, "DiscordApi", return_value=client
             ):
                 receipt = automation.run_automation(args)

--- a/tests/test_factoryctl.py
+++ b/tests/test_factoryctl.py
@@ -1301,6 +1301,57 @@ class FactoryCtlTest(unittest.TestCase):
             ),
         )
 
+    def test_real_product_sot_worker_result_rejects_shallow_pass_without_quality_floor(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        result = worker_result("product_sot_result", source_card=card)
+        result["evidence_kind"] = "real"
+        result["reusable_for_product"] = True
+        result["findings_summary"] = "done"
+        result["next_action"] = "continue"
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="product_sot_result",
+            card=card,
+        )
+
+        self.assertIn("product_sot_result reusable PASS requires quality_floor", errors)
+
+    def test_real_product_sot_worker_result_accepts_quality_floor_pass(self) -> None:
+        card = factoryctl.load_json_like(ROOT / "templates" / "vfinal-factory-card.json")
+        result = worker_result("product_sot_result", source_card=card)
+        result["evidence_kind"] = "real"
+        result["reusable_for_product"] = True
+        result["findings_summary"] = "Product SOT covers source traceability, requirement graph, scope boundaries, risks, operations, metrics and open decisions with product-specific evidence."
+        result["next_action"] = "Route the approved Product SOT into full-scope coverage and Method Contract checks."
+        result["quality_floor"] = {
+            "result": "PASS",
+            "anti_generic_checked": True,
+            "source_traceability_checked": True,
+            "requirement_graph_checked": True,
+            "operator_readability_checked": True,
+            "depth_dimensions": [
+                "source_traceability",
+                "scope_boundaries",
+                "requirement_graph",
+                "risks",
+                "operations",
+                "metrics",
+                "open_decisions",
+            ],
+            "rejects_shallow_output": True,
+            "basis": "Quality floor confirms this Product SOT is product-specific and not a generic summary.",
+        }
+
+        errors = factoryctl.validate_worker_result_record(
+            result,
+            expected_field="product_sot_result",
+            card=card,
+        )
+
+        self.assertNotIn("product_sot_result reusable PASS requires quality_floor", errors)
+        self.assertFalse([error for error in errors if error.startswith("quality_floor")], errors)
+
     def test_worker_result_schema_declares_sdlc_feedback_loop_ref(self) -> None:
         schema = json.loads((ROOT / "schemas" / "worker-result.schema.json").read_text(encoding="utf-8"))
 

--- a/tests/test_hermes_live_kanban_adapter.py
+++ b/tests/test_hermes_live_kanban_adapter.py
@@ -4448,7 +4448,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
 
     def test_no_idle_resumes_reconciled_canonical_frontier_without_creating_parallel_card(self) -> None:
         fake = FakeHermes()
-        frontier_task_id = "t_f8canonical"
+        frontier_task_id = "fixture-frontier-canonical"
         fake.tasks[frontier_task_id] = {
             "id": frontier_task_id,
             "status": "blocked",
@@ -4476,8 +4476,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             ],
             "events": [{"type": "blocked", "payload": {"kind": "transient", "reason": "adapter authorizes resume"}}],
         }
-        fake.tasks["t_oldf7"] = {
-            "id": "t_oldf7",
+        fake.tasks["fixture-old-f7"] = {
+            "id": "fixture-old-f7",
             "status": "blocked",
             "title": "F7 - superseded stale branch",
             "current_step_key": "F7-method-contract",
@@ -4495,7 +4495,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                         "frontier_reconciliation_result": "selected_single_canonical_frontier",
                         "canonical_frontier_task_id": frontier_task_id,
                         "canonical_frontier_status": "blocked_until_reducer_adapter_authorizes_resume_or_rerun",
-                        "stale_non_consumable_tasks": ["t_oldf7"],
+                        "stale_non_consumable_tasks": ["fixture-old-f7"],
                     }
                 }
             ),

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -62,7 +62,8 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn("Hermes Kanban remains the source of truth", readme)
         self.assertIn("Hermes and Receipt Five remain the source of truth", readme)
         self.assertIn("Overkill Factory is a production line for projects built by agents.", readme)
-        self.assertIn('the factory is not "a smart chat."', readme)
+        self.assertIn('the factory is not "a smart chat" and not a', readme)
+        self.assertIn("mini-Hermes", readme)
         self.assertIn(project_release_tag(), readme)
         self.assertIn("Factory V2", readme)
         self.assertIn("docs/architecture/factory-v2-control-plane.md", readme)
@@ -131,7 +132,8 @@ class OpenSourceDocsTest(unittest.TestCase):
             "[English](README.md)",
             "Mapa público:",
             "A Overkill Factory é uma linha de produção para projetos feitos por agentes.",
-            'O ponto mais importante: a fábrica não é "um chat inteligente".',
+            'O ponto mais importante: a fábrica não é "um chat inteligente" e não é um',
+            "mini-Hermes",
             "linha de produção em etapas para trabalho de produto controlado",
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",

--- a/tests/test_public_safety_scan.py
+++ b/tests/test_public_safety_scan.py
@@ -132,6 +132,21 @@ class PublicSafetyScanTest(unittest.TestCase):
         self.assertEqual(len(findings), 2)
         self.assertTrue(all(finding.startswith("docs/") for finding in findings), findings)
 
+    def test_worktree_scan_skips_local_worktree_scratch_space(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir()
+            (root / ".worktrees" / "task" / "factory-artifacts").mkdir(parents=True)
+            (root / "docs" / "public.md").write_text("public factory docs", encoding="utf-8")
+            (root / ".worktrees" / "task" / "factory-artifacts" / "private.md").write_text(
+                PRIVATE_MARKER,
+                encoding="utf-8",
+            )
+
+            findings = public_safety_scan.scan_worktree(root)
+
+        self.assertEqual(findings, [])
+
     def test_worktree_scan_tolerates_missing_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             missing = Path(tmp) / "already-gone"

--- a/tests/test_swiss_watch_audit.py
+++ b/tests/test_swiss_watch_audit.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("swiss_watch_audit", ROOT / "scripts" / "swiss_watch_audit.py")
+assert SPEC is not None
+swiss_watch_audit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(swiss_watch_audit)
+
+
+class SwissWatchAuditTests(unittest.TestCase):
+    def test_audit_materializes_reliability_scorecard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "swiss-watch-audit.json"
+            md = Path(tmp) / "swiss-watch-audit.md"
+            self.assertEqual(
+                swiss_watch_audit.main(
+                    [
+                        "--created-at",
+                        "2026-06-28T00:00:00+00:00",
+                        "--out",
+                        str(out),
+                        "--markdown",
+                        str(md),
+                    ]
+                ),
+                0,
+            )
+            audit = json.loads(out.read_text(encoding="utf-8"))
+            markdown_text = md.read_text(encoding="utf-8")
+
+        self.assertEqual(audit["record_type"], "swiss_watch_reliability_audit")
+        self.assertEqual(audit["result"], "PASS")
+        self.assertTrue(audit["rule_zero"]["factory_must_not_become_mini_hermes"])
+        self.assertIn("kanban", audit["rule_zero"]["prefer_hermes_native_primitives"])
+        self.assertEqual(audit["summary"]["runtime_authority"], "hermes_kanban")
+        self.assertEqual(audit["summary"]["failing_phase_count"], 0)
+        self.assertIn("mini-Hermes", markdown_text)
+
+    def test_audit_rejects_missing_rule_zero(self) -> None:
+        audit = swiss_watch_audit.build_audit(
+            swiss_watch_audit.factoryctl.load_json_like(ROOT / "templates" / "factory-workflow-compiled-plan.json"),
+            swiss_watch_audit.factoryctl.load_json_like(ROOT / "templates" / "hermes-typed-block-policy.json"),
+            swiss_watch_audit.factoryctl.load_json_like(ROOT / "agents" / "worker-registry.public.json"),
+            created_at="2026-06-28T00:00:00+00:00",
+        )
+        audit["rule_zero"]["factory_must_not_become_mini_hermes"] = False
+
+        errors = swiss_watch_audit.validate_audit(audit)
+
+        self.assertIn("rule_zero.factory_must_not_become_mini_hermes must be true", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the Swiss Watch reliability program as executable repository machinery instead of documentation-only intent.

This PR adds:
- executable Swiss Watch audit script and markdown/json scorecard output
- public maintenance docs for the reliability program and gear matrix
- worker result quality-floor checks for reusable Product SOT PASS results
- public-safety regressions for local scratch/worktree space
- no-idle/frontier fixture cleanup so public tests do not carry private markers
- README updates that clarify the factory is not a mini-Hermes and keeps Hermes-native runtime authority

Note: the CI workflow update was intentionally left out of this branch because the available GitHub token does not have the `workflow` scope. The audit is still documented in the release validation path and can be wired into GitHub Actions with a workflow-scoped token later.

## Validation

Ran locally on branch `swiss-watch-reliability-program-public`:

- `python3 -m unittest discover -s tests -q` — 1130 tests OK
- `python3 scripts/factoryctl.py doctor` — PASS
- `python3 scripts/factoryctl.py run minimal` — PASS
- `python3 scripts/swiss_watch_audit.py --out .tmp/swiss-watch-audit.json --markdown .tmp/swiss-watch-audit.md` — OK
- `python3 scripts/validate_document_governance.py` — OK
- `python3 scripts/generate_factory_reference_docs.py --check` — OK
- `python3 scripts/validate_public_json_artifacts.py` — OK
- `python3 scripts/validate_promise_implementation_map.py` — OK
- `python3 scripts/validate_public_surface_sync.py` — OK
- `python3 scripts/validate_worker_profiles.py` — OK
- `python3 scripts/factoryctl.py validate-v2-runtime-contracts` — OK
- `python3 scripts/factoryctl.py validate-agent-skill-boundaries` — OK
- `python3 scripts/factoryctl.py validate-reference-superiority` — OK
- `python3 scripts/public_safety_scan.py` — OK
- `python3 scripts/secret_safety_scan.py` — OK
- `python3 scripts/supply_chain_proof.py --check --no-write` — PASS
- `.tmp/docs-venv/bin/python -m mkdocs build --strict --site-dir .tmp/mkdocs-site-swiss-watch` — OK

## Public boundary

No secrets or private runtime evidence are included. Generated `.tmp/` artifacts remain local and ignored.
