### PR TITLE
fix: make no-idle watchdog fail loud on no-progress loops

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -3261,7 +3261,7 @@ def internal_review_reviewer_for_blocker(item: dict[str, Any]) -> str:
 
 def existing_internal_review_task_refs(rows: dict[str, list[dict[str, Any]]], target_task_ref: str) -> list[str]:
     refs: list[str] = []
-    for status in ("ready", "running", "todo", "blocked", "done"):
+    for status in ("ready", "running", "todo", "blocked"):
         for item in rows.get(status, []):
             body = task_body_json_object(item)
             if body.get("marker") != NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER:
@@ -3473,12 +3473,27 @@ def remediation_task_runtime_metadata(
     }
 
 
+def review_record_timestamp(record: dict[str, Any], fallback: float = 0.0) -> float:
+    for key in ("completed_at", "updated_at", "created_at", "started_at"):
+        value = parse_timestamp_seconds(record.get(key))
+        if value is not None:
+            return value
+    return fallback
+
+
 def internal_review_pass_references(record: dict[str, Any], blocked_refs: set[str]) -> list[str]:
     body = task_body_json_object(record)
     text = task_record_text(record)
     text_lower = text.lower()
     result = str(body.get("result") or body.get("verdict") or "").strip().upper()
-    pass_seen = result == "PASS" or "independent review pass" in text_lower or "review pass" in text_lower or '"result": "pass' in text_lower or " pass" in text_lower
+    if result in {"FAIL", "FAILED", "BLOCK", "BLOCKED"}:
+        return []
+    pass_seen = (
+        result == "PASS"
+        or "independent review pass" in text_lower
+        or "review pass" in text_lower
+        or '"result": "pass' in text_lower
+    )
     if not pass_seen:
         return []
     if str(record.get("assignee") or "").strip() not in {"independent-reviewer", "autoreview-gate"}:
