### PR TITLE
fix: classify external gates before materialization repair

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -1243,9 +1243,9 @@ def human_gate_decision_package_complete(record: dict[str, Any]) -> bool:
 def is_human_gate_decision_ready_blocker(record: dict[str, Any]) -> bool:
     if not is_human_gate_blocker(record):
         return False
-    if is_operator_input_blocker(record):
-        return False
     if not human_gate_decision_package_complete(record):
+        return False
+    if has_explicit_operator_input_request(record):
         return False
     text = task_record_text(record)
     return any(
@@ -1358,6 +1358,14 @@ def is_factory_materialization_contract_blocker(record: dict[str, Any]) -> bool:
         "human must provide",
         "requires external credential",
         "requires production credential",
+        "requires external api key",
+        "external api key",
+        "requires private key",
+        "private key material from the operator",
+        "operator private key",
+        "requires wallet key",
+        "wallet key",
+        "secret value from operator",
         "requires paid cloud",
         "requires mainnet",
         "requires funds",
@@ -1648,6 +1656,34 @@ def is_operator_understanding_confirmation_blocker(record: dict[str, Any]) -> bo
     return any(marker in text for marker in markers)
 
 
+def has_explicit_operator_input_request(record: dict[str, Any]) -> bool:
+    text = task_record_text(record)
+    explicit_markers = (
+        "missing input",
+        "missing inputs",
+        "required input",
+        "required inputs",
+        "needed input",
+        "needed inputs",
+        "provide exact",
+        "provide requested",
+        "operator must provide",
+        "waiting for operator to provide",
+        "human must provide",
+        "requires external credential",
+        "requires production credential",
+        "requires external api key",
+        "external api key",
+        "requires private key",
+        "private key material from the operator",
+        "operator private key",
+        "requires wallet key",
+        "wallet key",
+        "secret value from operator",
+    )
+    return is_operator_understanding_confirmation_blocker(record) or any(marker in text for marker in explicit_markers)
+
+
 def is_operator_input_blocker(record: dict[str, Any]) -> bool:
     text = task_record_text(record)
     external_input_markers = (
@@ -1662,6 +1698,14 @@ def is_operator_input_blocker(record: dict[str, Any]) -> bool:
         "needed inputs",
         "provide exact",
         "provide requested",
+        "requires external api key",
+        "external api key",
+        "requires private key",
+        "private key material from the operator",
+        "operator private key",
+        "requires wallet key",
+        "wallet key",
+        "secret value from operator",
         "target_repo_paths",
         "target url",
         "target_url",
@@ -2653,6 +2697,7 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         item
         for item in blocked
         if is_operator_input_blocker(item)
+        and not is_human_gate_decision_ready_blocker(item)
         and not is_factory_materialization_contract_blocker(item)
     ]
     operator_input_refs = sorted(task_record_id(item) for item in operator_input_blockers if task_record_id(item))

--- a/factory/reports/factory-failure-mode-audit-2026-06-30.md
+++ b/factory/reports/factory-failure-mode-audit-2026-06-30.md
@@ -46,6 +46,9 @@ Mandate:
 | FM-020 | ISO timestamp in ready-work-unit materialization plan crashes ordering | no-idle aborts before classifying/reconciling | `int(completed_at)` on ISO strings | fixed locally: uses `parse_timestamp_seconds`; regression added | Merge/CI | P0 |
 | FM-021 | Directed materialization remediation replays stale done task | blocker persists, no fresh repair spawned | idempotency replay returned terminal repair task | fixed locally for materialization repair with bounded stale replacement; regression added | Extend same pattern to package/review/post-review repairs | P0 |
 
+| FM-022 | Materialization text mixed with external API/private key requirement | no-idle creates internal repair for work requiring operator/credential input | external markers did not include API/private-key phrases | fixed locally: external API/private key/wallet key markers route to operator input, not materialization repair; regression added | Merge/CI | P1 |
+| FM-023 | Complete human-gate package mentions `target_repo_paths`/scan scope as context | decision-ready gate is misclassified as operator input | contextual operator-input markers outranked complete human gate packet | fixed locally: complete decision package wins unless explicit operator input is requested; regression added | Merge/CI | P1 |
+
 ## Live-board observations during audit
 
 - 2026-06-30T12:32Z: board had `blocked=3`, `running=1`, `todo=14`; running task was `Repair factory materialization contracts` and blockers were WU-09/WU-10/WU-13 input/capability materialization issues.

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4717,6 +4717,85 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(created_body["operator_input_required"])
         self.assertNotIn("parents", created_tasks[0])
 
+    def test_no_idle_external_api_key_not_materialization_contract_repair(self) -> None:
+        blocker_id = "t_" + "externalkey"
+        rows = {
+            "blocked": [
+                {
+                    "id": blocker_id,
+                    "status": "blocked",
+                    "assignee": "cloud-infra-security-specialist",
+                    "title": "F15/WU-15 - Cloud source packet blocked on external API key",
+                    "body": (
+                        "source_packet_artifact and worker packet are present, but this route requires "
+                        "external API key / private key material from the operator before execution."
+                    ),
+                    "events": [
+                        {
+                            "type": "blocked",
+                            "payload": {
+                                "kind": "needs_input",
+                                "reason": "requires external API key before runtime_contract can be used",
+                            },
+                        }
+                    ],
+                }
+            ],
+            "todo": [],
+            "ready": [],
+            "running": [],
+            "done": [],
+        }
+
+        state = adapter.classify_no_idle_state(rows)
+
+        self.assertEqual(state["classification"], "only_operator_input_blockers_seen")
+        self.assertTrue(state["operator_input_required"])
+        self.assertFalse(state["remediation_required"])
+        self.assertEqual(state["operator_input_task_refs"], [blocker_id])
+        self.assertNotIn(blocker_id, state.get("materialization_contract_task_refs") or [])
+
+    def test_no_idle_human_gate_packet_complete_wins_over_contextual_target_repo_paths(self) -> None:
+        blocker_id = "t_" + "humangatepaths"
+        rows = {
+            "blocked": [
+                {
+                    "id": blocker_id,
+                    "status": "blocked",
+                    "assignee": "human-gate-clerk",
+                    "title": "Owner decision package ready",
+                    "body": json.dumps(
+                        {
+                            "human_gate_packet": human_gate_packet_fixture(),
+                            "status": "ready for operator decision",
+                            "context_note": "target_repo_paths and scan scope are listed only as evidence context, not as requested operator material.",
+                        }
+                    ),
+                    "latest_summary": "Decision package prepared and delivered; ready for operator decision.",
+                    "events": [
+                        {
+                            "type": "blocked",
+                            "payload": {
+                                "kind": "human_gate",
+                                "reason": "awaiting human decision after delivered package",
+                            },
+                        }
+                    ],
+                }
+            ],
+            "todo": [],
+            "ready": [],
+            "running": [],
+            "done": [],
+        }
+
+        state = adapter.classify_no_idle_state(rows)
+
+        self.assertEqual(state["classification"], "only_human_gate_blockers_seen")
+        self.assertTrue(state["human_gate_required"])
+        self.assertFalse(state["operator_input_required"])
+        self.assertEqual(state["human_gate_task_refs"], [blocker_id])
+
     def test_no_idle_replaces_stale_materialization_contract_repair_task(self) -> None:
         fake = StaleThenFreshReconcileHermes(stale_creates=1)
         blocker_id = "t_" + "matstale"


### PR DESCRIPTION
## Summary
- prevent external API/private-key/wallet-key blockers from being treated as internal materialization repairs
- let complete human-gate decision packages win over contextual `target_repo_paths` / scan-scope mentions unless explicit operator input is requested
- update the failure-mode matrix with FM-022/FM-023

## Tests
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q`
- `python3 factory/scripts/public_safety_scan.py`
- `git diff --check`
