### PR TITLE
fix: signal ready dispatch alongside running work

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -2615,13 +2615,19 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
     post_review_gate_refs = sorted(task_record_id(item) for item in post_review_gate_candidates if task_record_id(item))
     closed_post_review_gate_refs = closed_post_review_owner_gate_refs(done)
     if running:
+        ready_refs = sorted(task_record_id(item) for item in ready if task_record_id(item))
+        running_refs = sorted(task_record_id(item) for item in running if task_record_id(item))
         return {
             "status": "active",
             "classification": "running_work_exists",
             "blocked": False,
             "remediation_required": False,
             "human_gate_required": False,
-            "next_action": "observe running Hermes tasks",
+            "operator_input_required": False,
+            "native_dispatch_required_next": bool(ready_refs),
+            "ready_task_refs": ready_refs,
+            "running_task_refs": running_refs,
+            "next_action": "run native Hermes dispatch for ready work while observing running tasks" if ready_refs else "observe running Hermes tasks",
             "state": state,
         }
     if ready:

--- a/factory/reports/factory-failure-mode-audit-2026-06-30.md
+++ b/factory/reports/factory-failure-mode-audit-2026-06-30.md
@@ -49,6 +49,8 @@ Mandate:
 | FM-022 | Materialization text mixed with external API/private key requirement | no-idle creates internal repair for work requiring operator/credential input | external markers did not include API/private-key phrases | fixed locally: external API/private key/wallet key markers route to operator input, not materialization repair; regression added | Merge/CI | P1 |
 | FM-023 | Complete human-gate package mentions `target_repo_paths`/scan scope as context | decision-ready gate is misclassified as operator input | contextual operator-input markers outranked complete human gate packet | fixed locally: complete decision package wins unless explicit operator input is requested; regression added | Merge/CI | P1 |
 
+| FM-024 | Ready work exists while another worker is running | ready tasks can sit idle if orchestrator reads only `running_work_exists` | running branch hid `native_dispatch_required_next` and ready refs | fixed locally: running state now exposes ready/running refs and dispatch signal when ready exists | Merge/CI | P1 |
+
 ## Live-board observations during audit
 
 - 2026-06-30T12:32Z: board had `blocked=3`, `running=1`, `todo=14`; running task was `Repair factory materialization contracts` and blockers were WU-09/WU-10/WU-13 input/capability materialization issues.

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4717,6 +4717,38 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(created_body["operator_input_required"])
         self.assertNotIn("parents", created_tasks[0])
 
+    def test_no_idle_reports_dispatch_available_when_ready_exists_alongside_running(self) -> None:
+        running_id = "t_" + "runalive"
+        ready_id = "t_" + "readywork"
+        rows = {
+            "running": [
+                {
+                    "id": running_id,
+                    "status": "running",
+                    "assignee": "worker-a",
+                    "title": "Long running work",
+                }
+            ],
+            "ready": [
+                {
+                    "id": ready_id,
+                    "status": "ready",
+                    "assignee": "worker-b",
+                    "title": "Ready parallel work",
+                }
+            ],
+            "blocked": [],
+            "todo": [],
+            "done": [],
+        }
+
+        state = adapter.classify_no_idle_state(rows)
+
+        self.assertEqual(state["classification"], "running_work_exists")
+        self.assertTrue(state["native_dispatch_required_next"])
+        self.assertEqual(state["ready_task_refs"], [ready_id])
+        self.assertEqual(state["running_task_refs"], [running_id])
+
     def test_no_idle_external_api_key_not_materialization_contract_repair(self) -> None:
         blocker_id = "t_" + "externalkey"
         rows = {


### PR DESCRIPTION
## Summary
- expose `native_dispatch_required_next` when ready work exists alongside running work
- include ready/running task refs in the `running_work_exists` no-idle state
- record FM-024 in the failure-mode audit matrix

## Tests
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q`
- `python3 factory/scripts/public_safety_scan.py`
- `git diff --check`
