### PR TITLE
fix: ignore review repair titles as review failures

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -3575,7 +3575,10 @@ def internal_review_fail_references(record: dict[str, Any], blocked_refs: set[st
     body = task_body_json_object(record)
     text = task_record_text(record)
     text_lower = text.lower()
+    title_lower = str(record.get("title") or "").lower()
     if body.get("marker") == NO_IDLE_REVIEW_FAIL_REPAIR_MARKER:
+        return []
+    if title_lower.startswith("repair ") and " after internal review fail" in title_lower:
         return []
     if "no_repair_required" in text_lower and "not a current independent review fail" in text_lower:
         return []

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -6800,6 +6800,35 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertNotEqual(state["classification"], "internal_review_fail_repair_task_already_exists")
         self.assertNotIn(repair_id, state.get("existing_repair_task_refs") or [])
 
+    def test_no_idle_ignores_review_fail_repair_title_even_when_body_marker_missing(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "blockfail"
+        repair_id = "t_" + "repairtitle"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "cloud-infra-security-specialist",
+            "title": "F15/WU-15 - Cloud/IAM/KMS/Secret Manager/budget non-material readiness packet",
+            "body": "review-required: independent-reviewer must review before this card is done",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "review-required"}}],
+        }
+        fake.tasks[repair_id] = {
+            "id": repair_id,
+            "status": "done",
+            "assignee": "cloud-infra-security-specialist",
+            "title": "Repair t_blockfail after internal review FAIL",
+            "body": "{}",
+            "latest_summary": "NO_REPAIR_REQUIRED not a current independent REVIEW FAIL; stale duplicate readback.",
+            "events": [{"type": "completed", "payload": {"summary": "NO_REPAIR_REQUIRED not a current independent REVIEW FAIL"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertNotEqual(state["classification"], "internal_review_fail_repair_task_created")
+        self.assertNotEqual(state["classification"], "internal_review_fail_repair_task_already_exists")
+
     def test_no_idle_reports_running_closeout_without_mutation_when_not_remediating(self) -> None:
         fake = FakeHermes()
         running_id = "t_" + "runclose2"


### PR DESCRIPTION
## Summary
- Also ignore completed repair tasks by title (`Repair ... after internal review FAIL`) when detecting independent review FAIL evidence.
- Covers live snapshots where the repair task body/marker is absent or incomplete but the title still identifies it as repair work, not an independent review.

## Test Plan
- `python -m pytest tests/test_hermes_live_kanban_adapter.py -q` -> 160 passed, 3 subtests passed
- `python factory/scripts/public_safety_scan.py` -> OK
- `git diff --check` -> OK

Observed on KAXIS board after #554: done repair readbacks were still reused as fresh `review_task_ref`s when body markers were unavailable in the live task snapshot.