### PR TITLE
chore: release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ public releases.
 
 ## Unreleased
 
+## 3.0.1 - 2026-06-29
+
 - Activate the V3 master plan operationally instead of leaving it as release
   bookkeeping: worker profiles, Hermes profile bindings and the worker registry
   now carry `v3.0.0-master-plan-100` activation metadata, required checks,

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V3 is the current public kernel release line. The latest public release
-is v3.0.0.
+is v3.0.1.
 
 V3 means the public kernel has executable contracts for the factory line plus
 release-grade guards for the operating model itself:

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -328,7 +328,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V3 é a linha atual de release do kernel público. A release pública mais
-recente é v3.0.0.
+recente é v3.0.1.
 
 V3 significa que o kernel público tem contratos executáveis para a linha da
 fábrica e também guards de release para o próprio modelo operacional:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "3.0.0"
+version = "3.0.1"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release bookkeeping for Overkill Factory v3.0.1.

This releases the V3 Production Activation work merged in PR #536 so the latest GitHub release points to the factory code that actually contains the master-plan operational activation.

## Changes

- Bump package version to `3.0.1`.
- Move the V3 Production Activation changelog entry under `3.0.1 - 2026-06-29`.
- Update README and README.pt-BR latest public release text to `v3.0.1`.

## Verification run before opening this PR

```bash
python3 -m unittest discover -s tests -q
python3 scripts/generate_factory_reference_docs.py --check
python3 scripts/validate_public_json_artifacts.py
python3 scripts/validate_public_surface_sync.py
python3 scripts/factoryctl.py v3-production-activation-check --live-hermes --live-hermes-out .tmp/factory-hermes-live-smoke-release-3.0.1.json
python3 scripts/public_safety_scan.py
python3 scripts/secret_safety_scan.py
git diff --check
```

All passed locally.
