### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ public releases.
 
 ## Unreleased
 
+## 3.0.0 - 2026-06-29
+
+- Promote the public kernel to the V3 release line after the V3 master update
+  plan landed in PR #534.
+- Add executable V3 readiness guards for the master update plan, Hermes-first
+  runtime truth spine, canonical frontier/no-idle autonomy, gerente/agent
+  freshness and V3 release readiness.
+- Add a simplified public map at `docs/reference/public-map.md` so external
+  operators can understand the repository through a clear first-value path
+  instead of the older complex visual map.
+- Make the central boundaries executable: Hermes/Kanban own runtime state,
+  queues, dispatch, task lifecycle and boards; Overkill Factory owns method,
+  gates, rules, schemas, audits, validations and release checks.
+- Prevent the historical stale-gerente failure mode by requiring manager and
+  affected agent skills, profiles, configs and bindings to stay current with
+  factory contracts before E2E or release.
+- Consolidate waves 4-9 into a V3 release readiness policy covering
+  artifact-first human gates, Receipt Five anti-overclaim, Product SOT/method/
+  architecture boundaries, capability/security/release authority, Solana AI Kit
+  routing and the Factory Perfect Run bar.
+
 ## 2.0.15 - 2026-06-28
 
 - Add a schema-backed Decomposition Coverage Review between Product Creation

--- a/README.md
+++ b/README.md
@@ -313,35 +313,36 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 
 ## Current Release State
 
-Factory V2 is the current public kernel release line. The latest public release
-is v2.0.15.
+Factory V3 is the current public kernel release line. The latest public release
+is v3.0.0.
 
-V2 means the public kernel has executable contracts for the factory line:
+V3 means the public kernel has executable contracts for the factory line plus
+release-grade guards for the operating model itself:
 
 - deterministic phase graph, compiled workflow, command inbox, event log,
   decision outbox and promotion packets;
-- Hermes/Kanban as the real runtime source of truth for cards, workers and
-  transitions;
-- worker authority contracts: agents produce evidence, but they do not choose
-  the route, phase, human gate or promotion path;
+- Hermes/Kanban as the real runtime source of truth for cards, workers,
+  dependencies, typed blocks, dispatch and task lifecycle;
+- no mini-Hermes: the factory owns method, gates, rules, schemas, audits,
+  validations and release checks, not runtime queues or schedulers;
+- runtime truth spine: worker packet, dispatch request, running task and
+  consumable worker result are distinct states;
+- canonical frontier/no-idle guard: repairable gaps route to repair before
+  human input, and no-idle remains recovery/audit, not route authority;
+- gerente and agent freshness guard: factory changes must update manager and
+  affected agent skills, profiles, configs and bindings before E2E or release;
 - Product Experience control plane: product-facing work needs Product
   Experience Plan, Product Face Packet, professional design process, project
   design system, `DESIGN.md` and Product Face Result proof;
-- capability acquisition runtime lane: when a specialist is missing, the
-  factory searches skill providers, capability packs and reference sources,
-  writes a `capability_acquisition_run` receipt, and blocks only after that
-  search is complete;
-- Hermes typed block policy: dependency waits do not page the operator,
-  same-cause block loops become triage, capability blocks require acquisition,
-  and transient holds route repair/retry instead of generic human approval;
-- Solana AI Kit first-class routing for Solana/on-chain work, with usage
-  receipts, signer boundaries and onchain work packages;
-- strict human-gate packets: the operator receives material first, then the
-  decision question;
-- readiness claims that separate public kernel readiness from runtime,
-  product-run and production proof.
+- capability acquisition and security/release authority: missing specialists
+  route through capability acquisition, Solana/on-chain work requires Solana AI
+  Kit routing, and production/mainnet/funds/secrets/release decisions require
+  explicit authority;
+- artifact-first human gates and Receipt Five anti-overclaim: the operator gets
+  material before the decision question, and `done` requires evidence readback;
+- simplified public map and first-value path for external operators.
 
-That claim is intentionally scoped. Factory V2 does not mean a specific product
+That claim is intentionally scoped. Factory V3 does not mean a specific product
 is production-ready. A product built by the factory still needs its own source
 material, Product SOT, worker execution, evidence, reviews, human gates and
 production readiness proof.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -316,34 +316,36 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 
 ## Estado Atual De Release
 
-Factory V2 é a linha atual de release do kernel público. A release pública mais
-recente é v2.0.15.
+Factory V3 é a linha atual de release do kernel público. A release pública mais
+recente é v3.0.0.
 
-V2 significa que o kernel público tem contratos executáveis para a linha da
-fábrica:
+V3 significa que o kernel público tem contratos executáveis para a linha da
+fábrica e também guards de release para o próprio modelo operacional:
 
 - phase graph determinístico, workflow compilado, command inbox, event log,
   decision outbox e promotion packets;
