### PR TITLE
fix: let review pass override instructional fail text

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -3475,12 +3475,13 @@ def remediation_task_runtime_metadata(
 def internal_review_pass_references(record: dict[str, Any], blocked_refs: set[str]) -> list[str]:
     body = task_body_json_object(record)
     text = task_record_text(record)
+    text_lower = text.lower()
     result = str(body.get("result") or body.get("verdict") or "").strip().upper()
-    pass_seen = result == "PASS" or "independent review pass" in text or "review pass" in text or '"result": "pass' in text or " pass" in text
+    pass_seen = result == "PASS" or "independent review pass" in text_lower or "review pass" in text_lower or '"result": "pass' in text_lower or " pass" in text_lower
     if not pass_seen:
         return []
     if str(record.get("assignee") or "").strip() not in {"independent-reviewer", "autoreview-gate"}:
-        if "independent review" not in text and "review" not in text:
+        if "independent review" not in text_lower and "review" not in text_lower:
             return []
     refs: set[str] = set()
     for key in ("reviewed_task_ref", "blocked_task_ref", "target_task_ref", "task_ref"):
@@ -3581,6 +3582,8 @@ def internal_review_fail_references(record: dict[str, Any], blocked_refs: set[st
     if title_lower.startswith("repair ") and " after internal review fail" in title_lower:
         return []
     if "no_repair_required" in text_lower and "not a current independent review fail" in text_lower:
+        return []
+    if internal_review_pass_references(record, blocked_refs):
         return []
     result = str(body.get("result") or body.get("verdict") or "").strip().upper()
     fail_seen = result == "FAIL" or "review fail" in text_lower or "review failed" in text_lower or '"result": "fail' in text_lower

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -6829,6 +6829,37 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertNotEqual(state["classification"], "internal_review_fail_repair_task_created")
         self.assertNotEqual(state["classification"], "internal_review_fail_repair_task_already_exists")
 
+    def test_no_idle_review_pass_completion_overrides_instructional_review_fail_text(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "blockpass"
+        review_id = "t_" + "reviewpass"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "cloud-infra-security-specialist",
+            "title": "F15/WU-15 - Cloud readiness",
+            "body": "review-required",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "review-required"}}],
+        }
+        fake.tasks[review_id] = {
+            "id": review_id,
+            "status": "done",
+            "assignee": "security-orchestrator",
+            "title": "Internal review: accept repaired WU-15 cloud readiness packet",
+            "body": (
+                f"Target repaired task: {blocker_id}. Completion must use wording: "
+                "REVIEW PASS or REVIEW FAIL."
+            ),
+            "events": [{"type": "completed", "payload": {"summary": f"REVIEW PASS for target {blocker_id}"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_pass_reduced_blockers")
+        self.assertEqual(fake.tasks[blocker_id]["status"], "done")
+
     def test_no_idle_reports_running_closeout_without_mutation_when_not_remediating(self) -> None:
         fake = FakeHermes()
         running_id = "t_" + "runclose2"


### PR DESCRIPTION
## Summary
- Make internal review PASS detection case-insensitive and let PASS closeout dominate instructional text that mentions `REVIEW FAIL` as an allowed wording.
- Prevent internal review request instructions from being reinterpreted as a current FAIL result.

## Test Plan
- `python -m pytest tests/test_hermes_live_kanban_adapter.py -q` -> 161 passed, 3 subtests passed
- `python factory/scripts/public_safety_scan.py` -> OK
- `git diff --check` -> OK

Live KAXIS verification before PR: fail candidates became empty while WU-15 PASS closeout candidates remained available.