### PR TITLE
fix: prioritize materialization blockers over board repair

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -2670,10 +2670,10 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
     materialization_contract_refs = sorted(
         task_record_id(item) for item in materialization_contract_blockers if task_record_id(item)
     )
-    if blocked and materialization_contract_blockers and len(materialization_contract_blockers) == len(blocked) and not todo:
+    if blocked and materialization_contract_blockers:
         return {
             "status": "remediation_required",
-            "classification": "only_materialization_contract_blockers_seen",
+            "classification": "materialization_contract_blockers_seen",
             "blocked": True,
             "remediation_required": True,
             "human_gate_required": False,
@@ -2683,8 +2683,9 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             "materialization_contract_task_refs": materialization_contract_refs,
             "remediation_strategy": "create_materialization_contract_repair_task",
             "remediation_reason": (
-                "All visible blocked work is stopped by missing runtime/security contracts, source packets, "
-                "target repo paths, or parent artifacts. This is a factory materialization defect, not an operator gate."
+                "Visible blocked work is stopped by missing runtime/security contracts, source packets, "
+                "traceability artifacts, target repo paths, or parent artifacts. This is a factory "
+                "materialization defect, not an operator gate, even when unrelated todo backlog exists."
             ),
             "next_action": "create internal materialization-contract repair work and dispatch it; do not ask the operator",
             "state": state,
@@ -10929,6 +10930,7 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
     targeted_legacy_repair_available = legacy_remediation_strategy in {
         "create_targeted_review_repair_task",
         "create_post_review_owner_gate_package_task",
+        "create_materialization_contract_repair_task",
     }
     runtime_contract_repair_required = (
         not targeted_legacy_repair_available

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4717,6 +4717,126 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(created_body["operator_input_required"])
         self.assertNotIn("parents", created_tasks[0])
 
+    def test_no_idle_creates_materialization_repair_for_missing_source_packet_and_traceability_artifact(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "wu12block"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "title": "F15/WU-12 - Onchain Work Package: Solana/Quasar accounts, PDAs, authority and DevNet-only validation plan",
+            "assignee": "solana-quasar-builder",
+            "current_step_key": "F15-runtime-execution",
+            "body": (
+                "work_unit_id: WU-12\n"
+                "source_packet_artifact: /workspace/f15_worker_packets.json#WU-12\n"
+                "dependencies: WU-07=" + "t_" + "6a427946\n"
+                "stop_rules:\n- Onchain Work Package missing\n- Auditor unavailable\n"
+            ),
+            "events": [
+                {
+                    "kind": "blocked",
+                    "payload": {
+                        "kind": "capability",
+                        "reason": (
+                            "WU-12 stop rule fired: required Onchain Work Package/source packet is missing "
+                            "and WU-07 has no traceable ledger/reconciliation artifact; cannot construct "
+                            "PDA/signer map without inventing authority boundaries."
+                        ),
+                    },
+                }
+            ],
+            "comments": [
+                {
+                    "author": "solana-quasar-builder",
+                    "body": (
+                        "Required unblock: materialize/attach the WU-12 Onchain Work Package/source packet "
+                        "and traceable WU-07 ledger/event artifact. No Mainnet/funds/signing action was performed."
+                    ),
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(
+            state["classification"],
+            "deterministic_materialization_contract_repair_task_created",
+        )
+        self.assertEqual(state["materialization_contract_task_refs"], ["kanban:<redacted>"])
+        self.assertTrue(state["native_dispatch_required_next"])
+        self.assertFalse(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        created_tasks = [task for task_id, task in fake.tasks.items() if task_id != blocker_id]
+        self.assertEqual(len(created_tasks), 1)
+        created_body = json.loads(str(created_tasks[0]["body"]))
+        self.assertEqual(
+            created_body["targeted_remediation"]["plan_action"],
+            "repair_materialization_contract_inputs",
+        )
+        self.assertIn(blocker_id, created_body["targeted_remediation"]["materialization_contract_task_refs"])
+
+    def test_no_idle_prioritizes_materialization_blocker_over_board_contract_with_unrelated_todo(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "wu12block2"
+        todo_id = "t_" + "unrelatedtodo"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "title": "F15/WU-12 - Onchain Work Package: Solana/Quasar accounts, PDAs, authority and DevNet-only validation plan",
+            "assignee": "solana-quasar-builder",
+            "current_step_key": "F15-runtime-execution",
+            "body": (
+                "work_unit_id: WU-12\n"
+                "source_packet_artifact: /workspace/f15_worker_packets.json#WU-12\n"
+                "dependencies: WU-07=" + "t_" + "6a427946\n"
+            ),
+            "events": [
+                {
+                    "kind": "blocked",
+                    "payload": {
+                        "kind": "capability",
+                        "reason": (
+                            "WU-12 stop rule fired: required Onchain Work Package/source packet is missing "
+                            "and WU-07 has no traceable ledger/reconciliation artifact."
+                        ),
+                    },
+                }
+            ],
+            "comments": [
+                {
+                    "author": "solana-quasar-builder",
+                    "body": "Required unblock: materialize/attach the WU-12 source packet and traceable WU-07 ledger/event artifact.",
+                }
+            ],
+        }
+        fake.tasks[todo_id] = {
+            "id": todo_id,
+            "status": "todo",
+            "title": "F15/WU-99 - unrelated backlog item",
+            "assignee": "implementation-worker",
+            "body": "Not ready yet; unrelated todo backlog should not mask materialization blocker.",
+            "events": [{"kind": "created"}],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(
+            state["classification"],
+            "deterministic_materialization_contract_repair_task_created",
+        )
+        self.assertEqual(state["materialization_contract_task_refs"], ["kanban:<redacted>"])
+        self.assertTrue(state["native_dispatch_required_next"])
+        created_tasks = [task for task_id, task in fake.tasks.items() if task_id not in {blocker_id, todo_id}]
+        self.assertEqual(len(created_tasks), 1)
+
     def test_no_idle_creates_owner_gate_package_after_product_sot_candidate_done(self) -> None:
         fake = FakeHermes()
         sot_task_id = "t_" + "sotdone1"


### PR DESCRIPTION
## Summary
- Treat visible materialization blockers as targeted no-idle repair work even when unrelated TODO backlog exists.
- Let materialization-contract repair preempt generic board-contract repair instead of looping on `repair_board_contract`.
- Add regression coverage for the live WU-12 class: missing Onchain Work Package/source packet plus missing WU-07 traceability artifact.

## Root cause
The factory was not truly working when only blocked materialization work remained with unrelated TODO backlog. `no-idle` detected the missing-artifact blocker but the deterministic board reconciler preempted it because `create_materialization_contract_repair_task` was not considered a targeted legacy repair. This caused generic board-contract repair loops instead of the specific artifact materialization repair.

## Test Plan
- `python -m pytest tests/test_hermes_live_kanban_adapter.py -q` -> 163 passed, 3 subtests passed
- `python factory/scripts/public_safety_scan.py` -> OK
- `git diff --check` -> OK

Live KAXIS board was manually unblocked with a targeted repair while this fix was developed; WU-12 is now running under `solana-quasar-builder`.