-- Hermes/Kanban como fonte de verdade real para cards, workers e transições;
-- contratos de autoridade dos workers: agentes produzem evidência, mas não
-  escolhem rota, fase, human gate ou promoção;
+- Hermes/Kanban como fonte de verdade real para cards, workers, dependências,
+  typed blocks, dispatch e ciclo de vida das tarefas;
+- sem mini-Hermes: a fábrica possui método, gates, regras, schemas, auditorias,
+  validações e checks de release, não filas, schedulers ou runtime paralelo;
+- runtime truth spine: worker packet, pedido de dispatch, tarefa rodando e
+  resultado consumível do worker são estados diferentes;
+- canonical frontier/no-idle: gaps reparáveis vão para repair antes de input
+  humano, e no-idle continua sendo recovery/auditoria, não autoridade de rota;
+- freshness de gerente e agentes: mudanças da fábrica precisam atualizar skills,
+  profiles, configs e bindings do gerente e dos agentes afetados antes de E2E
+  ou release;
 - Product Experience control plane: trabalho com interface precisa de Product
   Experience Plan, Product Face Packet, processo profissional de design, design
   system do projeto, `DESIGN.md` e Product Face Result;
-- lane runtime de aquisição de capability: quando falta especialista, a fábrica
-  pesquisa skill providers, capability packs e referências, escreve um receipt
-  `capability_acquisition_run` e só bloqueia depois da busca completa;
-- política Hermes de bloqueios tipados: espera de dependência não aciona o
-  operador, loops de bloqueio viram triagem, capability exige aquisição e holds
-  transitórios viram reparo/retry em vez de aprovação humana genérica;
-- Solana AI Kit como rota de primeira classe para Solana/on-chain, com usage
-  receipt, signer boundary e onchain work package;
-- human gates estritos: o operador recebe o material antes da pergunta de
-  decisão;
-- readiness claims que separam kernel público, runtime, run de produto e prova
-  de produção.
+- capability acquisition e autoridade de security/release: especialistas
+  faltantes passam por acquisition, Solana/on-chain exige Solana AI Kit, e
+  produção/mainnet/funds/secrets/release exigem autoridade explícita;
+- human gates artifact-first e Receipt Five anti-overclaim: o operador recebe o
+  material antes da pergunta, e `done` exige evidência lida de volta;
+- public map simplificado e first-value path para operadores externos.
 
-Esse claim é deliberadamente limitado. Factory V2 não significa que um produto
+Esse claim é deliberadamente limitado. Factory V3 não significa que um produto
 específico está pronto para produção. Um produto criado pela fábrica ainda
 exige fonte real, Product SOT, execução de workers, evidência, revisões, human
 gates e prova própria de production readiness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "2.0.15"
+version = "3.0.0"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_open_source_docs.py
+++ b/tests/test_open_source_docs.py
@@ -65,7 +65,7 @@ class OpenSourceDocsTest(unittest.TestCase):
         self.assertIn('the factory is not "a smart chat" and not a', readme)
         self.assertIn("mini-Hermes", readme)
         self.assertIn(project_release_tag(), readme)
-        self.assertIn("Factory V2", readme)
+        self.assertIn("Factory V3", readme)
         self.assertIn("docs/architecture/factory-v2-control-plane.md", readme)
         self.assertIn("docs/reference/factory-kernel-reference.md", readme)
         self.assertIn("python scripts/generate_factory_reference_docs.py --check", readme)
@@ -138,7 +138,7 @@ class OpenSourceDocsTest(unittest.TestCase):
             "Hermes Kanban continua sendo a fonte de verdade",
             "Hermes e Receipt Five continuam sendo a fonte de verdade",
             project_release_tag(),
-            "Factory V2",
+            "Factory V3",
             "docs/architecture/factory-v2-control-plane.md",
             "docs/reference/factory-kernel-reference.md",
             "python scripts/generate_factory_reference_docs.py --check",


### PR DESCRIPTION
## Summary

Release bookkeeping for Overkill Factory v3.0.0.

This PR does not add new runtime behavior beyond the already-merged V3 kernel work in PR #534. It promotes that merged kernel to an explicit public release line.

Changes:

- bumps package version from 2.0.15 to 3.0.0
- adds CHANGELOG entry for 3.0.0
- updates README and README.pt-BR current release state from Factory V2/v2.0.15 to Factory V3/v3.0.0
- updates open-source docs tests to assert the V3 release language

## Release scope

V3 means the public kernel now has executable guards for:

- Hermes-first/Kanban-first runtime truth
- no mini-Hermes boundary
- canonical frontier/no-idle as audit and recovery, not route authority
- manager/agent freshness before E2E or release
- V3 release readiness across human gates, Receipt Five, method/architecture, security/release authority, Solana AI Kit and public map

This release does not claim that any specific product is production-ready. Product production readiness still requires product-specific source, Product SOT, worker execution, evidence, reviews, human gates and production proof.

## Verification run locally

- python3 -m unittest tests.test_open_source_docs -q
- python3 -m unittest discover -s tests -q
- python3 scripts/factory_master_update_plan_audit.py --out .tmp/factory-master-update-plan-audit.json --markdown .tmp/factory-master-update-plan-audit.md
- python3 scripts/factory_v3_release_readiness_audit.py --out .tmp/factory-v3-release-readiness-audit.json --markdown .tmp/factory-v3-release-readiness-audit.md
- python3 scripts/validate_document_governance.py
- python3 scripts/validate_public_json_artifacts.py
- python3 scripts/validate_public_surface_sync.py
- python3 scripts/generate_factory_reference_docs.py --check
- python3 scripts/public_safety_scan.py
- python3 scripts/secret_safety_scan.py
- python3 scripts/factoryctl.py doctor
- python3 scripts/factoryctl.py run minimal