@@ -3609,12 +3624,23 @@ def internal_review_fail_repair_candidates(rows: dict[str, list[dict[str, Any]]]
     blocked_by_id = {task_record_id(item): item for item in rows.get("blocked", []) if task_record_id(item)}
     if not blocked_by_id:
         return []
+    blocked_refs = set(blocked_by_id)
+    latest_pass_by_ref: dict[str, float] = {}
+    for index, review in enumerate(rows.get("done", [])):
+        for blocked_ref in internal_review_pass_references(review, blocked_refs):
+            latest_pass_by_ref[blocked_ref] = max(
+                latest_pass_by_ref.get(blocked_ref, float("-inf")),
+                review_record_timestamp(review, fallback=float(index)),
+            )
     candidates: list[dict[str, Any]] = []
-    for review in rows.get("done", []):
+    for index, review in enumerate(rows.get("done", [])):
         review_id = task_record_id(review)
         if not review_id:
             continue
-        for blocked_ref in internal_review_fail_references(review, set(blocked_by_id)):
+        review_timestamp = review_record_timestamp(review, fallback=float(index))
+        for blocked_ref in internal_review_fail_references(review, blocked_refs):
+            if latest_pass_by_ref.get(blocked_ref, float("-inf")) >= review_timestamp:
+                continue
             candidates.append({
                 "task_ref": blocked_ref,
                 "review_task_ref": review_id,
@@ -6683,8 +6709,8 @@ def latest_ready_work_unit_materialization_plan_path(rows: dict[str, list[dict[s
             continue
         path = ready_work_unit_materialization_plan_path_from_task(task)
         if path is not None:
-            completed = int(task.get("completed_at") or task.get("created_at") or index)
-            candidates.append((completed, path))
+            completed = parse_timestamp_seconds(task.get("completed_at") or task.get("created_at"))
+            candidates.append((int(completed if completed is not None else index), path))
     if not candidates:
         return None
     candidates.sort(key=lambda item: item[0])
@@ -11083,22 +11109,39 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
                 "human_gate_required": False,
                 "operator_input_required": False,
             }
-            remediation_task_id = create_materialization_contract_repair_task(
-                hermes_bin=args.hermes_bin,
-                board=args.board,
-                workspace=args.workspace,
-                assignee=args.assignee,
-                classification=classification,
-                runner=runner,
-            )
-            task_runtime = remediation_task_runtime_metadata(
-                hermes_bin=args.hermes_bin,
-                board=args.board,
-                task_id=remediation_task_id,
-                runner=runner,
-            )
+            stale_remediation_task_refs: list[str] = []
+            remediation_replacement_attempts = 0
+            remediation_task_id = ""
+            task_runtime: dict[str, Any] = {}
+            for attempt in range(0, 4):
+                create_classification = dict(classification)
+                if attempt:
+                    create_classification["remediation_replacement_attempt"] = attempt
+                    create_classification["stale_remediation_task_refs"] = list(stale_remediation_task_refs)
+                remediation_task_id = create_materialization_contract_repair_task(
+                    hermes_bin=args.hermes_bin,
+                    board=args.board,
+                    workspace=args.workspace,
+                    assignee=args.assignee,
+                    classification=create_classification,
+                    runner=runner,
+                )
+                task_runtime = remediation_task_runtime_metadata(
+                    hermes_bin=args.hermes_bin,
+                    board=args.board,
+                    task_id=remediation_task_id,
+                    runner=runner,
+                )
+                if not (remediation_task_id and task_runtime.get("remediation_task_stale")):
+                    break
+                if remediation_task_id in stale_remediation_task_refs:
+                    break
+                stale_remediation_task_refs.append(remediation_task_id)
+                remediation_replacement_attempts += 1
             classification["targeted_remediation_plan"] = targeted_remediation_plan
             classification["remediation_task_ref"] = remediation_task_id
+            classification["stale_remediation_task_refs"] = stale_remediation_task_refs
+            classification["remediation_replacement_attempts"] = remediation_replacement_attempts
             classification.update(task_runtime)
             classification["native_dispatch_required_next"] = bool(
                 remediation_task_id

--- a/factory/reports/factory-failure-mode-audit-2026-06-30.md
+++ b/factory/reports/factory-failure-mode-audit-2026-06-30.md
@@ -1,0 +1,66 @@
+# Overkill Factory failure-mode audit — 2026-06-30
+
+Status: in progress
+Scope: no-idle runtime, reducers, dispatch/guard lifecycle, worker blockers, artifact materialization, internal reviews, safety gates.
+
+Mandate:
+- Minimize avoidable stopped-factory scenarios.
+- Do not count a live guard process as proof of useful work.
+- Internal missing artifacts/contracts/reviews must self-repair.
+- Real human gates remain explicit: cost/budget, production/mainnet/funds/custody/signing/credentials/authority decisions.
+
+## Current high-risk architecture observations
+
+1. `adapters/hermes/live_kanban_adapter.py` is a hotspot: ~11.5k lines, 291 top-level functions.
+2. `no_idle()` is ~1,282 lines and mixes classification, reconcile preemption, task creation, stale id replacement, reducer outputs, and public sanitization.
+3. `classify_no_idle_state()` is ~451 lines and encodes many overlapping blocker classes.
+4. Recent fixes #551-#557 show the same architectural pattern: specific reducer/repair intent being masked by generic reconcile/board repair or stale task interpretation.
+5. Guard/process liveness can be misleading unless tied to material progress: running/ready changes, blocker reduction, or distinct frontier work.
+
+## Failure-mode matrix draft
+
+| ID | Scenario | Symptom | Root risk | Current mitigation | Gap / audit question | Priority |
+|---|---|---|---|---|---|---|
+| FM-001 | Materialization blocker + unrelated TODO backlog | no-idle loops on `repair_board_contract`; Spawned=0 | specific repair preempted by generic board repair | PR #557 regression tests | Search for other targeted strategies missing from `targeted_legacy_repair_available` | P0 |
+| FM-002 | Stale remediation id replay | no-idle returns terminal/done task id; no fresh worker starts | idempotency hides progress | PR #552 bounded stale replacement | Test all remediation creators, not only board reconcile | P0 |
+| FM-003 | Review PASS instruction contains REVIEW FAIL wording | PASS review parsed as FAIL | body instructions mixed with terminal result | PR #556 | Verify all review parsers prefer events/comments/metadata over body templates | P0 |
+| FM-004 | Completed repair readback interpreted as review FAIL | duplicate repair chain, done grows, blocker remains | repair tasks reused as authority | PR #553/#555 | Add lineage depth / duplicate-title loop monitor | P0 |
+| FM-005 | Terminal repair counted as active repair | no new repair created although only done repair exists | active/terminal state conflation | PR #554 | Apply same rule to all repair classes | P0 |
+| FM-006 | Guard/watchdog alive but no progress | user sees process running while factory stopped | guard dispatches on stale remediation id or loops empty | local active guard had no-progress breaker; repo watchdog now has `--max-unchanged-no-progress` test/logic | Keep CI green and ensure cron uses the versioned watchdog, not only local script | P0 |
+| FM-006A | Stale remediation id presented as created remediation | watchdog says remediation created although no fresh worker can start | `remediation_task_id` truthy without checking `remediation_task_stale` | fixed locally with regression `test_watchdog_does_not_call_stale_remediation_id_created` | Merge/CI | P0 |
+| FM-007 | Missing worker skill ref | worker crashes before work | manual card uses skill absent from target profile | skill doc updated | Add preflight in card creation / no-idle repair creator to reject invalid skills | P1 |
+| FM-008 | Internal review-required blocker without reviewer card | worker blocks waiting for internal reviewer; no reducer creates review | no-idle lacks reviewer-card creation for some domains | manual WU-12 review created | Add generic internal-review-required detector/creator for `review-required:<profile>` | P0 |
+| FM-009 | Done task without declared artifact readback | downstream trusts process done, but files absent | done != quality/evidence | missing declared artifact materializer exists | Audit whether all done transitions enforce artifact readback | P0 |
+| FM-010 | False human/operator gate from forbidden text | factory asks user though text is only safety boundary | keyword-only gate classifier | existing mitigations in classifier | Fuzz classifier with forbidden_actions examples | P1 |
+| FM-011 | True human gate suppressed as internal repair | unsafe automation attempts around mainnet/funds/signing | overbroad internal-materialization markers | external markers list | Add negative tests for mainnet/funds/custody/signing phrasing mixed with missing artifacts | P0 |
+| FM-012 | Running worker stale/heartbeat dead | guard waits forever | running count without heartbeat freshness | Hermes dispatch reclaim maybe handles | Audit reclaim thresholds and active guard freshness checks | P1 |
+| FM-013 | Ready task undispatched due to profile missing | ready>0 but Spawned=0 | assignee profile invalid/missing | profile discovery docs | Add ready-profile-invalid classification and repair/reassign path | P1 |
+| FM-014 | Duplicate independent reviews | multiple auditors on same target, reducers race | idempotency missing/stale across manual/no-idle cards | some idempotency keys used manually | Enforce idempotency key pattern in review creators | P1 |
+| FM-015 | Public/private leakage in audit/debug output | tokens/paths/task IDs leak into public surface | unsanitized debug/report | public_safety_scan | Include new audit reports in scan baseline | P0 |
+
+| FM-016 | Active running task without deterministic runtime contract | no-idle returns `factory_phase_invariant_violation`; active worker may keep running while watchdog does not classify no-progress because running>0 | safety invariant detects the issue but has no automated containment/recovery path | existing tests assert blocking/no dispatch | Needs architecture decision: auto-block/reclaim unsafe active worker vs fail-loud operator event; do not silently observe | P0 |
+
+| FM-017 | Internal review FAIL mentions PASS evidence and is reduced as PASS | blocked task incorrectly completed; repair skipped | PASS parser accepted generic ` pass` text | fixed locally: structured FAIL/BLOCK now wins over text; regression added | Merge/CI | P0 |
+| FM-018 | Older review FAIL preempts newer review PASS | duplicate repair loop after valid PASS | FAIL reducer ran before considering latest PASS for same target | fixed locally: newer PASS timestamp suppresses older FAIL; regression added | Merge/CI | P0 |
+| FM-019 | Done/malformed internal review request blocks fresh review forever | `review-required` blocker remains with no active reviewer | existing review detector counted `done` request tasks | fixed locally: only non-terminal review requests count as existing; regression added | Merge/CI | P0 |
+| FM-020 | ISO timestamp in ready-work-unit materialization plan crashes ordering | no-idle aborts before classifying/reconciling | `int(completed_at)` on ISO strings | fixed locally: uses `parse_timestamp_seconds`; regression added | Merge/CI | P0 |
+| FM-021 | Directed materialization remediation replays stale done task | blocker persists, no fresh repair spawned | idempotency replay returned terminal repair task | fixed locally for materialization repair with bounded stale replacement; regression added | Extend same pattern to package/review/post-review repairs | P0 |
+
+## Live-board observations during audit
+
+- 2026-06-30T12:32Z: board had `blocked=3`, `running=1`, `todo=14`; running task was `Repair factory materialization contracts` and blockers were WU-09/WU-10/WU-13 input/capability materialization issues.
+- 2026-06-30T12:39Z: after the materialization repair completed, `no-idle --create-remediation` reduced internal review PASS blockers; board moved to `blocked=1`, `done=172`, `running=1`, `todo=12`.
+- Remaining live issue at that point: `F15/WU-17 - Test automation and remote proof harness` blocked for missing input/capability materialization, while WU-18 was running without explicit `current_step_key`/workflow fields. This matches FM-016: runtime contract invariant detection exists but should be made fail-loud in watchdog supervision.
+
+## Immediate audit commands/baseline
+
+- `python3 -m pytest tests/test_hermes_live_kanban_adapter.py -q` baseline after #557: 163 passed, 3 subtests passed.
+- `python factory/scripts/public_safety_scan.py` baseline after #557: OK.
+
+## Next work
+
+1. Run targeted watchdog tests and inspect whether repo watchdog has no-progress behavior matching local guard.
+2. Search all `remediation_strategy` values and confirm each either preempts generic board repair or intentionally yields.
+3. Add tests for internal review-required reviewer creation where no reviewer card exists.
+4. Add negative tests for real human gates mixed with materialization language.
+5. Add tests for running heartbeat stale/no-progress guard behavior.

--- a/factory/scripts/factory_no_idle_watchdog.py
+++ b/factory/scripts/factory_no_idle_watchdog.py
@@ -223,16 +223,19 @@ def emit_operator_event(
 
 
 def no_idle_signature(no_idle_result: dict[str, Any], dispatch_result: dict[str, Any] | None) -> dict[str, Any]:
-    state = no_idle_result.get("no_idle_state") if isinstance(no_idle_result.get("no_idle_state"), dict) else {}
-    counts = state.get("state") if isinstance(state.get("state"), dict) else {}
+    raw_state = no_idle_result.get("no_idle_state")
+    state = raw_state if isinstance(raw_state, dict) else {}
+    raw_counts = state.get("state")
+    counts = raw_counts if isinstance(raw_counts, dict) else {}
     dispatch_state = dispatch_result.get("dispatch_observed_state") if isinstance(dispatch_result, dict) else {}
     spawned = dispatch_result.get("spawned") if isinstance(dispatch_result, dict) else []
     remediation_task_ref = no_idle_result.get("remediation_task_id")
     explicit_remediation_created = state.get("remediation_task_created")
+    remediation_task_stale = state.get("remediation_task_stale") is True
     remediation_created = (
         explicit_remediation_created is True
         if explicit_remediation_created is not None
-        else bool(remediation_task_ref)
+        else bool(remediation_task_ref) and not remediation_task_stale
     )
     return {
         "status": state.get("status"),
@@ -356,6 +359,34 @@ def summarize_board(board: str, signature: dict[str, Any]) -> str:
     return f"[Overkill Factory] {board}: estado {status or 'desconhecido'}."
 
 
+def is_no_progress_signature(signature: dict[str, Any]) -> bool:
+    raw_counts = signature.get("counts")
+    counts: dict[str, Any] = raw_counts if isinstance(raw_counts, dict) else {}
+    ready_count = int(counts.get("ready") or 0)
+    running_count = int(counts.get("running") or 0)
+    todo_count = int(counts.get("todo") or 0)
+    blocked_count = int(counts.get("blocked") or 0)
+    spawned_count = int(signature.get("spawned_count") or 0)
+    if signature.get("human_gate_required") is True or signature.get("operator_input_required") is True:
+        return False
+    if signature.get("classification") == "factory_phase_invariant_violation":
+        return ready_count == 0 and spawned_count == 0 and (running_count + todo_count + blocked_count) > 0
+    if signature.get("status") not in {"remediation_required", "dependency_gated", "blocked"}:
+        return False
+    return ready_count == 0 and running_count == 0 and spawned_count == 0 and (todo_count + blocked_count) > 0
+
+
+def repeated_no_progress_summary(board: str, count: int, signature: dict[str, Any]) -> str:
+    raw_counts = signature.get("counts")
+    counts: dict[str, Any] = raw_counts if isinstance(raw_counts, dict) else {}
+    return (
+        f"[Overkill Factory] {board}: sem progresso material repetido por {count} ciclos; "
+        f"running={counts.get('running', 0)} ready={counts.get('ready', 0)} "
+        f"todo={counts.get('todo', 0)} blocked={counts.get('blocked', 0)}. "
+        "Pare de tratar watchdog vivo como progresso; audite no-idle/dispatch/reducer."
+    )
+
+
 def process_board(
     *,
     board: str,
@@ -368,6 +399,7 @@ def process_board(
     assignee: str,
     inbox_dir: Path,
     emit_events: bool,
+    max_unchanged_no_progress: int,
     state: dict[str, Any],
     runner: Runner = default_runner,
 ) -> str | None:
@@ -397,8 +429,19 @@ def process_board(
             "all-nonempty discovered boards are audit-only unless --allow-discovered-board-mutation is set"
         )
     previous = state.setdefault("boards", {}).get(board)
+    board_watch = state.setdefault("board_watch", {}).setdefault(board, {})
+    no_progress = is_no_progress_signature(signature)
+    if previous == signature and no_progress:
+        unchanged_count = int(board_watch.get("unchanged_no_progress_count") or 1) + 1
+    elif no_progress:
+        unchanged_count = 1
+    else:
+        unchanged_count = 0
+    board_watch["unchanged_no_progress_count"] = unchanged_count
     state["boards"][board] = signature
     if previous == signature:
+        if no_progress and max_unchanged_no_progress > 0 and unchanged_count >= max_unchanged_no_progress:
+            return repeated_no_progress_summary(board, unchanged_count, signature)
         return None
     summary = summarize_board(board, signature)
     requires_user = (
@@ -454,6 +497,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--max-dispatch", type=int, default=1)
+    parser.add_argument(
+        "--max-unchanged-no-progress",
+        type=int,
+        default=3,
+        help=(
+            "Emit an explicit no-progress alert after this many identical watchdog cycles with "
+            "running=0, ready=0, spawned=0 and unfinished work still present. Set 0 to disable."
+        ),
+    )
     parser.add_argument("--workspace", default="scratch")
     parser.add_argument("--assignee", default="factory-orchestrator")
     parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
@@ -495,6 +547,7 @@ def main(argv: list[str] | None = None, *, runner: Runner = default_runner) -> i
             assignee=args.assignee,
             inbox_dir=args.inbox_dir,
             emit_events=args.emit_events,
+            max_unchanged_no_progress=args.max_unchanged_no_progress,
             state=state,
             runner=runner,
         )

--- a/factory/tests/test_factory_no_idle_watchdog.py
+++ b/factory/tests/test_factory_no_idle_watchdog.py
@@ -324,6 +324,161 @@ class FactoryNoIdleWatchdogTest(unittest.TestCase):
         self.assertIn("no-idle detectado", first.getvalue())
         self.assertEqual(second.getvalue(), "")
 
+    def test_watchdog_does_not_call_stale_remediation_id_created(self) -> None:
+        fake = FakeRunner()
+        fake.no_idle_payloads["product-alpha"] = {
+            "mode": "no-idle",
+            "board": "product-alpha",
+            "remediation_task_id": "kanban:redacted-stale",
+            "no_idle_state": {
+                "status": "remediation_required",
+                "classification": "repair_board_contract",
+                "remediation_task_stale": True,
+                "remediation_task_status": "done",
+                "native_dispatch_required_next": False,
+                "state": {
+                    "todo": {"count": 3},
+                    "blocked": {"count": 1},
+                    "ready": {"count": 0},
+                    "running": {"count": 0},
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                result = watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--dispatch",
+                        "--state-file",
+                        str(Path(tmp) / "state.json"),
+                    ],
+                    runner=fake,
+                )
+
+        output = buffer.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("já está concluída e não destravou", output)
+        self.assertNotIn("remediação segura criada", output)
+        self.assertFalse(any(len(call) > 2 and call[2] == "dispatch" for call in fake.calls))
+
+    def test_watchdog_alerts_after_repeated_unchanged_no_progress_signature(self) -> None:
+        fake = FakeRunner()
+        fake.no_idle_payloads["product-alpha"] = {
+            "mode": "no-idle",
+            "board": "product-alpha",
+            "remediation_task_id": None,
+            "no_idle_state": {
+                "status": "remediation_required",
+                "classification": "unfinished_work_without_ready_running_or_human_gate_only_block",
+                "native_dispatch_required_next": True,
+                "state": {
+                    "todo": {"count": 3},
+                    "blocked": {"count": 1},
+                    "ready": {"count": 0},
+                    "running": {"count": 0},
+                },
+            },
+        }
+        fake.dispatch_payloads["product-alpha"] = {
+            "mode": "dispatch",
+            "board": "product-alpha",
+            "spawned": [],
+            "dispatch_observed_state": {
+                "ready_before_count": 0,
+                "running_before_count": 0,
+                "running_after_count": 0,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            state_file = Path(tmp) / "state.json"
+            first = io.StringIO()
+            second = io.StringIO()
+            with redirect_stdout(first):
+                watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--dispatch",
+                        "--state-file",
+                        str(state_file),
+                        "--max-unchanged-no-progress",
+                        "2",
+                    ],
+                    runner=fake,
+                )
+            with redirect_stdout(second):
+                watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--dispatch",
+                        "--state-file",
+                        str(state_file),
+                        "--max-unchanged-no-progress",
+                        "2",
+                    ],
+                    runner=fake,
+                )
+            self.assertIn("no-idle detectado", first.getvalue())
+            self.assertIn("sem progresso material repetido", second.getvalue())
+            state = json.loads(state_file.read_text(encoding="utf-8"))
+            self.assertEqual(state["board_watch"]["product-alpha"]["unchanged_no_progress_count"], 2)
+
+    def test_watchdog_alerts_repeated_phase_invariant_even_with_running_worker(self) -> None:
+        fake = FakeRunner()
+        fake.no_idle_payloads["product-alpha"] = {
+            "mode": "no-idle",
+            "board": "product-alpha",
+            "remediation_task_id": None,
+            "no_idle_state": {
+                "status": "blocked",
+                "classification": "factory_phase_invariant_violation",
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "native_dispatch_required_next": False,
+                "state": {
+                    "todo": {"count": 2},
+                    "blocked": {"count": 1},
+                    "ready": {"count": 0},
+                    "running": {"count": 1},
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            state_file = Path(tmp) / "state.json"
+            first = io.StringIO()
+            second = io.StringIO()
+            with redirect_stdout(first):
+                watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--state-file",
+                        str(state_file),
+                        "--max-unchanged-no-progress",
+                        "2",
+                    ],
+                    runner=fake,
+                )
+            with redirect_stdout(second):
+                watchdog.main(
+                    [
+                        "--board",
+                        "product-alpha",
+                        "--state-file",
+                        str(state_file),
+                        "--max-unchanged-no-progress",
+                        "2",
+                    ],
+                    runner=fake,
+                )
+            self.assertIn("estado blocked", first.getvalue())
+            self.assertIn("sem progresso material repetido", second.getvalue())
+            self.assertIn("running=1", second.getvalue())
+
     def test_watchdog_summarizes_dependency_gated_without_remediation_language(self) -> None:
         fake = FakeRunner()
         fake.no_idle_payloads["product-alpha"] = {

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4717,6 +4717,42 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(created_body["operator_input_required"])
         self.assertNotIn("parents", created_tasks[0])
 
+    def test_no_idle_replaces_stale_materialization_contract_repair_task(self) -> None:
+        fake = StaleThenFreshReconcileHermes(stale_creates=1)
+        blocker_id = "t_" + "matstale"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "solana-quasar-builder",
+            "title": "F15/WU-12 - Onchain Work Package",
+            "body": "Onchain Work Package/source packet is missing; WU-07 has no traceable ledger artifact.",
+            "events": [
+                {
+                    "type": "blocked",
+                    "payload": {
+                        "kind": "capability",
+                        "reason": "source_packet_artifact missing for onchain work package",
+                    },
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "deterministic_materialization_contract_repair_task_created")
+        self.assertEqual(state["stale_remediation_task_refs"], ["kanban:<redacted>"])
+        self.assertEqual(state["remediation_replacement_attempts"], 1)
+        self.assertFalse(state["remediation_task_stale"])
+        self.assertTrue(state["native_dispatch_required_next"])
+        ready_repairs = [
+            task for task in fake.tasks.values()
+            if adapter.task_body_json_object(task).get("marker") == adapter.NO_IDLE_MATERIALIZATION_CONTRACT_REPAIR_MARKER
+            and task.get("status") == "ready"
+        ]
+        self.assertEqual(len(ready_repairs), 1)
+
     def test_no_idle_creates_materialization_repair_for_missing_source_packet_and_traceability_artifact(self) -> None:
         fake = FakeHermes()
         blocker_id = "t_" + "wu12block"
@@ -6979,6 +7015,180 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         state = result["no_idle_state"]
         self.assertEqual(state["classification"], "internal_review_pass_reduced_blockers")
         self.assertEqual(fake.tasks[blocker_id]["status"], "done")
+
+    def test_no_idle_does_not_reduce_internal_review_fail_that_mentions_pass_evidence(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "failpassword"
+        review_id = "t_" + "failpassreview"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "evidence-reconciler",
+            "title": "F15/WU-00 - Evidence package",
+            "body": "review-required: independent-reviewer must review before this card is done",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "review-required"}}],
+        }
+        fake.tasks[review_id] = {
+            "id": review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "F15/WU-00R - Independent review of evidence package",
+            "completed_at": 200,
+            "body": json.dumps(
+                {
+                    "record_type": "factory_internal_review_result",
+                    "result": "FAIL",
+                    "reviewed_task_ref": blocker_id,
+                    "blocking_findings": ["missing PASS evidence readback"],
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                }
+            ),
+            "events": [{"type": "completed", "payload": {"summary": "FAIL: missing PASS evidence readback"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_fail_repair_task_created")
+        self.assertEqual(fake.tasks[blocker_id]["status"], "blocked")
+        self.assertNotEqual(fake.tasks[blocker_id].get("result"), "DONE")
+
+    def test_no_idle_latest_internal_review_pass_preempts_older_fail(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "latestpass"
+        old_fail_id = "t_" + "oldfail"
+        new_pass_id = "t_" + "newpass"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "product-architect",
+            "title": "F15/WU-01 - Planning packet",
+            "body": "review-required: independent-reviewer must review before this card is done",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "review-required"}}],
+        }
+        fake.tasks[old_fail_id] = {
+            "id": old_fail_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Old independent review FAIL",
+            "completed_at": 100,
+            "body": json.dumps(
+                {
+                    "record_type": "factory_internal_review_result",
+                    "result": "FAIL",
+                    "reviewed_task_ref": blocker_id,
+                    "blocking_findings": ["old missing evidence"],
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                }
+            ),
+            "events": [{"type": "completed", "payload": {"summary": "FAIL"}}],
+        }
+        fake.tasks[new_pass_id] = {
+            "id": new_pass_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "New independent review PASS",
+            "completed_at": 200,
+            "body": json.dumps(
+                {
+                    "record_type": "factory_internal_review_result",
+                    "result": "PASS",
+                    "reviewed_task_ref": blocker_id,
+                    "blocking_findings": [],
+                    "human_gate_required": False,
+                    "operator_input_required": False,
+                }
+            ),
+            "events": [{"type": "completed", "payload": {"summary": "PASS"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_pass_reduced_blockers")
+        self.assertEqual(fake.tasks[blocker_id]["status"], "done")
+        repairs = [
+            task for task in fake.tasks.values()
+            if adapter.task_body_json_object(task).get("marker") == adapter.NO_IDLE_REVIEW_FAIL_REPAIR_MARKER
+        ]
+        self.assertEqual(repairs, [])
+
+    def test_no_idle_replaces_done_internal_review_request_without_result(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "reviewstale"
+        old_review_id = "t_" + "oldreviewrequest"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "assignee": "evidence-reconciler",
+            "title": "F15/WU-00 - Evidence package",
+            "body": "review-required: independent-reviewer must review before this card is done",
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "review-required"}}],
+        }
+        fake.tasks[old_review_id] = {
+            "id": old_review_id,
+            "status": "done",
+            "assignee": "independent-reviewer",
+            "title": "Old malformed internal review request",
+            "body": json.dumps(
+                {
+                    "packet_type": "factory_internal_review_request",
+                    "marker": adapter.NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER,
+                    "target_task_ref": blocker_id,
+                    "reviewer_role": "independent-reviewer",
+                }
+            ),
+            "events": [{"type": "completed", "payload": {"summary": "completed without PASS/FAIL result"}}],
+        }
+        args = adapter.build_parser().parse_args(["no-idle", "--board", TEST_BOARD, "--create-remediation"])
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "internal_review_task_created")
+        review_tasks = [
+            task for task in fake.tasks.values()
+            if adapter.task_body_json_object(task).get("marker") == adapter.NO_IDLE_INTERNAL_REVIEW_REQUEST_MARKER
+            and task.get("status") == "ready"
+        ]
+        self.assertEqual(len(review_tasks), 1)
+        self.assertNotEqual(review_tasks[0]["id"], old_review_id)
+
+    def test_latest_ready_work_unit_materialization_plan_accepts_iso_completed_at(self) -> None:
+        test_dir = ROOT / ".tmp" / "test-ready-work-unit-iso"
+        test_dir.mkdir(parents=True, exist_ok=True)
+        plan_path = test_dir / "READY_WORK_UNIT_HERMES_MATERIALIZATION_PLAN.json"
+        plan_path.write_text(json.dumps({"record_type": "ready_work_unit_hermes_materialization_plan"}), encoding="utf-8")
+        try:
+            rows = {
+                "done": [
+                    {
+                        "id": "t_" + "planiso",
+                        "status": "done",
+                        "completed_at": "2026-06-28T18:00:00Z",
+                        "body": json.dumps(
+                            {
+                                "required_output": "ready_work_unit_hermes_materialization_plan",
+                                "artifacts": {
+                                    "plan": {
+                                        "path_ref": str(plan_path.relative_to(ROOT)),
+                                    }
+                                }
+                            }
+                        ),
+                    }
+                ]
+            }
+
+            result = adapter.latest_ready_work_unit_materialization_plan_path(rows)
+        finally:
+            plan_path.unlink(missing_ok=True)
+
+        self.assertEqual(result, plan_path)
 
     def test_no_idle_reports_running_closeout_without_mutation_when_not_remediating(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary
- add regression for stale remediation IDs so watchdog no longer reports terminal/stale remediations as freshly created
- add persistent no-progress loop detection to the versioned no-idle watchdog via `--max-unchanged-no-progress`
- make repeated `factory_phase_invariant_violation` fail loud even when a worker is still `running`
- harden internal-review reducers:
  - structured FAIL/BLOCK can no longer be reduced as PASS just because text mentions PASS evidence
  - newer PASS preempts older FAIL for the same blocked task
  - terminal/malformed internal review request cards no longer block fresh reviewer creation
- fix ready-work-unit materialization plan ordering with ISO timestamps
- replace stale terminal materialization repair tasks with a fresh bounded retry
- add the expanded factory failure-mode audit matrix

## Tests
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_factory_no_idle_watchdog.py tests/test_hermes_live_kanban_adapter.py -q`
- `python3 factory/scripts/public_safety_scan.py`
- `git diff --check`
