### PR TITLE
chore: release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ public releases.
 
 ## Unreleased
 
+## 3.0.2 - 2026-06-29
+
 - Add a literal 17-item master-plan Definition of Done audit that separates
   local implementation support from external live proof, so Telegram/operator
   gaps cannot be hidden behind a generic 100% score.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Ignored local folders such as `.tmp/`, `build/`, `dist/`, `site/` and
 ## Current Release State
 
 Factory V3 is the current public kernel release line. The latest public release
-is v3.0.1.
+is v3.0.2.
 
 V3 means the public kernel has executable contracts for the factory line plus
 release-grade guards for the operating model itself:

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -335,7 +335,7 @@ Pastas locais ignoradas como `.tmp/`, `build/`, `dist/`, `site/` e
 ## Estado Atual De Release
 
 Factory V3 é a linha atual de release do kernel público. A release pública mais
-recente é v3.0.1.
+recente é v3.0.2.
 
 V3 significa que o kernel público tem contratos executáveis para a linha da
 fábrica e também guards de release para o próprio modelo operacional:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "overkill-factory"
-version = "3.0.1"
+version = "3.0.2"
 description = "Gated production line for Hermes-powered agentic product work."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release bookkeeping for Overkill Factory v3.0.2.

This publishes the literal master-plan DoD guard work merged in PR #538.

## Release contents

- Literal 17-item master-plan Definition of Done audit.
- Explicit separation between local implementation support and external live proof.
- Operator artifacts for manager intake, progress cards, delivery receipts, Product Face proof, learnback, Telegram start smoke and manager profile smoke.
- Human gate text fallback plus dependency-free PDF output.
- V3 release readiness now requires `factoryctl literal-dod-audit`.

## Verified before PR

- `python3 -m unittest discover -s tests -q`
- `python3 scripts/generate_factory_reference_docs.py --check`
- `python3 scripts/validate_public_json_artifacts.py`
- `python3 scripts/validate_public_surface_sync.py`
- `python3 scripts/factoryctl.py v3-production-activation-check --live-hermes --live-hermes-out .tmp/factory-hermes-live-smoke-3.0.2.json`
- `python3 scripts/public_safety_scan.py`
- `python3 scripts/secret_safety_scan.py`
- `git diff --check`

## Honest limitation

The release still reports literal DoD as `PARTIAL_EXTERNAL` until a real Telegram/operator live start is verified. That is intentional anti-overclaim behavior.
