### PR TITLE
fix: enforce factory quality and no-idle reducers

### DIFF
--- a/docs/concepts/factory-flow.md
+++ b/docs/concepts/factory-flow.md
@@ -137,7 +137,10 @@ they should not become mandatory user labor.
 For Telegram-first operation, important decisions should not be made from a
 short chat summary alone. The operator should receive a briefing package with a
 deep document and PDF attachment, and the bot should proactively push meaningful
-state changes instead of waiting for the operator to poll.
+state changes instead of waiting for the operator to poll. If the decision is an
+artifact review, the artifact under review is the main content: a Product SOT
+review must deliver the Product SOT candidate itself, not only a formal approval
+cover sheet.
 
 Telegram delivery is plain-text first. Markdown/PDF are ordinary file
 attachments; Telegram rich cards, rich drafts, media groups and table-rendered

--- a/docs/concepts/operator-journey.md
+++ b/docs/concepts/operator-journey.md
@@ -103,8 +103,8 @@ support, learnback and factory maturity audit.
 | 5. Source Resolution | Facts, inference, decisions, conflicts and gaps are separated. | Source resolution. |
 | 6. Understanding Confirmation | The factory summarizes its product understanding and asks for correction or confirmation. | Operator understanding confirmation. |
 | 7. Product Outcome & Discovery | The desired result, user, problem and assumptions are clarified. | Outcome and discovery notes. |
-| 8. Operator Briefing | Major decisions receive a deep document, PDF and optional diagram/video/audio explanation. | Operator briefing package. |
-| 9. Product SOT | The product or slice is defined in one source-of-truth candidate. | Product SOT. |
+| 8. Operator Briefing | Major decisions receive a deep document, PDF and optional diagram/video/audio explanation. Artifact-review decisions must include the artifact itself, not only a formal approval cover sheet. | Operator briefing package. |
+| 9. Product SOT | The product or slice is defined in one source-of-truth candidate. Product SOT review delivers the SOT candidate itself plus clear deltas/questions before asking for approval or correction. | Product SOT. |
 | 10. Method Router | The factory chooses the right process weight. | Router decision. |
 | 11. Method Contract | The chosen method, exclusions, evidence and blockers are recorded. | Method contract. |
 | 12. Pack Selection | Product and surface capability needs are identified. | Required packs and missing packs. |

--- a/docs/operations/human-gate-delivery.md
+++ b/docs/operations/human-gate-delivery.md
@@ -4,22 +4,40 @@ Human gates are artifact-first. A gate package that asks for approval without de
 
 The gerente must send the decision package before asking for a decision. For Product SOT review, architecture review, Product Face review, security/risk review, release review, or any similar artifact review, the package must include the artifact itself or a faithful owner-readable projection plus the complete artifact as attachment/reference. A summary-only approval packet is not a valid operator package.
 
+The primary operator surface must be a one-screen decision memo, not a dump. Attachments may carry the full artifact, but the first Telegram/Desktop message must stand on its own.
+
 A gate is valid only when the operator receives:
 
-- executive summary;
-- context;
-- decision requested;
-- options;
-- consequences;
-- approved scope;
-- forbidden scope;
-- evidence refs;
+- decision requested in the first lines;
+- plain-language summary of the artifact under review;
+- what approval authorizes next;
+- what approval explicitly does NOT authorize;
+- allowed replies/options;
+- consequences of each option when material;
+- evidence refs/attachments as supporting material, not primary UX;
 - urgency;
 - next safe action;
 - Telegram/Desktop-safe fallback;
 - delivery receipt requirement.
 
+Invalid gate UX:
+
+- formal approval cover sheet without the reviewed artifact;
+- raw JSON as primary content;
+- local paths as the main thing the operator must inspect;
+- PDF/attachment-first delivery without a readable decision memo;
+- long defensive/process explanation before the actual decision;
+- asking the operator to inspect Kanban or request the material.
+
 Raw JSON is never the operator-facing gate.
+
+Attachment quality rule:
+
+- The primary attachment for an artifact-review gate must be an operator-grade PDF or equivalent designed artifact.
+- JSON manifests are internal evidence/readback, not operator review attachments unless the operator explicitly asks.
+- A PDF that is just monospace/plain-text fallback is not acceptable for normal Product SOT, architecture, release or security gates.
+- Fallback TXT/PDF renderers are allowed only as emergency accessibility/readback fallback and must be labeled as fallback, not as the primary gate artifact.
+- Product-grade gates must preserve hierarchy, sections, decision options, scope-in/scope-out, forbidden authorizations and evidence pointers in a readable designed layout.
 
 The canonical package is:
 

--- a/docs/operations/human-gate-delivery.md
+++ b/docs/operations/human-gate-delivery.md
@@ -1,9 +1,10 @@
 # Human Gate Delivery
 
-Human gates are artifact-first.
+Human gates are artifact-first. A gate package that asks for approval without delivering the actual artifact under review is invalid.
 
-The gerente must send the decision package before asking for a decision. A gate
-is valid only when the operator receives:
+The gerente must send the decision package before asking for a decision. For Product SOT review, architecture review, Product Face review, security/risk review, release review, or any similar artifact review, the package must include the artifact itself or a faithful owner-readable projection plus the complete artifact as attachment/reference. A summary-only approval packet is not a valid operator package.
+
+A gate is valid only when the operator receives:
 
 - executive summary;
 - context;

--- a/docs/reference/factory-kernel-reference.md
+++ b/docs/reference/factory-kernel-reference.md
@@ -37,7 +37,7 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
 | JSON schemas | 244 | `schemas/*.json` |
-| Templates | 160 | `templates/*` |
+| Templates | 161 | `templates/*` |
 | Public surfaces | 18 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
@@ -562,6 +562,7 @@ Templates are starter records paired with schemas. They are examples of valid sh
 - `templates/product-face-state-journey-driver.json`
 - `templates/product-implementation-readiness.json`
 - `templates/product-quality-pack.json`
+- `templates/product-sot-one-screen-human-gate.md`
 - `templates/product-sot.json`
 - `templates/product-sot.md`
 - `templates/product-source-ledger.json`

--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -67,6 +67,9 @@ NO_IDLE_REMEDIATION_MARKER = "factory_no_idle_remediation"
 NO_IDLE_REVIEW_REPAIR_MARKER = "factory_no_idle_review_repair"
 NO_IDLE_POST_REVIEW_GATE_MARKER = "factory_no_idle_post_review_gate_package"
 NO_IDLE_RUNNING_RESULT_CLOSEOUT_MARKER = "factory_no_idle_running_result_closeout"
+NO_IDLE_REVIEW_PASS_REDUCER_MARKER = "factory_no_idle_review_pass_reducer"
+NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER = "factory_no_idle_internal_review_request"
+NO_IDLE_REVIEW_FAIL_REPAIR_MARKER = "factory_no_idle_review_fail_repair"
 NO_IDLE_CANONICAL_FRONTIER_RESUME_MARKER = "factory_no_idle_canonical_frontier_resume"
 NO_IDLE_RUNNING_RESULT_CLOSEOUT_TIMEOUT_SECONDS = 5 * 60
 FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID = "overkill-vfinal"
@@ -328,11 +331,21 @@ def slugify_phase_node(value: Any) -> str:
     return slug or "phase"
 
 
+def resolve_factory_workflow_catalog_path(path: Path = FACTORY_WORKFLOW_CATALOG_PATH) -> Path:
+    if path.exists():
+        return path
+    repo_root_candidate = ROOT.parent / "docs" / "factory-workflow.catalog.json"
+    if repo_root_candidate.exists():
+        return repo_root_candidate
+    return path
+
+
 def load_factory_run_graph_backbone_from_catalog(
     path: Path = FACTORY_WORKFLOW_CATALOG_PATH,
     *,
     language: str = "en-US",
 ) -> tuple[dict[str, Any], ...]:
+    path = resolve_factory_workflow_catalog_path(path)
     catalog = json.loads(path.read_text(encoding="utf-8"))
     phases = catalog.get("phases")
     if not isinstance(phases, list) or not phases:
@@ -2723,7 +2736,12 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             for item in todo
             if task_record_id(item) and is_factory_owned_repair_task(item)
         ]
-        if repair_todo_refs and (human_gate_dependency_refs or factory_package_dependency_refs):
+        dependency_gated_repair_refs = sorted(
+            task_ref
+            for task_ref in repair_todo_refs
+            if dependency_blockers.get(task_ref)
+        )
+        if dependency_gated_repair_refs:
             return {
                 "status": "remediation_required",
                 "classification": "factory_repair_task_dependency_gated_by_blocker_it_repairs",
@@ -2736,9 +2754,9 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
                 "factory_owned_package_task_refs": sorted(set(factory_package_dependency_refs + factory_package_refs)),
                 "dependency_gated_task_refs": sorted(dependency_blockers),
                 "dependency_blocker_task_refs": blocker_refs,
-                "repair_task_refs": sorted(repair_todo_refs),
+                "repair_task_refs": dependency_gated_repair_refs,
                 "remediation_reason": (
-                    "A factory-owned repair task is dependency-gated by a blocked gate/package "
+                    "A factory-owned repair task is dependency-gated by a blocked gate/package/input "
                     "that it is supposed to repair. The repair must be re-created or unlinked as "
                     "an independent ready work unit with a repairs_task_ref, not as a child of the blocker."
                 ),
@@ -3035,6 +3053,117 @@ def no_idle_review_repair_body(
     }
 
 
+def internal_review_required_blockers(rows: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    blocked_refs = {task_record_id(item) for item in rows.get("blocked", []) if task_record_id(item)}
+    pass_reviewed_refs: set[str] = set()
+    for review in rows.get("done", []):
+        pass_reviewed_refs.update(internal_review_pass_references(review, blocked_refs))
+    for item in rows.get("blocked", []):
+        item_ref = task_record_id(item)
+        if item_ref in pass_reviewed_refs:
+            continue
+        text = task_record_text(item)
+        if "review-required" not in text and "review required" not in text and "review_required" not in text:
+            continue
+        if "operator" in text and ("approval" in text or "input" in text or "decision" in text):
+            continue
+        if is_human_gate_decision_ready_blocker(item):
+            continue
+        if "owner review" in text or "owner approval" in text or "product sot owner" in text:
+            continue
+        if "independent-reviewer" in text or "must independently review" in text or "must review" in text:
+            blockers.append(item)
+    return blockers
+
+
+def internal_review_reviewer_for_blocker(item: dict[str, Any]) -> str:
+    text = task_record_text(item)
+    for candidate in ("independent-reviewer", "qa-verification-worker", "security-orchestrator"):
+        if candidate in text:
+            return candidate
+    return "independent-reviewer"
+
+
+def existing_internal_review_task_refs(rows: dict[str, list[dict[str, Any]]], target_task_ref: str) -> list[str]:
+    refs: list[str] = []
+    for status in ("ready", "running", "todo", "blocked", "done"):
+        for item in rows.get(status, []):
+            body = task_body_json_object(item)
+            if body.get("marker") != NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER:
+                continue
+            if str(body.get("target_task_ref") or "").strip() != target_task_ref:
+                continue
+            ref = task_record_id(item)
+            if ref:
+                refs.append(ref)
+    return refs
+
+
+def create_internal_review_request_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    workspace: str,
+    blocker: dict[str, Any],
+    rows: dict[str, list[dict[str, Any]]],
+    runner: Runner,
+) -> str:
+    target_ref = task_record_id(blocker)
+    if not target_ref:
+        return ""
+    existing = existing_internal_review_task_refs(rows, target_ref)
+    if existing:
+        return existing[0]
+    reviewer = internal_review_reviewer_for_blocker(blocker)
+    body = {
+        "packet_type": "factory_internal_review_request",
+        "marker": NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER,
+        "board": board,
+        "target_task_ref": target_ref,
+        "reviewer_role": reviewer,
+        "review_scope": "internal_factory_work_product_review",
+        "objective": "Independently review the blocked factory-owned work product and return PASS/FAIL evidence without asking the operator.",
+        "source_blocker": {
+            "task_ref": target_ref,
+            "title": str(blocker.get("title") or ""),
+            "assignee": str(blocker.get("assignee") or ""),
+            "block_reason": task_record_text(blocker)[:2000],
+        },
+        "required_result_contract": {
+            "result": "PASS or FAIL",
+            "reviewed_task_ref": target_ref,
+            "blocking_findings": "list; empty on PASS",
+            "human_gate_required": False,
+            "operator_input_required": False,
+        },
+        "forbidden_actions": [
+            "ask the operator for a status ping or approval for this internal review",
+            "approve product/business/legal/economic/security/release/mainnet/funds/custody/signing authority",
+            "make this review task a child of the blocked task it is meant to review",
+        ],
+        "human_gate_required": False,
+        "operator_input_required": False,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+    }
+    digest = idempotency_digest_fragment(contract_digest(body))
+    return create_task(
+        hermes_bin=hermes_bin,
+        board=board,
+        title=f"Review {target_ref} internal factory work product",
+        body=compact_json_argument(body),
+        assignee=reviewer,
+        idempotency_key=f"overkill:no-idle-internal-review:{public_safe_slug(board, fallback='board')}:{target_ref}:{digest}",
+        created_by=NO_IDLE_AUTHOR,
+        workspace=workspace,
+        blocked=False,
+        workflow_template_id=FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID,
+        current_step_key=FACTORY_KANBAN_DEFAULT_STEP_KEY,
+        runner=runner,
+    )
+
+
 def create_no_idle_review_repair_task(
     *,
     hermes_bin: str,
@@ -3168,6 +3297,274 @@ def remediation_task_runtime_metadata(
         "remediation_task_stale": stale,
         "native_dispatch_required_next": status in {"ready", "unknown", ""},
     }
+
+
+def internal_review_pass_references(record: dict[str, Any], blocked_refs: set[str]) -> list[str]:
+    body = task_body_json_object(record)
+    text = task_record_text(record)
+    result = str(body.get("result") or body.get("verdict") or "").strip().upper()
+    pass_seen = result == "PASS" or "independent review pass" in text or "review pass" in text or '"result": "pass' in text or " pass" in text
+    if not pass_seen:
+        return []
+    if str(record.get("assignee") or "").strip() not in {"independent-reviewer", "autoreview-gate"}:
+        if "independent review" not in text and "review" not in text:
+            return []
+    refs: set[str] = set()
+    for key in ("reviewed_task_ref", "blocked_task_ref", "target_task_ref", "task_ref"):
+        value = str(body.get(key) or "").strip()
+        if value:
+            refs.add(value)
+    for key in ("reviewed_task_refs", "blocked_task_refs", "target_task_refs"):
+        raw = body.get(key)
+        if isinstance(raw, list):
+            refs.update(str(item).strip() for item in raw if str(item or "").strip())
+    for blocked_ref in blocked_refs:
+        if blocked_ref and blocked_ref.lower() in text:
+            refs.add(blocked_ref)
+    return sorted(ref for ref in refs if ref in blocked_refs)
+
+
+def internal_review_pass_closeout_candidates(rows: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    blocked_by_id = {
+        task_record_id(item): item
+        for item in rows.get("blocked", [])
+        if task_record_id(item)
+    }
+    candidates: list[dict[str, Any]] = []
+    if not blocked_by_id:
+        return candidates
+    for review in rows.get("done", []):
+        review_id = task_record_id(review)
+        if not review_id:
+            continue
+        for blocked_ref in internal_review_pass_references(review, set(blocked_by_id)):
+            blocker = blocked_by_id[blocked_ref]
+            if is_human_gate_decision_ready_blocker(blocker):
+                continue
+            candidates.append(
+                {
+                    "task_ref": blocked_ref,
+                    "review_task_ref": review_id,
+                    "review_title": str(review.get("title") or ""),
+                }
+            )
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in candidates:
+        key = (str(item.get("task_ref")), str(item.get("review_task_ref")))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
+def close_internal_review_pass_blockers(
+    *,
+    hermes_bin: str,
+    board: str,
+    candidates: list[dict[str, Any]],
+    runner: Runner,
+) -> list[dict[str, Any]]:
+    closed: list[dict[str, Any]] = []
+    for candidate in candidates:
+        task_id = str(candidate.get("task_ref") or "").strip()
+        review_id = str(candidate.get("review_task_ref") or "").strip()
+        if not task_id or not review_id:
+            continue
+        metadata = {
+            "marker": NO_IDLE_REVIEW_PASS_REDUCER_MARKER,
+            "record_type": "factory_no_idle_review_pass_reducer",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "task_ref": task_id,
+            "review_task_ref": review_id,
+            "review_title": candidate.get("review_title"),
+            "reason": "Internal independent review PASS reduces the original blocked factory task; no operator input required.",
+            "human_gate_required": False,
+            "operator_input_required": False,
+        }
+        complete_task(
+            hermes_bin=hermes_bin,
+            board=board,
+            task_id=task_id,
+            result="DONE",
+            summary="Closed by no-idle after internal independent review PASS.",
+            metadata=metadata,
+            required_readback_markers=[NO_IDLE_REVIEW_PASS_REDUCER_MARKER],
+            runner=runner,
+        )
+        closed.append({"task_ref": task_id, "review_task_ref": review_id})
+    return closed
+
+
+def internal_review_fail_references(record: dict[str, Any], blocked_refs: set[str]) -> list[str]:
+    body = task_body_json_object(record)
+    text = task_record_text(record)
+    result = str(body.get("result") or body.get("verdict") or "").strip().upper()
+    fail_seen = result == "FAIL" or "review fail" in text or "review failed" in text or '"result": "fail' in text
+    if not fail_seen:
+        return []
+    refs: set[str] = set()
+    for key in ("reviewed_task_ref", "blocked_task_ref", "target_task_ref", "task_ref"):
+        value = str(body.get(key) or "").strip()
+        if value:
+            refs.add(value)
+    for key in ("reviewed_task_refs", "blocked_task_refs", "target_task_refs"):
+        raw = body.get(key)
+        if isinstance(raw, list):
+            refs.update(str(item).strip() for item in raw if str(item or "").strip())
+    for blocked_ref in blocked_refs:
+        if blocked_ref and blocked_ref.lower() in text:
+            refs.add(blocked_ref)
+    return sorted(ref for ref in refs if ref in blocked_refs)
+
+
+def internal_review_fail_repair_candidates(rows: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    blocked_by_id = {task_record_id(item): item for item in rows.get("blocked", []) if task_record_id(item)}
+    if not blocked_by_id:
+        return []
+    candidates: list[dict[str, Any]] = []
+    for review in rows.get("done", []):
+        review_id = task_record_id(review)
+        if not review_id:
+            continue
+        for blocked_ref in internal_review_fail_references(review, set(blocked_by_id)):
+            candidates.append({
+                "task_ref": blocked_ref,
+                "review_task_ref": review_id,
+                "review_title": str(review.get("title") or ""),
+                "target_assignee": str(blocked_by_id[blocked_ref].get("assignee") or "factory-orchestrator"),
+            })
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in candidates:
+        key = (str(item.get("task_ref")), str(item.get("review_task_ref")))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
+def existing_review_fail_repair_task_refs(rows: dict[str, list[dict[str, Any]]], target_task_ref: str, review_task_ref: str) -> list[str]:
+    refs: list[str] = []
+    for status in ("ready", "running", "todo", "blocked", "done"):
+        for item in rows.get(status, []):
+            body = task_body_json_object(item)
+            if body.get("marker") != NO_IDLE_REVIEW_FAIL_REPAIR_MARKER:
+                continue
+            if str(body.get("target_task_ref") or "") != target_task_ref:
+                continue
+            if str(body.get("review_task_ref") or "") != review_task_ref:
+                continue
+            ref = task_record_id(item)
+            if ref:
+                refs.append(ref)
+    return refs
+
+
+def create_internal_review_fail_repair_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    workspace: str,
+    candidate: dict[str, Any],
+    rows: dict[str, list[dict[str, Any]]],
+    fallback_assignee: str,
+    runner: Runner,
+) -> str:
+    target_ref = str(candidate.get("task_ref") or "").strip()
+    review_ref = str(candidate.get("review_task_ref") or "").strip()
+    if not target_ref or not review_ref:
+        return ""
+    existing = existing_review_fail_repair_task_refs(rows, target_ref, review_ref)
+    if existing:
+        return existing[0]
+    assignee = str(candidate.get("target_assignee") or fallback_assignee or "factory-orchestrator").strip()
+    body = {
+        "packet_type": "factory_internal_review_fail_repair_request",
+        "marker": NO_IDLE_REVIEW_FAIL_REPAIR_MARKER,
+        "board": board,
+        "target_task_ref": target_ref,
+        "review_task_ref": review_ref,
+        "objective": "Repair the exact blocking findings from an internal independent review FAIL; do not ask the operator unless the repair uncovers a true human authority decision.",
+        "required_actions": [
+            "read the review FAIL evidence and target task comments",
+            "repair only the failed work-product evidence or artifact gap",
+            "return a new result with readback evidence and route back to independent review if required",
+        ],
+        "human_gate_required": False,
+        "operator_input_required": False,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+    }
+    digest = idempotency_digest_fragment(contract_digest(body))
+    return create_task(
+        hermes_bin=hermes_bin,
+        board=board,
+        title=f"Repair {target_ref} after internal review FAIL",
+        body=compact_json_argument(body),
+        assignee=assignee,
+        idempotency_key=f"overkill:no-idle-review-fail-repair:{public_safe_slug(board, fallback='board')}:{target_ref}:{review_ref}:{digest}",
+        created_by=NO_IDLE_AUTHOR,
+        workspace=workspace,
+        blocked=False,
+        workflow_template_id=FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID,
+        current_step_key=FACTORY_KANBAN_DEFAULT_STEP_KEY,
+        runner=runner,
+    )
+
+
+
+def release_dependency_gated_repair_tasks(
+    *,
+    hermes_bin: str,
+    board: str,
+    classification: dict[str, Any],
+    runner: Runner,
+) -> list[dict[str, Any]]:
+    released: list[dict[str, Any]] = []
+    raw_gated = classification.get("dependency_gated_task_refs")
+    common_blocker_refs = [str(ref) for ref in (classification.get("dependency_blocker_task_refs") or []) if str(ref or "").strip()]
+    repair_refs = [str(ref) for ref in (classification.get("repair_task_refs") or []) if str(ref or "").strip()]
+    blockers_by_task: dict[str, list[str]] = {}
+    if isinstance(raw_gated, dict):
+        blockers_by_task = {
+            str(task_ref): [str(ref) for ref in refs if str(ref or "").strip()]
+            for task_ref, refs in raw_gated.items()
+            if isinstance(refs, list)
+        }
+    else:
+        blockers_by_task = {repair_ref: common_blocker_refs for repair_ref in repair_refs}
+    for repair_ref in repair_refs:
+        parent_refs = [str(ref) for ref in blockers_by_task.get(repair_ref, []) if str(ref or "").strip()]
+        unlinked: list[str] = []
+        for parent_ref in parent_refs:
+            if unlink_task_dependency(
+                hermes_bin=hermes_bin,
+                board=board,
+                parent_task_id=parent_ref,
+                child_task_id=repair_ref,
+                work_unit_id="no-idle-repair",
+                authority_task_ref=None,
+                runner=runner,
+            ):
+                unlinked.append(parent_ref)
+        promote_task(
+            hermes_bin=hermes_bin,
+            board=board,
+            task_id=repair_ref,
+            reason=(
+                f"{NO_IDLE_REMEDIATION_MARKER}; repair task unlinked from blocked parent it repairs; "
+                "operator_input_required=false; human_gate_required=false"
+            ),
+            required_readback_markers=[NO_IDLE_REMEDIATION_MARKER],
+            runner=runner,
+        )
+        released.append({"repair_task_ref": repair_ref, "unlinked_parent_refs": unlinked})
+    return released
+
 
 
 def close_running_tasks_with_valid_worker_results(
@@ -9494,6 +9891,283 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
             write_json(args.out, public_envelope)
         return public_envelope
     artifact_materialization: list[dict[str, Any]] = []
+    review_fail_repair_candidates = internal_review_fail_repair_candidates(rows)
+    if review_fail_repair_candidates:
+        created_repair_task_refs: list[str] = []
+        existing_repair_task_refs: list[str] = []
+        for candidate in review_fail_repair_candidates:
+            target_ref = str(candidate.get("task_ref") or "").strip()
+            review_ref = str(candidate.get("review_task_ref") or "").strip()
+            existing_repair_task_refs.extend(existing_review_fail_repair_task_refs(rows, target_ref, review_ref))
+        if args.create_remediation:
+            for candidate in review_fail_repair_candidates:
+                target_ref = str(candidate.get("task_ref") or "").strip()
+                review_ref = str(candidate.get("review_task_ref") or "").strip()
+                if existing_review_fail_repair_task_refs(rows, target_ref, review_ref):
+                    continue
+                repair_ref = create_internal_review_fail_repair_task(
+                    hermes_bin=args.hermes_bin,
+                    board=args.board,
+                    workspace=args.workspace,
+                    candidate=candidate,
+                    rows=rows,
+                    fallback_assignee=args.assignee,
+                    runner=runner,
+                )
+                if repair_ref:
+                    created_repair_task_refs.append(repair_ref)
+        classification = {
+            "status": "dispatch_available" if created_repair_task_refs else "remediation_required",
+            "classification": "internal_review_fail_repair_task_created" if created_repair_task_refs else "internal_review_fail_repair_task_already_exists" if existing_repair_task_refs else "internal_review_fail_repair_required",
+            "blocked": not bool(created_repair_task_refs or existing_repair_task_refs),
+            "remediation_required": not bool(created_repair_task_refs or existing_repair_task_refs),
+            "human_gate_required": False,
+            "operator_input_required": False,
+            "native_dispatch_required_next": bool(created_repair_task_refs),
+            "review_fail_repair_candidates": review_fail_repair_candidates,
+            "created_repair_task_refs": created_repair_task_refs,
+            "existing_repair_task_refs": existing_repair_task_refs,
+            "next_action": "run native Hermes dispatch for created repair work" if created_repair_task_refs else "run no-idle with create-remediation to create the deterministic repair task" if not existing_repair_task_refs else "observe existing repair work",
+            "state": summarize_no_idle_rows(rows),
+        }
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "no-idle",
+            "board": args.board,
+            "blocked": bool(classification["blocked"]),
+            "no_idle_state": classification,
+            "board_reconcile_plan": initial_reconcile_plan,
+            "artifact_materialization": artifact_materialization,
+            "targeted_remediation_plan": {
+                "record_type": "factory_no_idle_review_fail_repair_plan",
+                "plan_action": "create_repair_task_for_internal_review_fail",
+                "native_dispatch_required_next": bool(created_repair_task_refs),
+                "human_gate_required": False,
+                "operator_input_required": False,
+            },
+            "remediation_task_id": created_repair_task_refs[0] if created_repair_task_refs else None,
+            "hook": {
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "no_shadow_dispatcher": True,
+                "dispatch_called_by_this_command": False,
+                "reporting_policy": "No-idle converted an internal review FAIL into deterministic repair work without operator wake-up.",
+            },
+        }
+        public_envelope = sanitize_public_refs(envelope)
+        if args.out:
+            write_json(args.out, public_envelope)
+        return public_envelope
+    internal_review_blockers = internal_review_required_blockers(rows)
+    if internal_review_blockers:
+        existing_review_refs = {
+            task_record_id(blocker): existing_internal_review_task_refs(rows, task_record_id(blocker))
+            for blocker in internal_review_blockers
+            if task_record_id(blocker)
+        }
+        if not args.create_remediation and not any(existing_review_refs.values()):
+            classification = {
+                "status": "remediation_required",
+                "classification": "internal_review_request_required",
+                "blocked": True,
+                "remediation_required": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "native_dispatch_required_next": False,
+                "internal_review_blocker_refs": [task_record_id(item) for item in internal_review_blockers if task_record_id(item)],
+                "next_action": "run no-idle with create-remediation so the runtime creates internal independent-review work without operator input",
+                "state": summarize_no_idle_rows(rows),
+            }
+            envelope = {
+                "$schema": LIVE_ADAPTER_SCHEMA,
+                "mode": "no-idle",
+                "board": args.board,
+                "blocked": True,
+                "no_idle_state": classification,
+                "board_reconcile_plan": initial_reconcile_plan,
+                "artifact_materialization": artifact_materialization,
+                "targeted_remediation_plan": {
+                    "record_type": "factory_no_idle_internal_review_plan",
+                    "plan_action": "create_internal_review_request_tasks",
+                    "native_dispatch_required_next": False,
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                },
+                "remediation_task_id": None,
+                "hook": {
+                    "runtime_authority": "hermes_kanban",
+                    "local_state_authority": False,
+                    "no_shadow_dispatcher": True,
+                    "dispatch_called_by_this_command": False,
+                    "reporting_policy": "No-idle found factory-owned internal review blockers; operator status/input is not required.",
+                },
+            }
+            public_envelope = sanitize_public_refs(envelope)
+            if args.out:
+                write_json(args.out, public_envelope)
+            return public_envelope
+        created_review_task_refs: list[str] = []
+        if args.create_remediation:
+            for blocker in internal_review_blockers:
+                blocker_ref = task_record_id(blocker)
+                if blocker_ref and existing_review_refs.get(blocker_ref):
+                    continue
+                review_task_ref = create_internal_review_request_task(
+                    hermes_bin=args.hermes_bin,
+                    board=args.board,
+                    workspace=args.workspace,
+                    blocker=blocker,
+                    rows=rows,
+                    runner=runner,
+                )
+                if review_task_ref:
+                    created_review_task_refs.append(review_task_ref)
+        if created_review_task_refs or any(existing_review_refs.values()):
+            classification = {
+                "status": "dispatch_available" if created_review_task_refs else "observed",
+                "classification": "internal_review_task_created" if created_review_task_refs else "internal_review_task_already_exists",
+                "blocked": False,
+                "remediation_required": False,
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "native_dispatch_required_next": bool(created_review_task_refs),
+                "created_review_task_refs": created_review_task_refs,
+                "existing_review_task_refs": existing_review_refs,
+                "internal_review_blocker_refs": [task_record_id(item) for item in internal_review_blockers if task_record_id(item)],
+                "next_action": "run native Hermes dispatch for created internal review work" if created_review_task_refs else "observe existing internal review work",
+                "state": summarize_no_idle_rows(rows),
+            }
+            envelope = {
+                "$schema": LIVE_ADAPTER_SCHEMA,
+                "mode": "no-idle",
+                "board": args.board,
+                "blocked": False,
+                "no_idle_state": classification,
+                "board_reconcile_plan": initial_reconcile_plan,
+                "artifact_materialization": artifact_materialization,
+                "targeted_remediation_plan": {
+                    "record_type": "factory_no_idle_internal_review_plan",
+                    "plan_action": "create_internal_review_request_tasks",
+                    "native_dispatch_required_next": bool(created_review_task_refs),
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                },
+                "remediation_task_id": created_review_task_refs[0] if created_review_task_refs else None,
+                "hook": {
+                    "runtime_authority": "hermes_kanban",
+                    "local_state_authority": False,
+                    "no_shadow_dispatcher": True,
+                    "dispatch_called_by_this_command": False,
+                    "reporting_policy": "No-idle created idempotent internal review work without a gerente/status interaction.",
+                },
+            }
+            public_envelope = sanitize_public_refs(envelope)
+            if args.out:
+                write_json(args.out, public_envelope)
+            return public_envelope
+    review_pass_closeout_candidates = internal_review_pass_closeout_candidates(rows)
+    if review_pass_closeout_candidates:
+        if not args.create_remediation:
+            classification = {
+                "status": "remediation_required",
+                "classification": "internal_review_pass_reducer_required",
+                "blocked": True,
+                "remediation_required": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "native_dispatch_required_next": False,
+                "internal_review_pass_closeout_candidates": review_pass_closeout_candidates,
+                "next_action": "run no-idle with create-remediation so internal review PASS reduces the original blocked task",
+                "state": summarize_no_idle_rows(rows),
+            }
+            envelope = {
+                "$schema": LIVE_ADAPTER_SCHEMA,
+                "mode": "no-idle",
+                "board": args.board,
+                "blocked": True,
+                "no_idle_state": classification,
+                "board_reconcile_plan": initial_reconcile_plan,
+                "artifact_materialization": artifact_materialization,
+                "targeted_remediation_plan": {
+                    "record_type": "factory_no_idle_review_pass_reducer_plan",
+                    "plan_action": "complete_blocked_tasks_with_internal_review_pass",
+                    "native_dispatch_required_next": False,
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                },
+                "remediation_task_id": None,
+                "hook": {
+                    "runtime_authority": "hermes_kanban",
+                    "local_state_authority": False,
+                    "no_shadow_dispatcher": True,
+                    "dispatch_called_by_this_command": False,
+                    "reporting_policy": "No-idle found internal review PASS closeout candidates; mutation requires create-remediation.",
+                },
+            }
+            public_envelope = sanitize_public_refs(envelope)
+            if args.out:
+                write_json(args.out, public_envelope)
+            return public_envelope
+        closed_review_pass_blockers = close_internal_review_pass_blockers(
+            hermes_bin=args.hermes_bin,
+            board=args.board,
+            candidates=review_pass_closeout_candidates,
+            runner=runner,
+        )
+        rows = {
+            status: list_tasks_by_status(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                status=status,
+                runner=runner,
+            )
+            for status in ("ready", "running", "todo", "blocked", "triage", "done")
+        }
+        rows = enrich_no_idle_rows(hermes_bin=args.hermes_bin, board=args.board, rows=rows, runner=runner)
+        classification = {
+            "status": "remediated",
+            "classification": "internal_review_pass_reduced_blockers",
+            "blocked": False,
+            "remediation_required": False,
+            "human_gate_required": False,
+            "operator_input_required": False,
+            "native_dispatch_required_next": bool(rows.get("ready")),
+            "closed_review_pass_blockers": closed_review_pass_blockers,
+            "next_action": (
+                "run native Hermes dispatch for ready work"
+                if rows.get("ready")
+                else "continue no-idle reconciliation from refreshed Hermes state"
+            ),
+            "state": summarize_no_idle_rows(rows),
+        }
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "no-idle",
+            "board": args.board,
+            "blocked": False,
+            "no_idle_state": classification,
+            "board_reconcile_plan": initial_reconcile_plan,
+            "artifact_materialization": artifact_materialization,
+            "targeted_remediation_plan": {
+                "record_type": "factory_no_idle_review_pass_reducer_plan",
+                "plan_action": "complete_blocked_tasks_with_internal_review_pass",
+                "native_dispatch_required_next": bool(rows.get("ready")),
+                "human_gate_required": False,
+                "operator_input_required": False,
+            },
+            "remediation_task_id": None,
+            "hook": {
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "no_shadow_dispatcher": True,
+                "dispatch_called_by_this_command": False,
+                "reporting_policy": "No-idle completed blocked tasks only after matching an internal independent review PASS.",
+            },
+        }
+        public_envelope = sanitize_public_refs(envelope)
+        if args.out:
+            write_json(args.out, public_envelope)
+        return public_envelope
     running_closeout_candidates = running_result_closeout_candidates(rows)
     if running_closeout_candidates:
         if not args.create_remediation:
@@ -9947,6 +10621,59 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
             write_json(args.out, public_envelope)
         return public_envelope
     legacy_classification = classify_no_idle_state(rows)
+    if (
+        legacy_classification.get("classification") == "factory_repair_task_dependency_gated_by_blocker_it_repairs"
+        and args.create_remediation
+    ):
+        classification = dict(legacy_classification)
+        targeted_remediation_plan = {
+            "record_type": "factory_no_idle_targeted_repair_plan",
+            "plan_action": "unlink_and_promote_dependency_gated_repair_task",
+            "board": args.board,
+            "dependency_gated_task_refs": classification.get("dependency_gated_task_refs") or [],
+            "dependency_blocker_task_refs": classification.get("dependency_blocker_task_refs") or [],
+            "repair_task_refs": classification.get("repair_task_refs") or [],
+            "native_dispatch_required_next": True,
+            "human_gate_required": False,
+            "operator_input_required": False,
+        }
+        released_repair_tasks = release_dependency_gated_repair_tasks(
+            hermes_bin=args.hermes_bin,
+            board=args.board,
+            classification=classification,
+            runner=runner,
+        )
+        classification["targeted_remediation_plan"] = targeted_remediation_plan
+        classification["released_repair_tasks"] = released_repair_tasks
+        classification["remediation_task_ref"] = released_repair_tasks[0]["repair_task_ref"] if released_repair_tasks else None
+        classification["native_dispatch_required_next"] = bool(released_repair_tasks)
+        classification["classification"] = (
+            "factory_repair_task_unlinked_and_promoted"
+            if released_repair_tasks
+            else "factory_repair_task_unlink_promote_failed"
+        )
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "no-idle",
+            "board": args.board,
+            "blocked": not bool(released_repair_tasks),
+            "no_idle_state": classification,
+            "board_reconcile_plan": reconcile_plan,
+            "artifact_materialization": artifact_materialization,
+            "targeted_remediation_plan": targeted_remediation_plan,
+            "remediation_task_id": classification.get("remediation_task_ref"),
+            "hook": {
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "no_shadow_dispatcher": True,
+                "dispatch_called_by_this_command": False,
+                "reporting_policy": "No-idle repaired a remediation task that was incorrectly linked under the blocker it repairs.",
+            },
+        }
+        public_envelope = sanitize_public_refs(envelope)
+        if args.out:
+            write_json(args.out, public_envelope)
+        return public_envelope
     if legacy_classification.get("classification") in {
         "hermes_native_dependency_wait",
         "hermes_typed_block_loop_detected",
@@ -10126,10 +10853,36 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
     targeted_remediation_plan: dict[str, Any] | None = None
     if classification.get("remediation_required") and args.create_remediation:
         classification = dict(classification)
-        if classification.get("classification") in {
+        if classification.get("classification") == "factory_repair_task_dependency_gated_by_blocker_it_repairs":
+            targeted_remediation_plan = {
+                "record_type": "factory_no_idle_targeted_repair_plan",
+                "plan_action": "unlink_and_promote_dependency_gated_repair_task",
+                "board": args.board,
+                "dependency_gated_task_refs": classification.get("dependency_gated_task_refs") or [],
+                "dependency_blocker_task_refs": classification.get("dependency_blocker_task_refs") or [],
+                "repair_task_refs": classification.get("repair_task_refs") or [],
+                "native_dispatch_required_next": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+            }
+            released_repair_tasks = release_dependency_gated_repair_tasks(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                classification=classification,
+                runner=runner,
+            )
+            classification["targeted_remediation_plan"] = targeted_remediation_plan
+            classification["released_repair_tasks"] = released_repair_tasks
+            classification["remediation_task_ref"] = released_repair_tasks[0]["repair_task_ref"] if released_repair_tasks else None
+            classification["native_dispatch_required_next"] = bool(released_repair_tasks)
+            classification["classification"] = (
+                "factory_repair_task_unlinked_and_promoted"
+                if released_repair_tasks
+                else "factory_repair_task_unlink_promote_failed"
+            )
+        elif classification.get("classification") in {
             "only_factory_owned_package_blockers_seen",
             "todo_dependency_gated_by_factory_owned_package_blocker",
-            "factory_repair_task_dependency_gated_by_blocker_it_repairs",
         }:
             targeted_remediation_plan = {
                 "record_type": "factory_no_idle_targeted_repair_plan",

--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -3066,13 +3066,22 @@ def internal_review_required_blockers(rows: dict[str, list[dict[str, Any]]]) -> 
         text = task_record_text(item)
         if "review-required" not in text and "review required" not in text and "review_required" not in text:
             continue
-        if "operator" in text and ("approval" in text or "input" in text or "decision" in text):
+        has_internal_review_marker = (
+            "independent-reviewer" in text
+            or "must independently review" in text
+            or "must review" in text
+        )
+        if (
+            not has_internal_review_marker
+            and "operator" in text
+            and ("approval" in text or "input" in text or "decision" in text)
+        ):
             continue
         if is_human_gate_decision_ready_blocker(item):
             continue
         if "owner review" in text or "owner approval" in text or "product sot owner" in text:
             continue
-        if "independent-reviewer" in text or "must independently review" in text or "must review" in text:
+        if has_internal_review_marker:
             blockers.append(item)
     return blockers
 

--- a/factory/scripts/render_human_gate_pdf.py
+++ b/factory/scripts/render_human_gate_pdf.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Render a human gate decision package to an operator-readable fallback.
+"""Render a human gate decision package to an emergency text/PDF fallback.
 
-The production path may attach a PDF renderer later, but this script already
-creates the required Telegram/Desktop-safe artifact-first fallback from the same
-schema-backed package. It refuses raw JSON-only gates.
+This is NOT the product-grade primary gate artifact for normal Product SOT,
+architecture, security or release gates. It exists only so Telegram/Desktop has
+an accessibility/readback fallback when the designed artifact renderer is
+unavailable. Operator-facing production gates must use a designed PDF/equivalent
+artifact plus this fallback, never raw JSON-only delivery.
 """
 from __future__ import annotations
 

--- a/factory/scripts/work_product_quality_firewall.py
+++ b/factory/scripts/work_product_quality_firewall.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+import argparse
+import json
+import sys
+
+
+@dataclass(frozen=True)
+class QualityFinding:
+    code: str
+    severity: str
+    message: str
+
+
+@dataclass(frozen=True)
+class QualityResult:
+    artifact_type: str
+    process_pass: bool
+    readback_pass: bool
+    quality_pass: bool
+    findings: list[QualityFinding] = field(default_factory=list)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _nonempty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return True
+
+
+def _count(value: Any) -> int:
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value)
+    if isinstance(value, str):
+        return 1 if value.strip() else 0
+    return 1 if value is not None else 0
+
+
+def _finding(code: str, message: str, severity: str = "error") -> QualityFinding:
+    return QualityFinding(code=code, severity=severity, message=message)
+
+
+def detect_lazy_output(text: str, artifact_type: str = "generic") -> list[QualityFinding]:
+    """Detect deterministic signs of shallow/satisficing work.
+
+    This intentionally uses simple, auditable heuristics. It is not an LLM judge.
+    """
+    lower = (text or "").lower()
+    findings: list[QualityFinding] = []
+    vague_markers = [
+        "considerar",
+        "avaliar posteriormente",
+        "pode ser",
+        "deve considerar",
+        "a definir",
+        "tbd",
+        "todo",
+    ]
+    if len(lower.strip()) < 600:
+        findings.append(_finding("too_short", f"{artifact_type} is too short to be decision-grade."))
+    if sum(1 for marker in vague_markers if marker in lower) >= 2:
+        findings.append(_finding("vague_language", f"{artifact_type} uses repeated vague/lazy language."))
+    if "acceptance" not in lower and "critério" not in lower and "criterio" not in lower:
+        findings.append(_finding("missing_acceptance_criteria", f"{artifact_type} has no acceptance criteria signal."))
+    if "source" not in lower and "fonte" not in lower and "ref" not in lower:
+        findings.append(_finding("missing_source_signal", f"{artifact_type} has no source traceability signal."))
+    return findings
+
+
+def validate_product_sot_prd_grade(sot: Mapping[str, Any] | str) -> QualityResult:
+    """Validate that a Product SOT is PRD-grade, not a shallow scope summary."""
+    findings: list[QualityFinding] = []
+    process_pass = _nonempty(sot)
+    readback_pass = process_pass
+
+    if isinstance(sot, str):
+        text = sot
+        lower = sot.lower()
+        required_text_signals = {
+            "missing_product_intent": ["product intent", "intenção do produto", "intencao do produto"],
+            "missing_source_traceability": ["source traceability", "rastreabilidade", "fonte"],
+            "missing_user_journeys": ["user journey", "jornada do usuário", "jornada do usuario"],
+            "missing_admin_journeys": ["admin journey", "jornada admin", "admin"],
+            "missing_functional_requirements": ["functional requirement", "requisito funcional"],
+            "missing_non_functional_requirements": ["non-functional", "não funcional", "nao funcional", "nfr"],
+            "missing_state_model": ["state model", "modelo de estado"],
+            "missing_data_ledger_reconciliation": ["reconciliation", "reconciliação", "reconciliacao", "ledger"],
+            "missing_downstream_handoff": ["downstream handoff", "handoff", "arquitetura"],
+        }
+        for code, signals in required_text_signals.items():
+            if not any(signal in lower for signal in signals):
+                findings.append(_finding(code, f"Product SOT text lacks {code.replace('missing_', '').replace('_', ' ')}."))
+        findings.extend(detect_lazy_output(text, "product_sot"))
+    else:
+        data = _as_mapping(sot)
+        if not _nonempty(data.get("product_intent")):
+            findings.append(_finding("missing_product_intent", "Product SOT must state product intent, not only scope."))
+        if _count(data.get("source_traceability")) < 2:
+            findings.append(_finding("missing_source_traceability", "Product SOT must map sources to requirements."))
+        if _count(data.get("personas")) < 1:
+            findings.append(_finding("missing_personas", "Product SOT must name product personas/operators."))
+        if _count(data.get("user_journeys")) < 2:
+            findings.append(_finding("missing_user_journeys", "Product SOT must include user journeys."))
+        if _count(data.get("admin_journeys")) < 1:
+            findings.append(_finding("missing_admin_journeys", "Product SOT must include admin/operator journeys."))
+        if _count(data.get("functional_requirements")) < 3:
+            findings.append(_finding("missing_functional_requirements", "Product SOT must include functional requirements."))
+        if _count(data.get("non_functional_requirements")) < 2:
+            findings.append(_finding("missing_non_functional_requirements", "Product SOT must include non-functional requirements."))
+        if _count(data.get("state_model_requirements")) < 5:
+            findings.append(_finding("missing_state_model", "Product SOT must include state model requirements."))
+        if _count(data.get("data_ledger_reconciliation_requirements")) < 1:
+            findings.append(_finding("missing_data_ledger_reconciliation", "Product SOT must include data/ledger/reconciliation requirements."))
+        if _count(data.get("acceptance_criteria_by_flow")) < 2:
+            findings.append(_finding("missing_acceptance_criteria", "Product SOT must include acceptance criteria by flow."))
+        handoff = data.get("downstream_handoff")
+        if not isinstance(handoff, Mapping) or not {"architecture", "ux", "security", "implementation", "qa"}.issubset(handoff.keys()):
+            findings.append(_finding("missing_downstream_handoff", "Product SOT must hand off to architecture, UX, security, implementation, and QA."))
+
+    quality_pass = process_pass and readback_pass and not [f for f in findings if f.severity == "error"]
+    return QualityResult(
+        artifact_type="product_sot",
+        process_pass=process_pass,
+        readback_pass=readback_pass,
+        quality_pass=quality_pass,
+        findings=findings,
+    )
+
+
+def validate_human_gate_artifact(package: Mapping[str, Any]) -> QualityResult:
+    data = _as_mapping(package)
+    findings: list[QualityFinding] = []
+    process_pass = _nonempty(data.get("primary_message")) and _nonempty(data.get("valid_replies"))
+    readback_pass = process_pass
+
+    attachment = _as_mapping(data.get("primary_attachment"))
+    media_type = str(attachment.get("media_type", "")).lower()
+    path = str(attachment.get("path", "")).lower()
+    if media_type == "application/json" or path.endswith(".json"):
+        findings.append(_finding("primary_attachment_json", "Raw JSON cannot be the primary human gate attachment."))
+    if media_type == "application/pdf" or path.endswith(".pdf"):
+        if attachment.get("fallback_renderer") is True:
+            findings.append(_finding("fallback_pdf_primary", "Fallback text-style PDF cannot be the primary normal gate artifact."))
+        if attachment.get("designed_artifact") is not True:
+            findings.append(_finding("primary_pdf_not_marked_designed", "Primary PDF must be marked/proven as designed operator artifact."))
+    elif not findings:
+        findings.append(_finding("unsupported_primary_attachment", "Primary gate attachment must be designed PDF/equivalent, not a technical dump."))
+
+    message = str(data.get("primary_message", ""))
+    if len(message.strip()) < 80:
+        findings.append(_finding("primary_message_too_short", "Gate message must state the decision and consequence."))
+    if _count(data.get("approval_does_not_authorize")) < 4:
+        findings.append(_finding("missing_non_authorization_boundary", "Gate must state what approval does not authorize."))
+    if _count(data.get("approval_authorizes")) < 1:
+        findings.append(_finding("missing_authorization_boundary", "Gate must state exactly what approval authorizes."))
+
+    quality_pass = process_pass and readback_pass and not [f for f in findings if f.severity == "error"]
+    return QualityResult("human_gate_artifact", process_pass, readback_pass, quality_pass, findings)
+
+
+def validate_completion_readback(completion: Mapping[str, Any], root: str | Path) -> QualityResult:
+    data = _as_mapping(completion)
+    base = Path(root)
+    findings: list[QualityFinding] = []
+    artifact_paths = data.get("artifact_paths", []) or []
+    process_pass = _nonempty(data)
+
+    for item in artifact_paths:
+        p = Path(str(item))
+        candidate = p if p.is_absolute() else base / p
+        if not candidate.exists():
+            findings.append(_finding("claimed_artifact_missing", f"Claimed artifact does not exist: {item}"))
+
+    readback_pass = not findings
+    quality_pass = process_pass and readback_pass
+    return QualityResult("completion_readback", process_pass, readback_pass, quality_pass, findings)
+
+
+def can_promote(result: QualityResult | Iterable[QualityResult]) -> bool:
+    if isinstance(result, QualityResult):
+        results = [result]
+    else:
+        results = list(result)
+    return bool(results) and all(r.process_pass and r.readback_pass and r.quality_pass for r in results)
+
+
+def result_to_dict(result: QualityResult) -> dict[str, Any]:
+    return {
+        "artifact_type": result.artifact_type,
+        "process_pass": result.process_pass,
+        "readback_pass": result.readback_pass,
+        "quality_pass": result.quality_pass,
+        "findings": [finding.__dict__ for finding in result.findings],
+    }
+
+
+def load_artifact(path: Path) -> Any:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    return text
+
+
+def validate_artifact(artifact_type: str, path: Path, *, root: Path | None = None) -> QualityResult:
+    payload = load_artifact(path)
+    if artifact_type == "product_sot":
+        return validate_product_sot_prd_grade(payload)
+    if artifact_type == "human_gate":
+        if not isinstance(payload, Mapping):
+            return QualityResult(
+                "human_gate_artifact",
+                process_pass=False,
+                readback_pass=True,
+                quality_pass=False,
+                findings=[_finding("invalid_human_gate_payload", "Human gate artifact must be a JSON object/package.")],
+            )
+        return validate_human_gate_artifact(payload)
+    if artifact_type == "completion_readback":
+        if not isinstance(payload, Mapping):
+            return QualityResult(
+                "completion_readback",
+                process_pass=False,
+                readback_pass=False,
+                quality_pass=False,
+                findings=[_finding("invalid_completion_payload", "Completion readback input must be a JSON object.")],
+            )
+        return validate_completion_readback(payload, root or path.parent)
+    raise ValueError(f"unsupported artifact_type: {artifact_type}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate Overkill Factory work-product quality floor.")
+    parser.add_argument("artifact_type", choices=["product_sot", "human_gate", "completion_readback"])
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--root", type=Path, help="Root directory for completion readback artifact paths")
+    parser.add_argument("--json", action="store_true", help="Emit JSON result")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = validate_artifact(args.artifact_type, args.path, root=args.root)
+    payload = result_to_dict(result)
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(f"{result.artifact_type}: quality_pass={result.quality_pass} process_pass={result.process_pass} readback_pass={result.readback_pass}")
+        for finding in result.findings:
+            print(f"{finding.severity}: {finding.code}: {finding.message}")
+    return 0 if result.quality_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/factory/templates/product-sot-one-screen-human-gate.md
+++ b/factory/templates/product-sot-one-screen-human-gate.md
@@ -1,0 +1,35 @@
+# Product SOT one-screen human gate template
+
+Use this as the primary operator-facing message before/with attachments.
+
+```text
+Decisão pendente:
+Aprovar ou corrigir a Product SOT de <produto>.
+
+O que a SOT diz:
+- <ponto essencial 1>
+- <ponto essencial 2>
+- <ponto essencial 3>
+- <ponto essencial 4>
+
+Se você aprovar:
+<o que a fábrica pode fazer em seguida>.
+
+Aprovar NÃO autoriza:
+<ações sensíveis ainda proibidas: implementação/deploy/mainnet/fundos/secrets/custody/signing/etc>.
+
+Responda uma destas:
+1. Aprovo a SOT.
+2. Não aprovo. Corrigir: ...
+3. Ainda falta: ...
+
+Anexos/ref:
+- SOT completa
+- manifest/readback
+```
+
+Rules:
+- Keep the primary message one-screen and decision-grade.
+- Attachments support review; they are not the primary UX.
+- Do not lead with receipt, JSON, file paths, or process apology.
+- Do not hide what approval does and does not authorize.

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -6497,7 +6497,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
                     "operator_input_required": False,
                 }
             ),
-            "latest_summary": "Independent review PASS for t_block001; reducer should close the reviewed task.",
+            "latest_summary": "Independent review PASS for reviewed task; reducer should close the reviewed task.",
             "events": [{"type": "completed", "payload": {"summary": "PASS"}}],
         }
         args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -1025,7 +1025,8 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertIn("credential_not_proven", result["checks"][0]["blocked_reasons"])
 
     def test_factory_run_graph_backbone_is_derived_from_workflow_catalog(self) -> None:
-        catalog = json.loads((ROOT / "docs" / "factory-workflow.catalog.json").read_text(encoding="utf-8"))
+        catalog_path = adapter.resolve_factory_workflow_catalog_path(ROOT / "docs" / "factory-workflow.catalog.json")
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
         expected_phase_ids = [
             phase["phase_id"]
             for phase in catalog["phases"]
@@ -6415,6 +6416,155 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(metadata["closed_from_worker_result"]["record_type"], "implementation_result")
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
+    def test_no_idle_creates_internal_review_task_without_operator_status_ping(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "reviewme"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "evidence-reconciler",
+            "title": "F15/WU-00 - Freeze/replay source and gate evidence index",
+            "body": "review-required: evidence index PASS; independent-reviewer must review before this card is treated as done.",
+            "events": [
+                {
+                    "type": "blocked",
+                    "payload": {
+                        "kind": "needs_input",
+                        "reason": "review-required: independent-reviewer must review before this card is treated as done",
+                    },
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_task_created")
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertTrue(state["native_dispatch_required_next"])
+        review_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.task_body_json_object(task).get("marker") == adapter.NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER
+        ]
+        self.assertEqual(len(review_tasks), 1)
+        self.assertEqual(review_tasks[0]["status"], "ready")
+        self.assertEqual(review_tasks[0]["assignee"], "independent-reviewer")
+        self.assertEqual(json.loads(str(review_tasks[0]["body"]))["target_task_ref"], blocker_id)
+        parents = review_tasks[0].get("parents")
+        self.assertNotIn(blocker_id, parents if isinstance(parents, list) else [])
+
+        second = adapter.no_idle(args, runner=fake)
+        self.assertEqual(second["no_idle_state"]["classification"], "internal_review_task_already_exists")
+        review_tasks_after = [
+            task for task in fake.tasks.values()
+            if adapter.task_body_json_object(task).get("marker") == adapter.NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER
+        ]
+        self.assertEqual(len(review_tasks_after), 1)
+
+    def test_no_idle_reduces_internal_review_pass_to_original_blocked_task(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "block001"
+        review_id = "t_" + "review01"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "evidence-reconciler",
+            "title": "F15/WU-00 - Freeze/replay source and gate evidence index",
+            "body": "review-required: independent-reviewer must review before this card is treated as done",
+            "events": [
+                {
+                    "type": "blocked",
+                    "payload": {
+                        "kind": "needs_input",
+                        "reason": "review-required: independent-reviewer must review before this card is treated as done",
+                    },
+                }
+            ],
+        }
+        fake.tasks[review_id] = {
+            "id": review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "F15/WU-00R - Independent review of WU-00 evidence index",
+            "body": json.dumps(
+                {
+                    "record_type": "factory_internal_review_result",
+                    "result": "PASS",
+                    "reviewed_task_ref": blocker_id,
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                }
+            ),
+            "latest_summary": "Independent review PASS for t_block001; reducer should close the reviewed task.",
+            "events": [{"type": "completed", "payload": {"summary": "PASS"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_pass_reduced_blockers")
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertEqual(fake.tasks[blocker_id]["status"], "done")
+        self.assertEqual(fake.tasks[blocker_id]["result"], "DONE")
+        metadata = json.loads(str(fake.tasks[blocker_id]["metadata"]))
+        self.assertEqual(metadata["marker"], adapter.NO_IDLE_REVIEW_PASS_REDUCER_MARKER)
+        self.assertEqual(metadata["review_task_ref"], review_id)
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
+    def test_no_idle_creates_repair_task_for_internal_review_fail(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "blockfail"
+        review_id = "t_" + "reviewfail"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "product-architect",
+            "title": "F15/WU-01 - 20apy predecessor study",
+            "body": "review-required: independent-reviewer must review before this card is done",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "review-required"}}],
+        }
+        fake.tasks[review_id] = {
+            "id": review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "F15/WU-01R - Independent review of WU-01",
+            "body": json.dumps(
+                {
+                    "record_type": "factory_internal_review_result",
+                    "result": "FAIL",
+                    "reviewed_task_ref": blocker_id,
+                    "blocking_findings": ["missing source traceability"],
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                }
+            ),
+            "events": [{"type": "completed", "payload": {"summary": "FAIL"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_fail_repair_task_created")
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertTrue(state["native_dispatch_required_next"])
+        repairs = [
+            task for task in fake.tasks.values()
+            if adapter.task_body_json_object(task).get("marker") == adapter.NO_IDLE_REVIEW_FAIL_REPAIR_MARKER
+        ]
+        self.assertEqual(len(repairs), 1)
+        self.assertEqual(repairs[0]["status"], "ready")
+        self.assertEqual(repairs[0]["assignee"], "product-architect")
+        repair_body = adapter.task_body_json_object(repairs[0])
+        self.assertEqual(repair_body["target_task_ref"], blocker_id)
+        self.assertEqual(repair_body["review_task_ref"], review_id)
+        self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
+
     def test_no_idle_reports_running_closeout_without_mutation_when_not_remediating(self) -> None:
         fake = FakeHermes()
         running_id = "t_" + "runclose2"
@@ -7658,6 +7808,93 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(state["repair_task_refs"], [repair_id])
         self.assertEqual(state["factory_owned_package_task_refs"], [gate_id])
         self.assertIn("re-created or unlinked", state["remediation_reason"])
+
+    def test_no_idle_repairs_factory_repair_task_gated_by_needs_input_parent_it_repairs(self) -> None:
+        blocker_id = "t_" + "block001"
+        repair_id = "t_" + "repair01"
+
+        state = adapter.classify_no_idle_state(
+            {
+                "ready": [],
+                "running": [],
+                "todo": [
+                    {
+                        "id": repair_id,
+                        "status": "todo",
+                        "assignee": "security-orchestrator",
+                        "title": "F15/WU-01S - Security triage for 20apy sanitized inventory",
+                        "body": json.dumps(
+                            {
+                                "marker": "factory_no_idle_remediation",
+                                "plan_action": "repair_internal_needs_input_blocker",
+                                "repairs_task_ref": blocker_id,
+                                "objective": "Internal remediation for WU-01, not a human gate.",
+                            }
+                        ),
+                        "parents": [blocker_id],
+                    }
+                ],
+                "blocked": [
+                    {
+                        "id": blocker_id,
+                        "status": "blocked",
+                        "assignee": "product-architect",
+                        "title": "F15/WU-01 - 20apy predecessor study",
+                        "body": "Worker produced a needs_input block after tool safety denied repo preflight; internal remediation exists.",
+                        "events": [
+                            {
+                                "kind": "blocked",
+                                "payload": {
+                                    "kind": "needs_input",
+                                    "reason": "authorize sanitized inventory/secret-safe scan path or provide sanitized export",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(state["status"], "remediation_required")
+        self.assertEqual(state["classification"], "factory_repair_task_dependency_gated_by_blocker_it_repairs")
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertEqual(state["repair_task_refs"], [repair_id])
+        self.assertEqual(state["operator_input_task_refs"], [])
+        self.assertEqual(state["dependency_blocker_task_refs"], [blocker_id])
+        self.assertIn("re-created or unlinked", state["remediation_reason"])
+
+    def test_no_idle_unlinks_and_promotes_repair_task_gated_by_parent_it_repairs(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "block001"
+        repair_id = "t_" + "repair01"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "product-architect",
+            "title": "F15/WU-01 - 20apy predecessor study",
+            "body": "needs_input after denied preflight; internal factory_no_idle_remediation exists",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "needs sanitized export"}}],
+            "children": [repair_id],
+        }
+        fake.tasks[repair_id] = {
+            "id": repair_id,
+            "status": "todo",
+            "assignee": "security-orchestrator",
+            "title": "F15/WU-01X - Build sanitized 20apy content export",
+            "body": json.dumps({"marker": "factory_no_idle_remediation", "repairs_task_ref": blocker_id}),
+            "parents": [blocker_id],
+            "events": [],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "factory_repair_task_unlinked_and_promoted")
+        self.assertEqual(fake.tasks[repair_id]["status"], "ready")
+        self.assertEqual(fake.tasks[repair_id]["parents"], [])
+        self.assertFalse(any(len(call) >= 5 and call[4] == "create" for call in fake.calls))
 
     def test_no_idle_reports_dependency_gated_todo_without_generic_remediation(self) -> None:
         fake = FakeHermes()

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -6424,7 +6424,10 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             "status": "blocked",
             "assignee": "evidence-reconciler",
             "title": "F15/WU-00 - Freeze/replay source and gate evidence index",
-            "body": "review-required: evidence index PASS; independent-reviewer must review before this card is treated as done.",
+            "body": (
+                "review-required: evidence index PASS; independent-reviewer must review before this card is treated as done. "
+                "Stop rule mentions operator input/approval only as forbidden escalation, not as the current blocker."
+            ),
             "events": [
                 {
                     "type": "blocked",

--- a/factory/tests/test_work_product_quality_firewall.py
+++ b/factory/tests/test_work_product_quality_firewall.py
@@ -1,0 +1,181 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "work_product_quality_firewall.py"
+SPEC = importlib.util.spec_from_file_location("work_product_quality_firewall", MODULE_PATH)
+assert SPEC is not None
+quality = importlib.util.module_from_spec(SPEC)
+sys.modules["work_product_quality_firewall"] = quality
+assert SPEC.loader is not None
+SPEC.loader.exec_module(quality)
+
+
+def test_shallow_product_sot_scope_summary_fails_prd_grade_quality():
+    sot = {
+        "record_type": "product_sot_candidate",
+        "product": "KAXIS V1",
+        "scope_in": ["USDC stake", "cadastro", "admin"],
+        "scope_out": ["Pix", "mobile"],
+        "acceptance_criteria": ["operator can approve scope"],
+    }
+
+    result = quality.validate_product_sot_prd_grade(sot)
+
+    assert result.process_pass is True
+    assert result.quality_pass is False
+    codes = {finding.code for finding in result.findings}
+    assert "missing_product_intent" in codes
+    assert "missing_source_traceability" in codes
+    assert "missing_user_journeys" in codes
+    assert "missing_admin_journeys" in codes
+    assert "missing_downstream_handoff" in codes
+
+
+def test_prd_grade_product_sot_passes_quality_firewall():
+    sot = {
+        "record_type": "product_sot_candidate",
+        "product_intent": "KAXIS V1 delivers a global web/onchain USDC stake product with Web3 mostly under the hood.",
+        "source_traceability": [
+            {"source_ref": "complement#flow-v6", "requirement_ids": ["REQ-UX-001", "REQ-STAKE-001"]},
+            {"source_ref": "20apy-ff#repo-study", "requirement_ids": ["REQ-ARCH-001"]},
+        ],
+        "personas": ["retail investor", "operations admin"],
+        "user_journeys": [
+            {"id": "UJ-01", "steps": ["login", "complete cadastro", "claim KX benefit", "enter platform"]},
+            {"id": "UJ-02", "steps": ["choose stake", "pay USDC", "see active position", "redeem at maturity"]},
+        ],
+        "admin_journeys": [
+            {"id": "AJ-01", "steps": ["review user", "inspect payment intent", "reconcile stake", "handle exception"]},
+        ],
+        "functional_requirements": [
+            {"id": "REQ-STAKE-001", "text": "User can create a USDC stake payment intent."},
+            {"id": "REQ-ADMIN-001", "text": "Admin can reconcile user positions and payment events."},
+            {"id": "REQ-UX-001", "text": "Flow-v6 states map to real system states."},
+        ],
+        "non_functional_requirements": [
+            {"id": "NFR-AUDIT-001", "text": "Every financial display is traceable to ledger/onchain/database events."},
+            {"id": "NFR-SEC-001", "text": "No production signing or secrets use without later gate."},
+        ],
+        "state_model_requirements": [
+            "empty", "loading", "error", "success", "blocked", "pending", "expired", "review"
+        ],
+        "data_ledger_reconciliation_requirements": [
+            "payment intent must reconcile against wallet/onchain/database events",
+            "divergence must surface as explicit operational state",
+        ],
+        "acceptance_criteria_by_flow": {
+            "cadastro": ["CPF/WhatsApp/user/referrer fields validated", "blocked/expired code states exist"],
+            "stake": ["USDC payment intent is traceable", "maturity/redemption state is visible"],
+        },
+        "decisions_and_open_questions": [
+            {"id": "D-001", "status": "open", "owner": "architecture", "text": "Normalize exact stake pool rules."}
+        ],
+        "downstream_handoff": {
+            "architecture": ["onchain/offchain boundaries", "ledger requirements"],
+            "ux": ["flow-v6 states", "blocked modules"],
+            "security": ["custody/signing forbidden now", "PII/admin constraints"],
+            "implementation": ["functional requirements", "acceptance criteria"],
+            "qa": ["journey and state acceptance criteria"],
+        },
+    }
+
+    result = quality.validate_product_sot_prd_grade(sot)
+
+    assert result.process_pass is True
+    assert result.readback_pass is True
+    assert result.quality_pass is True
+    assert result.findings == []
+
+
+def test_quality_firewall_refuses_process_pass_without_quality_pass():
+    result = quality.QualityResult(
+        artifact_type="product_sot",
+        process_pass=True,
+        readback_pass=True,
+        quality_pass=False,
+        findings=[quality.QualityFinding("too_shallow", "error", "Artifact is shallow")],
+    )
+
+    assert quality.can_promote(result) is False
+
+
+def test_completion_readback_fails_missing_claimed_artifact():
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        completion = {
+            "artifact_paths": ["exists.json", "missing.json"],
+            "changed": ["claimed artifacts"],
+            "verification_result": "PASS",
+        }
+        (root / "exists.json").write_text("{}", encoding="utf-8")
+
+        result = quality.validate_completion_readback(completion, root)
+
+    assert result.readback_pass is False
+    assert result.quality_pass is False
+    assert any(f.code == "claimed_artifact_missing" for f in result.findings)
+
+
+def test_human_gate_primary_json_attachment_fails_operator_quality():
+    package = {
+        "record_type": "operator_delivery_receipt",
+        "primary_message": "Decisão pendente: aprovar Product SOT. Aprovar não autoriza deploy/mainnet/fundos.",
+        "primary_attachment": {"path": "manifest.json", "media_type": "application/json", "role": "primary"},
+        "valid_replies": ["Aprovo", "Corrigir: ..."],
+        "approval_authorizes": ["seguir para arquitetura"],
+        "approval_does_not_authorize": ["deploy", "mainnet", "fundos", "secrets", "custody", "signing"],
+    }
+
+    result = quality.validate_human_gate_artifact(package)
+
+    assert result.quality_pass is False
+    assert any(f.code == "primary_attachment_json" for f in result.findings)
+
+
+def test_human_gate_designed_pdf_passes_operator_quality():
+    package = {
+        "record_type": "operator_delivery_receipt",
+        "primary_message": "Decisão pendente: aprovar Product SOT revisada. Se aprovar, segue para método/arquitetura. Aprovar não autoriza implementação, deploy, mainnet, fundos, secrets, custody ou signing.",
+        "primary_attachment": {"path": "gate.pdf", "media_type": "application/pdf", "role": "primary", "designed_artifact": True, "fallback_renderer": False},
+        "valid_replies": ["Aprovo", "Corrigir: ...", "Ainda falta: ..."],
+        "approval_authorizes": ["seguir para método", "seguir para arquitetura"],
+        "approval_does_not_authorize": ["implementação", "deploy", "mainnet", "fundos", "secrets", "custody", "signing"],
+    }
+
+    result = quality.validate_human_gate_artifact(package)
+
+    assert result.quality_pass is True
+    assert result.findings == []
+
+
+def test_cli_returns_nonzero_for_shallow_product_sot(tmp_path):
+    path = tmp_path / "shallow_sot.json"
+    path.write_text(json.dumps({"scope_in": ["stake"], "scope_out": ["deploy"]}), encoding="utf-8")
+
+    exit_code = quality.main(["product_sot", str(path), "--json"])
+
+    assert exit_code == 1
+
+
+def test_cli_returns_zero_for_designed_human_gate(tmp_path):
+    path = tmp_path / "gate.json"
+    path.write_text(
+        json.dumps(
+            {
+                "primary_message": "Decisão pendente: aprovar Product SOT revisada. Aprovar libera só método/arquitetura e não libera implementação, deploy, mainnet, fundos, secrets, custody ou signing.",
+                "primary_attachment": {"path": "gate.pdf", "media_type": "application/pdf", "designed_artifact": True, "fallback_renderer": False},
+                "valid_replies": ["Aprovo", "Corrigir: ..."],
+                "approval_authorizes": ["seguir para método"],
+                "approval_does_not_authorize": ["implementação", "deploy", "mainnet", "fundos", "secrets", "custody", "signing"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = quality.main(["human_gate", str(path), "--json"])
+
+    assert exit_code == 0

--- a/factory/tests/test_work_product_quality_firewall.py
+++ b/factory/tests/test_work_product_quality_firewall.py
@@ -17,9 +17,9 @@ SPEC.loader.exec_module(quality)
 def test_shallow_product_sot_scope_summary_fails_prd_grade_quality():
     sot = {
         "record_type": "product_sot_candidate",
-        "product": "KAXIS V1",
-        "scope_in": ["USDC stake", "cadastro", "admin"],
-        "scope_out": ["Pix", "mobile"],
+        "product": "Product Alpha V1",
+        "scope_in": ["stablecoin subscription", "signup", "admin"],
+        "scope_out": ["instant payment rail", "mobile"],
         "acceptance_criteria": ["operator can approve scope"],
     }
 
@@ -38,10 +38,10 @@ def test_shallow_product_sot_scope_summary_fails_prd_grade_quality():
 def test_prd_grade_product_sot_passes_quality_firewall():
     sot = {
         "record_type": "product_sot_candidate",
-        "product_intent": "KAXIS V1 delivers a global web/onchain USDC stake product with Web3 mostly under the hood.",
+        "product_intent": "Product Alpha V1 delivers a global web subscription product with complex payment and operations flows.",
         "source_traceability": [
-            {"source_ref": "complement#flow-v6", "requirement_ids": ["REQ-UX-001", "REQ-STAKE-001"]},
-            {"source_ref": "20apy-ff#repo-study", "requirement_ids": ["REQ-ARCH-001"]},
+            {"source_ref": "brief#flow-v6", "requirement_ids": ["REQ-UX-001", "REQ-SUB-001"]},
+            {"source_ref": "legacy-app#repo-study", "requirement_ids": ["REQ-ARCH-001"]},
         ],
         "personas": ["retail investor", "operations admin"],
         "user_journeys": [


### PR DESCRIPTION
## Summary
- Adds an executable Work Product Quality Firewall for PRD-grade Product SOT, readback, and operator-grade human gate artifacts.
- Moves internal review-required handling into no-idle runtime logic so review tasks are created idempotently without operator/status pings.
- Adds reducers for internal review PASS and FAIL: PASS completes the original blocker; FAIL creates deterministic repair work.
- Fixes dependency-gated repair tasks that were incorrectly linked under the blocker they repair.
- Keeps Hermes runtime authority/no-shadow-dispatcher boundaries explicit.

## Test plan
- `cd factory && python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py tests/test_work_product_quality_firewall.py -q`
- `cd factory && python -m py_compile adapters/hermes/live_kanban_adapter.py scripts/work_product_quality_firewall.py`

Fixes #546
Fixes #547
Fixes #548
Fixes #549
