### PR TITLE
docs: deepen public product manual

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -2,7 +2,7 @@
 
 Overkill Factory is a product factory for agentic work. That sentence matters. It is not a chat prompt, not a TODO list, and not a wrapper around a coding agent. It is a way to turn an unclear product signal into controlled production: source, product definition, method, work packets, Hermes execution, review, evidence, release or block, then learning.
 
-The current public kernel is version `3.0.2`. It exposes 26 compiled phases, 14 route classes, 8 method engines, 17 operating-system areas, 40 public workers, 244 JSON schemas, 156 JSON templates, and 97 tests. Those numbers are not decoration. They are here because the manual is tied to the executable repository, not to a sales story.
+The current public kernel is version `3.0.2`. It exposes 26 compiled phases, 14 route classes, 8 method engines, 17 operating-system areas, 40 public workers, 244 JSON schemas, 156 JSON templates, and 97 test files. Those numbers are not decoration. They are here because the manual is tied to the executable repository, not to a sales story.
 
 ## Why this exists
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,47 +1,36 @@
 # Overkill Factory
 
-Overkill Factory is a product factory for agentic work on top of Hermes.
+Overkill Factory is a product factory for agentic work. That sentence matters. It is not a chat prompt, not a TODO list, and not a wrapper around a coding agent. It is a way to turn an unclear product signal into controlled production: source, product definition, method, work packets, Hermes execution, review, evidence, release or block, then learning.
 
-It is not a chatbot, a SaaS wrapper, or a second Hermes. Hermes owns the runtime floor: boards, cards, dependencies, typed blocks, dispatch, worker execution, comments, logs, and state transitions. Overkill Factory owns the production method: intake, source truth, product definition, method selection, gates, worker authority, evidence, review, release decisions, and learnback.
+The current public kernel is version `3.0.2`. It exposes 26 compiled phases, 14 route classes, 8 method engines, 17 operating-system areas, 40 public workers, 244 JSON schemas, 156 JSON templates, and 97 tests. Those numbers are not decoration. They are here because the manual is tied to the executable repository, not to a sales story.
 
-The public kernel in this repository is version `3.0.2`. The executable surface currently contains 26 compiled phases, 14 route classes, 8 method engines, 17 operating-system areas, 40 public workers, 244 schemas, 156 templates, and 97 tests.
+## Why this exists
 
-## The shortest useful explanation
+Most agentic work fails in boring ways. The agent starts too soon. The brief is fuzzy. The wrong worker picks up the job. A reviewer says "looks good" without replaying the evidence. A human gate becomes a vague chat question. A run is marked done because a file exists, not because the requested product is actually usable.
 
-A request enters the factory. The factory does not immediately ask an agent to build. It first protects the source, understands the material, confirms the product truth, chooses the right method, checks risk and capability, turns the work into bounded units, dispatches specialist workers through Hermes, demands evidence, reviews the result, and only then releases, blocks, or learns.
+Overkill Factory exists to make those failures harder.
 
-```text
-source -> understanding -> product truth -> method -> plan -> work units
--> Hermes workers -> evidence -> review -> release or block -> learnback
-```
+The point is not to slow agents down. The point is to make speed trustworthy. Fast work is useful only when the factory knows what the work is, who is allowed to do it, what proof is required, and what happens when the proof is missing.
 
-The point is not to slow agents down. The point is to make speed trustworthy.
+## The simple picture
 
-## Who this documentation is for
+A request enters the factory. The factory first protects the source: what did the operator actually ask, what material exists, what is missing, and what cannot be assumed. Then it creates product truth, chooses a method, builds bounded work, sends the right workers through Hermes, checks the results, and either releases, blocks, or learns.
 
-Read this if you are:
+If that sounds like a lot, good. Product creation is a lot. The user experience should still feel simple: ask, see the state, receive clear decisions, and get proof when something is claimed as done.
 
-- an operator who wants to run product work through the factory;
-- a technical investor or partner trying to understand the system;
-- a non-technical reader who wants the idea without internal jargon;
-- an engineer who needs to inspect or contribute to the public kernel;
-- an agent that must continue work without relying on private chat memory.
+## Where to read first
 
-## Reading path
+Read these in order:
 
-1. **Manual** explains the product and mental model.
-2. **Operating Model** explains the factory in motion.
-3. **Lifecycle** explains every compiled phase.
-4. **Trust and Evidence** explains how the factory avoids fake progress.
-5. **Technical Model** explains the implementation.
-6. **Usage** gives the commands for a first local proof.
-7. **Reference** collects terms, commands, paths, and registries.
+1. [Manual](manual.md) for the human explanation.
+2. [Operating model](operating-model.md) for what happens during a run.
+3. [Lifecycle](lifecycle.md) for the phase-by-phase path.
+4. [Trust and evidence](trust-and-evidence.md) for how the factory fights false progress.
+5. [Usage](usage.md) for commands you can run now.
 
-Portuguese version: [Português](../pt-BR/index.md).
+Engineers can then read [Technical model](technical-model.md) and [Reference](reference.md). Nontechnical readers can stop after the manual and operating model and still understand what the project is.
 
 ## First local proof
-
-From a checkout of this repository:
 
 ```bash
 cd factory
@@ -49,4 +38,8 @@ python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
 ```
 
-A passing local proof means the public kernel and example path are coherent. It does not mean a real operator-owned Hermes runtime has delivered a specific product. Real product delivery still requires Hermes runtime state, worker results, readback, review, Receipt Five, and any required human gate.
+A passing local proof means the public kernel is coherent. It does not prove that a private product run shipped, that a live Hermes runtime is configured, or that a human approved a risky decision. The manual keeps that boundary visible on purpose.
+
+## What changed in this documentation
+
+The old docs were useful to maintainers, but they read like a pile of internal departments. The current docs are a product manual. The old material is preserved under `factory/legacy-docs/` for history and compatibility. The public `docs/` tree is now the canonical explanation.

--- a/docs/en/lifecycle.md
+++ b/docs/en/lifecycle.md
@@ -1,272 +1,447 @@
 # Factory lifecycle
 
-The compiled workflow is the factual source for this page. It currently contains `26` compiled phases from `docs/factory-workflow.catalog.json`.
+The compiled workflow is the factual source for this page. It currently contains `26` phases in `docs/factory-workflow.catalog.json`.
 
-You can regenerate or inspect the plan from the implementation side:
+Do not read this as a rigid waterfall. It is a map of what the factory protects. Hermes state, dependencies, blockers, risk, and evidence still decide what can move in a live run.
+
+The practical reading is simple: every phase answers a question, requires artifacts, blocks dangerous shortcuts, and gives the operator a clearer next state.
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
 
-Read the lifecycle as a production path, not as a rigid waterfall. Hermes runtime state, dependencies, blockers, risk, and evidence decide what can move. The phase list tells you what the factory is protecting at each step.
+## F0 — Pre-Start / Sealed Source Envelope
 
-### F0 — Pre-Start / Sealed Source Envelope
+The factory separates conversation from execution. Source enters a sealed envelope before it becomes a card, so the first summary cannot destroy the original intent.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Pre-Start / Sealed Source Envelope`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Required artifacts: `factory_bridge_source_envelope`, `factory_bridge_start_request`.
 
-What must exist before the run moves on: `factory_bridge_source_envelope`, `factory_bridge_start_request`. The gate holding the line is: Start Boundary. The workers normally involved are: `overkill-factory-gerente`, `factory-orchestrator`.
+Gates that hold progress: `Start Boundary`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Workers normally involved: `overkill-factory-gerente`, `factory-orchestrator`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Shortcuts this phase prevents:
 
-### F1 — Intake
+- summarize or reinterpret source material in the bridge.
+- create Hermes board/card directly from bridge.
+- start without explicit runtime target policy.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Intake`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-What must exist before the run moves on: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`. The gate holding the line is: Source Gate. The workers normally involved are: `factory-orchestrator`.
+## F1 — Intake
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+The request becomes a classified signal. Operator interface, start conversation, and source resolution prevent the factory from starting from a polished guess.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Required artifacts: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`.
 
-### F2 — Source Ledger
+Gates that hold progress: `Source Gate`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Source Ledger`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Workers normally involved: `factory-orchestrator`.
 
-What must exist before the run moves on: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`. The gate holding the line is: Source Gate. The workers normally involved are: `source-ledger-worker`.
+Shortcuts this phase prevents:
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+- route implementation before source resolution.
+- create Product SOT from raw input.
+- require the operator to poll for status.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-### F3 — Source Resolution
+## F2 — Source Ledger
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Source Resolution`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The source ledger records where each claim came from. Fact, inference, decision, conflict, and gap must not collapse into one convenient story.
 
-What must exist before the run moves on: `discovery_brief`. The gate holding the line is: Discovery Gate. The workers normally involved are: `source-ledger-worker`, `product-sot-planner`.
+Required artifacts: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Gates that hold progress: `Source Gate`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Workers normally involved: `source-ledger-worker`.
 
-### F4 — Product Outcome And Discovery
+Shortcuts this phase prevents:
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Product Outcome And Discovery`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+- ask user to reconcile internal source bookkeeping.
+- create outcome contract or Product SOT before understanding is confirmed.
 
-What must exist before the run moves on: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`. The gate holding the line is: Outcome Gate, Discovery Gate. The workers normally involved are: `product-sot-planner`.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+## F3 — Source Resolution
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Source becomes operational understanding. If discovery is still missing, the factory blocks instead of letting a worker fill the gap with imagination.
 
-### F5 — Product SOT
+Required artifacts: `discovery_brief`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Product SOT`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Gates that hold progress: `Discovery Gate`.
 
-What must exist before the run moves on: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`. The gate holding the line is: Product SOT Gate. The workers normally involved are: `product-sot-planner`.
+Workers normally involved: `source-ledger-worker`, `product-sot-planner`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Shortcuts this phase prevents:
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+- turn unresolved gaps into execution scope.
 
-### F6 — Agentic Method Router
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Agentic Method Router`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+## F4 — Product Outcome And Discovery
 
-What must exist before the run moves on: `factory_phase_lock`, `method_contract`. The gate holding the line is: Method Gate. The workers normally involved are: `factory-orchestrator`.
+The expected outcome, user, problem, and assumptions become explicit. The operator must be able to correct direction before planning hardens.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Required artifacts: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Gates that hold progress: `Outcome Gate`, `Discovery Gate`.
 
-### F7 — Method Contract
+Workers normally involved: `product-sot-planner`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Method Contract`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Shortcuts this phase prevents:
 
-What must exist before the run moves on: `factory_phase_lock`, `method_contract`. The gate holding the line is: Method Gate. The workers normally involved are: `factory-orchestrator`.
+- treat outcome candidate as approved Product SOT.
+- draft Product SOT before operator understanding confirmation.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+## F5 — Product SOT
 
-### F8 — Pack And Product Experience Selection
+Product SOT becomes product truth. It protects scope, non-scope, acceptance criteria, and complete coverage before material execution.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Pack And Product Experience Selection`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Required artifacts: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`.
 
-What must exist before the run moves on: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`. The gate holding the line is: Pack Gate, Product Experience Gate, Surface Pack Gate. The workers normally involved are: `product-face`, `factory-orchestrator`.
+Gates that hold progress: `Product SOT Gate`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Workers normally involved: `product-sot-planner`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Shortcuts this phase prevents:
 
-### F9 — Risk And Authority Gates
+- execute from paper instead of Product SOT.
+- ask operator to approve Product SOT from a short chat summary only.
+- start architecture, repo cleanup, human gate or worker packet while Product SOT owner package is missing.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Risk And Authority Gates`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-What must exist before the run moves on: `access_capability`, `budget_contract`. The gate holding the line is: Access Gate, Budget Gate, Human Gate when required. The workers normally involved are: `human-gate-clerk`.
+## F6 — Agentic Method Router
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+The route chooses the lane: product, bug, release, incident, security, UX, analytics, integration, or agent work. The factory stops treating every request as generic work.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Required artifacts: `factory_phase_lock`, `method_contract`.
 
-### F10 — Security Architecture
+Gates that hold progress: `Method Gate`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Security Architecture`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Workers normally involved: `factory-orchestrator`.
 
-What must exist before the run moves on: `factory_phase_lock`, `security_architecture_plan`. The gate holding the line is: Security Architecture Gate. The workers normally involved are: `security-orchestrator`.
+Shortcuts this phase prevents:
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+- ask user to choose internal method machinery.
+- start architecture or repo cleanup before Method Contract.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-### F11 — Executable Plans
+## F7 — Method Contract
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Executable Plans`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The method records how the work will be done and proven. TDD, security-first, or design-first must change artifacts, gates, and evidence, not just wording.
 
-What must exist before the run moves on: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`. The gate holding the line is: Ready Gate. The workers normally involved are: `decomposition-planner`.
+Required artifacts: `factory_phase_lock`, `method_contract`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Gates that hold progress: `Method Gate`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Workers normally involved: `factory-orchestrator`.
 
-### F12 — Autonomy Readiness
+Shortcuts this phase prevents:
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Autonomy Readiness`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+- start implementation with undocumented process choices.
+- materialize future-phase cards while active frontier is still product_sot or method_contract.
 
-What must exist before the run moves on: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`. The gate holding the line is: Decomposition Coverage Gate, Access & Capability Gate. The workers normally involved are: `independent-reviewer`, `factory-orchestrator`.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+## F8 — Pack And Product Experience Selection
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+The factory checks capability packs and surface proof for the product type. Web, CLI, docs, agentic UI, Solana, mobile, and fintech do not need the same proof.
 
-### F13 — Ready Gate
+Required artifacts: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Ready Gate`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Gates that hold progress: `Pack Gate`, `Product Experience Gate`, `Surface Pack Gate`.
 
-What must exist before the run moves on: `gate_report`. The gate holding the line is: Ready Gate. The workers normally involved are: `factory-orchestrator`.
+Workers normally involved: `product-face`, `factory-orchestrator`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Shortcuts this phase prevents:
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+- activate a pack without proof or coverage.
+- start product-facing implementation before surface state coverage.
+- treat generic UI proof as Product Experience proof.
+- move to implementation with unnamed surface pack or proof profile.
 
-### F15 — Runtime Execution
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Runtime Execution`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+## F9 — Risk And Authority Gates
 
-What must exist before the run moves on: `worker_packets`. The gate holding the line is: Runtime Gate. The workers normally involved are: `implementation-worker`, `qa-verification-worker`.
+Authority, access, budget, and risk are checked before sensitive execution. If the decision belongs to the operator, the factory prepares a decision package; if it is internal repair, it does not dump the problem on the human.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Required artifacts: `access_capability`, `budget_contract`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Gates that hold progress: `Access Gate`, `Budget Gate`, `Human Gate when required`.
 
-### F16 — Worker Results
+Workers normally involved: `human-gate-clerk`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Worker Results`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Shortcuts this phase prevents:
 
-What must exist before the run moves on: `worker_results`. The gate holding the line is: Done Gate. The workers normally involved are: `evidence-reconciler`.
+- infer approval from silence.
+- ask for planning-only continuation approval.
+- ask for architecture or repo cleanup approval while downstream is frozen.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+## F10 — Security Architecture
 
-### F17 — Verification
+Security enters as architecture, not as an end scan. Trust boundaries, secrets, keys, supply chain, privacy, onchain, and rollback need to appear early when they matter.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Verification`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Required artifacts: `factory_phase_lock`, `security_architecture_plan`.
 
-What must exist before the run moves on: `verification_plan`, `verification_result`. The gate holding the line is: Verification Gate. The workers normally involved are: `qa-verification-worker`.
+Gates that hold progress: `Security Architecture Gate`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Workers normally involved: `security-orchestrator`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Shortcuts this phase prevents:
 
-### F18 — Independent Review
+- build material risk before architecture.
+- start security architecture while Product SOT or Method Contract is still missing.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Independent Review`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-What must exist before the run moves on: `review_result`. The gate holding the line is: Review Gate. The workers normally involved are: `independent-reviewer`.
+## F11 — Executable Plans
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Architecture and risk become a development plan. The goal is to move from idea to executable units without losing dependencies or stop criteria.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Required artifacts: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`.
 
-### F20 — Closure Summary
+Gates that hold progress: `Ready Gate`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Closure Summary`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Workers normally involved: `decomposition-planner`.
 
-What must exist before the run moves on: `closure_summary`. The gate holding the line is: Closure Gate. The workers normally involved are: `handoff-packer`.
+Shortcuts this phase prevents:
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+- execute before plans, coverage review and stop criteria exist.
+- mark decomposition review as passed from the planner that created the decomposition.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-### F21 — Receipt Five
+## F12 — Autonomy Readiness
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Receipt Five`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The product is decomposed into work units. Each unit needs owner, reviewer, proof, dependency, and done rule; otherwise it becomes loose agent work.
 
-What must exist before the run moves on: `receipt_five`. The gate holding the line is: Done Gate. The workers normally involved are: `evidence-reconciler`.
+Required artifacts: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Gates that hold progress: `Decomposition Coverage Gate`, `Access & Capability Gate`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Workers normally involved: `independent-reviewer`, `factory-orchestrator`.
 
-### F22 — Completion Audit
+Shortcuts this phase prevents:
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Completion Audit`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+- start autonomous work with missing review, access or limits.
+- let a single reviewer approve the complete decomposition alone.
+- create Product Implementation Readiness from a failed or missing decomposition coverage review.
 
-What must exist before the run moves on: `completion_audit`. The gate holding the line is: Completion Audit. The workers normally involved are: `evidence-reconciler`.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+## F13 — Ready Gate
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Before work runs, the factory checks implementation readiness: SOT, method, research, architecture, packs, access, workers, and required proof.
 
-### F23 — Production Operations
+Required artifacts: `gate_report`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Production Operations`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Gates that hold progress: `Ready Gate`.
 
-What must exist before the run moves on: `production_readiness_plan`. The gate holding the line is: Release Gate. The workers normally involved are: `release-ops-worker`.
+Workers normally involved: `factory-orchestrator`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Shortcuts this phase prevents:
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+- dispatch blocked workers.
 
-### F24 — Release Or Block
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Release Or Block`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+## F15 — Runtime Execution
 
-What must exist before the run moves on: `release_decision`. The gate holding the line is: Release Gate, Human Gate when required. The workers normally involved are: `release-ops-worker`, `human-gate-clerk`.
+Workers execute narrow scopes and return structured results. The result must carry evidence, authority boundary, and next state.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Required artifacts: `worker_packets`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Gates that hold progress: `Runtime Gate`.
 
-### F25 — Monitoring Support
+Workers normally involved: `implementation-worker`, `qa-verification-worker`.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Monitoring Support`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Shortcuts this phase prevents:
 
-What must exist before the run moves on: `incident_support_plan`. The gate holding the line is: Support Gate. The workers normally involved are: `release-ops-worker`.
+- spawn without route readiness.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+## F16 — Worker Results
 
-### F26 — Learnback
+The factory runs objective verification: tests, scans, screenshots, journeys, logs, contracts, or remote proof depending on the work.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Learnback`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+Required artifacts: `worker_results`.
 
-What must exist before the run moves on: `factory_learning_proposal`. The gate holding the line is: Learning Gate. The workers normally involved are: `skill-eval-distiller`.
+Gates that hold progress: `Done Gate`.
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Workers normally involved: `evidence-reconciler`.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Shortcuts this phase prevents:
 
-### F27 — Factory Maturity Audit
+- treat packet existence as proof.
 
-This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Factory Maturity Audit`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
 
-What must exist before the run moves on: `factory_maturity_scorecard`. The gate holding the line is: Maturity Gate. The workers normally involved are: `skill-eval-distiller`.
+## F17 — Verification
 
-The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
+Independent review consumes the actual artifact. A pass without readback, same executor/reviewer, or unconsumed finding is false progress.
 
-The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
+Required artifacts: `verification_plan`, `verification_result`.
+
+Gates that hold progress: `Verification Gate`.
+
+Workers normally involved: `qa-verification-worker`.
+
+Shortcuts this phase prevents:
+
+- claim done without command evidence.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F18 — Independent Review
+
+Receipt Five reconciles request, change, evidence, review, and remaining work. It is the line between “changed” and “proven”.
+
+Required artifacts: `review_result`.
+
+Gates that hold progress: `Review Gate`.
+
+Workers normally involved: `independent-reviewer`.
+
+Shortcuts this phase prevents:
+
+- allow executor to self-approve.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F20 — Closure Summary
+
+Handoff preserves replayable state for pause, transfer, or recovery. It is not approval; it is honest context and evidence transfer.
+
+Required artifacts: `closure_summary`.
+
+Gates that hold progress: `Closure Gate`.
+
+Workers normally involved: `handoff-packer`.
+
+Shortcuts this phase prevents:
+
+- hide unresolved blockers in prose.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F21 — Receipt Five
+
+Completion audit compares obligations to delivered proof. It closes when they match and blocks when anything material is missing.
+
+Required artifacts: `receipt_five`.
+
+Gates that hold progress: `Done Gate`.
+
+Workers normally involved: `evidence-reconciler`.
+
+Shortcuts this phase prevents:
+
+- mark done without Receipt Five.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F22 — Completion Audit
+
+Production operations check owner, environment, monitoring, rollback, incident route, and release channel. A live product needs operational ground.
+
+Required artifacts: `completion_audit`.
+
+Gates that hold progress: `Completion Audit`.
+
+Workers normally involved: `evidence-reconciler`.
+
+Shortcuts this phase prevents:
+
+- close skipped method or evidence requirements.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F23 — Production Operations
+
+Release only happens with promotion, evidence, and authority. If the proof does not support it, the correct state is blocked.
+
+Required artifacts: `production_readiness_plan`.
+
+Gates that hold progress: `Release Gate`.
+
+Workers normally involved: `release-ops-worker`.
+
+Shortcuts this phase prevents:
+
+- release without owner, rollback or approval.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F24 — Release Or Block
+
+After delivery, monitoring and support keep the product observable. Incidents become routes, not improvisation.
+
+Required artifacts: `release_decision`.
+
+Gates that hold progress: `Release Gate`, `Human Gate when required`.
+
+Workers normally involved: `release-ops-worker`, `human-gate-clerk`.
+
+Shortcuts this phase prevents:
+
+- promote without production-strict evidence.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F25 — Monitoring Support
+
+Learnback turns repeated findings into docs, tests, skills, gates, or issues. The factory learns, but it does not mutate itself silently.
+
+Required artifacts: `incident_support_plan`.
+
+Gates that hold progress: `Support Gate`.
+
+Workers normally involved: `release-ops-worker`.
+
+Shortcuts this phase prevents:
+
+- ship without support owner when support is material.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F26 — Learnback
+
+Maturity audit asks whether the chosen method was good enough. It defends against a factory that follows process while choosing a weak process.
+
+Required artifacts: `factory_learning_proposal`.
+
+Gates that hold progress: `Learning Gate`.
+
+Workers normally involved: `skill-eval-distiller`.
+
+Shortcuts this phase prevents:
+
+- auto-activate critical factory changes.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.
+
+## F27 — Factory Maturity Audit
+
+The final audit looks at the factory itself: coverage, gaps, reliability, operators, workers, and rules that need to evolve.
+
+Required artifacts: `factory_maturity_scorecard`.
+
+Gates that hold progress: `Maturity Gate`.
+
+Workers normally involved: `skill-eval-distiller`.
+
+Shortcuts this phase prevents:
+
+- commit raw study or private evidence.
+
+The operator should not need to read this phase JSON to understand the run. The human projection should say what is clear, what is missing, who owns the next step, and what proof unlocks progress.

--- a/docs/en/lifecycle.md
+++ b/docs/en/lifecycle.md
@@ -1,302 +1,272 @@
-# Factory Lifecycle
+# Factory lifecycle
 
-The compiled workflow is the factual source for this page.
+The compiled workflow is the factual source for this page. It currently contains `26` compiled phases from `docs/factory-workflow.catalog.json`.
 
-Current compiled plan: `26` phases from `docs/factory-workflow.catalog.json`, generated with:
+You can regenerate or inspect the plan from the implementation side:
 
 ```bash
 cd factory
-python3 scripts/factoryctl.py compile-workflow --out .tmp/docs-rewrite-workflow-plan.json
+python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
 
-The phase list is a teaching model and a contract surface. Runtime execution is still graph-shaped: dependencies, gates, evidence, risk, and Hermes state decide what can move.
-
-## Phase reference
+Read the lifecycle as a production path, not as a rigid waterfall. Hermes runtime state, dependencies, blockers, risk, and evidence decide what can move. The phase list tells you what the factory is protecting at each step.
 
 ### F0 — Pre-Start / Sealed Source Envelope
 
-Purpose: move the run through **Pre-Start / Sealed Source Envelope** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Pre-Start / Sealed Source Envelope`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `factory_bridge_source_envelope`, `factory_bridge_start_request`.
+What must exist before the run moves on: `factory_bridge_source_envelope`, `factory_bridge_start_request`. The gate holding the line is: Start Boundary. The workers normally involved are: `overkill-factory-gerente`, `factory-orchestrator`.
 
-Required gates: Start Boundary.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `overkill-factory-gerente`, `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: summarize or reinterpret source material in the bridge, create Hermes board/card directly from bridge, start without explicit runtime target policy.
 ### F1 — Intake
 
-Purpose: move the run through **Intake** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Intake`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`.
+What must exist before the run moves on: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`. The gate holding the line is: Source Gate. The workers normally involved are: `factory-orchestrator`.
 
-Required gates: Source Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: route implementation before source resolution, create Product SOT from raw input, require the operator to poll for status.
 ### F2 — Source Ledger
 
-Purpose: move the run through **Source Ledger** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Source Ledger`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`.
+What must exist before the run moves on: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`. The gate holding the line is: Source Gate. The workers normally involved are: `source-ledger-worker`.
 
-Required gates: Source Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `source-ledger-worker`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: ask user to reconcile internal source bookkeeping, create outcome contract or Product SOT before understanding is confirmed.
 ### F3 — Source Resolution
 
-Purpose: move the run through **Source Resolution** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Source Resolution`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `discovery_brief`.
+What must exist before the run moves on: `discovery_brief`. The gate holding the line is: Discovery Gate. The workers normally involved are: `source-ledger-worker`, `product-sot-planner`.
 
-Required gates: Discovery Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `source-ledger-worker`, `product-sot-planner`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: turn unresolved gaps into execution scope.
 ### F4 — Product Outcome And Discovery
 
-Purpose: move the run through **Product Outcome And Discovery** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Product Outcome And Discovery`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`.
+What must exist before the run moves on: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`. The gate holding the line is: Outcome Gate, Discovery Gate. The workers normally involved are: `product-sot-planner`.
 
-Required gates: Outcome Gate, Discovery Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `product-sot-planner`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: treat outcome candidate as approved Product SOT, draft Product SOT before operator understanding confirmation.
 ### F5 — Product SOT
 
-Purpose: move the run through **Product SOT** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Product SOT`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`.
+What must exist before the run moves on: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`. The gate holding the line is: Product SOT Gate. The workers normally involved are: `product-sot-planner`.
 
-Required gates: Product SOT Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `product-sot-planner`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: execute from paper instead of Product SOT, ask operator to approve Product SOT from a short chat summary only, start architecture, repo cleanup, human gate or worker packet while Product SOT owner package is missing.
 ### F6 — Agentic Method Router
 
-Purpose: move the run through **Agentic Method Router** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Agentic Method Router`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `factory_phase_lock`, `method_contract`.
+What must exist before the run moves on: `factory_phase_lock`, `method_contract`. The gate holding the line is: Method Gate. The workers normally involved are: `factory-orchestrator`.
 
-Required gates: Method Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: ask user to choose internal method machinery, start architecture or repo cleanup before Method Contract.
 ### F7 — Method Contract
 
-Purpose: move the run through **Method Contract** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Method Contract`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `factory_phase_lock`, `method_contract`.
+What must exist before the run moves on: `factory_phase_lock`, `method_contract`. The gate holding the line is: Method Gate. The workers normally involved are: `factory-orchestrator`.
 
-Required gates: Method Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: start implementation with undocumented process choices, materialize future-phase cards while active frontier is still product_sot or method_contract.
 ### F8 — Pack And Product Experience Selection
 
-Purpose: move the run through **Pack And Product Experience Selection** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Pack And Product Experience Selection`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`.
+What must exist before the run moves on: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`. The gate holding the line is: Pack Gate, Product Experience Gate, Surface Pack Gate. The workers normally involved are: `product-face`, `factory-orchestrator`.
 
-Required gates: Pack Gate, Product Experience Gate, Surface Pack Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `product-face`, `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: activate a pack without proof or coverage, start product-facing implementation before surface state coverage, treat generic UI proof as Product Experience proof, move to implementation with unnamed surface pack or proof profile.
 ### F9 — Risk And Authority Gates
 
-Purpose: move the run through **Risk And Authority Gates** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Risk And Authority Gates`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `access_capability`, `budget_contract`.
+What must exist before the run moves on: `access_capability`, `budget_contract`. The gate holding the line is: Access Gate, Budget Gate, Human Gate when required. The workers normally involved are: `human-gate-clerk`.
 
-Required gates: Access Gate, Budget Gate, Human Gate when required.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `human-gate-clerk`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: infer approval from silence, ask for planning-only continuation approval, ask for architecture or repo cleanup approval while downstream is frozen.
 ### F10 — Security Architecture
 
-Purpose: move the run through **Security Architecture** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Security Architecture`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `factory_phase_lock`, `security_architecture_plan`.
+What must exist before the run moves on: `factory_phase_lock`, `security_architecture_plan`. The gate holding the line is: Security Architecture Gate. The workers normally involved are: `security-orchestrator`.
 
-Required gates: Security Architecture Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `security-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: build material risk before architecture, start security architecture while Product SOT or Method Contract is still missing.
 ### F11 — Executable Plans
 
-Purpose: move the run through **Executable Plans** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Executable Plans`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`.
+What must exist before the run moves on: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`. The gate holding the line is: Ready Gate. The workers normally involved are: `decomposition-planner`.
 
-Required gates: Ready Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `decomposition-planner`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: execute before plans, coverage review and stop criteria exist, mark decomposition review as passed from the planner that created the decomposition.
 ### F12 — Autonomy Readiness
 
-Purpose: move the run through **Autonomy Readiness** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Autonomy Readiness`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`.
+What must exist before the run moves on: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`. The gate holding the line is: Decomposition Coverage Gate, Access & Capability Gate. The workers normally involved are: `independent-reviewer`, `factory-orchestrator`.
 
-Required gates: Decomposition Coverage Gate, Access & Capability Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `independent-reviewer`, `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: start autonomous work with missing review, access or limits, let a single reviewer approve the complete decomposition alone, create Product Implementation Readiness from a failed or missing decomposition coverage review.
 ### F13 — Ready Gate
 
-Purpose: move the run through **Ready Gate** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Ready Gate`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `gate_report`.
+What must exist before the run moves on: `gate_report`. The gate holding the line is: Ready Gate. The workers normally involved are: `factory-orchestrator`.
 
-Required gates: Ready Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `factory-orchestrator`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: dispatch blocked workers.
 ### F15 — Runtime Execution
 
-Purpose: move the run through **Runtime Execution** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Runtime Execution`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `worker_packets`.
+What must exist before the run moves on: `worker_packets`. The gate holding the line is: Runtime Gate. The workers normally involved are: `implementation-worker`, `qa-verification-worker`.
 
-Required gates: Runtime Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `implementation-worker`, `qa-verification-worker`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: spawn without route readiness.
 ### F16 — Worker Results
 
-Purpose: move the run through **Worker Results** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Worker Results`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `worker_results`.
+What must exist before the run moves on: `worker_results`. The gate holding the line is: Done Gate. The workers normally involved are: `evidence-reconciler`.
 
-Required gates: Done Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `evidence-reconciler`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: treat packet existence as proof.
 ### F17 — Verification
 
-Purpose: move the run through **Verification** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Verification`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `verification_plan`, `verification_result`.
+What must exist before the run moves on: `verification_plan`, `verification_result`. The gate holding the line is: Verification Gate. The workers normally involved are: `qa-verification-worker`.
 
-Required gates: Verification Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `qa-verification-worker`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: claim done without command evidence.
 ### F18 — Independent Review
 
-Purpose: move the run through **Independent Review** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Independent Review`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `review_result`.
+What must exist before the run moves on: `review_result`. The gate holding the line is: Review Gate. The workers normally involved are: `independent-reviewer`.
 
-Required gates: Review Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `independent-reviewer`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: allow executor to self-approve.
 ### F20 — Closure Summary
 
-Purpose: move the run through **Closure Summary** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Closure Summary`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `closure_summary`.
+What must exist before the run moves on: `closure_summary`. The gate holding the line is: Closure Gate. The workers normally involved are: `handoff-packer`.
 
-Required gates: Closure Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `handoff-packer`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: hide unresolved blockers in prose.
 ### F21 — Receipt Five
 
-Purpose: move the run through **Receipt Five** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Receipt Five`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `receipt_five`.
+What must exist before the run moves on: `receipt_five`. The gate holding the line is: Done Gate. The workers normally involved are: `evidence-reconciler`.
 
-Required gates: Done Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `evidence-reconciler`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: mark done without Receipt Five.
 ### F22 — Completion Audit
 
-Purpose: move the run through **Completion Audit** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Completion Audit`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `completion_audit`.
+What must exist before the run moves on: `completion_audit`. The gate holding the line is: Completion Audit. The workers normally involved are: `evidence-reconciler`.
 
-Required gates: Completion Audit.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `evidence-reconciler`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: close skipped method or evidence requirements.
 ### F23 — Production Operations
 
-Purpose: move the run through **Production Operations** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Production Operations`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `production_readiness_plan`.
+What must exist before the run moves on: `production_readiness_plan`. The gate holding the line is: Release Gate. The workers normally involved are: `release-ops-worker`.
 
-Required gates: Release Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `release-ops-worker`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: release without owner, rollback or approval.
 ### F24 — Release Or Block
 
-Purpose: move the run through **Release Or Block** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Release Or Block`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `release_decision`.
+What must exist before the run moves on: `release_decision`. The gate holding the line is: Release Gate, Human Gate when required. The workers normally involved are: `release-ops-worker`, `human-gate-clerk`.
 
-Required gates: Release Gate, Human Gate when required.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `release-ops-worker`, `human-gate-clerk`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: promote without production-strict evidence.
 ### F25 — Monitoring Support
 
-Purpose: move the run through **Monitoring Support** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Monitoring Support`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `incident_support_plan`.
+What must exist before the run moves on: `incident_support_plan`. The gate holding the line is: Support Gate. The workers normally involved are: `release-ops-worker`.
 
-Required gates: Support Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `release-ops-worker`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: ship without support owner when support is material.
 ### F26 — Learnback
 
-Purpose: move the run through **Learnback** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Learnback`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `factory_learning_proposal`.
+What must exist before the run moves on: `factory_learning_proposal`. The gate holding the line is: Learning Gate. The workers normally involved are: `skill-eval-distiller`.
 
-Required gates: Learning Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `skill-eval-distiller`.
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.
 
-Blocked shortcuts: auto-activate critical factory changes.
 ### F27 — Factory Maturity Audit
 
-Purpose: move the run through **Factory Maturity Audit** without letting a worker skip the factory state.
+This phase answers a plain question: "do we have enough ground to move forward without inventing the missing pieces?" The internal name is `Factory Maturity Audit`, but its practical job is to protect the next step. If the phase skips evidence, the rest of the run can look orderly while being weak in reality.
 
-Required artifacts: `factory_maturity_scorecard`.
+What must exist before the run moves on: `factory_maturity_scorecard`. The gate holding the line is: Maturity Gate. The workers normally involved are: `skill-eval-distiller`.
 
-Required gates: Maturity Gate.
+The common failure is rushing. The factory blocks shortcuts such as: none listed. That is not ceremony. It is the difference between autonomous work and autonomous theater.
 
-Workers: `skill-eval-distiller`.
-
-Blocked shortcuts: commit raw study or private evidence.
-
+The operator should not need to read every JSON field in this phase. They should see the state in plain language: what is understood, what is missing, who owns the next step, and what evidence will unlock the phase. If the answer is "we do not know yet", the factory should say that early, open the right blocker, and propose the smallest safe next step.

--- a/docs/en/manual.md
+++ b/docs/en/manual.md
@@ -72,3 +72,28 @@ First it asks what "customer" means in this product, what onboarding must achiev
 Only after that does implementation become sensible. A frontend worker may receive one packet. A backend worker may receive another. A product-face worker may need screenshots and viewport proof. A QA worker may need a journey test. A reviewer may need to compare the result against the Product SOT. The operator should not have to coordinate all of that by hand.
 
 That is the practical value of the factory. It turns one vague request into a set of small, reviewable, evidence-backed pieces.
+
+## What the factory takes off the operator's shoulders
+
+The practical promise is autonomy with responsibility. The operator provides direction, context, constraints, and real decisions. The operator should not become the manual coordinator for source ledger, Product SOT, worker packets, review, proof, release, and learnback.
+
+When the factory works well, it handles what normally becomes human babysitting:
+
+- notices incomplete source before work starts;
+- turns a request into reviewable product definition;
+- chooses the right route for bug, feature, release, incident, security, UX, or agent work;
+- creates small packets instead of one huge mission;
+- demands proof from the worker that executed;
+- calls independent review when risk requires it;
+- prepares a readable human gate package when the decision belongs to the operator;
+- blocks with a clear reason when access, authority, evidence, or safety is missing.
+
+That changes the relationship with agents. The human stops being the system's laziness detector and returns to owning product direction and important decisions.
+
+## The front desk can be simple; the contract behind it cannot be weak
+
+Telegram, Discord, cockpit, or CLI may be the front door. The operator may start with a short sentence, a document, a repo, a bug, or a business goal. The conversation should be simple.
+
+But simple intake does not mean informal execution. Behind the conversation, the factory still needs source, scope, method, gates, workers, and evidence. If it skips that, it merely replaced a form with chat and stayed fragile.
+
+That is why the factory separates the manager, who speaks to the operator, from the orchestrator, who handles routing and runtime. The operator receives status and decisions in human language. Hermes and the contracts hold real state.

--- a/docs/en/manual.md
+++ b/docs/en/manual.md
@@ -1,67 +1,74 @@
-# Product Manual
+# Product manual
 
-Overkill Factory exists because agentic work often looks productive before it is actually controlled.
+Overkill Factory is easier to understand if you start with the pain it solves.
 
-A normal agent workflow can answer quickly, write code quickly, and produce a convincing status update quickly. The failure usually appears later: the source was misunderstood, a partial slice quietly replaced the full product, a worker declared done without proof, a risk was treated as a checklist, or the operator had to notice that the system was idle.
+A person asks for something: build a product, fix a bug, review a risky change, prepare a release, handle an incident, improve a worker, or turn an idea into a working system. A normal agentic workflow often turns that into one big instruction. The agent tries to be helpful, starts working, and reports progress. Sometimes that works. Often it produces motion without control.
 
-The factory turns that fragile workflow into a production line.
+Overkill Factory treats product work as controlled production. The factory does not ask an agent to "figure it out". It asks the system to preserve the source, define the product, choose the method, split the work, execute through Hermes, verify evidence, and close with a receipt.
 
-## What the factory is
+## What "factory" means here
 
-Overkill Factory is a method layer and public kernel for running product work through bounded agents.
+A factory is not a metaphor for bureaucracy. It means there is a line. Work enters at one end and must pass through states that protect the operator.
 
-It gives the work a shape:
+A product request should not jump straight to implementation if nobody has resolved the source. A release should not ship because an executor says it is ready. A security-sensitive change should not skip architecture. A human gate should not be hidden inside a chat comment. A worker should not be allowed to approve its own work.
 
-- the source is captured before it is interpreted;
-- product truth is separated from assumptions;
-- method is selected by contract, not by vibes;
-- workers receive bounded packets;
-- every important transition needs evidence;
-- human gates stay human;
-- non-human blockers are repaired by the factory instead of being dumped on the operator;
-- completion means evidence-backed delivery, not a confident message.
+That is controlled production. It is the difference between "an agent worked on it" and "the factory can explain what happened, why it happened, who had authority, and what evidence proves the result".
 
-## What Hermes owns
+## The operator experience
 
-Hermes is the factory floor. It owns durable runtime state: Kanban boards, cards, dependencies, typed blocks, worker dispatch, comments, logs, schedules, workspaces, and state transitions.
+The operator should not have to babysit the factory. They should not have to notice that a worker was lazy, that a review result was never consumed, or that a blocker was really a factory-owned task. The factory owns the process. The human owns real decisions.
 
-The factory must not recreate that runtime in prompt space. If something is runtime state, Hermes is the authority.
+A good run feels like this:
 
-## What Overkill Factory owns
+- The operator gives a goal or source material.
+- The factory says what it understood and what is missing.
+- The factory creates a product definition that can be reviewed.
+- Work is split into pieces small enough for workers to finish and prove.
+- Hermes tracks the live state.
+- Reviews are independent where the risk requires it.
+- Human gates arrive as decision packages, not vague interruptions.
+- Completion comes with Receipt Five, not a cheerful status message.
 
-Overkill Factory owns the production method around Hermes:
+## The product truth layer
 
-- the phase graph;
-- the route registry;
-- method contracts;
-- templates and schemas;
-- worker authority rules;
-- Product SOT / product truth contracts;
-- Product Experience and Product Face proof expectations;
-- security, access, and release gates;
-- evidence and Receipt Five rules;
-- public validation commands.
+The most important artifact is product truth. The factory calls it Product SOT, because it is the source of truth for the product. The name is technical, but the idea is ordinary: before workers build, everyone needs to know what product is being built.
 
-The factory can project status and prepare packets, but it should not pretend that a local projection is the real runtime.
+A Product SOT should answer what the user asked for, what is in scope, what is out of scope, what risks matter, what evidence will count, and what would make the work unacceptable. Without that, the factory cannot safely choose a method or assign workers.
 
-## What agents own
+This is where many agent systems drift. They turn a large brief into a short summary, then build from the summary. Overkill Factory is designed to avoid that. A summary is not product truth. A helpful guess is not product truth. Product truth must be grounded in source material and reviewed when it matters.
 
-Agents are bounded workers. They do not own the route. They do not decide that the product is done. They execute a packet, return evidence, and accept review.
+## Methods are chosen, not improvised
 
-A worker can be strong without being trusted blindly. The factory is designed around that distinction.
+Different work needs different methods. A bug fix needs reproduction and regression proof. A new product needs product definition and scope coverage. A release needs readiness, rollback, and approval. A security change needs threat thinking and evidence.
 
-## What humans own
+The route registry and method engines make that explicit. The factory currently has 14 route classes and 8 method engines. The point is not to impress the reader with a large list. The point is that the factory should not handle every request the same way.
 
-Humans own real authority decisions: funding, production access, signing, release acceptance, material risk, final business judgment, and explicit waivers.
+When the method is right, the worker gets a bounded packet. It knows the task, the limits, the evidence expected, and the authority it does not have. That makes autonomy safer. The worker can move fast inside the lane because the lane is clear.
 
-A human gate should be rare and clear. It should not ask the operator to read internal machinery. It should present the decision, the artifact, the evidence, the risk, and the consequences.
+## Hermes is the floor
 
-## The core promise
+Hermes is where runtime state lives. Cards, dependencies, comments, workspaces, workers, blockers, and transitions belong there. Overkill Factory defines the production method and checks. Hermes runs the floor.
 
-The factory's promise is not "agents will never fail." The promise is: when agents fail, the system should know where, why, what evidence is missing, whether the blocker is human or non-human, and what the next safe action is.
+That separation matters. If the factory tried to become a second Hermes, it would become another hidden state machine. If Hermes held state but the factory ignored method and evidence, workers would move cards without product discipline. The design is deliberately split: Hermes owns live state; Overkill Factory owns the production contract.
 
-That is the difference between autonomous theater and controlled production.
+## Done means evidence
 
-## The public/private boundary
+The factory is strict about completion because agentic work can look convincing while being wrong. A file can exist and still be useless. A test can pass and still miss the product. A reviewer can approve without checking the right thing. A worker can say done and forget the artifact.
 
-This repository is the public kernel: code, contracts, tests, examples, public worker registries, and public docs. A real product run happens in an operator-owned Hermes runtime. That runtime may contain private boards, private source materials, secrets, evidence, product decisions, and human approvals. Those do not belong in public GitHub.
+Receipt Five exists to prevent that. It records what was requested, what was done, what evidence proves it, who reviewed it, what remains risky or blocked, and what the next state is. If that evidence is missing, the honest answer is not "done". It is blocked, incomplete, or ready for review.
+
+## What this project is not
+
+Overkill Factory is not trying to hide complexity from the world. It is trying to put complexity in the right place. The operator should see clear state and real decisions. The workers should see exact packets. The code should carry schemas and tests. The public docs should explain enough for a new reader to trust the system without reading every internal file.
+
+That is the bar for the project: simple on the outside, rigorous on the inside, honest at the boundary.
+
+## A concrete example
+
+Imagine the operator says: "Build the customer onboarding flow." A weak agentic system may start designing screens immediately. The factory should not.
+
+First it asks what "customer" means in this product, what onboarding must achieve, which accounts or permissions exist, what the user must see, what must be logged, and what counts as a successful first run. If the product already has a design system, the factory should use it. If the flow touches money, identity, custody, or production data, the risk gates change.
+
+Only after that does implementation become sensible. A frontend worker may receive one packet. A backend worker may receive another. A product-face worker may need screenshots and viewport proof. A QA worker may need a journey test. A reviewer may need to compare the result against the Product SOT. The operator should not have to coordinate all of that by hand.
+
+That is the practical value of the factory. It turns one vague request into a set of small, reviewable, evidence-backed pieces.

--- a/docs/en/operating-model.md
+++ b/docs/en/operating-model.md
@@ -1,72 +1,73 @@
 # Operating model
 
-This page explains what happens during a factory run. It avoids the internal folder tour and follows the life of a request instead.
+This page follows the life of a request inside the factory. The central question is not “which script runs?”, but “how does a request become safe, proven, reviewable work?”.
 
-A request starts as a signal. It may be a product idea, a bug, a release, an incident, a security change, a UX request, a data request, an integration, or a worker improvement. The factory's first job is not to build. Its first job is to understand what kind of work it is and what would make progress safe.
+A request starts as a signal. It may be a product idea, a bug, a release, an incident, a screen, an integration, an audit, an agent change, or an improvement to the factory itself. The wrong answer is to start building. The right answer is to preserve source, understand the work type, choose the method, and only then execute.
 
-## 1. Intake protects the source
+## 1. The request enters through the right door
 
-The factory receives source material and turns it into a source envelope. That envelope should preserve what the operator actually provided. It should not silently compress the request into a convenient summary.
+The factory may speak with the operator through Telegram, Discord, a cockpit, CLI, or another channel. The channel is the front desk. It is not the source of truth.
 
-Then the source ledger records what is known, what is missing, what conflicts, and what still needs the operator. This sounds basic, but it prevents one of the most expensive agent failures: building from a misunderstood brief.
+The operator provides material, goal, constraints, and decisions when those decisions truly belong to the operator. The factory should own the rest: source recording, fact/inference separation, Product SOT, routing, worker packets, Hermes state, evidence, review, human gates, and Receipt Five closure.
 
-The operator should see a plain explanation: "this is what we understood, this is what we still need, this is what we cannot assume." If that explanation is not clear, the run is already weak.
+That removes babysitting from the operator. The human should not have to notice that a worker was shallow, a review was not consumed, a board is idle because of process laziness, or a decision package is missing. When that happens, the factory failed.
 
-## 2. Routing chooses the kind of factory run
+## 2. Source is protected before planning
 
-The route class decides the shape of the work. A bug repair is not a release. A release is not a greenfield product. A Solana/onchain audit is not a docs update. The factory currently exposes these route classes:
+The first important artifact is the source envelope. It preserves what arrived before the factory summarizes, interprets, or decomposes it. Then the source ledger separates five things agents often mix:
 
-- `product_creation`: used for `product_new` requests. Method family `None`; main gates: Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: used for `feature, slice` requests. Method family `None`; main gates: Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: used for `bug` requests. Method family `None`; main gates: Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: used for `incident` requests. Method family `None`; main gates: Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: used for `migration, refactor, integration` requests. Method family `None`; main gates: Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: used for `release` requests. Method family `None`; main gates: Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: used for `feature, product_new, security, ux_ui, data_analytics, agent_skill` requests. Method family `None`; main gates: Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: used for `doc` requests. Method family `None`; main gates: Docs Utility Gate, First Run Gate.
-- `security_remediation`: used for `security` requests. Method family `None`; main gates: Security Architecture Gate, Security Review Gate.
-- `critical_integration`: used for `integration` requests. Method family `None`; main gates: Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: used for `migration` requests. Method family `None`; main gates: Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: used for `ux_ui, product_new, feature` requests. Method family `None`; main gates: Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: used for `data_analytics, product_new, feature` requests. Method family `None`; main gates: Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: used for `agent_skill` requests. Method family `None`; main gates: Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+- fact from the source;
+- reasonable inference;
+- decision already made;
+- conflict between sources;
+- gap that still needs resolution.
 
-The route does not give a worker permission to do anything by itself. It selects the lane, the method family, and the gates that must be satisfied.
+This simple separation changes the run. Without it, a short summary becomes “truth” and the product starts crooked.
 
-## 3. Product truth becomes the contract
+## 3. The factory works in five layers
 
-For product work, the Product SOT turns source material into a usable product definition. This is the point where the factory says: "this is the product we are actually building".
+The legacy docs had a useful map that is still current. The factory operates in five layers:
 
-A weak Product SOT makes every downstream step weaker. Workers can still produce code, docs, designs, or review comments, but they may be optimizing for the wrong thing. That is why the factory blocks downstream execution when product truth is missing or unreviewed.
+1. Truth layer: source, source resolution, Product SOT, decisions, conflicts, and gaps.
+2. Method and planning layer: route, method, architecture, Product Creation Plan, Product Experience Plan, data, evals, and loop plan.
+3. Risk, authority, access, and cost layer: risk, budget, secrets, production, mainnet, privacy, compliance, and human gates.
+4. Execution and evidence layer: Hermes, worker packets, worker results, Product Face, QA, review, remote proof, and Receipt Five.
+5. Operations and learning layer: release, monitoring, support, incidents, learnback, and maturity audit.
 
-## 4. Method binds the route to evidence
+The point of the map is that “doing the task” is only one part. The factory also needs to know whether the right task was chosen, authority existed, the product was proven, and the factory learned from the run.
 
-The method contract says how this run should be handled. The method engines currently include:
+## 4. Routing chooses the right weight
 
-- `spec_first_sdd`: None. Used when the route needs `spec_first`. Routes: .
-- `test_first_tdd`: None. Used when the route needs `test_first`. Routes: .
-- `behavior_first_bdd`: None. Used when the route needs `behavior_first`. Routes: .
-- `discovery_research`: None. Used when the route needs `discovery_first`. Routes: .
-- `security_first_threat_model`: None. Used when the route needs `security_first`. Routes: .
-- `design_first_product_experience`: None. Used when the route needs `design_first`. Routes: .
-- `legacy_diagnosis`: None. Used when the route needs `legacy_diagnosis`. Routes: .
-- `incident_first`: None. Used when the route needs `incident_first`. Routes: .
+Routes are how the factory says: this request is not like the others.
 
-The method matters because it changes the evidence. Test-first work needs tests and regression proof. Design-first work needs product experience proof. Security-first work needs threat modeling and security evidence. Incident-first work needs mitigation, status, and learnback.
+A bug needs reproduction and regression. A new product needs Product SOT and scope coverage. A release needs readiness, rollback, and owner. An incident needs severity, mitigation, and learnback. A critical integration needs contract, fallback, and tests. A security change needs architecture and review. A screen needs Product Face, states, journey, and visual proof.
 
-A method is not a slogan. It should produce artifacts, gates, worker packets, and stop conditions.
+The factory has fourteen route classes. Exact detail lives in the registries, but the public idea is this: every work type gets different gates and proof. That prevents one generic agent from treating docs, mainnet, UI, release, and incidents as variations of the same task.
 
-## 5. Work is broken into packets
+## 5. Product SOT is product truth, not a pretty document
 
-A worker packet is a small contract. It tells the worker what to do, what not to do, what evidence to attach, and what authority it has. This is where the factory avoids the vague instruction "build the thing".
+Product SOT is the reviewable product definition. It should state what is in scope, what is out, which users matter, which promises must be kept, what risks exist, and what evidence counts as acceptance.
 
-Good packets are narrow. They can be executed, reviewed, retried, and closed. Bad packets are broad missions with no clear proof. The factory should create the former and block the latter.
+For whole-product work, the factory also needs Full Product SOT Scope Coverage. That prevents the first practical slice from silently becoming the whole product. Every important requirement must be planned, blocked with owner, out of scope with rationale, human-owned, or done with proof.
 
-## 6. Hermes runs the floor
+Without that coverage, workers can do a lot of work and still deliver a product that is too narrow.
 
-Hermes Kanban remains the runtime source of truth. Cards, dependencies, comments, worker status, workspaces, and transitions live there. The factory prepares and validates production contracts; Hermes records what is actually happening.
+## 6. Method connects intent to proof
 
-This split is important. Local files can prove that the public kernel is coherent. They cannot prove that a live operator-owned Hermes run completed. Live completion needs runtime state, worker results, review, evidence, and human decisions when required.
+The Method Contract records how the work will be done. It may choose a spec-first, test-first, behavior-first, discovery-first, security-first, design-first, legacy-diagnosis, or incident-first path.
+
+The point is not the method name. The point is that the method changes evidence:
+
+- test-first needs tests and regression proof;
+- design-first needs Product Experience Plan, Product Face Packet, and surface proof;
+- security-first needs threat model, trust boundary, scan, and review;
+- discovery-first needs uncertainty turned into operational decision;
+- legacy-diagnosis needs baseline, rollback, and regression protection;
+- incident-first needs mitigation, status, cause, and learnback.
+
+A method that does not change artifact, gate, or proof is just a slogan.
+
+
 
 ## Operator bridge modes
 
@@ -76,22 +77,54 @@ The bridge modes are `status_bridge`, `start_bridge`, `question_bridge`, `decisi
 
 The bridge separates `overkill-factory-gerente` as the operator-facing concierge from `factory-orchestrator` as the factory routing/runtime-control role. Durable Operator Inbox records preserve decisions, questions, and handoffs in the default Hermes store. Factory Mechanic remains the self-improvement owner for learnback and factory changes. The bridge cannot grant authority, invent approvals, close gates, or claim runtime completion without evidence.
 
-## 7. Review is a different job from execution
+## 7. Capability packs prevent fake competence
 
-The executor should not be the final judge of material work. The factory uses readback, verification, independent review, and Receipt Five to separate "the worker says it is done" from "the factory can prove it is done".
+The factory should not pretend one generic agent covers every product. Web SaaS, CLI/TUI, cloud, agent runtime, Solana, native mobile, desktop, games, fintech, analytics, browser extensions, and hardware need different proof.
 
-If review passes, the result must be consumed back into the original task. If review fails, the factory should create repair work. A review result that sits unused is not progress. It is another blocked state.
+Capability packs say what is ready and what is still a template. Core packs such as web, CLI/TUI, cloud, agent-runtime, Solana AI Kit, onboarding, and public docs may proceed when route and gates match. Mobile, desktop, game, AI/ML, fintech, regulated domain, analytics, browser extension, and hardware packs need specialists, bindings, smoke, eval, and evidence before material execution.
 
-## 8. Human gates are rare but real
+That is an honesty boundary. Blocking for a missing pack is better than pretending expertise.
 
-A human gate is required when the decision belongs to the operator: risk acceptance, budget, production authority, mainnet, secrets, release, or another explicit ownership boundary. The factory should not ask for human approval just because it is unsure how to continue.
+## 8. Work becomes small worker packets
 
-When a human gate is needed, the operator should receive a decision package: the choice, the evidence, the risk, the recommended option, and the consequence of each path. A raw JSON file is not a good human gate. A vague chat question is worse.
+A worker packet is a bounded task. It tells the worker what to do, what it receives, what to return, what evidence to attach, and what authority it does not have.
 
-## 9. Release, block, or learn
+A good packet can be executed, reviewed, and retried. A bad packet says “build the product” and leaves the operator to guess whether it is good.
 
-A run ends in one of three honest states.
+Important workers cover orchestration, source ledger, Product SOT, architecture, Product Face, builders, QA, security, review, release, handoff, evidence reconciliation, human gates, and skill/eval distillation. The name is not enough. Every worker needs a profile, Hermes binding, receipt field, evidence policy, and authority boundary.
 
-It can release when the evidence is strong enough and the required gates passed. It can block when proof, access, authority, or safety is missing. Or it can learn when the run exposes a better method, a missing worker, a weak validator, or a repeated failure pattern.
+## 9. Hermes is the floor, the factory is the contract
 
-Learning is also gated. The factory should not silently rewrite itself because one run felt awkward. It should propose a change, test it, and promote it only when it is safe.
+Hermes Kanban remains the runtime source of truth. It stores cards, dependencies, status, workers, workspaces, comments, and transitions. The factory should not create a hidden second runtime.
+
+The factory prepares the contract: missing artifacts, blocking gates, required workers, acceptable evidence, and real human approvals. Hermes records live work.
+
+When the factory creates Hermes tasks, it should use native dependencies. If a phase depends on work units, those work units must be parents of the following phase. If mandatory work is discovered late, it must enter the graph before downstream work moves. Discovering required work after a phase is already done is a graph violation.
+
+## 10. No-idle is not a parallel dispatcher
+
+No-idle exists to detect dangerous silence. If work is running, it observes. If work is ready, Hermes dispatches. If the block is dependency_wait, it waits for the dependency. If the block is needs_input and a decision package exists, the manager calls the operator. If a package, readback, PDF, artifact, or internal repair is missing, the factory repairs instead of dumping the problem on the human.
+
+That rule matters. No-idle must not become mini-Hermes. It is a board-integrity auditor, not the normal source of authority.
+
+## 11. Product Face proves the face of the product
+
+A product with an interface needs product experience proof, not only backend or architecture. Product Face covers web visual UI, CLI/TUI, docs/onboarding, agentic interfaces, wallet UI, and other surface types.
+
+For web, proof may include screenshots, viewports, states, journeys, console, accessibility basics, overflow, and comparison with the Product Face Packet. For CLI/TUI, it needs transcript, help, install, error, and terminal behavior. For docs/onboarding, it needs first-success replay and reader criteria. For agentic interfaces, it needs user control, permissions, recovery, and boundaries.
+
+A screenshot does not prove the whole product. Product Face is one evidence layer, consumed together with SOT, method, QA, review, and Receipt Five.
+
+## 12. Human gates are packages, not loose questions
+
+A human gate enters only when the decision belongs to the operator: production, mainnet, funds, secrets, budget, authority, release, material risk, or explicit waiver.
+
+The gate must be artifact-first. The operator receives the artifact or a faithful projection, a one-screen summary, clear options, consequences, authorized scope, and what approval does not authorize. Raw JSON, local paths, or vague chat questions are not valid human gates.
+
+The human-facing voice is the manager. Worker, cron, Kanban event, and artifact dump may feed internal state, but they should not notify the operator directly.
+
+## 13. Honest closure
+
+A run ends in release, block, or learn.
+
+Release needs current evidence, readback, consumed review, Receipt Five, and satisfied gates. Block needs a clear reason, owner, and smallest safe next action. Learnback needs proposal, test, review, and promotion; the factory should not silently mutate itself because one run felt strange.

--- a/docs/en/operating-model.md
+++ b/docs/en/operating-model.md
@@ -1,85 +1,72 @@
-# Operating Model
+# Operating model
 
-This page describes the factory as it operates, not as an internal folder tree.
+This page explains what happens during a factory run. It avoids the internal folder tour and follows the life of a request instead.
 
-The simple mental model is: the factory receives a signal, protects the truth, chooses a safe route, creates bounded work, executes through Hermes, verifies evidence, and either releases, blocks, or learns.
+A request starts as a signal. It may be a product idea, a bug, a release, an incident, a security change, a UX request, a data request, an integration, or a worker improvement. The factory's first job is not to build. Its first job is to understand what kind of work it is and what would make progress safe.
 
-## 1. A signal enters
+## 1. Intake protects the source
 
-A signal can be a product paper, bug report, feature idea, incident, repository, release request, UX request, integration, migration, security issue, analytics request, or agent/runtime change.
+The factory receives source material and turns it into a source envelope. That envelope should preserve what the operator actually provided. It should not silently compress the request into a convenient summary.
 
-The route registry currently exposes these route classes:
+Then the source ledger records what is known, what is missing, what conflicts, and what still needs the operator. This sounds basic, but it prevents one of the most expensive agent failures: building from a misunderstood brief.
 
-- `product_creation`: request types product_new; method family `spec_first`; gates Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: request types feature, slice; method family `behavior_first`; gates Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: request types bug; method family `test_first`; gates Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: request types incident; method family `incident_first`; gates Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: request types migration, refactor, integration; method family `legacy_diagnosis`; gates Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: request types release; method family `spec_first`; gates Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: request types feature, product_new, security, ux_ui, data_analytics, agent_skill; method family `research_first`; gates Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: request types doc; method family `docs_first`; gates Docs Utility Gate, First Run Gate.
-- `security_remediation`: request types security; method family `security_first`; gates Security Architecture Gate, Security Review Gate.
-- `critical_integration`: request types integration; method family `spec_first`; gates Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: request types migration; method family `legacy_diagnosis`; gates Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: request types ux_ui, product_new, feature; method family `design_first`; gates Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: request types data_analytics, product_new, feature; method family `analytics_first`; gates Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: request types agent_skill; method family `agent_eval_first`; gates Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+The operator should see a plain explanation: "this is what we understood, this is what we still need, this is what we cannot assume." If that explanation is not clear, the run is already weak.
 
-The route class matters because a bug should not be handled like a greenfield product, and a release should not be handled like discovery. The method and gates change with the route.
+## 2. Routing chooses the kind of factory run
 
-## 2. Source comes before interpretation
+The route class decides the shape of the work. A bug repair is not a release. A release is not a greenfield product. A Solana/onchain audit is not a docs update. The factory currently exposes these route classes:
 
-The factory first captures and resolves source material. It should not turn a long product paper into a shallow summary and call that truth.
+- `product_creation`: used for `product_new` requests. Method family `None`; main gates: Source Gate, Product SOT Gate, Ready Gate.
+- `feature_delivery`: used for `feature, slice` requests. Method family `None`; main gates: Source Gate, Method Gate, Ready Gate.
+- `bug_repair`: used for `bug` requests. Method family `None`; main gates: Reproduction Gate, Regression Gate, Receipt Gate.
+- `incident_response`: used for `incident` requests. Method family `None`; main gates: Severity Gate, Mitigation Gate, Learnback Gate.
+- `brownfield_discovery`: used for `migration, refactor, integration` requests. Method family `None`; main gates: Brownfield Baseline Gate, Regression Gate, Rollback Gate.
+- `release_promotion`: used for `release` requests. Method family `None`; main gates: Production Readiness Gate, Rollback Gate, Release Gate.
+- `research_validation`: used for `feature, product_new, security, ux_ui, data_analytics, agent_skill` requests. Method family `None`; main gates: Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
+- `docs_onboarding`: used for `doc` requests. Method family `None`; main gates: Docs Utility Gate, First Run Gate.
+- `security_remediation`: used for `security` requests. Method family `None`; main gates: Security Architecture Gate, Security Review Gate.
+- `critical_integration`: used for `integration` requests. Method family `None`; main gates: Dependency Gate, Contract Test Gate, Fallback Gate.
+- `migration_execution`: used for `migration` requests. Method family `None`; main gates: Migration Plan Gate, Regression Gate, Rollback Gate.
+- `ux_product_experience`: used for `ux_ui, product_new, feature` requests. Method family `None`; main gates: Product Experience Gate, Product Face Gate, Independent Design Review Gate.
+- `analytics_data`: used for `data_analytics, product_new, feature` requests. Method family `None`; main gates: Data Contract Gate, Privacy Gate, Metrics Proof Gate.
+- `agent_quality_change`: used for `agent_skill` requests. Method family `None`; main gates: Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
 
-The expected sequence is:
+The route does not give a worker permission to do anything by itself. It selects the lane, the method family, and the gates that must be satisfied.
 
-- capture the source envelope;
-- classify the signal;
-- resolve source references;
-- build a source ledger;
-- identify conflicts or missing material;
-- confirm understanding with the operator when product truth matters.
+## 3. Product truth becomes the contract
 
-Only after this can the factory create the product definition artifacts that downstream workers depend on.
+For product work, the Product SOT turns source material into a usable product definition. This is the point where the factory says: "this is the product we are actually building".
 
-## 3. Product truth becomes executable scope
+A weak Product SOT makes every downstream step weaker. Workers can still produce code, docs, designs, or review comments, but they may be optimizing for the wrong thing. That is why the factory blocks downstream execution when product truth is missing or unreviewed.
 
-The Product SOT is the source-of-truth product definition used by the factory. It is not a casual summary. It is the artifact that downstream method, architecture, planning, decomposition, implementation, and review must trace to.
+## 4. Method binds the route to evidence
 
-A product-facing run must also cover the full Product SOT scope. That prevents a first slice from silently becoming the whole product.
+The method contract says how this run should be handled. The method engines currently include:
 
-## 4. Method is selected by contract
+- `spec_first_sdd`: None. Used when the route needs `spec_first`. Routes: .
+- `test_first_tdd`: None. Used when the route needs `test_first`. Routes: .
+- `behavior_first_bdd`: None. Used when the route needs `behavior_first`. Routes: .
+- `discovery_research`: None. Used when the route needs `discovery_first`. Routes: .
+- `security_first_threat_model`: None. Used when the route needs `security_first`. Routes: .
+- `design_first_product_experience`: None. Used when the route needs `design_first`. Routes: .
+- `legacy_diagnosis`: None. Used when the route needs `legacy_diagnosis`. Routes: .
+- `incident_first`: None. Used when the route needs `incident_first`. Routes: .
 
-The method engine registry currently contains:
+The method matters because it changes the evidence. Test-first work needs tests and regression proof. Design-first work needs product experience proof. Security-first work needs threat modeling and security evidence. Incident-first work needs mitigation, status, and learnback.
 
-- `spec_first_sdd` — Spec-First SDD Engine: family `spec_first`; used by product_creation, feature_delivery, critical_integration, migration_execution.
-- `test_first_tdd` — Test-First TDD Engine: family `test_first`; used by feature_delivery, bug_repair, critical_integration, migration_execution.
-- `behavior_first_bdd` — Behavior-First BDD Engine: family `behavior_first`; used by product_creation, feature_delivery, ux_product_experience.
-- `discovery_research` — Discovery and Research Engine: family `discovery_first`; used by product_creation, research_validation, brownfield_discovery.
-- `security_first_threat_model` — Security-First Threat Model Engine: family `security_first`; used by security_remediation, release_promotion, critical_integration, agent_quality_change.
-- `design_first_product_experience` — Design-First Product Experience Engine: family `design_first`; used by ux_product_experience, product_creation, feature_delivery.
-- `legacy_diagnosis` — Legacy Diagnosis Engine: family `legacy_diagnosis`; used by brownfield_discovery, migration_execution, bug_repair.
-- `incident_first` — Incident-First Engine: family `incident_first`; used by incident_response, bug_repair, security_remediation.
+A method is not a slogan. It should produce artifacts, gates, worker packets, and stop conditions.
 
-A method label is not enough. The factory must bind the selected route to artifacts, gates, workers, and proof requirements. For example, test-first work needs test proof. Design-first work needs Product Experience proof. Security-first work needs threat modeling and security evidence.
+## 5. Work is broken into packets
 
-## 5. Planning creates bounded execution
+A worker packet is a small contract. It tells the worker what to do, what not to do, what evidence to attach, and what authority it has. This is where the factory avoids the vague instruction "build the thing".
 
-The Product Creation Plan and work units convert product truth into executable packets. A worker packet should tell a specialist what to do, what not to do, what evidence to return, and what authority it has.
+Good packets are narrow. They can be executed, reviewed, retried, and closed. Bad packets are broad missions with no clear proof. The factory should create the former and block the latter.
 
-This is where the factory avoids the classic failure: "agent, please build everything." The worker receives a bounded job instead of a vague mission.
+## 6. Hermes runs the floor
 
-## 6. Hermes executes the runtime work
+Hermes Kanban remains the runtime source of truth. Cards, dependencies, comments, worker status, workspaces, and transitions live there. The factory prepares and validates production contracts; Hermes records what is actually happening.
 
-Hermes Kanban remains the runtime source of truth. Cards, dependencies, worker status, comments, workspaces, and transitions live there.
-
-The factory can validate contracts and prepare packets, but execution authority comes from the runtime state. If the runtime says a card is blocked, the factory must respect that and either repair the blocker or deliver the correct human gate.
-
-## 7. Review is separate from execution
-
-A worker's `done` event is not automatically proof. The factory expects readback, verification, and independent review where required.
-
-Executor and reviewer should be separate identities for material work. Review can pass, fail, or create repair work. A review that passes but is not reduced back into the original task is still an orchestration problem.
+This split is important. Local files can prove that the public kernel is coherent. They cannot prove that a live operator-owned Hermes run completed. Live completion needs runtime state, worker results, review, evidence, and human decisions when required.
 
 ## Operator bridge modes
 
@@ -89,25 +76,22 @@ The bridge modes are `status_bridge`, `start_bridge`, `question_bridge`, `decisi
 
 The bridge separates `overkill-factory-gerente` as the operator-facing concierge from `factory-orchestrator` as the factory routing/runtime-control role. Durable Operator Inbox records preserve decisions, questions, and handoffs in the default Hermes store. Factory Mechanic remains the self-improvement owner for learnback and factory changes. The bridge cannot grant authority, invent approvals, close gates, or claim runtime completion without evidence.
 
-## 8. Human gates are explicit
+## 7. Review is a different job from execution
 
-A human gate is not an excuse to stop. It is a real decision package. The operator should receive the artifact, the decision needed, the risks, the evidence, and the recommended choices.
+The executor should not be the final judge of material work. The factory uses readback, verification, independent review, and Receipt Five to separate "the worker says it is done" from "the factory can prove it is done".
 
-Internal review-required blockers are factory-owned unless they require explicit operator authority.
+If review passes, the result must be consumed back into the original task. If review fails, the factory should create repair work. A review result that sits unused is not progress. It is another blocked state.
 
-## 9. Receipt Five closes the loop
+## 8. Human gates are rare but real
 
-Receipt Five is the evidence package for completion or blocking. It should answer:
+A human gate is required when the decision belongs to the operator: risk acceptance, budget, production authority, mainnet, secrets, release, or another explicit ownership boundary. The factory should not ask for human approval just because it is unsure how to continue.
 
-- what was requested;
-- what was built or decided;
-- what evidence proves it;
-- what was reviewed;
-- what remains blocked or risky;
-- what the next operational state is.
+When a human gate is needed, the operator should receive a decision package: the choice, the evidence, the risk, the recommended option, and the consequence of each path. A raw JSON file is not a good human gate. A vague chat question is worse.
 
-Without that package, "done" is not a factory-grade claim.
+## 9. Release, block, or learn
 
-## 10. Learnback improves the factory
+A run ends in one of three honest states.
 
-A finished run can expose better methods, missing skills, weak validators, or new failure patterns. Learnback turns those into reviewable improvements instead of silently changing the factory.
+It can release when the evidence is strong enough and the required gates passed. It can block when proof, access, authority, or safety is missing. Or it can learn when the run exposes a better method, a missing worker, a weak validator, or a repeated failure pattern.
+
+Learning is also gated. The factory should not silently rewrite itself because one run felt awkward. It should propose a change, test it, and promote it only when it is safe.

--- a/docs/en/reference.md
+++ b/docs/en/reference.md
@@ -1,94 +1,108 @@
 # Reference
 
-This page collects the short-form facts used by the manual.
+This page collects the short-form facts a reader usually needs after reading the manual. It is intentionally human-sized. The full generated kernel reference is maintained under `factory/legacy-docs/generated/`.
 
-## Main commands
+## Route classes
+
+- `product_creation`: used for `product_new` requests. Method family `None`; main gates: Source Gate, Product SOT Gate, Ready Gate.
+- `feature_delivery`: used for `feature, slice` requests. Method family `None`; main gates: Source Gate, Method Gate, Ready Gate.
+- `bug_repair`: used for `bug` requests. Method family `None`; main gates: Reproduction Gate, Regression Gate, Receipt Gate.
+- `incident_response`: used for `incident` requests. Method family `None`; main gates: Severity Gate, Mitigation Gate, Learnback Gate.
+- `brownfield_discovery`: used for `migration, refactor, integration` requests. Method family `None`; main gates: Brownfield Baseline Gate, Regression Gate, Rollback Gate.
+- `release_promotion`: used for `release` requests. Method family `None`; main gates: Production Readiness Gate, Rollback Gate, Release Gate.
+- `research_validation`: used for `feature, product_new, security, ux_ui, data_analytics, agent_skill` requests. Method family `None`; main gates: Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
+- `docs_onboarding`: used for `doc` requests. Method family `None`; main gates: Docs Utility Gate, First Run Gate.
+- `security_remediation`: used for `security` requests. Method family `None`; main gates: Security Architecture Gate, Security Review Gate.
+- `critical_integration`: used for `integration` requests. Method family `None`; main gates: Dependency Gate, Contract Test Gate, Fallback Gate.
+- `migration_execution`: used for `migration` requests. Method family `None`; main gates: Migration Plan Gate, Regression Gate, Rollback Gate.
+- `ux_product_experience`: used for `ux_ui, product_new, feature` requests. Method family `None`; main gates: Product Experience Gate, Product Face Gate, Independent Design Review Gate.
+- `analytics_data`: used for `data_analytics, product_new, feature` requests. Method family `None`; main gates: Data Contract Gate, Privacy Gate, Metrics Proof Gate.
+- `agent_quality_change`: used for `agent_skill` requests. Method family `None`; main gates: Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+
+## Method engines
+
+- `spec_first_sdd`: None. Used when the route needs `spec_first`. Routes: .
+- `test_first_tdd`: None. Used when the route needs `test_first`. Routes: .
+- `behavior_first_bdd`: None. Used when the route needs `behavior_first`. Routes: .
+- `discovery_research`: None. Used when the route needs `discovery_first`. Routes: .
+- `security_first_threat_model`: None. Used when the route needs `security_first`. Routes: .
+- `design_first_product_experience`: None. Used when the route needs `design_first`. Routes: .
+- `legacy_diagnosis`: None. Used when the route needs `legacy_diagnosis`. Routes: .
+- `incident_first`: None. Used when the route needs `incident_first`. Routes: .
+
+## Operating-system areas
+
+- `deterministic_control_plane_os`: deterministic_control_plane_os.
+- `product_truth_research_os`: product_truth_research_os.
+- `method_os`: method_os.
+- `product_architecture_os`: product_architecture_os.
+- `product_experience_design_brand_os`: product_experience_design_brand_os.
+- `work_unit_execution_dispatch_os`: work_unit_execution_dispatch_os.
+- `authority_autonomy_os`: authority_autonomy_os.
+- `hermes_worker_runtime_os`: hermes_worker_runtime_os.
+- `evidence_receipt_os`: evidence_receipt_os.
+- `capability_provider_os`: capability_provider_os.
+- `agent_profile_authority_os`: agent_profile_authority_os.
+- `security_os`: security_os.
+- `quality_verification_os`: quality_verification_os.
+- `operator_experience_os`: operator_experience_os.
+- `release_operations_os`: release_operations_os.
+- `velocity_cost_throughput_os`: velocity_cost_throughput_os.
+- `factory_learning_os`: factory_learning_os.
+
+## Important paths
+
+- `README.md`: public English entry.
+- `README.pt-BR.md`: public Portuguese entry.
+- `docs/en/`: English product manual.
+- `docs/pt-BR/`: Portuguese product manual.
+- `docs/assets/public-map/`: public visual map assets.
+- `docs/factory-workflow.catalog.json`: public workflow catalog.
+- `docs/promise-implementation-map.public.json`: public promise-to-implementation map.
+- `docs/public-surface.manifest.json`: manifest for public surfaces.
+- `factory/scripts/factoryctl.py`: main command surface.
+- `factory/schemas/`: JSON schemas for records and contracts.
+- `factory/templates/`: examples, registries, and template contracts.
+- `factory/agents/`: public worker registry, profiles, bindings, and readiness records.
+- `factory/tests/`: regression tests.
+- `factory/legacy-docs/`: preserved old docs and generated reference material, not canonical public docs.
+
+## Core terms
+
+Product SOT is the product source of truth. It should say what is being built, what is in scope, what is out of scope, what evidence counts, and what would make the run unacceptable.
+
+Method Contract is the chosen way to handle the work. It binds the route to gates, artifacts, workers, and evidence.
+
+Worker Packet is the bounded instruction given to a worker. It includes task, limits, authority, and expected output.
+
+Gate Report explains whether a task can move, why it is blocked, and which evidence or action would unblock it.
+
+Receipt Five is the completion receipt. It connects request, work, evidence, review, remaining risk, and next state.
+
+Human Gate is a real operator decision. It should come with a readable package, not a vague chat question.
+
+Readback means the factory reads and checks the artifact a worker claims to have produced.
+
+No-idle is the guard that detects silent stalls and pushes the next safe action or fails visibly.
+
+## Public claim boundary
+
+The public repository can prove local kernel coherence. It cannot prove a private product delivery. Live product delivery needs an operator-owned Hermes runtime, live worker results, product-specific evidence, review, and human approval where required.
+
+## Useful commands
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
-python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 python3 scripts/factoryctl.py route-registry
 python3 scripts/factoryctl.py method-engines
 python3 scripts/factoryctl.py operating-systems
+python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py
+python3 scripts/validate_worker_profiles.py
 python3 scripts/public_safety_scan.py
 python3 scripts/secret_safety_scan.py
 ```
-
-## Repository paths
-
-- `docs/en/` — canonical English documentation.
-- `docs/pt-BR/` — canonical Portuguese documentation.
-- `docs/factory-workflow.catalog.json` — public workflow catalog consumed by the compiler.
-- `docs/promise-implementation-map.public.json` — public promise-to-implementation map.
-- `docs/public-surface.manifest.json` — public surface manifest.
-- `factory/scripts/factoryctl.py` — public control helper.
-- `factory/schemas/` — contract schemas.
-- `factory/templates/` — contract templates and registries.
-- `factory/agents/` — public worker/profile/binding registries.
-- `factory/tests/` — validation suite.
-- `factory/legacy-docs/` — non-canonical older documentation.
-
-## Phase table
-
-| Phase | Name | Gates | Workers |
-| --- | --- | --- | --- |
-| F0 | Pre-Start / Sealed Source Envelope | Start Boundary | overkill-factory-gerente, factory-orchestrator |
-| F1 | Intake | Source Gate | factory-orchestrator |
-| F2 | Source Ledger | Source Gate | source-ledger-worker |
-| F3 | Source Resolution | Discovery Gate | source-ledger-worker, product-sot-planner |
-| F4 | Product Outcome And Discovery | Outcome Gate, Discovery Gate | product-sot-planner |
-| F5 | Product SOT | Product SOT Gate | product-sot-planner |
-| F6 | Agentic Method Router | Method Gate | factory-orchestrator |
-| F7 | Method Contract | Method Gate | factory-orchestrator |
-| F8 | Pack And Product Experience Selection | Pack Gate, Product Experience Gate, Surface Pack Gate | product-face, factory-orchestrator |
-| F9 | Risk And Authority Gates | Access Gate, Budget Gate, Human Gate when required | human-gate-clerk |
-| F10 | Security Architecture | Security Architecture Gate | security-orchestrator |
-| F11 | Executable Plans | Ready Gate | decomposition-planner |
-| F12 | Autonomy Readiness | Decomposition Coverage Gate, Access & Capability Gate | independent-reviewer, factory-orchestrator |
-| F13 | Ready Gate | Ready Gate | factory-orchestrator |
-| F15 | Runtime Execution | Runtime Gate | implementation-worker, qa-verification-worker |
-| F16 | Worker Results | Done Gate | evidence-reconciler |
-| F17 | Verification | Verification Gate | qa-verification-worker |
-| F18 | Independent Review | Review Gate | independent-reviewer |
-| F20 | Closure Summary | Closure Gate | handoff-packer |
-| F21 | Receipt Five | Done Gate | evidence-reconciler |
-| F22 | Completion Audit | Completion Audit | evidence-reconciler |
-| F23 | Production Operations | Release Gate | release-ops-worker |
-| F24 | Release Or Block | Release Gate, Human Gate when required | release-ops-worker, human-gate-clerk |
-| F25 | Monitoring Support | Support Gate | release-ops-worker |
-| F26 | Learnback | Learning Gate | skill-eval-distiller |
-| F27 | Factory Maturity Audit | Maturity Gate | skill-eval-distiller |
-
-## Route classes
-
-- `product_creation`: request types product_new; method family `spec_first`; gates Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: request types feature, slice; method family `behavior_first`; gates Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: request types bug; method family `test_first`; gates Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: request types incident; method family `incident_first`; gates Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: request types migration, refactor, integration; method family `legacy_diagnosis`; gates Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: request types release; method family `spec_first`; gates Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: request types feature, product_new, security, ux_ui, data_analytics, agent_skill; method family `research_first`; gates Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: request types doc; method family `docs_first`; gates Docs Utility Gate, First Run Gate.
-- `security_remediation`: request types security; method family `security_first`; gates Security Architecture Gate, Security Review Gate.
-- `critical_integration`: request types integration; method family `spec_first`; gates Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: request types migration; method family `legacy_diagnosis`; gates Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: request types ux_ui, product_new, feature; method family `design_first`; gates Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: request types data_analytics, product_new, feature; method family `analytics_first`; gates Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: request types agent_skill; method family `agent_eval_first`; gates Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
-
-## Glossary
-
-- **Hermes Kanban**: the runtime floor that owns boards, cards, dispatch, comments, logs, dependencies, and state transitions.
-- **Overkill Factory**: the product-production method and contract kernel that sits around Hermes.
-- **Product SOT**: the product source of truth used for downstream planning and execution.
-- **Method Contract**: the binding between a route, method engine, artifacts, gates, workers, and proof.
-- **Worker packet**: a bounded execution request for a specialist worker.
-- **Human gate**: a real operator decision with artifact, evidence, risk, and consequence.
-- **Receipt Five**: the final evidence package for release or block.
-- **Readback**: verification that claimed artifacts still exist and can be inspected.
-- **No-idle**: guardrail that detects stalled or false-progress runtime states.

--- a/docs/en/reference.md
+++ b/docs/en/reference.md
@@ -1,93 +1,124 @@
 # Reference
 
-This page collects the short-form facts a reader usually needs after reading the manual. It is intentionally human-sized. The full generated kernel reference is maintained under `factory/legacy-docs/generated/`.
+This page collects the short-form facts a reader normally needs after the manual. It does not replace registries or the generated reference. It translates the most important names for someone operating or evaluating the factory.
+
+## Where things live
+
+- `README.md` and `README.pt-BR.md`: short public entrypoints.
+- `docs/en/` and `docs/pt-BR/`: canonical public manual.
+- `docs/factory-workflow.catalog.json`: compiled public workflow.
+- `docs/promise-implementation-map.public.json`: public promise-to-implementation map.
+- `docs/public-surface.manifest.json`: public surface manifest.
+- `factory/scripts/factoryctl.py`: main command surface.
+- `factory/schemas/`: JSON contracts for valid records.
+- `factory/templates/`: base contracts, examples, and registries.
+- `factory/agents/`: workers, profiles, Hermes bindings, capability packs, and readiness.
+- `factory/tests/`: behavior regression coverage.
+- `factory/legacy-docs/`: old docs preserved as technical reference; not the canonical public manual.
+- `factory/legacy-docs/generated/`: generated kernel reference for maintainers.
+
+## Short mental path
+
+```text
+source
+-> understanding
+-> Product SOT
+-> method
+-> packs and gates
+-> work units
+-> Hermes
+-> worker results
+-> verification and review
+-> Receipt Five
+-> release, block, or learnback
+```
+
+If a run looks done but cannot point to that path, it is probably missing proof.
 
 ## Route classes
 
-- `product_creation`: used for `product_new` requests. Method family `None`; main gates: Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: used for `feature, slice` requests. Method family `None`; main gates: Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: used for `bug` requests. Method family `None`; main gates: Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: used for `incident` requests. Method family `None`; main gates: Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: used for `migration, refactor, integration` requests. Method family `None`; main gates: Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: used for `release` requests. Method family `None`; main gates: Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: used for `feature, product_new, security, ux_ui, data_analytics, agent_skill` requests. Method family `None`; main gates: Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: used for `doc` requests. Method family `None`; main gates: Docs Utility Gate, First Run Gate.
-- `security_remediation`: used for `security` requests. Method family `None`; main gates: Security Architecture Gate, Security Review Gate.
-- `critical_integration`: used for `integration` requests. Method family `None`; main gates: Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: used for `migration` requests. Method family `None`; main gates: Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: used for `ux_ui, product_new, feature` requests. Method family `None`; main gates: Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: used for `data_analytics, product_new, feature` requests. Method family `None`; main gates: Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: used for `agent_skill` requests. Method family `None`; main gates: Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+The fourteen route classes exist to stop the factory from treating every request the same way.
 
-## Method engines
+- `product_creation`: product creation; needs Product SOT, scope coverage, and ready gate.
+- `feature_delivery`: feature or slice; needs method, acceptance criteria, and proof proportional to risk.
+- `bug_repair`: bug work; needs reproduction or explicit reason, fix, and regression.
+- `incident_response`: incident work; needs severity, mitigation, communication, and learnback.
+- `brownfield_discovery` / `migration_execution`: brownfield, refactor, integration, or migration; needs baseline, contract, regression, and rollback.
+- `release_promotion`: release work; needs production readiness, rollback, owner, and authority.
+- `research_validation`: research; must become an operational decision, not just smart commentary.
+- `docs_onboarding`: docs/onboarding; must prove reader utility or first success.
+- `security_remediation`: security; needs architecture, scans, review, and residual-risk treatment.
+- `ux_product_experience`: UX/Product Experience; needs Product Face, states, journeys, design, and review.
+- `analytics_data`: analytics/data; needs metric contract, privacy, and quality proof.
+- `agent_quality_change`: agent/skill/model; needs eval, profile readiness, and learnback.
 
-- `spec_first_sdd`: None. Used when the route needs `spec_first`. Routes: .
-- `test_first_tdd`: None. Used when the route needs `test_first`. Routes: .
-- `behavior_first_bdd`: None. Used when the route needs `behavior_first`. Routes: .
-- `discovery_research`: None. Used when the route needs `discovery_first`. Routes: .
-- `security_first_threat_model`: None. Used when the route needs `security_first`. Routes: .
-- `design_first_product_experience`: None. Used when the route needs `design_first`. Routes: .
-- `legacy_diagnosis`: None. Used when the route needs `legacy_diagnosis`. Routes: .
-- `incident_first`: None. Used when the route needs `incident_first`. Routes: .
+## Main methods
 
-## Operating-system areas
+The method changes how work is proven.
 
-- `deterministic_control_plane_os`: deterministic_control_plane_os.
-- `product_truth_research_os`: product_truth_research_os.
-- `method_os`: method_os.
-- `product_architecture_os`: product_architecture_os.
-- `product_experience_design_brand_os`: product_experience_design_brand_os.
-- `work_unit_execution_dispatch_os`: work_unit_execution_dispatch_os.
-- `authority_autonomy_os`: authority_autonomy_os.
-- `hermes_worker_runtime_os`: hermes_worker_runtime_os.
-- `evidence_receipt_os`: evidence_receipt_os.
-- `capability_provider_os`: capability_provider_os.
-- `agent_profile_authority_os`: agent_profile_authority_os.
-- `security_os`: security_os.
-- `quality_verification_os`: quality_verification_os.
-- `operator_experience_os`: operator_experience_os.
-- `release_operations_os`: release_operations_os.
-- `velocity_cost_throughput_os`: velocity_cost_throughput_os.
-- `factory_learning_os`: factory_learning_os.
+- Spec-first: useful when the risk is building the wrong thing.
+- Test-first: useful when behavior must be locked by regression.
+- Behavior-first: useful when journey and acceptance matter more than internals.
+- Discovery-first: useful when the question is not mature yet.
+- Security-first: required when threat, secret, key, production, onchain, or abuse matters.
+- Design-first: required when visible experience is part of the product.
+- Legacy-diagnosis: needed when an old system, unknown behavior, or migration exists.
+- Incident-first: needed when the product is broken, at risk, or needs operational response.
 
-## Important paths
+## Capability packs
 
-- `README.md`: public English entry.
-- `README.pt-BR.md`: public Portuguese entry.
-- `docs/en/`: English product manual.
-- `docs/pt-BR/`: Portuguese product manual.
-- `docs/assets/public-map/`: public visual map assets.
-- `docs/factory-workflow.catalog.json`: public workflow catalog.
-- `docs/promise-implementation-map.public.json`: public promise-to-implementation map.
-- `docs/public-surface.manifest.json`: manifest for public surfaces.
-- `factory/scripts/factoryctl.py`: main command surface.
-- `factory/schemas/`: JSON schemas for records and contracts.
-- `factory/templates/`: examples, registries, and template contracts.
-- `factory/agents/`: public worker registry, profiles, bindings, and readiness records.
-- `factory/tests/`: regression tests.
-- `factory/legacy-docs/`: preserved old docs and generated reference material, not canonical public docs.
+A capability pack answers: “do we have specialist coverage for this product type?”.
+
+Core packs currently include web/SaaS, CLI/TUI, cloud-native, agent-runtime, Solana AI Kit, onboarding, and public docs. They still need normal gates, but the factory recognizes basic coverage.
+
+Template packs include native mobile, desktop, games, AI/ML, fintech, regulated domain, data analytics, browser extensions, and hardware/IoT. They should not execute materially just because a card asked for them. They need activation, specialists, bindings, smoke, eval, and evidence.
+
+## Product Face
+
+Product Face proves the face of the product. It changes by surface:
+
+- web visual: screenshots, viewports, states, console, accessibility basics, and overflow;
+- CLI/TUI: transcript, help, install, errors, and terminal behavior;
+- docs/onboarding: first-success replay, links, and reader criteria;
+- agentic interface: user control, permissions, memory/data, recovery, and boundaries;
+- wallet/onchain UI: visual proof plus signing, transaction, and key boundary.
+
+Product Face Packet is planning. Product Face Result is proof.
+
+## Workers and authority
+
+A worker is not a prompt character. To be operable it needs four layers:
+
+1. role in the public registry;
+2. agent profile;
+3. Hermes binding;
+4. card-specific worker packet.
+
+The worker executes inside received authority. It does not approve gates, invent evidence, touch production, handle keys, or change scope outside the contract.
 
 ## Core terms
 
-Product SOT is the product source of truth. It should say what is being built, what is in scope, what is out of scope, what evidence counts, and what would make the run unacceptable.
+Product SOT is product truth.
 
-Method Contract is the chosen way to handle the work. It binds the route to gates, artifacts, workers, and evidence.
+Full Product SOT Scope Coverage shows that every important SOT promise is planned, blocked, out of scope, human-owned, or proven.
 
-Worker Packet is the bounded instruction given to a worker. It includes task, limits, authority, and expected output.
+Method Contract connects route, method, gates, workers, and evidence.
 
-Gate Report explains whether a task can move, why it is blocked, and which evidence or action would unblock it.
+Worker Packet is the bounded task sent to a worker.
 
-Receipt Five is the completion receipt. It connects request, work, evidence, review, remaining risk, and next state.
+Worker Result is the worker return with evidence.
 
-Human Gate is a real operator decision. It should come with a readable package, not a vague chat question.
+Gate Report explains whether something can move, why it is blocked, and what unlocks it.
 
-Readback means the factory reads and checks the artifact a worker claims to have produced.
+Receipt Five is the done receipt: request, change, evidence, review, and next state.
 
-No-idle is the guard that detects silent stalls and pushes the next safe action or fails visibly.
+Human Gate is a material operator decision with a readable package.
 
-## Public claim boundary
+Readback is real reading of the produced artifact.
 
-The public repository can prove local kernel coherence. It cannot prove a private product delivery. Live product delivery needs an operator-owned Hermes runtime, live worker results, product-specific evidence, review, and human approval where required.
+No-idle is the guard against silent idle, not a second dispatcher.
+
+Learnback is learning promoted with proof, not loose chat memory.
 
 ## Useful commands
 
@@ -95,10 +126,10 @@ The public repository can prove local kernel coherence. It cannot prove a privat
 cd factory
 python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
-python3 scripts/factoryctl.py route-registry
-python3 scripts/factoryctl.py method-engines
-python3 scripts/factoryctl.py operating-systems
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+python3 scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py
@@ -106,3 +137,7 @@ python3 scripts/validate_worker_profiles.py
 python3 scripts/public_safety_scan.py
 python3 scripts/secret_safety_scan.py
 ```
+
+## Public claim boundary
+
+The public repository proves local kernel coherence. It does not prove that a private product was delivered. Real delivery needs a live Hermes runtime, current worker results, product-specific evidence, consumed review, and human approval when risk requires it.

--- a/docs/en/technical-model.md
+++ b/docs/en/technical-model.md
@@ -80,3 +80,35 @@ The validators are there to catch those mismatches. They are not a replacement f
 A safe change usually touches three layers at once: the human explanation, the executable contract, and the tests or validators. If you change docs only, you may improve communication but not behavior. If you change code only, the public surface may lie. If you change tests only, you may enforce an old model.
 
 For public documentation work, the safest rule is simple: write from current code and command output, not from memory. Then run the validators. If the validators complain, treat that as a product signal, not as an annoyance.
+
+## Hermes bindings and live profiles
+
+A worker is operable only when four layers match: registry role, agent profile, Hermes binding, and card-specific worker packet. A profile name alone is not enough.
+
+The binding defines skill refs, queue policy, result schema, receipt field, and evidence path policy. That prevents a nice prompt persona from being treated as a real worker without a runtime contract.
+
+Readiness also has a boundary. An old smoke, a locally materialized profile, or a degraded ledger does not prove live execution. It says a configuration path exists. Real completion still needs a current worker result and evidence consumed by the gate.
+
+## Phase engine and Kanban graph
+
+The factory uses the phase engine to compute the current frontier from materialized artifacts. The phase declared on a card does not beat reality. If Product SOT, Method Contract, decision package, or readiness is missing, the later phase blocks.
+
+In Hermes, this must become a native graph: cards, dependencies, typed blockers, and linked work units. The factory may reconcile and repair, but it should not maintain a hidden parallel list. Runtime should show operational truth.
+
+## Operator interface
+
+The operator interface is a projection. Telegram, Discord, cockpit, and CLI bridge can receive source, send status, and deliver decision packages. They do not replace Hermes, Receipt Five, or worker results.
+
+The product rule is: the manager speaks to the human; workers and raw events feed internal state. A human gate needs a readable memo and the artifact under review, not a JSON dump or local path.
+
+## Artifact readback and durable attachments
+
+The Hermes integration should not accept “a file exists” as completion. For runtime artifacts and attachments, the factory needs readback: row or blob exists, size and hash match, parsing succeeded when applicable, safety checks passed, and the reference can be consumed later.
+
+References such as `artifact_readback` and `kanban-attachment` live at that boundary. They prevent metadata, local paths, or temporary files from being treated as permanent proof.
+
+## SDLC Feedback Loop
+
+Material autonomous work needs to keep the thread between signal, triage, model/profile choice, execution, evidence, and learnback. That thread is the SDLC Feedback Loop.
+
+Without it, a failure becomes chat memory; a model choice becomes implicit; learnback becomes opinion without a target. With it, the factory knows where the signal came from, why it chose a route, what proof returned, and what rule may change later.

--- a/docs/en/technical-model.md
+++ b/docs/en/technical-model.md
@@ -1,106 +1,82 @@
-# Technical Model
+# Technical model
 
-Overkill Factory is implemented as a Python package, CLI, contract library, Hermes adapter surface, public worker registry, and documentation site.
+This page explains the implementation model without pretending that every reader wants to live inside the codebase.
 
-It is intentionally not a replacement for Hermes.
+The short version: Hermes owns runtime state. Overkill Factory owns the production contracts around that state. The repository contains the scripts, schemas, templates, registries, tests, and public docs that make the contract checkable.
 
 ## Repository shape
 
-```text
-README.md              public English entry
-README.pt-BR.md        public Portuguese entry
-docs/                  canonical public documentation and public catalogs
-factory/               implementation, contracts, tests, examples, legacy docs
-```
+The public repository has two important top-level areas:
 
-Inside `factory/`:
+- `docs/`: the public product manual and public catalogs.
+- `factory/`: the implementation, including scripts, schemas, templates, agents, adapters, examples, fixtures, tests, skills, and legacy docs.
 
-- `scripts/` contains `factoryctl.py` and validators;
-- `schemas/` contains JSON schemas for contracts;
-- `templates/` contains canonical example/contract templates;
-- `agents/` contains public worker registries, profiles, readiness, and bindings;
-- `adapters/hermes/` contains integration code for Hermes runtime boundaries;
-- `examples/` and `fixtures/` contain public examples and validation fixtures;
-- `tests/` protects behavior and public claims;
-- `legacy-docs/` preserves non-canonical older documentation.
+Old technical docs live under `factory/legacy-docs/`. They are preserved for history and compatibility, but they are not the canonical public explanation.
 
-## Public kernel counts
+## The executable surface
 
-The current executable surface inspected for this documentation contains:
+`factoryctl` is the main command surface. It validates cards, builds gate reports, compiles the workflow, prints registries, prepares worker packets, and runs the local public proof path.
 
-- 244 schemas;
-- 156 JSON templates;
-- 97 tests;
-- 40 public workers;
-- 14 route classes;
-- 8 method engines;
-- 17 operating-system areas;
-- 26 compiled workflow phases.
+The docs should never outrun this executable surface. If the docs claim a capability, the claim should trace to code, schema, test, command output, or a current product decision.
 
-## `factoryctl`
+## Runtime state
 
-`factoryctl` is the public control helper. It validates contracts, creates local proof artifacts, compiles workflow plans, generates worker packets, checks public JSON artifacts, and runs smoke paths.
+Hermes owns runtime state: Kanban cards, worker tasks, dependencies, transitions, comments, workspaces, blocked states, and done states. The factory should not recreate that state in prose or in a hidden sidecar.
 
-Important commands:
+The factory adds discipline around the runtime. It decides what artifacts are required, which gates apply, which worker profile should handle a task, what evidence must return, and what authority is forbidden.
 
-```bash
-cd factory
-python3 scripts/factoryctl.py doctor
-python3 scripts/factoryctl.py run minimal
-python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
-python3 scripts/factoryctl.py validate-runtime-contracts
-python3 scripts/factoryctl.py route-registry
-python3 scripts/factoryctl.py operating-systems
-python3 scripts/factoryctl.py method-engines
-```
+## Contracts and schemas
 
-`factoryctl` can prove local contract coherence. It does not replace Hermes runtime proof.
+The repository currently contains 244 JSON schemas and 156 JSON templates. That is the backbone of the system. The schemas define what valid records look like. The templates give examples or default contracts. The tests keep those contracts from drifting silently.
 
-## Runtime boundary
+Important contract families include workflow plans, factory commands, run events, promotion packets, worker authority, Product SOT, method contracts, capability packs, gate reports, Receipt Five, human gates, and runtime proof records.
 
-Hermes owns runtime state. Overkill Factory owns method contracts and checks.
+## Routes, methods, and operating systems
 
-That means:
+The route registry currently exposes 14 route classes. The method registry exposes 8 method engines. The operating-system registry exposes 17 operating-system areas.
 
-- a local JSON file is not a real running board;
-- a generated packet is not completed work;
-- a worker profile is not a worker result;
-- a passing local smoke is not a production release;
-- a human gate cannot be faked by a script.
+Route classes answer "what kind of work is this?" Method engines answer "how should this kind of work be handled?" Operating-system areas answer "which part of the factory owns this capability?"
 
-## Operating-system registry
+This gives the factory a way to adapt without becoming vague. It can handle product creation, bug repair, incidents, releases, security work, analytics, UX, migration, and agent quality changes without pretending they are the same job.
 
-The factory groups critical areas into operating-system entries:
+## Workers and profiles
 
-- **Deterministic Control Plane OS** (`deterministic_control_plane_os`): owner `factory-orchestrator`, status `active`. Own the reducer-first factory spine: phase graph, commands, events, decision outbox, replay and promotion boundaries.
-- **Product Truth and Research OS** (`product_truth_research_os`): owner `source-ledger-worker`, status `active`. Own deep product starts before Product SOT: sources, claims, conflicts, brownfield study, research decisions and operator understanding.
-- **Method OS** (`method_os`): owner `factory-orchestrator`, status `active`. Turn method routing into deterministic method engines rather than broad method-family labels.
-- **Product Architecture OS** (`product_architecture_os`): owner `product-architect`, status `active`. Own architecture candidates, trust boundaries, integration shape, data boundaries and technical decisions before decomposition.
-- **Product Experience, Design and Brand OS** (`product_experience_design_brand_os`): owner `product-face`, status `active`. Own UX, information architecture, brand/identity, design system, component proof, accessibility and visual regression for product surfaces.
-- **Work Unit and Execution Dispatch OS** (`work_unit_execution_dispatch_os`): owner `decomposition-planner`, status `active`. Own vertical work units, dispatch readiness, Hermes materialization plans, worker packets and execution ordering.
-- **Authority and Autonomy OS** (`authority_autonomy_os`): owner `factory-orchestrator`, status `active`. Decide when the factory proceeds, repairs, asks the operator, blocks or escalates without turning speed into unsafe YOLO.
-- **Hermes Worker Runtime OS** (`hermes_worker_runtime_os`): owner `factory-orchestrator`, status `blocked_pending_runtime_proof`. Own live worker operability: profile readiness, Hermes binding freshness, dispatch, no-idle, worker results and reconciliation.
-- **Evidence and Receipt OS** (`evidence_receipt_os`): owner `evidence-reconciler`, status `active`. Own proof tiers, evidence freshness, artifact readback, Receipt Five reconciliation and product-specific proof bundles.
-- **Capability Pack and Provider OS** (`capability_provider_os`): owner `factory-orchestrator`, status `active`. Own domain detection, capability pack activation, provider readiness, specialist acquisition and fail-closed pack execution.
-- **Agent and Profile Authority OS** (`agent_profile_authority_os`): owner `factory-orchestrator`, status `active`. Own worker identity, permissions, profile linting, binding readiness and the rule that agents execute contracts instead of deciding the line.
-- **Security OS** (`security_os`): owner `security-orchestrator`, status `active`. Own threat modeling, secrets, supply chain, privacy, runtime hardening, specialist security routing and risk evidence.
-- **Quality and Verification OS** (`quality_verification_os`): owner `qa-verification-worker`, status `active`. Own tests, QA plans, repair loops, visual verification, accessibility, product quality and independent evidence before done.
-- **Operator Experience OS** (`operator_experience_os`): owner `overkill-factory-gerente`, status `active`. Make one manager interface enough for Telegram-first operation: start, status, decisions, changes, briefings and proof.
-- **Release and Operations OS** (`release_operations_os`): owner `release-ops-worker`, status `active`. Own production readiness, release decision, rollback, monitoring, incident support and human R4 authority.
-- **Velocity, Cost and Throughput OS** (`velocity_cost_throughput_os`): owner `factory-orchestrator`, status `active`. Govern throughput, parallel lanes, retry budgets, token and time budgets, batching, dedupe and status cadence.
-- **Factory Learning OS** (`factory_learning_os`): owner `skill-eval-distiller`, status `hardened_existing`. Turn learnback, Hermes /learn drafts and repeated findings into inactive, reviewable, testable factory improvements.
+The public registry currently lists 40 public workers. A worker name is not enough. A worker needs a profile, a binding, result expectations, skill refs, evidence policy, and authority limits.
 
-These entries are not marketing categories. They name ownership, contracts, required proof, and failure boundaries.
+That is why the repository includes worker registries, worker profiles, Hermes profile bindings, readiness ledgers, and validators. A worker should not be a character in a prompt. It should be an operable role with a contract.
 
-## Method engines
+## Generated reference
 
-Method engines bind a route to proof. A method family cannot authorize execution by itself. The selected engine must produce the right artifacts and gates for the work.
+The full generated kernel reference is produced by `factory/scripts/generate_factory_reference_docs.py`. The generated output now lives under `factory/legacy-docs/generated/` because the public manual should stay readable. The generated file is still useful for maintainers and validators.
 
-- `spec_first_sdd` — Spec-First SDD Engine: family `spec_first`; used by product_creation, feature_delivery, critical_integration, migration_execution.
-- `test_first_tdd` — Test-First TDD Engine: family `test_first`; used by feature_delivery, bug_repair, critical_integration, migration_execution.
-- `behavior_first_bdd` — Behavior-First BDD Engine: family `behavior_first`; used by product_creation, feature_delivery, ux_product_experience.
-- `discovery_research` — Discovery and Research Engine: family `discovery_first`; used by product_creation, research_validation, brownfield_discovery.
-- `security_first_threat_model` — Security-First Threat Model Engine: family `security_first`; used by security_remediation, release_promotion, critical_integration, agent_quality_change.
-- `design_first_product_experience` — Design-First Product Experience Engine: family `design_first`; used by ux_product_experience, product_creation, feature_delivery.
-- `legacy_diagnosis` — Legacy Diagnosis Engine: family `legacy_diagnosis`; used by brownfield_discovery, migration_execution, bug_repair.
-- `incident_first` — Incident-First Engine: family `incident_first`; used by incident_response, bug_repair, security_remediation.
+## Validation stack
+
+The implementation is guarded by public JSON validators, public surface sync checks, promise-to-implementation checks, worker profile validation, public safety scans, secret safety scans, MkDocs strict build, and the Python test suite.
+
+The current public docs are meant to be read by humans, but they are still tied to these checks. That is what keeps the manual from becoming a story detached from the product.
+
+## How a request becomes state
+
+The factory does not trust a request just because it arrived in a chat. First it records source. Then it turns that source into structured artifacts. Those artifacts decide the route, the method, the gates, and the worker packets. Only then should runtime execution begin.
+
+That order is deliberate. If a worker starts from a vague instruction, the system has no stable way to decide whether the answer is right. If the request becomes state first, every later step can point back to the same source. The worker can be wrong, but the factory has something concrete to compare against.
+
+## What should be generated and what should be written by people
+
+Some material is better generated from code: full command catalogs, schema coverage, worker inventories, and large reference tables. Hand-writing those by memory is how documentation goes stale.
+
+Other material should be written for humans: this manual, the operating model, the trust model, and the usage path. A new operator does not need a thousand-line generated reference as the first explanation. They need the story in plain language, then exact commands when they are ready.
+
+The current repository keeps both layers. Generated material still exists for validation and maintainers. The public manual stays readable.
+
+## What can fail
+
+The technical model is strict because the failure modes are subtle. A path can exist but point to legacy documentation. A public manifest can name a file that was moved. A worker profile can look configured while its binding points at stale docs. A local proof can pass while live Hermes has not been checked. A public claim can be true for the kernel and false for a private product run.
+
+The validators are there to catch those mismatches. They are not a replacement for judgment, but they remove a lot of easy ways to fool ourselves.
+
+## How to change the factory safely
+
+A safe change usually touches three layers at once: the human explanation, the executable contract, and the tests or validators. If you change docs only, you may improve communication but not behavior. If you change code only, the public surface may lie. If you change tests only, you may enforce an old model.
+
+For public documentation work, the safest rule is simple: write from current code and command output, not from memory. Then run the validators. If the validators complain, treat that as a product signal, not as an annoyance.

--- a/docs/en/trust-and-evidence.md
+++ b/docs/en/trust-and-evidence.md
@@ -61,3 +61,27 @@ The public security matrix is now part of this trust model instead of a separate
 Local checks can prove that the public kernel is coherent. They cannot prove that a private product run shipped. Live product completion needs live Hermes state, product-specific evidence, review, and human approvals when required.
 
 That boundary is not a weakness. It is how the factory stays honest.
+
+## Decision package before decision
+
+A human gate without the artifact is invalid. If the factory asks approval for Product SOT, architecture, security, release, or Product Face, it must deliver the material being approved or a faithful projection with full reference.
+
+The first message should fit in the operator's head: requested decision, plain summary, what approval authorizes, what it does not authorize, reply options, consequence, and urgency. Attachments may carry the complete document. JSON is internal evidence, not the operator's primary experience.
+
+## Typed blocks and the human boundary
+
+Not every block is a question for the operator. `dependency_wait` waits for dependency. `capability` searches or activates a pack. `transient` retries or repairs. `needs_input` reaches the operator only when a complete decision package exists.
+
+This prevents a common failure: turning every process failure into “the human must decide”. Often the right decision is for the factory to repair its own state.
+
+## Local evidence, live evidence, and public evidence
+
+A passing local command proves checkout coherence. A worker result proves a worker ran in that scope. Receipt Five proves closure when it points to request, change, evidence, review, and next state. Public publication also needs surface and secret safety.
+
+These proofs are not interchangeable. Do not use local smoke to claim live product delivery, artifact existence as readback, or generic human approval as waiver for release, security, funds, or mainnet.
+
+## Implementation readiness
+
+Product Implementation Readiness is where the factory asks: “do we have SOT, method, research, architecture, packs, access, workers, reviewers, and enough proof to let material execution start?”.
+
+If that answer is weak, the factory should block before spending worker time. That is cheaper than discovering at Receipt Five that the whole product was built on an old gap.

--- a/docs/en/trust-and-evidence.md
+++ b/docs/en/trust-and-evidence.md
@@ -1,60 +1,63 @@
-# Trust and Evidence
+# Trust and evidence
 
-The factory is built around a blunt rule: a process that looks alive is not the same as progress.
+Overkill Factory is built around one uncomfortable fact: a process that looks alive is not the same as progress.
 
-This matters because agentic systems can produce convincing status while doing the wrong work, skipping source truth, hiding blockers, or declaring completion without evidence. Overkill Factory treats that as a product failure, not a communication style issue.
+Agents can write files, move cards, produce confident summaries, and still miss the product. A dashboard can show activity while the real blocker sits untouched. A review can say pass without reading the artifact. A human can be asked for approval without being given the thing they are approving.
+
+The factory treats those as product failures.
 
 ## Evidence before confidence
 
-A worker statement is not enough. The factory expects evidence that can be inspected later: files, commands, test output, readback records, screenshots, receipts, review records, or structured artifacts.
+The factory prefers evidence over tone. A worker saying "done" is useful only if the claimed artifacts exist, can be read back, and match the requested work. A test result is useful only if it tests the relevant behavior. A review is useful only if it checks the right artifact and is consumed by the original task.
 
-The strongest evidence has three properties:
-
-1. it points to a real artifact;
-2. it can be read back after the worker finishes;
-3. it traces to the product truth or method contract it claims to satisfy.
-
-## Readback
-
-Readback means the factory checks that claimed artifacts still exist and contain the expected content. This prevents a worker from naming files that were never created, were created in the wrong workspace, or disappeared after the run.
-
-For critical artifacts, readback is not bureaucracy. It is the difference between "the agent said it" and "the system can prove it."
-
-## Independent review
-
-Execution and review are different jobs. A builder can finish a task, but a reviewer must inspect whether the result satisfies the contract. For material work, the same identity should not be both executor and reviewer.
-
-A review result must be reduced back into the original runtime state. If a review passes but the original card stays blocked forever, the factory is still failing.
-
-## No-idle
-
-No-idle is not supposed to be a normal route authority. It is a guardrail. Its job is to notice when the board is stuck, when a worker declared artifacts that cannot be read, when ready work is not being dispatched, or when a repair loop is duplicating itself.
-
-A valid no-idle system must fail loudly when unfinished work remains. Heartbeats are not progress.
-
-## Blockers
-
-The factory separates blockers into two broad kinds:
-
-- non-human blockers that the factory should repair or reroute;
-- human authority gates that require a real operator decision.
-
-A missing artifact, stale worker, failed readback, or needed internal review should not be dumped on the operator. Production access, funds, signer authority, release approval, or risk acceptance may require a human.
+That is why many factory records look strict. They are not strict because the project loves paperwork. They are strict because loose evidence creates false progress.
 
 ## Receipt Five
 
-Receipt Five is the closing evidence package. It should include the request, artifact evidence, verification evidence, review evidence, release/block decision, and remaining risks.
+Receipt Five is the completion receipt. It should answer five kinds of questions:
 
-A Receipt Five package is not a decorative summary. It is the proof boundary between work in progress and a claim that the factory can defend.
+1. What was requested?
+2. What was done or decided?
+3. What evidence proves it?
+4. Who reviewed it and what did the review say?
+5. What remains blocked, risky, or next?
+
+If Receipt Five cannot answer those questions, the honest state is not done. It may be ready for review, blocked, partially complete, or waiting for a human decision. But it is not done.
+
+## Readback
+
+Readback means the factory checks the artifact that a worker claims to have produced. It is not enough for a worker to say "I wrote the SOT" or "I added the test". The factory has to read the file, confirm it exists, and decide whether it is good enough for the next step.
+
+This protects against a very common failure: process compliance without work quality. The worker may have followed the card, but the product output may still be thin, wrong, or missing.
+
+## Independent review
+
+Material work should be reviewed by a different identity when risk requires it. The executor can explain what it did. It should not be the final judge.
+
+Review can pass, fail, or ask for repair. A pass must unblock or close the original task. A fail must create repair work. A review that sits unused is another form of false progress.
+
+## No-idle and blockers
+
+No-idle is not a productivity trick. It is a guard against silent stalls. If the board has work that should move, but nothing material changes, the factory should repair the state, dispatch the next safe worker, or fail visibly.
+
+A blocker should also be honest. Some blockers are real human decisions. Many are not. If the factory needs an internal review, a readback, a missing artifact, or a repair task, that is factory-owned work. It should not be pushed to the operator as if the human has to solve it.
+
+## Human gates
+
+Human gates are serious. They belong to decisions where the operator owns authority: production release, mainnet, funds, secrets, budget, major risk, or explicit approval boundaries.
+
+A good human gate is readable. It says what decision is needed, what evidence exists, what can go wrong, and what each option means. The operator should not have to parse raw JSON or reconstruct the situation from scattered comments.
 
 ## Security and risk
 
-Security is not a late checklist. It is a route and architecture concern. Material risk can require threat modeling, trust boundaries, identity/authorization checks, supply-chain checks, secrets handling, privacy review, incident thinking, and residual-risk ownership.
+Security is not a late checklist. It is a route and architecture concern. Material risk can require threat modeling, trust boundaries, identity and authorization checks, supply-chain checks, secrets handling, privacy review, incident thinking, and residual-risk ownership.
 
 The factory should never claim perfect security. It should claim the best possible security posture supported by evidence, gates, and explicit residual-risk decisions.
 
-The public security matrix is now part of this trust model instead of a separate operator archive. Machine-checkable security domains include: `networking`, `linux-systems`, `web-security`, `application-security`, `ethical-hacking`, `security-tools`, `cloud-security`, `detection-monitoring`, `security-operations`, `cryptography`, `key-management`, `future-security`, `supply-chain`, and `onchain-solana-quasar`. These domains route work to specialists such as cloud infrastructure security, OWASP/AppSec, Codex Security, detection and monitoring, crypto/key management, supply-chain gate, agentic AI security, and Solana/Quasar audit workers.
+The public security matrix is now part of this trust model instead of a separate operator archive. Machine-checkable security domains include: `networking`, `linux-systems`, `web-security`, `application-security`, `ethical-hacking`, `security-tools`, `cloud-security`, `detection-monitoring`, `security-operations`, `cryptography`, `key-management`, `future-security`, `supply-chain`, and `onchain-solana-quasar`.
 
-## Self-improvement is bounded
+## The honest boundary
 
-Local validation can prove that the public kernel is coherent. It cannot prove that a private product run is production-ready. Product readiness needs runtime state, product-specific evidence, review, Receipt Five, and human approval when risk requires it.
+Local checks can prove that the public kernel is coherent. They cannot prove that a private product run shipped. Live product completion needs live Hermes state, product-specific evidence, review, and human approvals when required.
+
+That boundary is not a weakness. It is how the factory stays honest.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -92,3 +92,43 @@ This is heavier than the public smoke path, but it is the right check before a b
 A real run requires a Hermes runtime owned by the operator. The public kernel can prepare contracts and validate local proof paths, but live cards, workers, comments, workspaces, evidence, and transitions live in Hermes.
 
 Do not treat `doctor` or `run minimal` as proof that a product shipped. Treat them as proof that this checkout is coherent enough to start from.
+
+## Checking a real card
+
+After the minimal smoke, the useful next step is validating a specific card. The public example lives at `factory/examples/minimal-hermes-project/card.md`.
+
+```bash
+cd factory
+python3 scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+python3 scripts/factoryctl.py status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
+```
+
+This shows required fields, risk and surface routing, required workers, and the status an operator would see. It is still not live execution; it is contract proof.
+
+## Before a public release
+
+A public change needs more than a docs build. Run the public checks, regenerate reference when needed, and do not commit `.tmp` as public proof. For a real release, the boundary is higher: preflight, production readiness, rollback, published surface, and current Hermes evidence when the claim talks about a live runtime.
+
+Use `validate_public_surface_sync.py --check-published` only when the public object has already been published or refreshed. Before that, it may correctly report the published surface as out of sync.
+
+## Telegram or Control Tower usage
+
+Telegram and Control Tower are operator interfaces. They can show status, deliver decision packages, and receive replies. They do not approve release alone, replace Hermes, or turn worker events into completion.
+
+If the operator speaks Portuguese, visible status, cards, and decision packages should use natural Portuguese too. Schema keys, logs, and internal IDs may remain English.
+
+## Release and production preflight
+
+When the question changes from “is the checkout coherent?” to “can I publish or promote?”, use a stronger layer:
+
+```bash
+cd factory
+python3 scripts/release_integration_preflight.py --out .tmp/release-check.json
+python3 scripts/factory_production_gate_receipts.py
+python3 scripts/factory_production_readiness.py --out .tmp/readiness-check.json
+python3 scripts/worktree_release_inventory.py --out .tmp/inventory-check.json
+```
+
+These commands may produce `BLOCKED` receipts. That is not necessarily an error. Often it is the correct result when live Hermes, private evidence, published surface, rollback, or readiness does not yet support a production claim.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -1,12 +1,10 @@
 # Usage
 
-This page is the first practical path for a local checkout.
+This page is the practical path for a local checkout. It does not pretend that a local checkout is the same as a live operator-owned Hermes runtime. It gives you a safe first proof, then shows the checks used before public documentation or claims should move.
 
 ## Requirements
 
-- Python 3.11 or newer.
-- A checkout of this repository.
-- Optional: Hermes runtime if you want live operator/worker execution. Local kernel checks do not require a live Hermes runtime.
+You need Python 3.11 or newer and a checkout of the repository. A live Hermes runtime is optional for local kernel validation. It becomes required only when you want real operator and worker execution.
 
 ## Local doctor
 
@@ -15,7 +13,7 @@ cd factory
 python3 scripts/factoryctl.py doctor
 ```
 
-A passing doctor checks the local package metadata, repository shape, minimal example path, public CLI surface, and V3 production-activation local proof. It may warn that Hermes runtime was not checked. That warning is honest: local validation is not live Hermes E2E proof.
+A passing doctor checks package metadata, repository shape, the minimal example, public CLI shape, and the local V3 activation proof. The command may warn that Hermes runtime was not checked. That warning is correct: local validation is not live Hermes E2E proof.
 
 ## Minimal run
 
@@ -31,7 +29,21 @@ Wrote .tmp/quickstart-result.json
 PASS: wrote .tmp/quickstart-result.json
 ```
 
-This proves the public minimal path can materialize a valid local proof artifact.
+This proves that the public minimal path can write a valid local proof artifact. It does not prove that a real product was delivered.
+
+## Inspect the factory instead of guessing
+
+Use the executable registries when you want facts:
+
+```bash
+cd factory
+python3 scripts/factoryctl.py route-registry
+python3 scripts/factoryctl.py method-engines
+python3 scripts/factoryctl.py operating-systems
+python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+```
+
+These commands are better than reading old prose because they come from the implementation surface.
 
 ## Build the documentation site
 
@@ -41,47 +53,42 @@ From the repository root:
 python3 -m mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/overkill-docs-site
 ```
 
-The docs are written as a GitHub-first manual and are already structured for MkDocs.
-
-## Inspect the route system
-
-```bash
-cd factory
-python3 scripts/factoryctl.py route-registry
-python3 scripts/factoryctl.py method-engines
-python3 scripts/factoryctl.py operating-systems
-```
-
-Use these commands when you want facts from the executable surface instead of from prose.
-
-## Compile the workflow
-
-```bash
-cd factory
-python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
-```
-
-This produces the phase plan used by the lifecycle documentation.
+The site is intentionally small: English, Portuguese, and public assets. The old technical archive is under `factory/legacy-docs/` and is not part of the main navigation.
 
 ## Public safety checks
 
-Before changing public docs or claims, run at least:
+Before changing public docs or public claims, run:
 
 ```bash
 cd factory
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py
+python3 scripts/validate_worker_profiles.py
 python3 scripts/public_safety_scan.py
 python3 scripts/secret_safety_scan.py
+python3 scripts/generate_factory_reference_docs.py --check
 ```
 
-If a check fails, do not describe the public surface as ready. Fix the mismatch or report the boundary honestly.
+`validate_public_surface_sync.py` checks that public surfaces still match their manifest. `validate_promise_implementation_map.py` checks that public promises still have implementation and boundary references. `public_safety_scan.py` and `secret_safety_scan.py` protect the public repo boundary.
 
-Generated outputs under `.tmp/`, validation snapshots, pilot records, and local proof artifacts are runtime evidence. They must not be committed as public source unless a specific public contract explicitly says the artifact is part of the repository surface.
+If a check fails, do not describe the public surface as ready. Fix the mismatch or state the boundary honestly.
+
+Generated outputs under `.tmp/`, validation snapshots, pilot records, and local proof artifacts are runtime evidence. They must not be committed as public source unless a specific public contract explicitly says the artifact belongs in the repository.
+
+## Full local validation
+
+For a deeper local pass:
+
+```bash
+cd factory
+python3 -m unittest discover -s tests -p 'test_*.py' -q
+```
+
+This is heavier than the public smoke path, but it is the right check before a broad docs or contract change.
 
 ## Live Hermes usage
 
-A real run requires an operator-owned Hermes runtime. The public kernel can prepare and validate contracts, but live cards, workers, comments, workspaces, evidence, and transitions live in Hermes.
+A real run requires a Hermes runtime owned by the operator. The public kernel can prepare contracts and validate local proof paths, but live cards, workers, comments, workspaces, evidence, and transitions live in Hermes.
 
-Do not treat `doctor` or `run minimal` as proof that a real product has shipped.
+Do not treat `doctor` or `run minimal` as proof that a product shipped. Treat them as proof that this checkout is coherent enough to start from.

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -1,47 +1,36 @@
 # Overkill Factory
 
-A Overkill Factory é uma fábrica de produto para trabalho com agentes em cima do Hermes.
+A Overkill Factory é uma fábrica de produto para trabalho com agentes. Não é um prompt grande, não é uma lista de tarefas e não é só uma casca em volta de um agente de código. Ela pega um pedido ainda meio cru e transforma isso em produção controlada: fonte, definição do produto, método, pacotes de trabalho, execução no Hermes, revisão, evidência, entrega ou bloqueio, e depois aprendizado.
 
-Ela não é chatbot, não é SaaS, não é um segundo Hermes. O Hermes é dono do chão de runtime: boards, cards, dependências, typed blocks, dispatch, execução de workers, comentários, logs e transições de estado. A Overkill Factory é dona do método de produção: intake, verdade de fonte, definição de produto, escolha de método, gates, autoridade de workers, evidência, revisão, decisões de release e learnback.
+O kernel público atual está na versão `3.0.2`. Ele expõe 26 fases compiladas, 14 classes de rota, 8 motores de método, 17 áreas de sistema operacional da fábrica, 40 workers públicos, 244 schemas JSON, 156 templates JSON e 97 testes. Esses números não estão aqui para enfeitar. Eles mostram que esta documentação está presa ao repositório que roda, não a uma narrativa bonita.
 
-O kernel público neste repositório está na versão `3.0.2`. A superfície executável atual contém 26 fases compiladas, 14 classes de rota, 8 method engines, 17 áreas de operating system, 40 workers públicos, 244 schemas, 156 templates e 97 testes.
+## Por que isso existe
 
-## A explicação mais curta que ainda é útil
+Trabalho com agente costuma falhar de jeitos bem comuns. O agente começa cedo demais. O briefing está frouxo. O worker errado assume a tarefa. Um revisor diz "parece bom" sem reler a evidência. Um gate humano vira uma pergunta vaga no chat. Uma execução é marcada como pronta porque um arquivo existe, não porque o produto pedido ficou realmente usável.
 
-Um pedido entra na fábrica. A fábrica não manda imediatamente um agente construir. Ela primeiro protege a fonte, entende o material, confirma a verdade do produto, escolhe o método correto, checa risco e capacidade, transforma o trabalho em unidades limitadas, despacha especialistas pelo Hermes, exige evidência, revisa o resultado e só então libera, bloqueia ou aprende.
+A Overkill Factory existe para tornar esses erros mais difíceis.
 
-```text
-fonte -> entendimento -> verdade do produto -> método -> plano -> work units
--> workers Hermes -> evidência -> revisão -> release ou bloqueio -> learnback
-```
+O objetivo é tornar a velocidade confiável. Não adianta o agente ser rápido se a fábrica não sabe exatamente o que ele deve fazer, quem tem autoridade para fazer, qual prova precisa voltar e o que acontece quando a prova não aparece.
 
-O objetivo não é deixar agentes lentos. O objetivo é tornar a velocidade confiável.
+## A imagem simples
 
-## Para quem esta documentação existe
+Um pedido entra na fábrica. Antes de sair fazendo, a fábrica protege a fonte: o que o operador pediu de verdade, que material existe, o que falta e o que não pode ser inventado. Depois ela cria a verdade do produto, escolhe um método, divide o trabalho em unidades pequenas, manda os workers certos pelo Hermes, checa os resultados e decide: entrega, bloqueia ou aprende.
 
-Leia se você é:
+Por dentro isso é complexo. Tem que ser. Criar produto de verdade é complexo. Mas a experiência do operador deveria ser simples: pedir, ver o estado, receber decisões claras e exigir prova quando alguém disser que terminou.
 
-- operador que quer rodar trabalho de produto pela fábrica;
-- investidor ou parceiro técnico tentando entender o sistema;
-- pessoa não técnica querendo entender a ideia sem jargão interno;
-- engenheiro que precisa inspecionar ou contribuir com o kernel público;
-- agente que precisa continuar trabalho sem depender de memória privada do chat.
+## Por onde começar
 
-## Caminho de leitura
+Leia nesta ordem:
 
-1. **Manual** explica o produto e o modelo mental.
-2. **Modelo Operacional** explica a fábrica em movimento.
-3. **Ciclo da Fábrica** explica cada fase compilada.
-4. **Confiança e Evidência** explica como a fábrica evita falso progresso.
-5. **Modelo Técnico** explica a implementação.
-6. **Uso** traz os comandos do primeiro teste local.
-7. **Referência** junta termos, comandos, paths e registries.
+1. [Manual](manual.md), para entender a ideia sem jargão.
+2. [Modelo operacional](operating-model.md), para ver o que acontece numa execução.
+3. [Ciclo da fábrica](lifecycle.md), para acompanhar fase por fase.
+4. [Confiança e evidência](trust-and-evidence.md), para entender como a fábrica evita progresso falso.
+5. [Uso](usage.md), para rodar comandos agora.
 
-English version: [English](../en/index.md).
+Quem vai contribuir no código pode seguir para [Modelo técnico](technical-model.md) e [Referência](reference.md). Quem só quer entender o produto consegue parar no manual e no modelo operacional sem ficar perdido.
 
-## Primeiro teste local
-
-Em um checkout deste repositório:
+## Primeira prova local
 
 ```bash
 cd factory
@@ -49,4 +38,8 @@ python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
 ```
 
-Um teste local passando significa que o kernel público e o caminho mínimo estão coerentes. Não significa que um runtime Hermes real de operador entregou um produto específico. Entrega real de produto ainda exige estado Hermes, resultado de workers, readback, revisão, Receipt Five e qualquer gate humano necessário.
+Um teste local passando significa que o kernel público está coerente. Não significa que um produto privado foi entregue, que um runtime Hermes vivo está configurado, nem que um humano aprovou uma decisão de risco. A documentação deixa essa fronteira visível de propósito.
+
+## O que mudou nesta documentação
+
+A documentação antiga tinha valor para manutenção, mas parecia um conjunto de departamentos internos. A documentação atual é um manual de produto. O material antigo foi preservado em `factory/legacy-docs/` por histórico e compatibilidade. A árvore pública `docs/` agora é a explicação canônica.

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -2,7 +2,7 @@
 
 A Overkill Factory é uma fábrica de produto para trabalho com agentes. Não é um prompt grande, não é uma lista de tarefas e não é só uma casca em volta de um agente de código. Ela pega um pedido ainda meio cru e transforma isso em produção controlada: fonte, definição do produto, método, pacotes de trabalho, execução no Hermes, revisão, evidência, entrega ou bloqueio, e depois aprendizado.
 
-O kernel público atual está na versão `3.0.2`. Ele expõe 26 fases compiladas, 14 classes de rota, 8 motores de método, 17 áreas de sistema operacional da fábrica, 40 workers públicos, 244 schemas JSON, 156 templates JSON e 97 testes. Esses números não estão aqui para enfeitar. Eles mostram que esta documentação está presa ao repositório que roda, não a uma narrativa bonita.
+O kernel público atual está na versão `3.0.2`. Ele expõe 26 fases compiladas, 14 classes de rota, 8 motores de método, 17 áreas de sistema operacional da fábrica, 40 workers públicos, 244 schemas JSON, 156 templates JSON e 97 arquivos de teste. Esses números não estão aqui para enfeitar. Eles mostram que esta documentação está presa ao repositório que roda, não a uma narrativa bonita.
 
 ## Por que isso existe
 

--- a/docs/pt-BR/lifecycle.md
+++ b/docs/pt-BR/lifecycle.md
@@ -1,302 +1,272 @@
-# Ciclo da Fábrica
+# Ciclo da fábrica
 
-O workflow compilado é a fonte factual desta página.
+O workflow compilado é a fonte factual desta página. Hoje ele contém `26` fases compiladas em `docs/factory-workflow.catalog.json`.
 
-Plano compilado atual: `26` fases a partir de `docs/factory-workflow.catalog.json`, gerado com:
+Você pode regenerar ou inspecionar o plano pelo lado da implementação:
 
 ```bash
 cd factory
-python3 scripts/factoryctl.py compile-workflow --out .tmp/docs-rewrite-workflow-plan.json
+python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
 
-A lista de fases é um modelo de ensino e uma superfície de contrato. A execução de runtime ainda é em grafo: dependências, gates, evidência, risco e estado Hermes decidem o que pode andar.
-
-## Referência de fases
+Leia o ciclo como um caminho de produção, não como uma cachoeira rígida. Estado vivo no Hermes, dependências, bloqueios, risco e evidência decidem o que pode andar. A lista de fases mostra o que a fábrica está protegendo em cada passo.
 
 ### F0 — Pre-Start / Sealed Source Envelope
 
-Objetivo: atravessar **Pre-Start / Sealed Source Envelope** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Pre-Start / Sealed Source Envelope`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `factory_bridge_source_envelope`, `factory_bridge_start_request`.
+O que precisa existir antes de avançar: `factory_bridge_source_envelope`, `factory_bridge_start_request`. O portão que segura a passagem é: Start Boundary. Os workers normalmente envolvidos são: `overkill-factory-gerente`, `factory-orchestrator`.
 
-Gates exigidos: Start Boundary.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `overkill-factory-gerente`, `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: summarize or reinterpret source material in the bridge, create Hermes board/card directly from bridge, start without explicit runtime target policy.
 ### F1 — Intake
 
-Objetivo: atravessar **Intake** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Intake`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`.
+O que precisa existir antes de avançar: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`. O portão que segura a passagem é: Source Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
 
-Gates exigidos: Source Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: route implementation before source resolution, create Product SOT from raw input, require the operator to poll for status.
 ### F2 — Source Ledger
 
-Objetivo: atravessar **Source Ledger** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Source Ledger`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`.
+O que precisa existir antes de avançar: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`. O portão que segura a passagem é: Source Gate. Os workers normalmente envolvidos são: `source-ledger-worker`.
 
-Gates exigidos: Source Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `source-ledger-worker`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: ask user to reconcile internal source bookkeeping, create outcome contract or Product SOT before understanding is confirmed.
 ### F3 — Source Resolution
 
-Objetivo: atravessar **Source Resolution** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Source Resolution`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `discovery_brief`.
+O que precisa existir antes de avançar: `discovery_brief`. O portão que segura a passagem é: Discovery Gate. Os workers normalmente envolvidos são: `source-ledger-worker`, `product-sot-planner`.
 
-Gates exigidos: Discovery Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `source-ledger-worker`, `product-sot-planner`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: turn unresolved gaps into execution scope.
 ### F4 — Product Outcome And Discovery
 
-Objetivo: atravessar **Product Outcome And Discovery** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Product Outcome And Discovery`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`.
+O que precisa existir antes de avançar: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`. O portão que segura a passagem é: Outcome Gate, Discovery Gate. Os workers normalmente envolvidos são: `product-sot-planner`.
 
-Gates exigidos: Outcome Gate, Discovery Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `product-sot-planner`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: treat outcome candidate as approved Product SOT, draft Product SOT before operator understanding confirmation.
 ### F5 — Product SOT
 
-Objetivo: atravessar **Product SOT** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Product SOT`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`.
+O que precisa existir antes de avançar: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`. O portão que segura a passagem é: Product SOT Gate. Os workers normalmente envolvidos são: `product-sot-planner`.
 
-Gates exigidos: Product SOT Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `product-sot-planner`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: execute from paper instead of Product SOT, ask operator to approve Product SOT from a short chat summary only, start architecture, repo cleanup, human gate or worker packet while Product SOT owner package is missing.
 ### F6 — Agentic Method Router
 
-Objetivo: atravessar **Agentic Method Router** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Agentic Method Router`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `factory_phase_lock`, `method_contract`.
+O que precisa existir antes de avançar: `factory_phase_lock`, `method_contract`. O portão que segura a passagem é: Method Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
 
-Gates exigidos: Method Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: ask user to choose internal method machinery, start architecture or repo cleanup before Method Contract.
 ### F7 — Method Contract
 
-Objetivo: atravessar **Method Contract** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Method Contract`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `factory_phase_lock`, `method_contract`.
+O que precisa existir antes de avançar: `factory_phase_lock`, `method_contract`. O portão que segura a passagem é: Method Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
 
-Gates exigidos: Method Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: start implementation with undocumented process choices, materialize future-phase cards while active frontier is still product_sot or method_contract.
 ### F8 — Pack And Product Experience Selection
 
-Objetivo: atravessar **Pack And Product Experience Selection** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Pack And Product Experience Selection`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`.
+O que precisa existir antes de avançar: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`. O portão que segura a passagem é: Pack Gate, Product Experience Gate, Surface Pack Gate. Os workers normalmente envolvidos são: `product-face`, `factory-orchestrator`.
 
-Gates exigidos: Pack Gate, Product Experience Gate, Surface Pack Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `product-face`, `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: activate a pack without proof or coverage, start product-facing implementation before surface state coverage, treat generic UI proof as Product Experience proof, move to implementation with unnamed surface pack or proof profile.
 ### F9 — Risk And Authority Gates
 
-Objetivo: atravessar **Risk And Authority Gates** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Risk And Authority Gates`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `access_capability`, `budget_contract`.
+O que precisa existir antes de avançar: `access_capability`, `budget_contract`. O portão que segura a passagem é: Access Gate, Budget Gate, Human Gate when required. Os workers normalmente envolvidos são: `human-gate-clerk`.
 
-Gates exigidos: Access Gate, Budget Gate, Human Gate when required.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `human-gate-clerk`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: infer approval from silence, ask for planning-only continuation approval, ask for architecture or repo cleanup approval while downstream is frozen.
 ### F10 — Security Architecture
 
-Objetivo: atravessar **Security Architecture** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Security Architecture`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `factory_phase_lock`, `security_architecture_plan`.
+O que precisa existir antes de avançar: `factory_phase_lock`, `security_architecture_plan`. O portão que segura a passagem é: Security Architecture Gate. Os workers normalmente envolvidos são: `security-orchestrator`.
 
-Gates exigidos: Security Architecture Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `security-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: build material risk before architecture, start security architecture while Product SOT or Method Contract is still missing.
 ### F11 — Executable Plans
 
-Objetivo: atravessar **Executable Plans** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Executable Plans`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`.
+O que precisa existir antes de avançar: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`. O portão que segura a passagem é: Ready Gate. Os workers normalmente envolvidos são: `decomposition-planner`.
 
-Gates exigidos: Ready Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `decomposition-planner`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: execute before plans, coverage review and stop criteria exist, mark decomposition review as passed from the planner that created the decomposition.
 ### F12 — Autonomy Readiness
 
-Objetivo: atravessar **Autonomy Readiness** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Autonomy Readiness`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`.
+O que precisa existir antes de avançar: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`. O portão que segura a passagem é: Decomposition Coverage Gate, Access & Capability Gate. Os workers normalmente envolvidos são: `independent-reviewer`, `factory-orchestrator`.
 
-Gates exigidos: Decomposition Coverage Gate, Access & Capability Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `independent-reviewer`, `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: start autonomous work with missing review, access or limits, let a single reviewer approve the complete decomposition alone, create Product Implementation Readiness from a failed or missing decomposition coverage review.
 ### F13 — Ready Gate
 
-Objetivo: atravessar **Ready Gate** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Ready Gate`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `gate_report`.
+O que precisa existir antes de avançar: `gate_report`. O portão que segura a passagem é: Ready Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
 
-Gates exigidos: Ready Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `factory-orchestrator`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: dispatch blocked workers.
 ### F15 — Runtime Execution
 
-Objetivo: atravessar **Runtime Execution** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Runtime Execution`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `worker_packets`.
+O que precisa existir antes de avançar: `worker_packets`. O portão que segura a passagem é: Runtime Gate. Os workers normalmente envolvidos são: `implementation-worker`, `qa-verification-worker`.
 
-Gates exigidos: Runtime Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `implementation-worker`, `qa-verification-worker`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: spawn without route readiness.
 ### F16 — Worker Results
 
-Objetivo: atravessar **Worker Results** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Worker Results`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `worker_results`.
+O que precisa existir antes de avançar: `worker_results`. O portão que segura a passagem é: Done Gate. Os workers normalmente envolvidos são: `evidence-reconciler`.
 
-Gates exigidos: Done Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `evidence-reconciler`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: treat packet existence as proof.
 ### F17 — Verification
 
-Objetivo: atravessar **Verification** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Verification`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `verification_plan`, `verification_result`.
+O que precisa existir antes de avançar: `verification_plan`, `verification_result`. O portão que segura a passagem é: Verification Gate. Os workers normalmente envolvidos são: `qa-verification-worker`.
 
-Gates exigidos: Verification Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `qa-verification-worker`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: claim done without command evidence.
 ### F18 — Independent Review
 
-Objetivo: atravessar **Independent Review** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Independent Review`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `review_result`.
+O que precisa existir antes de avançar: `review_result`. O portão que segura a passagem é: Review Gate. Os workers normalmente envolvidos são: `independent-reviewer`.
 
-Gates exigidos: Review Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `independent-reviewer`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: allow executor to self-approve.
 ### F20 — Closure Summary
 
-Objetivo: atravessar **Closure Summary** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Closure Summary`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `closure_summary`.
+O que precisa existir antes de avançar: `closure_summary`. O portão que segura a passagem é: Closure Gate. Os workers normalmente envolvidos são: `handoff-packer`.
 
-Gates exigidos: Closure Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `handoff-packer`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: hide unresolved blockers in prose.
 ### F21 — Receipt Five
 
-Objetivo: atravessar **Receipt Five** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Receipt Five`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `receipt_five`.
+O que precisa existir antes de avançar: `receipt_five`. O portão que segura a passagem é: Done Gate. Os workers normalmente envolvidos são: `evidence-reconciler`.
 
-Gates exigidos: Done Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `evidence-reconciler`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: mark done without Receipt Five.
 ### F22 — Completion Audit
 
-Objetivo: atravessar **Completion Audit** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Completion Audit`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `completion_audit`.
+O que precisa existir antes de avançar: `completion_audit`. O portão que segura a passagem é: Completion Audit. Os workers normalmente envolvidos são: `evidence-reconciler`.
 
-Gates exigidos: Completion Audit.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `evidence-reconciler`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: close skipped method or evidence requirements.
 ### F23 — Production Operations
 
-Objetivo: atravessar **Production Operations** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Production Operations`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `production_readiness_plan`.
+O que precisa existir antes de avançar: `production_readiness_plan`. O portão que segura a passagem é: Release Gate. Os workers normalmente envolvidos são: `release-ops-worker`.
 
-Gates exigidos: Release Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `release-ops-worker`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: release without owner, rollback or approval.
 ### F24 — Release Or Block
 
-Objetivo: atravessar **Release Or Block** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Release Or Block`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `release_decision`.
+O que precisa existir antes de avançar: `release_decision`. O portão que segura a passagem é: Release Gate, Human Gate when required. Os workers normalmente envolvidos são: `release-ops-worker`, `human-gate-clerk`.
 
-Gates exigidos: Release Gate, Human Gate when required.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `release-ops-worker`, `human-gate-clerk`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: promote without production-strict evidence.
 ### F25 — Monitoring Support
 
-Objetivo: atravessar **Monitoring Support** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Monitoring Support`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `incident_support_plan`.
+O que precisa existir antes de avançar: `incident_support_plan`. O portão que segura a passagem é: Support Gate. Os workers normalmente envolvidos são: `release-ops-worker`.
 
-Gates exigidos: Support Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `release-ops-worker`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: ship without support owner when support is material.
 ### F26 — Learnback
 
-Objetivo: atravessar **Learnback** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Learnback`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `factory_learning_proposal`.
+O que precisa existir antes de avançar: `factory_learning_proposal`. O portão que segura a passagem é: Learning Gate. Os workers normalmente envolvidos são: `skill-eval-distiller`.
 
-Gates exigidos: Learning Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `skill-eval-distiller`.
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
 
-Atalhos bloqueados: auto-activate critical factory changes.
 ### F27 — Factory Maturity Audit
 
-Objetivo: atravessar **Factory Maturity Audit** sem permitir que um worker pule o estado da fábrica.
+Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Factory Maturity Audit`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
 
-Artefatos exigidos: `factory_maturity_scorecard`.
+O que precisa existir antes de avançar: `factory_maturity_scorecard`. O portão que segura a passagem é: Maturity Gate. Os workers normalmente envolvidos são: `skill-eval-distiller`.
 
-Gates exigidos: Maturity Gate.
+O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
 
-Workers: `skill-eval-distiller`.
-
-Atalhos bloqueados: commit raw study or private evidence.
-
+O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.

--- a/docs/pt-BR/lifecycle.md
+++ b/docs/pt-BR/lifecycle.md
@@ -1,272 +1,447 @@
 # Ciclo da fábrica
 
-O workflow compilado é a fonte factual desta página. Hoje ele contém `26` fases compiladas em `docs/factory-workflow.catalog.json`.
+O workflow compilado é a fonte factual desta página. Hoje ele contém `26` fases em `docs/factory-workflow.catalog.json`.
 
-Você pode regenerar ou inspecionar o plano pelo lado da implementação:
+Esta página não deve ser lida como uma cachoeira rígida. Ela é um mapa do que a fábrica protege. Hermes, dependências, bloqueios, risco e evidência ainda decidem o que pode andar numa execução viva.
+
+A leitura prática é simples: cada fase responde uma pergunta, exige alguns artefatos, bloqueia atalhos perigosos e entrega ao operador uma visão mais clara do próximo passo.
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
 
-Leia o ciclo como um caminho de produção, não como uma cachoeira rígida. Estado vivo no Hermes, dependências, bloqueios, risco e evidência decidem o que pode andar. A lista de fases mostra o que a fábrica está protegendo em cada passo.
+## F0 — Pre-Start / Sealed Source Envelope
 
-### F0 — Pre-Start / Sealed Source Envelope
+A fábrica separa conversa de execução. O material entra num envelope de fonte antes de virar card, para o primeiro resumo não destruir a intenção original.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Pre-Start / Sealed Source Envelope`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O que precisa existir: `factory_bridge_source_envelope`, `factory_bridge_start_request`.
 
-O que precisa existir antes de avançar: `factory_bridge_source_envelope`, `factory_bridge_start_request`. O portão que segura a passagem é: Start Boundary. Os workers normalmente envolvidos são: `overkill-factory-gerente`, `factory-orchestrator`.
+Gates que seguram o avanço: `Start Boundary`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Workers normalmente envolvidos: `overkill-factory-gerente`, `factory-orchestrator`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Atalhos que esta fase impede:
 
-### F1 — Intake
+- summarize or reinterpret source material in the bridge.
+- create Hermes board/card directly from bridge.
+- start without explicit runtime target policy.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Intake`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O que precisa existir antes de avançar: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`. O portão que segura a passagem é: Source Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
+## F1 — Intake
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Aqui o pedido vira sinal classificado. A interface do operador, a conversa inicial e a resolução da fonte impedem que a fábrica comece com um chute bonito.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O que precisa existir: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`.
 
-### F2 — Source Ledger
+Gates que seguram o avanço: `Source Gate`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Source Ledger`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Workers normalmente envolvidos: `factory-orchestrator`.
 
-O que precisa existir antes de avançar: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`. O portão que segura a passagem é: Source Gate. Os workers normalmente envolvidos são: `source-ledger-worker`.
+Atalhos que esta fase impede:
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+- route implementation before source resolution.
+- create Product SOT from raw input.
+- require the operator to poll for status.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-### F3 — Source Resolution
+## F2 — Source Ledger
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Source Resolution`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O source ledger diz de onde veio cada afirmação. Fato, inferência, decisão, conflito e lacuna não podem virar uma massa só.
 
-O que precisa existir antes de avançar: `discovery_brief`. O portão que segura a passagem é: Discovery Gate. Os workers normalmente envolvidos são: `source-ledger-worker`, `product-sot-planner`.
+O que precisa existir: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Gates que seguram o avanço: `Source Gate`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Workers normalmente envolvidos: `source-ledger-worker`.
 
-### F4 — Product Outcome And Discovery
+Atalhos que esta fase impede:
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Product Outcome And Discovery`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+- ask user to reconcile internal source bookkeeping.
+- create outcome contract or Product SOT before understanding is confirmed.
 
-O que precisa existir antes de avançar: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`. O portão que segura a passagem é: Outcome Gate, Discovery Gate. Os workers normalmente envolvidos são: `product-sot-planner`.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+## F3 — Source Resolution
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+A fábrica transforma fonte em entendimento operacional. Se ainda falta descoberta, ela segura o avanço em vez de deixar o worker preencher buraco com imaginação.
 
-### F5 — Product SOT
+O que precisa existir: `discovery_brief`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Product SOT`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Gates que seguram o avanço: `Discovery Gate`.
 
-O que precisa existir antes de avançar: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`. O portão que segura a passagem é: Product SOT Gate. Os workers normalmente envolvidos são: `product-sot-planner`.
+Workers normalmente envolvidos: `source-ledger-worker`, `product-sot-planner`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Atalhos que esta fase impede:
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+- turn unresolved gaps into execution scope.
 
-### F6 — Agentic Method Router
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Agentic Method Router`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+## F4 — Product Outcome And Discovery
 
-O que precisa existir antes de avançar: `factory_phase_lock`, `method_contract`. O portão que segura a passagem é: Method Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
+O resultado esperado, o usuário, o problema e as hipóteses ficam explícitos. O operador precisa conseguir corrigir a direção antes de virar plano.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+O que precisa existir: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Gates que seguram o avanço: `Outcome Gate`, `Discovery Gate`.
 
-### F7 — Method Contract
+Workers normalmente envolvidos: `product-sot-planner`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Method Contract`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Atalhos que esta fase impede:
 
-O que precisa existir antes de avançar: `factory_phase_lock`, `method_contract`. O portão que segura a passagem é: Method Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
+- treat outcome candidate as approved Product SOT.
+- draft Product SOT before operator understanding confirmation.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+## F5 — Product SOT
 
-### F8 — Pack And Product Experience Selection
+O Product SOT vira a verdade do produto. Ele protege escopo, não-escopo, critérios de aceitação e cobertura completa antes de execução material.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Pack And Product Experience Selection`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O que precisa existir: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`.
 
-O que precisa existir antes de avançar: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`. O portão que segura a passagem é: Pack Gate, Product Experience Gate, Surface Pack Gate. Os workers normalmente envolvidos são: `product-face`, `factory-orchestrator`.
+Gates que seguram o avanço: `Product SOT Gate`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Workers normalmente envolvidos: `product-sot-planner`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Atalhos que esta fase impede:
 
-### F9 — Risk And Authority Gates
+- execute from paper instead of Product SOT.
+- ask operator to approve Product SOT from a short chat summary only.
+- start architecture, repo cleanup, human gate or worker packet while Product SOT owner package is missing.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Risk And Authority Gates`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O que precisa existir antes de avançar: `access_capability`, `budget_contract`. O portão que segura a passagem é: Access Gate, Budget Gate, Human Gate when required. Os workers normalmente envolvidos são: `human-gate-clerk`.
+## F6 — Agentic Method Router
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+A rota escolhe o tipo de caminho: produto, bug, release, incidente, segurança, UX, analytics, integração ou agente. A fábrica para de tratar tudo como tarefa genérica.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O que precisa existir: `factory_phase_lock`, `method_contract`.
 
-### F10 — Security Architecture
+Gates que seguram o avanço: `Method Gate`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Security Architecture`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Workers normalmente envolvidos: `factory-orchestrator`.
 
-O que precisa existir antes de avançar: `factory_phase_lock`, `security_architecture_plan`. O portão que segura a passagem é: Security Architecture Gate. Os workers normalmente envolvidos são: `security-orchestrator`.
+Atalhos que esta fase impede:
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+- ask user to choose internal method machinery.
+- start architecture or repo cleanup before Method Contract.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-### F11 — Executable Plans
+## F7 — Method Contract
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Executable Plans`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O método registra como o trabalho será feito e provado. Não basta dizer TDD, security-first ou design-first; o contrato precisa mudar artefatos, gates e evidência.
 
-O que precisa existir antes de avançar: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`. O portão que segura a passagem é: Ready Gate. Os workers normalmente envolvidos são: `decomposition-planner`.
+O que precisa existir: `factory_phase_lock`, `method_contract`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Gates que seguram o avanço: `Method Gate`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Workers normalmente envolvidos: `factory-orchestrator`.
 
-### F12 — Autonomy Readiness
+Atalhos que esta fase impede:
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Autonomy Readiness`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+- start implementation with undocumented process choices.
+- materialize future-phase cards while active frontier is still product_sot or method_contract.
 
-O que precisa existir antes de avançar: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`. O portão que segura a passagem é: Decomposition Coverage Gate, Access & Capability Gate. Os workers normalmente envolvidos são: `independent-reviewer`, `factory-orchestrator`.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+## F8 — Pack And Product Experience Selection
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+A fábrica confere se tem pacote de capacidade e prova de superfície para o tipo de produto. Web, CLI, docs, agente, Solana, mobile ou fintech não pedem a mesma prova.
 
-### F13 — Ready Gate
+O que precisa existir: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Ready Gate`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Gates que seguram o avanço: `Pack Gate`, `Product Experience Gate`, `Surface Pack Gate`.
 
-O que precisa existir antes de avançar: `gate_report`. O portão que segura a passagem é: Ready Gate. Os workers normalmente envolvidos são: `factory-orchestrator`.
+Workers normalmente envolvidos: `product-face`, `factory-orchestrator`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Atalhos que esta fase impede:
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+- activate a pack without proof or coverage.
+- start product-facing implementation before surface state coverage.
+- treat generic UI proof as Product Experience proof.
+- move to implementation with unnamed surface pack or proof profile.
 
-### F15 — Runtime Execution
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Runtime Execution`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+## F9 — Risk And Authority Gates
 
-O que precisa existir antes de avançar: `worker_packets`. O portão que segura a passagem é: Runtime Gate. Os workers normalmente envolvidos são: `implementation-worker`, `qa-verification-worker`.
+Autoridade, acesso, orçamento e risco entram antes da execução sensível. Se a decisão pertence ao operador, a fábrica prepara pacote de decisão; se é reparo interno, não joga no humano.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+O que precisa existir: `access_capability`, `budget_contract`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Gates que seguram o avanço: `Access Gate`, `Budget Gate`, `Human Gate when required`.
 
-### F16 — Worker Results
+Workers normalmente envolvidos: `human-gate-clerk`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Worker Results`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Atalhos que esta fase impede:
 
-O que precisa existir antes de avançar: `worker_results`. O portão que segura a passagem é: Done Gate. Os workers normalmente envolvidos são: `evidence-reconciler`.
+- infer approval from silence.
+- ask for planning-only continuation approval.
+- ask for architecture or repo cleanup approval while downstream is frozen.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+## F10 — Security Architecture
 
-### F17 — Verification
+Segurança entra como arquitetura, não como scan no fim. Trust boundary, segredo, chave, supply chain, privacidade, onchain e rollback precisam aparecer cedo quando importam.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Verification`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O que precisa existir: `factory_phase_lock`, `security_architecture_plan`.
 
-O que precisa existir antes de avançar: `verification_plan`, `verification_result`. O portão que segura a passagem é: Verification Gate. Os workers normalmente envolvidos são: `qa-verification-worker`.
+Gates que seguram o avanço: `Security Architecture Gate`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Workers normalmente envolvidos: `security-orchestrator`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Atalhos que esta fase impede:
 
-### F18 — Independent Review
+- build material risk before architecture.
+- start security architecture while Product SOT or Method Contract is still missing.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Independent Review`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O que precisa existir antes de avançar: `review_result`. O portão que segura a passagem é: Review Gate. Os workers normalmente envolvidos são: `independent-reviewer`.
+## F11 — Executable Plans
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+A arquitetura e os riscos viram plano de desenvolvimento. O objetivo é sair da ideia para unidades executáveis sem perder dependências e critérios de parada.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O que precisa existir: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`.
 
-### F20 — Closure Summary
+Gates que seguram o avanço: `Ready Gate`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Closure Summary`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Workers normalmente envolvidos: `decomposition-planner`.
 
-O que precisa existir antes de avançar: `closure_summary`. O portão que segura a passagem é: Closure Gate. Os workers normalmente envolvidos são: `handoff-packer`.
+Atalhos que esta fase impede:
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+- execute before plans, coverage review and stop criteria exist.
+- mark decomposition review as passed from the planner that created the decomposition.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-### F21 — Receipt Five
+## F12 — Autonomy Readiness
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Receipt Five`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O produto é quebrado em work units. Cada pedaço precisa de dono, reviewer, prova, dependência e regra de pronto; do contrário vira fila de agente solta.
 
-O que precisa existir antes de avançar: `receipt_five`. O portão que segura a passagem é: Done Gate. Os workers normalmente envolvidos são: `evidence-reconciler`.
+O que precisa existir: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Gates que seguram o avanço: `Decomposition Coverage Gate`, `Access & Capability Gate`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Workers normalmente envolvidos: `independent-reviewer`, `factory-orchestrator`.
 
-### F22 — Completion Audit
+Atalhos que esta fase impede:
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Completion Audit`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+- start autonomous work with missing review, access or limits.
+- let a single reviewer approve the complete decomposition alone.
+- create Product Implementation Readiness from a failed or missing decomposition coverage review.
 
-O que precisa existir antes de avançar: `completion_audit`. O portão que segura a passagem é: Completion Audit. Os workers normalmente envolvidos são: `evidence-reconciler`.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+## F13 — Ready Gate
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Antes de rodar, a fábrica checa prontidão de implementação: SOT, método, research, arquitetura, packs, acesso, workers e provas necessárias.
 
-### F23 — Production Operations
+O que precisa existir: `gate_report`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Production Operations`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Gates que seguram o avanço: `Ready Gate`.
 
-O que precisa existir antes de avançar: `production_readiness_plan`. O portão que segura a passagem é: Release Gate. Os workers normalmente envolvidos são: `release-ops-worker`.
+Workers normalmente envolvidos: `factory-orchestrator`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Atalhos que esta fase impede:
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+- dispatch blocked workers.
 
-### F24 — Release Or Block
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Release Or Block`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+## F15 — Runtime Execution
 
-O que precisa existir antes de avançar: `release_decision`. O portão que segura a passagem é: Release Gate, Human Gate when required. Os workers normalmente envolvidos são: `release-ops-worker`, `human-gate-clerk`.
+Workers executam escopos pequenos e devolvem resultado estruturado. O resultado precisa trazer evidência, limite de autoridade e próximo estado.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+O que precisa existir: `worker_packets`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Gates que seguram o avanço: `Runtime Gate`.
 
-### F25 — Monitoring Support
+Workers normalmente envolvidos: `implementation-worker`, `qa-verification-worker`.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Monitoring Support`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+Atalhos que esta fase impede:
 
-O que precisa existir antes de avançar: `incident_support_plan`. O portão que segura a passagem é: Support Gate. Os workers normalmente envolvidos são: `release-ops-worker`.
+- spawn without route readiness.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+## F16 — Worker Results
 
-### F26 — Learnback
+A fábrica roda verificação objetiva: testes, scans, screenshots, jornadas, logs, contratos ou provas remotas, conforme o tipo de trabalho.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Learnback`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O que precisa existir: `worker_results`.
 
-O que precisa existir antes de avançar: `factory_learning_proposal`. O portão que segura a passagem é: Learning Gate. Os workers normalmente envolvidos são: `skill-eval-distiller`.
+Gates que seguram o avanço: `Done Gate`.
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Workers normalmente envolvidos: `evidence-reconciler`.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+Atalhos que esta fase impede:
 
-### F27 — Factory Maturity Audit
+- treat packet existence as proof.
 
-Nesta fase, a fábrica tenta responder uma pergunta simples: "já temos base suficiente para avançar sem inventar?" O nome interno é `Factory Maturity Audit`, mas o papel prático é proteger o próximo passo. Se a fase pula evidência, todo o resto fica bonito no papel e fraco na execução.
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
 
-O que precisa existir antes de avançar: `factory_maturity_scorecard`. O portão que segura a passagem é: Maturity Gate. Os workers normalmente envolvidos são: `skill-eval-distiller`.
+## F17 — Verification
 
-O erro comum aqui é acelerar demais. A fábrica bloqueia atalhos como: none listed. Isso não é burocracia. É a diferença entre trabalho autônomo e teatro autônomo.
+Revisão independente consome o artefato real. Pass sem leitura, reviewer igual executor ou achado sem reparo são progresso falso.
 
-O operador não deveria precisar entender cada campo JSON desta fase. Ele deveria enxergar o estado em linguagem clara: o que já foi entendido, o que ainda falta, quem é dono do próximo passo e qual evidência vai destravar a fase. Se a resposta for "não sabemos", a fábrica deve dizer isso cedo, abrir o bloqueio certo e propor o menor próximo passo seguro.
+O que precisa existir: `verification_plan`, `verification_result`.
+
+Gates que seguram o avanço: `Verification Gate`.
+
+Workers normalmente envolvidos: `qa-verification-worker`.
+
+Atalhos que esta fase impede:
+
+- claim done without command evidence.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F18 — Independent Review
+
+Receipt Five reconcilia pedido, mudança, evidência, revisão e pendências. É a passagem entre “mexeu” e “provou”.
+
+O que precisa existir: `review_result`.
+
+Gates que seguram o avanço: `Review Gate`.
+
+Workers normalmente envolvidos: `independent-reviewer`.
+
+Atalhos que esta fase impede:
+
+- allow executor to self-approve.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F20 — Closure Summary
+
+Handoff guarda estado reproduzível para pausa, troca de operador ou retomada. Não é aprovação; é transferência honesta de contexto e evidência.
+
+O que precisa existir: `closure_summary`.
+
+Gates que seguram o avanço: `Closure Gate`.
+
+Workers normalmente envolvidos: `handoff-packer`.
+
+Atalhos que esta fase impede:
+
+- hide unresolved blockers in prose.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F21 — Receipt Five
+
+A auditoria de conclusão compara obrigações com provas entregues. Ela fecha quando bate e bloqueia quando falta algo.
+
+O que precisa existir: `receipt_five`.
+
+Gates que seguram o avanço: `Done Gate`.
+
+Workers normalmente envolvidos: `evidence-reconciler`.
+
+Atalhos que esta fase impede:
+
+- mark done without Receipt Five.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F22 — Completion Audit
+
+Operações de produção verificam dono, ambiente, monitoramento, rollback, incidentes e canal de release. Produto vivo precisa chão operacional.
+
+O que precisa existir: `completion_audit`.
+
+Gates que seguram o avanço: `Completion Audit`.
+
+Workers normalmente envolvidos: `evidence-reconciler`.
+
+Atalhos que esta fase impede:
+
+- close skipped method or evidence requirements.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F23 — Production Operations
+
+Release só acontece com promoção, evidência e autoridade. Se a prova não sustenta, a decisão correta é bloquear.
+
+O que precisa existir: `production_readiness_plan`.
+
+Gates que seguram o avanço: `Release Gate`.
+
+Workers normalmente envolvidos: `release-ops-worker`.
+
+Atalhos que esta fase impede:
+
+- release without owner, rollback or approval.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F24 — Release Or Block
+
+Depois da entrega, monitoramento e suporte mantêm o produto observável. Incidente não vira improviso; vira rota.
+
+O que precisa existir: `release_decision`.
+
+Gates que seguram o avanço: `Release Gate`, `Human Gate when required`.
+
+Workers normalmente envolvidos: `release-ops-worker`, `human-gate-clerk`.
+
+Atalhos que esta fase impede:
+
+- promote without production-strict evidence.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F25 — Monitoring Support
+
+Learnback transforma falhas repetidas em docs, testes, skills, gates ou issues. A fábrica aprende, mas não se altera em silêncio.
+
+O que precisa existir: `incident_support_plan`.
+
+Gates que seguram o avanço: `Support Gate`.
+
+Workers normalmente envolvidos: `release-ops-worker`.
+
+Atalhos que esta fase impede:
+
+- ship without support owner when support is material.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F26 — Learnback
+
+A auditoria de maturidade pergunta se o método escolhido foi bom o bastante. É a defesa contra uma fábrica que segue processo e mesmo assim escolhe processo fraco.
+
+O que precisa existir: `factory_learning_proposal`.
+
+Gates que seguram o avanço: `Learning Gate`.
+
+Workers normalmente envolvidos: `skill-eval-distiller`.
+
+Atalhos que esta fase impede:
+
+- auto-activate critical factory changes.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+
+## F27 — Factory Maturity Audit
+
+A auditoria final olha a própria fábrica: cobertura, gaps, confiabilidade, operadores, workers e regras que precisam evoluir.
+
+O que precisa existir: `factory_maturity_scorecard`.
+
+Gates que seguram o avanço: `Maturity Gate`.
+
+Workers normalmente envolvidos: `skill-eval-distiller`.
+
+Atalhos que esta fase impede:
+
+- commit raw study or private evidence.
+
+O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.

--- a/docs/pt-BR/manual.md
+++ b/docs/pt-BR/manual.md
@@ -72,3 +72,28 @@ Primeiro ela precisa entender o que "cliente" quer dizer naquele produto, o que 
 Só depois implementação faz sentido. Um worker de frontend pode receber um pacote. Um worker de backend pode receber outro. Um worker de Product Face talvez precise devolver screenshots e prova por viewport. QA pode precisar de teste de jornada. Um reviewer pode precisar comparar o resultado com o Product SOT. O operador não deveria coordenar tudo isso na mão.
 
 Esse é o valor prático da fábrica. Ela transforma um pedido vago em pedaços pequenos, revisáveis e sustentados por evidência.
+
+## O que a fábrica tira das costas do operador
+
+A promessa prática é autonomia com responsabilidade. O operador traz direção, contexto, restrições e decisões reais. Ele não deveria virar coordenador manual de source ledger, Product SOT, worker packet, review, proof, release e learnback.
+
+Quando a fábrica funciona bem, ela antecipa o que normalmente viraria cobrança humana:
+
+- percebe que a fonte está incompleta antes de começar;
+- transforma o pedido em definição de produto revisável;
+- escolhe a rota certa para bug, feature, release, incidente, segurança, UX ou agente;
+- cria pacotes pequenos em vez de uma missão gigante;
+- cobra prova do worker que executou;
+- chama review independente quando o risco pede;
+- prepara gate humano com artefato legível quando a decisão é do operador;
+- bloqueia com motivo claro quando falta acesso, autoridade, evidência ou segurança.
+
+Isso muda a relação com agentes. O humano deixa de ser fiscal de preguiça do sistema e volta a ser dono do produto e das decisões importantes.
+
+## A recepção pode ser simples; o contrato por trás não pode ser fraco
+
+Telegram, Discord, cockpit ou CLI podem ser a porta de entrada. O operador pode começar com uma frase curta, um documento, um repo, um bug ou um objetivo de negócio. A conversa deve ser simples.
+
+Mas simplicidade na entrada não significa informalidade na execução. Atrás da conversa, a fábrica precisa montar fonte, escopo, método, gates, workers e evidência. Se ela pula isso, só trocou formulário por chat e continua frágil.
+
+Por isso a fábrica separa o gerente, que fala com o operador, do orquestrador, que cuida de rota e runtime. O operador recebe status e decisões em linguagem humana. O Hermes e os contratos guardam o estado real.

--- a/docs/pt-BR/manual.md
+++ b/docs/pt-BR/manual.md
@@ -1,67 +1,74 @@
-# Manual do Produto
+# Manual do produto
 
-A Overkill Factory existe porque trabalho com agentes muitas vezes parece produtivo antes de estar realmente controlado.
+A Overkill Factory fica mais fácil de entender quando começamos pelo problema que ela resolve.
 
-Um fluxo comum com agente pode responder rápido, escrever código rápido e produzir um status convincente rápido. A falha normalmente aparece depois: a fonte foi mal entendida, uma fatia parcial substituiu o produto inteiro, um worker declarou `done` sem prova, um risco virou checklist, ou o operador teve que perceber que o sistema estava parado.
+Uma pessoa pede alguma coisa: criar um produto, corrigir um bug, revisar uma mudança arriscada, preparar um release, tratar um incidente, melhorar um worker ou transformar uma ideia num sistema funcionando. Em muitos fluxos com agentes, isso vira uma instrução grande. O agente tenta ajudar, começa a trabalhar e vai mandando status. Às vezes dá certo. Muitas vezes vira movimento sem controle.
 
-A fábrica transforma esse fluxo frágil em uma linha de produção.
+A Overkill Factory trata trabalho de produto como produção controlada. A fábrica não joga um "se vira" para o agente. Ela preserva a fonte, define o produto, escolhe o método, divide o trabalho, executa pelo Hermes, verifica evidência e fecha com recibo.
 
-## O que a fábrica é
+## O que "fábrica" quer dizer aqui
 
-Overkill Factory é uma camada de método e um kernel público para rodar trabalho de produto com agentes limitados por contratos.
+Fábrica não é sinônimo de burocracia. Quer dizer que existe uma linha de produção. O trabalho entra por um lado e precisa passar por estados que protegem o operador.
 
-Ela dá forma ao trabalho:
+Um pedido de produto não deveria pular direto para implementação se ninguém resolveu a fonte. Um release não deveria sair porque o executor disse que está pronto. Uma mudança sensível de segurança não deveria pular arquitetura. Um gate humano não deveria ficar escondido num comentário de chat. Um worker não deveria aprovar o próprio trabalho.
 
-- a fonte é capturada antes de ser interpretada;
-- verdade de produto é separada de suposição;
-- método é escolhido por contrato, não por impressão;
-- workers recebem pacotes limitados;
-- cada transição importante precisa de evidência;
-- gates humanos continuam humanos;
-- bloqueios não humanos são reparados pela fábrica em vez de serem jogados no operador;
-- conclusão significa entrega com evidência, não mensagem confiante.
+Isso é produção controlada. É a diferença entre "um agente mexeu nisso" e "a fábrica consegue explicar o que aconteceu, por que aconteceu, quem tinha autoridade e qual evidência prova o resultado".
 
-## O que o Hermes controla
+## A experiência do operador
 
-Hermes é o chão da fábrica. Ele controla o estado durável de runtime: Kanban, cards, dependências, typed blocks, dispatch de workers, comentários, logs, schedules, workspaces e transições de estado.
+O operador não deveria ter que cuidar da fábrica como babá. Ele não deveria precisar perceber que um worker foi raso, que uma revisão nunca foi consumida, ou que um bloqueio era na verdade trabalho da própria fábrica. A fábrica é dona do processo. O humano é dono das decisões reais.
 
-A fábrica não deve recriar esse runtime dentro de prompt. Se algo é estado de runtime, o Hermes é a autoridade.
+Uma boa execução se parece com isto:
 
-## O que a Overkill Factory controla
+- o operador entrega um objetivo ou material de origem;
+- a fábrica diz o que entendeu e o que falta;
+- a fábrica cria uma definição de produto que pode ser revisada;
+- o trabalho é quebrado em partes pequenas o bastante para um worker terminar e provar;
+- o Hermes guarda o estado vivo;
+- revisões são independentes quando o risco pede;
+- gates humanos chegam como pacotes de decisão, não como interrupções vagas;
+- a conclusão vem com Receipt Five, não com uma mensagem animada dizendo "pronto".
 
-A Overkill Factory controla o método de produção em volta do Hermes:
+## A camada de verdade do produto
 
-- phase graph;
-- route registry;
-- method contracts;
-- templates e schemas;
-- regras de autoridade de worker;
-- Product SOT / contratos de verdade de produto;
-- expectativas de Product Experience e Product Face;
-- gates de segurança, acesso e release;
-- regras de evidência e Receipt Five;
-- comandos públicos de validação.
+O artefato mais importante é a verdade do produto. A fábrica chama isso de Product SOT, porque é a fonte de verdade do produto. O nome é técnico, mas a ideia é simples: antes de construir, todo mundo precisa saber que produto está sendo construído.
 
-A fábrica pode projetar status e preparar pacotes, mas não deve fingir que uma projeção local é o runtime real.
+Um Product SOT precisa dizer o que foi pedido, o que entra no escopo, o que fica fora, quais riscos importam, que evidência vai contar e o que tornaria o trabalho inaceitável. Sem isso, a fábrica não consegue escolher método nem distribuir workers com segurança.
 
-## O que agentes controlam
+É aqui que muitos sistemas com agentes escorregam. Eles transformam um briefing grande num resumo curto e depois constroem a partir do resumo. A Overkill Factory foi desenhada para evitar isso. Resumo não é verdade do produto. Palpite útil não é verdade do produto. A verdade do produto precisa vir da fonte e precisa ser revisada quando o risco pede.
 
-Agentes são workers limitados. Eles não controlam a rota. Eles não decidem que o produto está pronto. Eles executam um pacote, devolvem evidência e aceitam revisão.
+## Métodos são escolhidos, não improvisados
 
-Um worker pode ser forte sem ser confiado cegamente. A fábrica foi desenhada em cima dessa diferença.
+Trabalhos diferentes pedem métodos diferentes. Bug precisa de reprodução e prova de regressão. Produto novo precisa de definição e cobertura de escopo. Release precisa de prontidão, rollback e aprovação. Mudança de segurança precisa de arquitetura, ameaça e evidência.
 
-## O que humanos controlam
+O registro de rotas e os motores de método deixam isso explícito. Hoje a fábrica tem 14 classes de rota e 8 motores de método. A ideia não é impressionar com uma lista grande. A ideia é impedir que todo pedido seja tratado do mesmo jeito.
 
-Humanos controlam decisões reais de autoridade: custo, acesso de produção, assinatura, aceite de release, risco material, julgamento de negócio e waivers explícitos.
+Quando o método está certo, o worker recebe um pacote limitado. Ele sabe a tarefa, os limites, a evidência esperada e a autoridade que ele não tem. Isso torna a autonomia mais segura. O worker pode andar rápido dentro da faixa porque a faixa está clara.
 
-Um gate humano deve ser raro e claro. Ele não deve obrigar o operador a ler maquinaria interna. Deve apresentar decisão, artefato, evidência, risco e consequências.
+## Hermes é o chão da fábrica
 
-## A promessa central
+O Hermes é onde o estado vivo mora. Cards, dependências, comentários, workspaces, workers, bloqueios e transições pertencem a ele. A Overkill Factory define o método de produção e os checks. O Hermes roda o chão da fábrica.
 
-A promessa da fábrica não é "agentes nunca vão falhar". A promessa é: quando agentes falharem, o sistema deve saber onde, por quê, qual evidência falta, se o bloqueio é humano ou não humano e qual é a próxima ação segura.
+Essa separação é importante. Se a fábrica tentasse virar um segundo Hermes, ela criaria outro estado escondido. Se o Hermes guardasse o estado mas a fábrica ignorasse método e evidência, os workers moveriam cards sem disciplina de produto. O desenho é separado de propósito: Hermes controla o estado vivo; Overkill Factory controla o contrato de produção.
 
-Essa é a diferença entre teatro autônomo e produção controlada.
+## Pronto quer dizer provado
 
-## Fronteira pública/privada
+A fábrica é rígida com conclusão porque trabalho com agente pode parecer convincente mesmo quando está errado. Um arquivo pode existir e não servir. Um teste pode passar e ainda não cobrir o produto. Um revisor pode aprovar sem checar a coisa certa. Um worker pode dizer que terminou e esquecer o artefato.
 
-Este repositório é o kernel público: código, contratos, testes, exemplos, registries públicos de workers e docs públicas. Uma execução real de produto acontece em um runtime Hermes do operador. Esse runtime pode conter boards privados, fontes privadas, segredos, evidências, decisões de produto e aprovações humanas. Isso não pertence ao GitHub público.
+O Receipt Five existe para evitar isso. Ele registra o que foi pedido, o que foi feito, qual evidência prova, quem revisou, o que ainda está arriscado ou bloqueado e qual é o próximo estado. Se essa evidência não existe, a resposta honesta não é "pronto". É bloqueado, incompleto ou pronto para revisão.
+
+## O que este projeto não é
+
+A Overkill Factory não tenta fingir que produto é simples. Ela tenta colocar a complexidade no lugar certo. O operador vê estado claro e decisões reais. Os workers recebem pacotes exatos. O código carrega schemas e testes. A documentação pública explica o suficiente para uma pessoa nova confiar no sistema sem ler cada arquivo interno.
+
+Esse é o nível esperado do projeto: simples por fora, rigoroso por dentro e honesto na fronteira.
+
+## Um exemplo concreto
+
+Imagine que o operador diga: "Crie o fluxo de onboarding do cliente." Um sistema fraco com agentes talvez comece a desenhar telas imediatamente. A fábrica não deveria fazer isso.
+
+Primeiro ela precisa entender o que "cliente" quer dizer naquele produto, o que o onboarding deve resolver, que contas ou permissões existem, o que o usuário precisa ver, o que precisa ser registrado e o que conta como uma primeira execução bem-sucedida. Se o produto já tem design system, a fábrica deve consumir isso. Se o fluxo toca dinheiro, identidade, custódia ou dados de produção, os gates de risco mudam.
+
+Só depois implementação faz sentido. Um worker de frontend pode receber um pacote. Um worker de backend pode receber outro. Um worker de Product Face talvez precise devolver screenshots e prova por viewport. QA pode precisar de teste de jornada. Um reviewer pode precisar comparar o resultado com o Product SOT. O operador não deveria coordenar tudo isso na mão.
+
+Esse é o valor prático da fábrica. Ela transforma um pedido vago em pedaços pequenos, revisáveis e sustentados por evidência.

--- a/docs/pt-BR/operating-model.md
+++ b/docs/pt-BR/operating-model.md
@@ -1,72 +1,73 @@
 # Modelo operacional
 
-Esta página explica o que acontece numa execução da fábrica. Em vez de fazer um passeio por pastas internas, ela acompanha a vida de um pedido.
+Esta página acompanha a vida de um pedido dentro da fábrica. A pergunta central não é “qual script roda?”, mas “como um pedido vira trabalho seguro, provado e revisável?”.
 
-Um pedido começa como um sinal. Pode ser uma ideia de produto, um bug, um release, um incidente, uma mudança de segurança, uma tela, um pedido de dados, uma integração ou uma melhoria de worker. O primeiro trabalho da fábrica não é construir. É entender que tipo de trabalho entrou e o que tornaria o avanço seguro.
+Um pedido começa como sinal. Pode ser uma ideia de produto, um bug, um release, um incidente, uma tela, uma integração, uma auditoria, uma mudança em agente ou uma melhoria na própria fábrica. A resposta errada é sair fazendo. A resposta certa é preservar a fonte, entender o tipo de trabalho, escolher o método e só então executar.
 
-## 1. A entrada protege a fonte
+## 1. O pedido entra pela porta certa
 
-A fábrica recebe o material de origem e cria um envelope de fonte. Esse envelope preserva o que o operador realmente entregou. Ele não deveria transformar tudo, em silêncio, num resumo conveniente.
+A fábrica pode conversar com o operador por Telegram, Discord, cockpit, CLI ou outro canal. Mas o canal é só a recepção. Ele não é a fonte de verdade.
 
-Depois, o source ledger registra o que já se sabe, o que falta, o que está em conflito e o que ainda precisa do operador. Parece básico, mas evita uma das falhas mais caras em sistemas com agentes: construir a partir de um briefing mal entendido.
+O operador entrega material, objetivo, restrições e decisões quando elas são realmente dele. A fábrica deve cuidar do resto: registrar fonte, separar fato de inferência, montar Product SOT, escolher rota, criar worker packets, acompanhar Hermes, cobrar evidência, pedir review, preparar gates humanos e fechar com Receipt Five.
 
-O operador deveria receber uma explicação simples: "foi isso que entendemos, isso ainda falta, isso não podemos assumir". Se essa explicação não estiver clara, a execução já nasceu fraca.
+Isso tira trabalho das costas do operador. Ele não deveria ter que perceber que um worker foi raso, que a revisão não foi consumida, que o board parou por preguiça de processo ou que faltava pacote de decisão. Se isso acontece, é falha da fábrica.
 
-## 2. A rota escolhe o tipo de execução
+## 2. A fonte é protegida antes do plano
 
-A classe de rota decide o formato do trabalho. Corrigir bug não é preparar release. Preparar release não é criar produto do zero. Auditar Solana/onchain não é atualizar documentação. Hoje a fábrica expõe estas classes de rota:
+O primeiro artefato importante é o envelope de fonte. Ele preserva o que chegou antes da fábrica resumir, interpretar ou decompor. Depois vem o source ledger, que separa cinco coisas que agentes costumam misturar:
 
-- `product_creation`: usado quando o pedido é `product_new`. A família de método é `None` e os portões principais são Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: usado quando o pedido é `feature, slice`. A família de método é `None` e os portões principais são Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: usado quando o pedido é `bug`. A família de método é `None` e os portões principais são Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: usado quando o pedido é `incident`. A família de método é `None` e os portões principais são Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: usado quando o pedido é `migration, refactor, integration`. A família de método é `None` e os portões principais são Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: usado quando o pedido é `release`. A família de método é `None` e os portões principais são Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: usado quando o pedido é `feature, product_new, security, ux_ui, data_analytics, agent_skill`. A família de método é `None` e os portões principais são Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: usado quando o pedido é `doc`. A família de método é `None` e os portões principais são Docs Utility Gate, First Run Gate.
-- `security_remediation`: usado quando o pedido é `security`. A família de método é `None` e os portões principais são Security Architecture Gate, Security Review Gate.
-- `critical_integration`: usado quando o pedido é `integration`. A família de método é `None` e os portões principais são Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: usado quando o pedido é `migration`. A família de método é `None` e os portões principais são Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: usado quando o pedido é `ux_ui, product_new, feature`. A família de método é `None` e os portões principais são Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: usado quando o pedido é `data_analytics, product_new, feature`. A família de método é `None` e os portões principais são Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: usado quando o pedido é `agent_skill`. A família de método é `None` e os portões principais são Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+- fato vindo da fonte;
+- inferência razoável;
+- decisão já tomada;
+- conflito entre fontes;
+- lacuna que ainda precisa ser resolvida.
 
-A rota não dá permissão para um worker sair fazendo o que quiser. Ela escolhe a faixa, a família de método e os gates que precisam ser satisfeitos.
+Essa separação parece simples, mas muda tudo. Sem ela, um resumo curto vira “verdade” e o produto começa torto.
 
-## 3. A verdade do produto vira contrato
+## 3. A fábrica trabalha em cinco camadas
 
-Em trabalho de produto, o Product SOT transforma o material de origem numa definição usável. É o momento em que a fábrica diz: "este é o produto que estamos construindo de verdade".
+A documentação legada tinha um bom mapa que continua atual. A fábrica opera em cinco camadas:
 
-Um Product SOT fraco enfraquece tudo que vem depois. Workers ainda podem produzir código, docs, design ou comentários de revisão, mas talvez estejam otimizando para a coisa errada. Por isso a fábrica bloqueia execução downstream quando a verdade do produto falta ou ainda não foi revisada.
+1. Camada de verdade: fonte, source resolution, Product SOT, decisões, conflitos e lacunas.
+2. Camada de método e planejamento: rota, método, arquitetura, Product Creation Plan, Product Experience Plan, dados, evals e loop plan.
+3. Camada de risco, autoridade, acesso e custo: risco, orçamento, segredos, produção, mainnet, privacidade, compliance e gates humanos.
+4. Camada de execução e evidência: Hermes, worker packets, worker results, Product Face, QA, review, proof remoto e Receipt Five.
+5. Camada de operação e aprendizado: release, monitoramento, suporte, incidente, learnback e auditoria de maturidade.
 
-## 4. O método liga a rota à evidência
+A utilidade desse mapa é mostrar que “fazer a tarefa” é só uma parte. A fábrica também precisa saber se a tarefa certa foi escolhida, se havia autoridade, se o produto foi provado e se a própria fábrica aprendeu algo.
 
-O contrato de método diz como esta execução deve ser tratada. Os motores de método atuais incluem:
+## 4. A rota escolhe o peso certo
 
-- `spec_first_sdd`: None. Entra quando a rota pede `spec_first`. Rotas: .
-- `test_first_tdd`: None. Entra quando a rota pede `test_first`. Rotas: .
-- `behavior_first_bdd`: None. Entra quando a rota pede `behavior_first`. Rotas: .
-- `discovery_research`: None. Entra quando a rota pede `discovery_first`. Rotas: .
-- `security_first_threat_model`: None. Entra quando a rota pede `security_first`. Rotas: .
-- `design_first_product_experience`: None. Entra quando a rota pede `design_first`. Rotas: .
-- `legacy_diagnosis`: None. Entra quando a rota pede `legacy_diagnosis`. Rotas: .
-- `incident_first`: None. Entra quando a rota pede `incident_first`. Rotas: .
+Rotas são a forma da fábrica dizer: este pedido não é igual aos outros.
 
-O método importa porque muda a evidência. Trabalho test-first precisa de teste e prova de regressão. Trabalho design-first precisa de prova de experiência de produto. Trabalho security-first precisa de threat modeling e evidência de segurança. Incidente precisa de mitigação, status e learnback.
+Um bug precisa de reprodução e regressão. Um produto novo precisa de Product SOT e cobertura de escopo. Um release precisa de prontidão, rollback e dono. Um incidente precisa de severidade, mitigação e learnback. Uma integração crítica precisa de contrato, fallback e teste. Uma mudança de segurança precisa de arquitetura e review. Uma tela precisa de Product Face, estados, jornada e prova visual.
 
-Método não é slogan. Ele precisa produzir artefatos, gates, pacotes de worker e critérios de parada.
+A fábrica tem quatorze classes de rota. O detalhe exato fica nos registries, mas a ideia pública é esta: cada tipo de trabalho ganha gates e provas diferentes. Isso impede que o mesmo agente genérico trate documentação, mainnet, UI, release e incidente como se fossem variações da mesma tarefa.
 
-## 5. O trabalho vira pacotes pequenos
+## 5. Product SOT é verdade do produto, não papel bonito
 
-Um worker packet é um contrato pequeno. Ele diz ao worker o que fazer, o que não fazer, que evidência anexar e que autoridade ele tem. É aqui que a fábrica evita o pedido vago: "constrói isso aí".
+Product SOT é a definição revisável do produto. Ele deve dizer o que entra, o que não entra, quais usuários importam, quais promessas precisam ser cumpridas, que riscos existem e que evidência vai contar como aceite.
 
-Pacotes bons são estreitos. Dá para executar, revisar, repetir e fechar. Pacotes ruins são missões grandes sem prova clara. A fábrica deve criar os primeiros e bloquear os segundos.
+A fábrica também precisa de Full Product SOT Scope Coverage quando o trabalho é produto completo. Isso impede que a primeira fatia prática seja confundida com o produto inteiro. Cada requisito importante precisa estar planejado, bloqueado com dono, fora de escopo com justificativa, delegado ao humano ou concluído com prova.
 
-## 6. O Hermes roda o chão da fábrica
+Sem essa cobertura, workers podem trabalhar muito e ainda entregar uma versão estreita demais do produto.
 
-Hermes Kanban continua sendo a fonte de verdade do runtime. Cards, dependências, comentários, status de worker, workspaces e transições vivem nele. A fábrica prepara e valida os contratos de produção; o Hermes registra o que está acontecendo de fato.
+## 6. Método liga intenção a prova
 
-Essa separação é importante. Arquivos locais provam que o kernel público está coerente. Eles não provam que uma execução viva, num Hermes do operador, terminou. Conclusão real precisa de estado de runtime, resultado de worker, revisão, evidência e decisões humanas quando o risco exige.
+O Method Contract registra como aquele trabalho será feito. Ele pode puxar um caminho spec-first, test-first, behavior-first, discovery-first, security-first, design-first, legacy-diagnosis ou incident-first.
+
+O ponto não é o nome do método. O ponto é que o método muda a evidência:
+
+- test-first precisa de teste e regressão;
+- design-first precisa de Product Experience Plan, Product Face Packet e prova por superfície;
+- security-first precisa de ameaça, fronteira de confiança, scan e review;
+- discovery-first precisa transformar incerteza em decisão operacional;
+- legacy-diagnosis precisa baseline, rollback e proteção contra regressão;
+- incident-first precisa mitigação, status, causa e learnback.
+
+Método que não muda artefato, gate ou prova é só slogan.
+
+
 
 ## Modos da ponte com o operador
 
@@ -76,22 +77,54 @@ Os modos da ponte são `status_bridge`, `start_bridge`, `question_bridge`, `deci
 
 A ponte separa o `overkill-factory-gerente`, que conversa com o operador, do `factory-orchestrator`, que cuida de rota e controle de runtime. O Durable Operator Inbox preserva decisões, perguntas e handoffs no default Hermes store. O Factory Mechanic continua sendo o dono de self-improvement e learnback. A ponte não pode conceder autoridade, inventar aprovação, fechar gate ou declarar conclusão sem evidência.
 
-## 7. Revisar é diferente de executar
+## 7. Capability packs evitam falsa competência
 
-O executor não deveria ser o juiz final de trabalho material. A fábrica usa readback, verificação, revisão independente e Receipt Five para separar "o worker disse que terminou" de "a fábrica consegue provar que terminou".
+A fábrica não deve fingir que um agente genérico cobre qualquer produto. Web SaaS, CLI/TUI, cloud, agente, Solana, mobile nativo, desktop, jogo, fintech, analytics, browser extension e hardware pedem provas diferentes.
 
-Se a revisão passa, o resultado precisa voltar para a tarefa original. Se falha, a fábrica deve criar trabalho de reparo. Uma revisão aprovada que fica parada não é progresso. É mais um estado bloqueado.
+Os capability packs dizem o que já está pronto e o que ainda é template. Packs core como web, CLI/TUI, cloud, agent-runtime, Solana AI Kit, onboarding e public docs podem seguir quando a rota e os gates batem. Packs de mobile, desktop, game, AI/ML, fintech, regulated domain, analytics, browser extension e hardware precisam ser ativados com especialistas, bindings, smoke, eval e evidência antes de execução material.
 
-## 8. Gates humanos são raros, mas reais
+Isso é uma fronteira de honestidade. Bloquear por falta de pack é melhor do que fingir especialista.
 
-Um gate humano entra quando a decisão pertence ao operador: aceitar risco, aprovar orçamento, mexer em produção, mainnet, segredos, release ou outra fronteira explícita de autoridade. A fábrica não deve pedir aprovação humana só porque não sabe continuar.
+## 8. O trabalho vira worker packet pequeno
 
-Quando o gate humano é necessário, o operador deve receber um pacote de decisão: a escolha, a evidência, o risco, a recomendação e a consequência de cada caminho. JSON cru não é um bom gate humano. Pergunta vaga no chat é pior.
+Um worker packet é uma tarefa com bordas. Ele diz ao worker o que fazer, o que receber, o que devolver, que evidência anexar e que autoridade ele não tem.
 
-## 9. Entregar, bloquear ou aprender
+Um bom packet consegue ser executado, revisado e refeito. Um packet ruim pede “construa o produto” e depois força o operador a adivinhar se ficou bom.
 
-Uma execução termina em um de três estados honestos.
+Workers importantes incluem orquestração, source ledger, Product SOT, arquitetura, Product Face, builders, QA, segurança, review, release, handoff, evidence reconciler, human-gate clerk e skill/eval distiller. O nome não basta. Cada worker precisa de perfil, binding Hermes, receipt field, política de evidência e limite de autoridade.
 
-Ela pode entregar quando a evidência é forte o bastante e os gates necessários passaram. Pode bloquear quando falta prova, acesso, autoridade ou segurança. Ou pode aprender quando a execução mostra um método melhor, um worker ausente, um validador fraco ou uma falha que se repete.
+## 9. Hermes é o chão, a fábrica é o contrato
 
-Aprendizado também tem gate. A fábrica não deve se reescrever em silêncio porque uma execução foi estranha. Ela deve propor a mudança, testar e promover só quando for seguro.
+Hermes Kanban continua sendo a fonte de verdade do runtime. Ele guarda cards, dependências, status, workers, workspaces, comentários e transições. A fábrica não deve criar um segundo runtime escondido.
+
+A fábrica prepara o contrato: que artefatos faltam, que gates bloqueiam, que workers entram, que tipo de evidência é aceitável e que aprovação humana é real. Hermes registra o trabalho vivo.
+
+Quando a fábrica cria tarefas Hermes, ela deve usar dependências nativas. Se uma fase depende de work units, esses work units precisam ser pais da fase seguinte. Se aparecem tarde, entram no grafo antes do downstream andar. Não é aceitável descobrir trabalho obrigatório depois que a fase já está “done”.
+
+## 10. No-idle não é despachante paralelo
+
+No-idle existe para detectar silêncio perigoso. Se há trabalho rodando, ele observa. Se há ready, Hermes despacha. Se há dependency_wait, ele espera a dependência. Se há needs_input com pacote de decisão pronto, o gerente chama o operador. Se falta pacote, readback, PDF, artefato ou reparo interno, a fábrica corrige em vez de jogar no humano.
+
+Essa regra importa muito. No-idle não pode virar um mini-Hermes. Ele é auditor de integridade do board, não fonte normal de autoridade.
+
+## 11. Product Face prova a cara do produto
+
+Produto com interface precisa provar experiência, não só backend ou arquitetura. Product Face cobre web visual, CLI/TUI, docs/onboarding, interface agentic, wallet UI e outros tipos de superfície.
+
+Para web, a prova pode incluir screenshots, viewports, estados, jornada, console, acessibilidade básica, overflow e comparação com o Product Face Packet. Para CLI/TUI, precisa transcript, help, instalação, erro e comportamento de terminal. Para docs/onboarding, precisa replay do primeiro sucesso e critério de leitor. Para interface agentic, precisa controle do usuário, permissões, recuperação e limites.
+
+Uma screenshot não prova produto inteiro. Product Face é uma parte da evidência, consumida junto com SOT, método, QA, review e Receipt Five.
+
+## 12. Gates humanos são pacotes, não perguntas soltas
+
+Gate humano só entra quando a decisão pertence ao operador: produção, mainnet, fundos, segredos, orçamento, autoridade, release, risco material ou waiver explícito.
+
+O gate deve ser artifact-first. O operador recebe o artefato ou uma projeção fiel, um resumo de uma tela, opções claras, consequência de cada opção, o que a aprovação autoriza e o que ela não autoriza. JSON cru, caminho local ou pergunta vaga no chat não são gate humano válido.
+
+A voz humana é o gerente. Worker, cron, evento Kanban e dump de artefato podem alimentar o estado interno, mas não deveriam notificar o operador diretamente.
+
+## 13. Fechamento honesto
+
+Uma execução termina em entregar, bloquear ou aprender.
+
+Entrega exige evidência atual, readback, review consumido, Receipt Five e gates satisfeitos. Bloqueio exige motivo claro, dono e menor próximo passo seguro. Learnback exige proposta, teste, review e promoção; a fábrica não deve se alterar em silêncio porque uma execução foi estranha.

--- a/docs/pt-BR/operating-model.md
+++ b/docs/pt-BR/operating-model.md
@@ -1,105 +1,97 @@
-# Modelo Operacional
+# Modelo operacional
 
-Esta página descreve a fábrica operando, não a árvore interna de pastas.
+Esta página explica o que acontece numa execução da fábrica. Em vez de fazer um passeio por pastas internas, ela acompanha a vida de um pedido.
 
-O modelo mental simples é: a fábrica recebe um sinal, protege a verdade, escolhe uma rota segura, cria trabalho limitado, executa pelo Hermes, verifica evidência e libera, bloqueia ou aprende.
+Um pedido começa como um sinal. Pode ser uma ideia de produto, um bug, um release, um incidente, uma mudança de segurança, uma tela, um pedido de dados, uma integração ou uma melhoria de worker. O primeiro trabalho da fábrica não é construir. É entender que tipo de trabalho entrou e o que tornaria o avanço seguro.
 
-## 1. Um sinal entra
+## 1. A entrada protege a fonte
 
-Um sinal pode ser paper de produto, bug, ideia de feature, incidente, repositório, pedido de release, pedido de UX, integração, migração, questão de segurança, analytics ou mudança em agente/runtime.
+A fábrica recebe o material de origem e cria um envelope de fonte. Esse envelope preserva o que o operador realmente entregou. Ele não deveria transformar tudo, em silêncio, num resumo conveniente.
 
-O route registry atual expõe estas classes de rota:
+Depois, o source ledger registra o que já se sabe, o que falta, o que está em conflito e o que ainda precisa do operador. Parece básico, mas evita uma das falhas mais caras em sistemas com agentes: construir a partir de um briefing mal entendido.
 
-- `product_creation`: tipos de pedido product_new; família de método `spec_first`; gates Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: tipos de pedido feature, slice; família de método `behavior_first`; gates Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: tipos de pedido bug; família de método `test_first`; gates Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: tipos de pedido incident; família de método `incident_first`; gates Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: tipos de pedido migration, refactor, integration; família de método `legacy_diagnosis`; gates Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: tipos de pedido release; família de método `spec_first`; gates Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: tipos de pedido feature, product_new, security, ux_ui, data_analytics, agent_skill; família de método `research_first`; gates Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: tipos de pedido doc; família de método `docs_first`; gates Docs Utility Gate, First Run Gate.
-- `security_remediation`: tipos de pedido security; família de método `security_first`; gates Security Architecture Gate, Security Review Gate.
-- `critical_integration`: tipos de pedido integration; família de método `spec_first`; gates Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: tipos de pedido migration; família de método `legacy_diagnosis`; gates Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: tipos de pedido ux_ui, product_new, feature; família de método `design_first`; gates Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: tipos de pedido data_analytics, product_new, feature; família de método `analytics_first`; gates Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: tipos de pedido agent_skill; família de método `agent_eval_first`; gates Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+O operador deveria receber uma explicação simples: "foi isso que entendemos, isso ainda falta, isso não podemos assumir". Se essa explicação não estiver clara, a execução já nasceu fraca.
 
-A rota importa porque um bug não deve ser tratado como produto greenfield, e um release não deve ser tratado como discovery. O método e os gates mudam conforme a rota.
+## 2. A rota escolhe o tipo de execução
 
-## 2. Fonte vem antes de interpretação
+A classe de rota decide o formato do trabalho. Corrigir bug não é preparar release. Preparar release não é criar produto do zero. Auditar Solana/onchain não é atualizar documentação. Hoje a fábrica expõe estas classes de rota:
 
-A fábrica primeiro captura e resolve o material de fonte. Ela não deve transformar um paper longo em resumo raso e chamar isso de verdade.
+- `product_creation`: usado quando o pedido é `product_new`. A família de método é `None` e os portões principais são Source Gate, Product SOT Gate, Ready Gate.
+- `feature_delivery`: usado quando o pedido é `feature, slice`. A família de método é `None` e os portões principais são Source Gate, Method Gate, Ready Gate.
+- `bug_repair`: usado quando o pedido é `bug`. A família de método é `None` e os portões principais são Reproduction Gate, Regression Gate, Receipt Gate.
+- `incident_response`: usado quando o pedido é `incident`. A família de método é `None` e os portões principais são Severity Gate, Mitigation Gate, Learnback Gate.
+- `brownfield_discovery`: usado quando o pedido é `migration, refactor, integration`. A família de método é `None` e os portões principais são Brownfield Baseline Gate, Regression Gate, Rollback Gate.
+- `release_promotion`: usado quando o pedido é `release`. A família de método é `None` e os portões principais são Production Readiness Gate, Rollback Gate, Release Gate.
+- `research_validation`: usado quando o pedido é `feature, product_new, security, ux_ui, data_analytics, agent_skill`. A família de método é `None` e os portões principais são Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
+- `docs_onboarding`: usado quando o pedido é `doc`. A família de método é `None` e os portões principais são Docs Utility Gate, First Run Gate.
+- `security_remediation`: usado quando o pedido é `security`. A família de método é `None` e os portões principais são Security Architecture Gate, Security Review Gate.
+- `critical_integration`: usado quando o pedido é `integration`. A família de método é `None` e os portões principais são Dependency Gate, Contract Test Gate, Fallback Gate.
+- `migration_execution`: usado quando o pedido é `migration`. A família de método é `None` e os portões principais são Migration Plan Gate, Regression Gate, Rollback Gate.
+- `ux_product_experience`: usado quando o pedido é `ux_ui, product_new, feature`. A família de método é `None` e os portões principais são Product Experience Gate, Product Face Gate, Independent Design Review Gate.
+- `analytics_data`: usado quando o pedido é `data_analytics, product_new, feature`. A família de método é `None` e os portões principais são Data Contract Gate, Privacy Gate, Metrics Proof Gate.
+- `agent_quality_change`: usado quando o pedido é `agent_skill`. A família de método é `None` e os portões principais são Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
 
-A sequência esperada é:
+A rota não dá permissão para um worker sair fazendo o que quiser. Ela escolhe a faixa, a família de método e os gates que precisam ser satisfeitos.
 
-- capturar o source envelope;
-- classificar o sinal;
-- resolver referências de fonte;
-- construir um source ledger;
-- identificar conflitos ou material faltante;
-- confirmar entendimento com o operador quando a verdade de produto importa.
+## 3. A verdade do produto vira contrato
 
-Só depois disso a fábrica pode criar artefatos de definição de produto usados por workers downstream.
+Em trabalho de produto, o Product SOT transforma o material de origem numa definição usável. É o momento em que a fábrica diz: "este é o produto que estamos construindo de verdade".
 
-## 3. Verdade de produto vira escopo executável
+Um Product SOT fraco enfraquece tudo que vem depois. Workers ainda podem produzir código, docs, design ou comentários de revisão, mas talvez estejam otimizando para a coisa errada. Por isso a fábrica bloqueia execução downstream quando a verdade do produto falta ou ainda não foi revisada.
 
-Product SOT é a definição de produto usada como fonte de verdade pela fábrica. Não é um resumo casual. É o artefato ao qual método, arquitetura, planejamento, decomposição, implementação e revisão precisam se conectar.
+## 4. O método liga a rota à evidência
 
-Uma execução de produto também precisa cobrir o escopo completo do Product SOT. Isso impede que uma primeira fatia vire silenciosamente o produto inteiro.
+O contrato de método diz como esta execução deve ser tratada. Os motores de método atuais incluem:
 
-## 4. Método é escolhido por contrato
+- `spec_first_sdd`: None. Entra quando a rota pede `spec_first`. Rotas: .
+- `test_first_tdd`: None. Entra quando a rota pede `test_first`. Rotas: .
+- `behavior_first_bdd`: None. Entra quando a rota pede `behavior_first`. Rotas: .
+- `discovery_research`: None. Entra quando a rota pede `discovery_first`. Rotas: .
+- `security_first_threat_model`: None. Entra quando a rota pede `security_first`. Rotas: .
+- `design_first_product_experience`: None. Entra quando a rota pede `design_first`. Rotas: .
+- `legacy_diagnosis`: None. Entra quando a rota pede `legacy_diagnosis`. Rotas: .
+- `incident_first`: None. Entra quando a rota pede `incident_first`. Rotas: .
 
-O registry de method engines contém:
+O método importa porque muda a evidência. Trabalho test-first precisa de teste e prova de regressão. Trabalho design-first precisa de prova de experiência de produto. Trabalho security-first precisa de threat modeling e evidência de segurança. Incidente precisa de mitigação, status e learnback.
 
-- `spec_first_sdd` — Spec-First SDD Engine: família `spec_first`; usado por product_creation, feature_delivery, critical_integration, migration_execution.
-- `test_first_tdd` — Test-First TDD Engine: família `test_first`; usado por feature_delivery, bug_repair, critical_integration, migration_execution.
-- `behavior_first_bdd` — Behavior-First BDD Engine: família `behavior_first`; usado por product_creation, feature_delivery, ux_product_experience.
-- `discovery_research` — Discovery and Research Engine: família `discovery_first`; usado por product_creation, research_validation, brownfield_discovery.
-- `security_first_threat_model` — Security-First Threat Model Engine: família `security_first`; usado por security_remediation, release_promotion, critical_integration, agent_quality_change.
-- `design_first_product_experience` — Design-First Product Experience Engine: família `design_first`; usado por ux_product_experience, product_creation, feature_delivery.
-- `legacy_diagnosis` — Legacy Diagnosis Engine: família `legacy_diagnosis`; usado por brownfield_discovery, migration_execution, bug_repair.
-- `incident_first` — Incident-First Engine: família `incident_first`; usado por incident_response, bug_repair, security_remediation.
+Método não é slogan. Ele precisa produzir artefatos, gates, pacotes de worker e critérios de parada.
 
-Nome de método não basta. A fábrica precisa ligar a rota escolhida a artefatos, gates, workers e provas. Por exemplo, trabalho test-first precisa de prova de teste. Trabalho design-first precisa de prova de Product Experience. Trabalho security-first precisa de threat modeling e evidência de segurança.
+## 5. O trabalho vira pacotes pequenos
 
-## 5. Planejamento cria execução limitada
+Um worker packet é um contrato pequeno. Ele diz ao worker o que fazer, o que não fazer, que evidência anexar e que autoridade ele tem. É aqui que a fábrica evita o pedido vago: "constrói isso aí".
 
-Product Creation Plan e work units transformam verdade de produto em pacotes executáveis. Um worker packet deve dizer ao especialista o que fazer, o que não fazer, qual evidência devolver e qual autoridade ele tem.
+Pacotes bons são estreitos. Dá para executar, revisar, repetir e fechar. Pacotes ruins são missões grandes sem prova clara. A fábrica deve criar os primeiros e bloquear os segundos.
 
-É aqui que a fábrica evita a falha clássica: "agente, construa tudo". O worker recebe um trabalho limitado, não uma missão vaga.
+## 6. O Hermes roda o chão da fábrica
 
-## 6. Hermes executa o trabalho de runtime
+Hermes Kanban continua sendo a fonte de verdade do runtime. Cards, dependências, comentários, status de worker, workspaces e transições vivem nele. A fábrica prepara e valida os contratos de produção; o Hermes registra o que está acontecendo de fato.
 
-Hermes Kanban continua sendo a fonte de verdade do runtime. Cards, dependências, status de workers, comentários, workspaces e transições vivem ali.
+Essa separação é importante. Arquivos locais provam que o kernel público está coerente. Eles não provam que uma execução viva, num Hermes do operador, terminou. Conclusão real precisa de estado de runtime, resultado de worker, revisão, evidência e decisões humanas quando o risco exige.
 
-A fábrica pode validar contratos e preparar pacotes, mas a autoridade de execução vem do estado do runtime. Se o runtime diz que um card está bloqueado, a fábrica precisa respeitar isso e reparar o bloqueio ou entregar o gate humano correto.
+## Modos da ponte com o operador
 
-## 7. Revisão é separada de execução
+A ponte pública com o operador é uma camada de interface. Ela traduz mensagens do operador para registros seguros da fábrica, mas não executa trabalho da fábrica sozinha. A execução continua pertencendo aos cards Hermes e aos workers atribuídos.
 
-Um evento `done` de worker não é prova automática. A fábrica espera readback, verificação e revisão independente quando necessário.
+Os modos da ponte são `status_bridge`, `start_bridge`, `question_bridge`, `decision_bridge`, `change_bridge`, `exception_bridge`, `handoff_bridge` e `learnback_forwarding`. Um pedido de início cria ou encaminha contexto de `factory_bridge_start_request`; ele não pula fonte, método nem gates de prontidão.
 
-Executor e reviewer devem ser identidades separadas em trabalho material. Revisão pode passar, falhar ou criar reparo. Uma revisão que passa mas não reduz o card original ainda é falha de orquestração.
+A ponte separa o `overkill-factory-gerente`, que conversa com o operador, do `factory-orchestrator`, que cuida de rota e controle de runtime. O Durable Operator Inbox preserva decisões, perguntas e handoffs no default Hermes store. O Factory Mechanic continua sendo o dono de self-improvement e learnback. A ponte não pode conceder autoridade, inventar aprovação, fechar gate ou declarar conclusão sem evidência.
 
-## 8. Gates humanos são explícitos
+## 7. Revisar é diferente de executar
 
-Gate humano não é desculpa para parar. É um pacote real de decisão. O operador deve receber o artefato, a decisão necessária, os riscos, as evidências e as opções recomendadas.
+O executor não deveria ser o juiz final de trabalho material. A fábrica usa readback, verificação, revisão independente e Receipt Five para separar "o worker disse que terminou" de "a fábrica consegue provar que terminou".
 
-Bloqueios internos de revisão são responsabilidade da fábrica, salvo quando exigem autoridade explícita do operador.
+Se a revisão passa, o resultado precisa voltar para a tarefa original. Se falha, a fábrica deve criar trabalho de reparo. Uma revisão aprovada que fica parada não é progresso. É mais um estado bloqueado.
 
-## 9. Receipt Five fecha o ciclo
+## 8. Gates humanos são raros, mas reais
 
-Receipt Five é o pacote de evidências de conclusão ou bloqueio. Ele deve responder:
+Um gate humano entra quando a decisão pertence ao operador: aceitar risco, aprovar orçamento, mexer em produção, mainnet, segredos, release ou outra fronteira explícita de autoridade. A fábrica não deve pedir aprovação humana só porque não sabe continuar.
 
-- o que foi pedido;
-- o que foi construído ou decidido;
-- qual evidência prova;
-- o que foi revisado;
-- o que continua bloqueado ou arriscado;
-- qual é o próximo estado operacional.
+Quando o gate humano é necessário, o operador deve receber um pacote de decisão: a escolha, a evidência, o risco, a recomendação e a consequência de cada caminho. JSON cru não é um bom gate humano. Pergunta vaga no chat é pior.
 
-Sem esse pacote, `done` não é uma afirmação de nível fábrica.
+## 9. Entregar, bloquear ou aprender
 
-## 10. Learnback melhora a fábrica
+Uma execução termina em um de três estados honestos.
 
-Uma execução finalizada pode revelar métodos melhores, skills faltantes, validadores fracos ou novos padrões de falha. Learnback transforma isso em melhoria revisável, não em mudança silenciosa da fábrica.
+Ela pode entregar quando a evidência é forte o bastante e os gates necessários passaram. Pode bloquear quando falta prova, acesso, autoridade ou segurança. Ou pode aprender quando a execução mostra um método melhor, um worker ausente, um validador fraco ou uma falha que se repete.
+
+Aprendizado também tem gate. A fábrica não deve se reescrever em silêncio porque uma execução foi estranha. Ela deve propor a mudança, testar e promover só quando for seguro.

--- a/docs/pt-BR/reference.md
+++ b/docs/pt-BR/reference.md
@@ -1,93 +1,124 @@
 # Referência
 
-Esta página reúne os fatos curtos que uma pessoa normalmente precisa depois de ler o manual. Ela é pequena de propósito. A referência completa gerada fica em `factory/legacy-docs/generated/`.
+Esta página reúne os fatos curtos que uma pessoa normalmente precisa depois do manual. Ela não tenta substituir os registries nem a referência gerada. Ela traduz os nomes mais importantes para uma pessoa que quer operar ou avaliar a fábrica.
+
+## Onde cada coisa mora
+
+- `README.md` e `README.pt-BR.md`: entrada pública curta.
+- `docs/en/` e `docs/pt-BR/`: manual público canônico.
+- `docs/factory-workflow.catalog.json`: workflow público compilado.
+- `docs/promise-implementation-map.public.json`: mapa de promessa pública para implementação.
+- `docs/public-surface.manifest.json`: manifest das superfícies públicas.
+- `factory/scripts/factoryctl.py`: principal superfície de comando.
+- `factory/schemas/`: contratos JSON que dizem o que é registro válido.
+- `factory/templates/`: contratos-base, exemplos e registries.
+- `factory/agents/`: workers, perfis, bindings Hermes, capability packs e readiness.
+- `factory/tests/`: regressão do comportamento da fábrica.
+- `factory/legacy-docs/`: docs antigas preservadas para referência técnica; não são o manual público canônico.
+- `factory/legacy-docs/generated/`: referência gerada do kernel para maintainers.
+
+## Caminho mental curto
+
+```text
+fonte
+-> entendimento
+-> Product SOT
+-> método
+-> packs e gates
+-> work units
+-> Hermes
+-> worker results
+-> verificação e review
+-> Receipt Five
+-> release, bloqueio ou learnback
+```
+
+Se uma execução parece pronta, mas não consegue apontar para esse caminho, provavelmente está faltando prova.
 
 ## Classes de rota
 
-- `product_creation`: usado quando o pedido é `product_new`. A família de método é `None` e os portões principais são Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: usado quando o pedido é `feature, slice`. A família de método é `None` e os portões principais são Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: usado quando o pedido é `bug`. A família de método é `None` e os portões principais são Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: usado quando o pedido é `incident`. A família de método é `None` e os portões principais são Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: usado quando o pedido é `migration, refactor, integration`. A família de método é `None` e os portões principais são Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: usado quando o pedido é `release`. A família de método é `None` e os portões principais são Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: usado quando o pedido é `feature, product_new, security, ux_ui, data_analytics, agent_skill`. A família de método é `None` e os portões principais são Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: usado quando o pedido é `doc`. A família de método é `None` e os portões principais são Docs Utility Gate, First Run Gate.
-- `security_remediation`: usado quando o pedido é `security`. A família de método é `None` e os portões principais são Security Architecture Gate, Security Review Gate.
-- `critical_integration`: usado quando o pedido é `integration`. A família de método é `None` e os portões principais são Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: usado quando o pedido é `migration`. A família de método é `None` e os portões principais são Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: usado quando o pedido é `ux_ui, product_new, feature`. A família de método é `None` e os portões principais são Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: usado quando o pedido é `data_analytics, product_new, feature`. A família de método é `None` e os portões principais são Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: usado quando o pedido é `agent_skill`. A família de método é `None` e os portões principais são Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+As quatorze classes de rota existem para impedir que todo pedido seja tratado do mesmo jeito.
 
-## Motores de método
+- `product_creation`: criação de produto; precisa de Product SOT, cobertura de escopo e ready gate.
+- `feature_delivery`: feature ou slice; precisa de método, critérios de aceite e prova proporcional ao risco.
+- `bug_repair`: bug; precisa de reprodução ou justificativa clara, correção e regressão.
+- `incident_response`: incidente; precisa de severidade, mitigação, comunicação e learnback.
+- `brownfield_discovery` / `migration_execution`: brownfield, refactor, integração ou migração; precisa de baseline, contrato, regressão e rollback.
+- `release_promotion`: release; precisa de prontidão de produção, rollback, owner e autoridade.
+- `research_validation`: research; precisa virar decisão operacional, não só comentário inteligente.
+- `docs_onboarding`: docs/onboarding; precisa provar utilidade para o leitor ou primeiro sucesso.
+- `security_remediation`: segurança; precisa de arquitetura, scans, review e tratamento de risco residual.
+- `ux_product_experience`: UX/Product Experience; precisa de Product Face, estados, jornadas, design e review.
+- `analytics_data`: analytics/data; precisa de contrato de métrica, privacidade e prova de qualidade.
+- `agent_quality_change`: agent/skill/model; precisa de eval, prontidão de perfil e learnback.
 
-- `spec_first_sdd`: None. Entra quando a rota pede `spec_first`. Rotas: .
-- `test_first_tdd`: None. Entra quando a rota pede `test_first`. Rotas: .
-- `behavior_first_bdd`: None. Entra quando a rota pede `behavior_first`. Rotas: .
-- `discovery_research`: None. Entra quando a rota pede `discovery_first`. Rotas: .
-- `security_first_threat_model`: None. Entra quando a rota pede `security_first`. Rotas: .
-- `design_first_product_experience`: None. Entra quando a rota pede `design_first`. Rotas: .
-- `legacy_diagnosis`: None. Entra quando a rota pede `legacy_diagnosis`. Rotas: .
-- `incident_first`: None. Entra quando a rota pede `incident_first`. Rotas: .
+## Métodos principais
 
-## Áreas operacionais
+O método muda a forma de provar o trabalho.
 
-- `deterministic_control_plane_os`: deterministic_control_plane_os.
-- `product_truth_research_os`: product_truth_research_os.
-- `method_os`: method_os.
-- `product_architecture_os`: product_architecture_os.
-- `product_experience_design_brand_os`: product_experience_design_brand_os.
-- `work_unit_execution_dispatch_os`: work_unit_execution_dispatch_os.
-- `authority_autonomy_os`: authority_autonomy_os.
-- `hermes_worker_runtime_os`: hermes_worker_runtime_os.
-- `evidence_receipt_os`: evidence_receipt_os.
-- `capability_provider_os`: capability_provider_os.
-- `agent_profile_authority_os`: agent_profile_authority_os.
-- `security_os`: security_os.
-- `quality_verification_os`: quality_verification_os.
-- `operator_experience_os`: operator_experience_os.
-- `release_operations_os`: release_operations_os.
-- `velocity_cost_throughput_os`: velocity_cost_throughput_os.
-- `factory_learning_os`: factory_learning_os.
+- Spec-first: bom quando o risco é construir a coisa errada.
+- Test-first: bom quando comportamento precisa ficar travado por regressão.
+- Behavior-first: bom quando jornada e aceite importam mais que detalhe interno.
+- Discovery-first: bom quando a pergunta ainda não está madura.
+- Security-first: obrigatório quando ameaça, segredo, chave, produção, onchain ou abuso importam.
+- Design-first: obrigatório quando a experiência visível é parte do produto.
+- Legacy-diagnosis: necessário quando existe sistema antigo, comportamento desconhecido ou migração.
+- Incident-first: necessário quando o produto está quebrado, em risco ou exigindo resposta operacional.
 
-## Caminhos importantes
+## Capability packs
 
-- `README.md`: entrada pública em inglês.
-- `README.pt-BR.md`: entrada pública em português.
-- `docs/en/`: manual do produto em inglês.
-- `docs/pt-BR/`: manual do produto em português.
-- `docs/assets/public-map/`: assets públicos do mapa visual.
-- `docs/factory-workflow.catalog.json`: catálogo público do workflow.
-- `docs/promise-implementation-map.public.json`: mapa público de promessa para implementação.
-- `docs/public-surface.manifest.json`: manifest das superfícies públicas.
-- `factory/scripts/factoryctl.py`: principal superfície de comando.
-- `factory/schemas/`: schemas JSON para registros e contratos.
-- `factory/templates/`: exemplos, registries e contratos-base.
-- `factory/agents/`: registry público de workers, perfis, bindings e readiness records.
-- `factory/tests/`: testes de regressão.
-- `factory/legacy-docs/`: docs antigas e referência gerada preservadas; não são a documentação pública canônica.
+Capability pack é a resposta para: “temos cobertura especialista para este tipo de produto?”.
+
+Packs core atualmente incluem web/SaaS, CLI/TUI, cloud-native, agent-runtime, Solana AI Kit, onboarding e public-docs. Eles ainda precisam dos gates normais, mas a fábrica reconhece cobertura básica.
+
+Packs template incluem mobile nativo, desktop, game, AI/ML, fintech, regulated domain, data analytics, browser extension e hardware/IoT. Esses não devem executar materialmente só porque o card pediu. Precisam de ativação, especialistas, bindings, smoke, eval e evidência.
+
+## Product Face
+
+Product Face é a prova da face do produto. Ele muda conforme a superfície:
+
+- web visual: screenshots, viewports, estados, console, acessibilidade básica e overflow;
+- CLI/TUI: transcript, help, instalação, erro e comportamento no terminal;
+- docs/onboarding: replay do primeiro sucesso, links e critério do leitor;
+- interface agentic: controle do usuário, permissões, memória/dados, recuperação e limites;
+- wallet/onchain UI: prova visual mais fronteira de assinatura, transação e chave.
+
+Product Face Packet é planejamento. Product Face Result é prova.
+
+## Workers e autoridade
+
+Worker não é personagem de prompt. Para ser operável, precisa de quatro camadas:
+
+1. papel no registry público;
+2. perfil de agente;
+3. binding Hermes;
+4. worker packet específico do card.
+
+O worker executa dentro da autoridade recebida. Ele não aprova gate, não inventa evidência, não toca produção, não mexe em chaves e não muda escopo fora do contrato.
 
 ## Termos centrais
 
-Product SOT é a fonte de verdade do produto. Ele deve dizer o que está sendo construído, o que entra no escopo, o que fica fora, que evidência conta e o que tornaria a execução inaceitável.
+Product SOT é a fonte de verdade do produto.
 
-Method Contract é a forma escolhida para tratar o trabalho. Ele liga a rota a gates, artefatos, workers e evidência.
+Full Product SOT Scope Coverage mostra que cada promessa importante do SOT está planejada, bloqueada, fora de escopo, delegada ao humano ou provada.
 
-Worker Packet é a instrução limitada entregue a um worker. Inclui tarefa, limites, autoridade e saída esperada.
+Method Contract liga rota, método, gates, workers e evidência.
 
-Gate Report explica se uma tarefa pode avançar, por que está bloqueada e que evidência ou ação destravaria o caminho.
+Worker Packet é a tarefa limitada entregue a um worker.
 
-Receipt Five é o recibo de conclusão. Ele conecta pedido, trabalho, evidência, revisão, risco restante e próximo estado.
+Worker Result é o retorno estruturado do worker com evidência.
 
-Human Gate é uma decisão real do operador. Deve vir com pacote legível, não com pergunta vaga no chat.
+Gate Report explica se algo pode avançar, por que está bloqueado e o que destrava.
 
-Readback quer dizer que a fábrica lê e confere o artefato que o worker disse ter produzido.
+Receipt Five é o recibo de conclusão: pedido, mudança, evidência, revisão e próximo estado.
 
-No-idle é o guard que detecta parada silenciosa e força o próximo passo seguro ou falha de forma visível.
+Human Gate é uma decisão material do operador com pacote legível.
 
-## Fronteira das claims públicas
+Readback é a leitura real do artefato produzido.
 
-O repositório público consegue provar coerência local do kernel. Ele não prova uma entrega privada de produto. Entrega real precisa de runtime Hermes do operador, resultados vivos de workers, evidência específica do produto, revisão e aprovação humana quando necessário.
+No-idle é o guard contra parada silenciosa, não um segundo despachante.
+
+Learnback é aprendizado promovido com prova, não memória solta de chat.
 
 ## Comandos úteis
 
@@ -95,10 +126,10 @@ O repositório público consegue provar coerência local do kernel. Ele não pro
 cd factory
 python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
-python3 scripts/factoryctl.py route-registry
-python3 scripts/factoryctl.py method-engines
-python3 scripts/factoryctl.py operating-systems
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+python3 scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py
@@ -106,3 +137,7 @@ python3 scripts/validate_worker_profiles.py
 python3 scripts/public_safety_scan.py
 python3 scripts/secret_safety_scan.py
 ```
+
+## Fronteira das claims públicas
+
+O repositório público prova coerência local do kernel. Ele não prova que um produto privado foi entregue. Entrega real precisa de Hermes vivo, estado de runtime, worker results atuais, evidência específica do produto, review consumido e aprovação humana quando o risco pedir.

--- a/docs/pt-BR/reference.md
+++ b/docs/pt-BR/reference.md
@@ -1,94 +1,108 @@
 # Referência
 
-Esta página reúne os fatos curtos usados pelo manual.
+Esta página reúne os fatos curtos que uma pessoa normalmente precisa depois de ler o manual. Ela é pequena de propósito. A referência completa gerada fica em `factory/legacy-docs/generated/`.
 
-## Comandos principais
+## Classes de rota
+
+- `product_creation`: usado quando o pedido é `product_new`. A família de método é `None` e os portões principais são Source Gate, Product SOT Gate, Ready Gate.
+- `feature_delivery`: usado quando o pedido é `feature, slice`. A família de método é `None` e os portões principais são Source Gate, Method Gate, Ready Gate.
+- `bug_repair`: usado quando o pedido é `bug`. A família de método é `None` e os portões principais são Reproduction Gate, Regression Gate, Receipt Gate.
+- `incident_response`: usado quando o pedido é `incident`. A família de método é `None` e os portões principais são Severity Gate, Mitigation Gate, Learnback Gate.
+- `brownfield_discovery`: usado quando o pedido é `migration, refactor, integration`. A família de método é `None` e os portões principais são Brownfield Baseline Gate, Regression Gate, Rollback Gate.
+- `release_promotion`: usado quando o pedido é `release`. A família de método é `None` e os portões principais são Production Readiness Gate, Rollback Gate, Release Gate.
+- `research_validation`: usado quando o pedido é `feature, product_new, security, ux_ui, data_analytics, agent_skill`. A família de método é `None` e os portões principais são Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
+- `docs_onboarding`: usado quando o pedido é `doc`. A família de método é `None` e os portões principais são Docs Utility Gate, First Run Gate.
+- `security_remediation`: usado quando o pedido é `security`. A família de método é `None` e os portões principais são Security Architecture Gate, Security Review Gate.
+- `critical_integration`: usado quando o pedido é `integration`. A família de método é `None` e os portões principais são Dependency Gate, Contract Test Gate, Fallback Gate.
+- `migration_execution`: usado quando o pedido é `migration`. A família de método é `None` e os portões principais são Migration Plan Gate, Regression Gate, Rollback Gate.
+- `ux_product_experience`: usado quando o pedido é `ux_ui, product_new, feature`. A família de método é `None` e os portões principais são Product Experience Gate, Product Face Gate, Independent Design Review Gate.
+- `analytics_data`: usado quando o pedido é `data_analytics, product_new, feature`. A família de método é `None` e os portões principais são Data Contract Gate, Privacy Gate, Metrics Proof Gate.
+- `agent_quality_change`: usado quando o pedido é `agent_skill`. A família de método é `None` e os portões principais são Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
+
+## Motores de método
+
+- `spec_first_sdd`: None. Entra quando a rota pede `spec_first`. Rotas: .
+- `test_first_tdd`: None. Entra quando a rota pede `test_first`. Rotas: .
+- `behavior_first_bdd`: None. Entra quando a rota pede `behavior_first`. Rotas: .
+- `discovery_research`: None. Entra quando a rota pede `discovery_first`. Rotas: .
+- `security_first_threat_model`: None. Entra quando a rota pede `security_first`. Rotas: .
+- `design_first_product_experience`: None. Entra quando a rota pede `design_first`. Rotas: .
+- `legacy_diagnosis`: None. Entra quando a rota pede `legacy_diagnosis`. Rotas: .
+- `incident_first`: None. Entra quando a rota pede `incident_first`. Rotas: .
+
+## Áreas operacionais
+
+- `deterministic_control_plane_os`: deterministic_control_plane_os.
+- `product_truth_research_os`: product_truth_research_os.
+- `method_os`: method_os.
+- `product_architecture_os`: product_architecture_os.
+- `product_experience_design_brand_os`: product_experience_design_brand_os.
+- `work_unit_execution_dispatch_os`: work_unit_execution_dispatch_os.
+- `authority_autonomy_os`: authority_autonomy_os.
+- `hermes_worker_runtime_os`: hermes_worker_runtime_os.
+- `evidence_receipt_os`: evidence_receipt_os.
+- `capability_provider_os`: capability_provider_os.
+- `agent_profile_authority_os`: agent_profile_authority_os.
+- `security_os`: security_os.
+- `quality_verification_os`: quality_verification_os.
+- `operator_experience_os`: operator_experience_os.
+- `release_operations_os`: release_operations_os.
+- `velocity_cost_throughput_os`: velocity_cost_throughput_os.
+- `factory_learning_os`: factory_learning_os.
+
+## Caminhos importantes
+
+- `README.md`: entrada pública em inglês.
+- `README.pt-BR.md`: entrada pública em português.
+- `docs/en/`: manual do produto em inglês.
+- `docs/pt-BR/`: manual do produto em português.
+- `docs/assets/public-map/`: assets públicos do mapa visual.
+- `docs/factory-workflow.catalog.json`: catálogo público do workflow.
+- `docs/promise-implementation-map.public.json`: mapa público de promessa para implementação.
+- `docs/public-surface.manifest.json`: manifest das superfícies públicas.
+- `factory/scripts/factoryctl.py`: principal superfície de comando.
+- `factory/schemas/`: schemas JSON para registros e contratos.
+- `factory/templates/`: exemplos, registries e contratos-base.
+- `factory/agents/`: registry público de workers, perfis, bindings e readiness records.
+- `factory/tests/`: testes de regressão.
+- `factory/legacy-docs/`: docs antigas e referência gerada preservadas; não são a documentação pública canônica.
+
+## Termos centrais
+
+Product SOT é a fonte de verdade do produto. Ele deve dizer o que está sendo construído, o que entra no escopo, o que fica fora, que evidência conta e o que tornaria a execução inaceitável.
+
+Method Contract é a forma escolhida para tratar o trabalho. Ele liga a rota a gates, artefatos, workers e evidência.
+
+Worker Packet é a instrução limitada entregue a um worker. Inclui tarefa, limites, autoridade e saída esperada.
+
+Gate Report explica se uma tarefa pode avançar, por que está bloqueada e que evidência ou ação destravaria o caminho.
+
+Receipt Five é o recibo de conclusão. Ele conecta pedido, trabalho, evidência, revisão, risco restante e próximo estado.
+
+Human Gate é uma decisão real do operador. Deve vir com pacote legível, não com pergunta vaga no chat.
+
+Readback quer dizer que a fábrica lê e confere o artefato que o worker disse ter produzido.
+
+No-idle é o guard que detecta parada silenciosa e força o próximo passo seguro ou falha de forma visível.
+
+## Fronteira das claims públicas
+
+O repositório público consegue provar coerência local do kernel. Ele não prova uma entrega privada de produto. Entrega real precisa de runtime Hermes do operador, resultados vivos de workers, evidência específica do produto, revisão e aprovação humana quando necessário.
+
+## Comandos úteis
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
-python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 python3 scripts/factoryctl.py route-registry
 python3 scripts/factoryctl.py method-engines
 python3 scripts/factoryctl.py operating-systems
+python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py
+python3 scripts/validate_worker_profiles.py
 python3 scripts/public_safety_scan.py
 python3 scripts/secret_safety_scan.py
 ```
-
-## Paths do repositório
-
-- `docs/en/` — documentação canônica em inglês.
-- `docs/pt-BR/` — documentação canônica em português.
-- `docs/factory-workflow.catalog.json` — catálogo público de workflow consumido pelo compilador.
-- `docs/promise-implementation-map.public.json` — mapa público de promessa para implementação.
-- `docs/public-surface.manifest.json` — manifesto da superfície pública.
-- `factory/scripts/factoryctl.py` — helper público de controle.
-- `factory/schemas/` — schemas de contratos.
-- `factory/templates/` — templates e registries de contratos.
-- `factory/agents/` — registries públicos de workers, profiles e bindings.
-- `factory/tests/` — suíte de validação.
-- `factory/legacy-docs/` — documentação antiga não canônica.
-
-## Tabela de fases
-
-| Fase | Nome | Gates | Workers |
-| --- | --- | --- | --- |
-| F0 | Pre-Start / Sealed Source Envelope | Start Boundary | overkill-factory-gerente, factory-orchestrator |
-| F1 | Intake | Source Gate | factory-orchestrator |
-| F2 | Source Ledger | Source Gate | source-ledger-worker |
-| F3 | Source Resolution | Discovery Gate | source-ledger-worker, product-sot-planner |
-| F4 | Product Outcome And Discovery | Outcome Gate, Discovery Gate | product-sot-planner |
-| F5 | Product SOT | Product SOT Gate | product-sot-planner |
-| F6 | Agentic Method Router | Method Gate | factory-orchestrator |
-| F7 | Method Contract | Method Gate | factory-orchestrator |
-| F8 | Pack And Product Experience Selection | Pack Gate, Product Experience Gate, Surface Pack Gate | product-face, factory-orchestrator |
-| F9 | Risk And Authority Gates | Access Gate, Budget Gate, Human Gate when required | human-gate-clerk |
-| F10 | Security Architecture | Security Architecture Gate | security-orchestrator |
-| F11 | Executable Plans | Ready Gate | decomposition-planner |
-| F12 | Autonomy Readiness | Decomposition Coverage Gate, Access & Capability Gate | independent-reviewer, factory-orchestrator |
-| F13 | Ready Gate | Ready Gate | factory-orchestrator |
-| F15 | Runtime Execution | Runtime Gate | implementation-worker, qa-verification-worker |
-| F16 | Worker Results | Done Gate | evidence-reconciler |
-| F17 | Verification | Verification Gate | qa-verification-worker |
-| F18 | Independent Review | Review Gate | independent-reviewer |
-| F20 | Closure Summary | Closure Gate | handoff-packer |
-| F21 | Receipt Five | Done Gate | evidence-reconciler |
-| F22 | Completion Audit | Completion Audit | evidence-reconciler |
-| F23 | Production Operations | Release Gate | release-ops-worker |
-| F24 | Release Or Block | Release Gate, Human Gate when required | release-ops-worker, human-gate-clerk |
-| F25 | Monitoring Support | Support Gate | release-ops-worker |
-| F26 | Learnback | Learning Gate | skill-eval-distiller |
-| F27 | Factory Maturity Audit | Maturity Gate | skill-eval-distiller |
-
-## Classes de rota
-
-- `product_creation`: tipos de pedido product_new; família de método `spec_first`; gates Source Gate, Product SOT Gate, Ready Gate.
-- `feature_delivery`: tipos de pedido feature, slice; família de método `behavior_first`; gates Source Gate, Method Gate, Ready Gate.
-- `bug_repair`: tipos de pedido bug; família de método `test_first`; gates Reproduction Gate, Regression Gate, Receipt Gate.
-- `incident_response`: tipos de pedido incident; família de método `incident_first`; gates Severity Gate, Mitigation Gate, Learnback Gate.
-- `brownfield_discovery`: tipos de pedido migration, refactor, integration; família de método `legacy_diagnosis`; gates Brownfield Baseline Gate, Regression Gate, Rollback Gate.
-- `release_promotion`: tipos de pedido release; família de método `spec_first`; gates Production Readiness Gate, Rollback Gate, Release Gate.
-- `research_validation`: tipos de pedido feature, product_new, security, ux_ui, data_analytics, agent_skill; família de método `research_first`; gates Source Quality Gate, Specialist Decision Gate, SOT Impact Gate.
-- `docs_onboarding`: tipos de pedido doc; família de método `docs_first`; gates Docs Utility Gate, First Run Gate.
-- `security_remediation`: tipos de pedido security; família de método `security_first`; gates Security Architecture Gate, Security Review Gate.
-- `critical_integration`: tipos de pedido integration; família de método `spec_first`; gates Dependency Gate, Contract Test Gate, Fallback Gate.
-- `migration_execution`: tipos de pedido migration; família de método `legacy_diagnosis`; gates Migration Plan Gate, Regression Gate, Rollback Gate.
-- `ux_product_experience`: tipos de pedido ux_ui, product_new, feature; família de método `design_first`; gates Product Experience Gate, Product Face Gate, Independent Design Review Gate.
-- `analytics_data`: tipos de pedido data_analytics, product_new, feature; família de método `analytics_first`; gates Data Contract Gate, Privacy Gate, Metrics Proof Gate.
-- `agent_quality_change`: tipos de pedido agent_skill; família de método `agent_eval_first`; gates Agent Eval Gate, Worker Profile Readiness Gate, Learnback Gate.
-
-## Glossário
-
-- **Hermes Kanban**: chão de runtime que controla boards, cards, dispatch, comentários, logs, dependências e transições.
-- **Overkill Factory**: método de produção de produto e kernel de contratos em volta do Hermes.
-- **Product SOT**: fonte da verdade do produto usada por planejamento e execução downstream.
-- **Method Contract**: ligação entre rota, method engine, artefatos, gates, workers e prova.
-- **Worker packet**: pedido de execução limitado para um worker especialista.
-- **Human gate**: decisão real de operador com artefato, evidência, risco e consequência.
-- **Receipt Five**: pacote final de evidência para release ou bloqueio.
-- **Readback**: verificação de que artefatos declarados ainda existem e podem ser inspecionados.
-- **No-idle**: proteção que detecta runtime parado ou falso progresso.

--- a/docs/pt-BR/technical-model.md
+++ b/docs/pt-BR/technical-model.md
@@ -80,3 +80,35 @@ Os validadores existem para pegar essas divergências. Eles não substituem julg
 Uma mudança segura normalmente mexe em três camadas ao mesmo tempo: a explicação humana, o contrato executável e os testes ou validadores. Se você muda só a doc, talvez melhore a comunicação sem mudar comportamento. Se muda só o código, a superfície pública pode mentir. Se muda só o teste, talvez esteja protegendo um modelo antigo.
 
 Para documentação pública, a regra mais segura é simples: escreva a partir do código atual e da saída real dos comandos, não de memória. Depois rode os validadores. Se eles reclamarem, trate isso como sinal de produto, não como incômodo.
+
+## Bindings Hermes e perfis vivos
+
+Um worker só é operável quando quatro camadas batem: papel no registry, perfil de agente, binding Hermes e worker packet específico do card. Nome de perfil sozinho não basta.
+
+O binding define skill refs, política de fila, schema de resultado, campo de recibo e política de caminho de evidência. Isso impede que uma persona bonita no prompt seja tratada como worker real sem contrato de runtime.
+
+A prontidão também tem fronteira. Um smoke antigo, um profile materializado localmente ou um ledger degradado não provam execução viva. Eles dizem que existe caminho de configuração. Para conclusão real, o card precisa de resultado atual de worker e evidência consumida pelo gate.
+
+## Phase engine e grafo Kanban
+
+A fábrica usa o phase engine para calcular a fronteira atual a partir de artefatos materializados. O phase declarado no card não vence a realidade. Se Product SOT, Method Contract, pacote de decisão ou readiness estão faltando, a fase posterior bloqueia.
+
+No Hermes, isso precisa virar grafo nativo: cards, dependências, typed blockers e work units ligados. A fábrica pode reconciliar e reparar, mas não deve manter uma lista paralela escondida. O objetivo é que o runtime mostre a verdade operacional.
+
+## Interface do operador
+
+A interface do operador é uma projeção. Telegram, Discord, cockpit e ponte CLI podem receber fonte, enviar status e entregar pacotes de decisão. Eles não substituem Hermes, Receipt Five ou worker results.
+
+A regra de produto é: o gerente fala com o humano; workers e eventos crus alimentam o estado interno. Um gate humano precisa de memo legível e artefato sob revisão, não dump de JSON nem caminho local.
+
+## Readback de artefato e anexos duráveis
+
+A integração com Hermes não deve aceitar “existe um arquivo” como conclusão. Para anexos e artefatos de runtime, a fábrica precisa de readback: linha ou blob existe, tamanho e hash batem, parse deu certo quando aplicável, safety checks passaram e a referência pode ser consumida depois.
+
+Referências como `artifact_readback` e `kanban-attachment` aparecem nessa fronteira. Elas existem para impedir que metadata, caminho local ou arquivo temporário sejam tratados como prova permanente.
+
+## SDLC Feedback Loop
+
+Trabalho material autônomo precisa manter o fio entre sinal, triage, escolha de modelo/perfil, execução, evidência e learnback. Esse fio é o SDLC Feedback Loop.
+
+Sem esse vínculo, uma falha vira lembrança de chat; uma escolha de modelo vira implícita; um learnback vira opinião sem alvo. Com o vínculo, a fábrica sabe de onde veio o sinal, por que escolheu aquele caminho, que prova voltou e que regra pode mudar depois.

--- a/docs/pt-BR/technical-model.md
+++ b/docs/pt-BR/technical-model.md
@@ -1,106 +1,82 @@
-# Modelo Técnico
+# Modelo técnico
 
-A Overkill Factory é implementada como pacote Python, CLI, biblioteca de contratos, superfície de adapter Hermes, registry público de workers e site de documentação.
+Esta página explica o modelo de implementação sem fingir que todo leitor quer morar dentro do código.
 
-Ela intencionalmente não substitui o Hermes.
+A versão curta é esta: Hermes controla estado de runtime. A Overkill Factory controla os contratos de produção em volta desse estado. O repositório guarda scripts, schemas, templates, registries, testes e documentação pública para tornar esse contrato verificável.
 
 ## Estrutura do repositório
 
-```text
-README.md              entrada pública em inglês
-README.pt-BR.md        entrada pública em português
-docs/                  documentação canônica e catálogos públicos
-factory/               implementação, contratos, testes, exemplos, docs legadas
-```
+O repositório público tem duas áreas principais:
 
-Dentro de `factory/`:
+- `docs/`: o manual público do produto e catálogos públicos.
+- `factory/`: a implementação, com scripts, schemas, templates, agentes, adapters, exemplos, fixtures, testes, skills e docs legadas.
 
-- `scripts/` contém `factoryctl.py` e validadores;
-- `schemas/` contém JSON schemas de contratos;
-- `templates/` contém templates e registries canônicos;
-- `agents/` contém registries públicos de workers, profiles, readiness e bindings;
-- `adapters/hermes/` contém integração com fronteiras do runtime Hermes;
-- `examples/` e `fixtures/` contêm exemplos públicos e fixtures de validação;
-- `tests/` protege comportamento e claims públicas;
-- `legacy-docs/` preserva documentação antiga não canônica.
+As docs técnicas antigas ficam em `factory/legacy-docs/`. Elas foram preservadas por histórico e compatibilidade, mas não são a explicação pública canônica.
 
-## Números do kernel público
+## A superfície executável
 
-A superfície executável atual inspecionada para esta documentação contém:
+`factoryctl` é a principal superfície de comando. Ele valida cards, cria gate reports, compila o workflow, imprime registries, prepara pacotes de worker e roda o caminho público de prova local.
 
-- 244 schemas;
-- 156 templates JSON;
-- 97 testes;
-- 40 workers públicos;
-- 14 classes de rota;
-- 8 method engines;
-- 17 áreas de operating system;
-- 26 fases compiladas de workflow.
+A documentação não deve correr na frente dessa superfície executável. Se a documentação afirma uma capacidade, essa afirmação precisa apontar para código, schema, teste, saída de comando ou decisão atual de produto.
 
-## `factoryctl`
+## Estado de runtime
 
-`factoryctl` é o helper público de controle. Ele valida contratos, cria artefatos locais de prova, compila planos de workflow, gera worker packets, checa artefatos JSON públicos e roda caminhos de smoke.
+O Hermes controla estado de runtime: cards Kanban, tarefas de worker, dependências, transições, comentários, workspaces, estados bloqueados e estados concluídos. A fábrica não deve recriar esse estado em texto ou num sidecar escondido.
 
-Comandos importantes:
+A fábrica adiciona disciplina em volta do runtime. Ela decide quais artefatos são obrigatórios, quais gates entram, que perfil de worker deve cuidar da tarefa, que evidência precisa voltar e que autoridade está proibida.
 
-```bash
-cd factory
-python3 scripts/factoryctl.py doctor
-python3 scripts/factoryctl.py run minimal
-python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
-python3 scripts/factoryctl.py validate-runtime-contracts
-python3 scripts/factoryctl.py route-registry
-python3 scripts/factoryctl.py operating-systems
-python3 scripts/factoryctl.py method-engines
-```
+## Contratos e schemas
 
-`factoryctl` pode provar coerência local de contratos. Ele não substitui prova de runtime Hermes.
+O repositório tem hoje 244 schemas JSON e 156 templates JSON. Essa é a espinha dorsal do sistema. Os schemas definem como um registro válido deve parecer. Os templates dão exemplos ou contratos-base. Os testes impedem esses contratos de mudarem em silêncio.
 
-## Fronteira de runtime
+Famílias importantes de contrato incluem planos de workflow, comandos da fábrica, eventos de execução, promotion packets, autoridade de worker, Product SOT, contratos de método, capability packs, gate reports, Receipt Five, gates humanos e provas de runtime.
 
-Hermes controla estado de runtime. Overkill Factory controla método, contratos e checks.
+## Rotas, métodos e sistemas operacionais
 
-Isso significa:
+O registro de rotas expõe 14 classes de rota. O registro de método expõe 8 motores de método. O registro de operating systems expõe 17 áreas da fábrica.
 
-- um JSON local não é um board real rodando;
-- um pacote gerado não é trabalho concluído;
-- um worker profile não é resultado de worker;
-- um smoke local passando não é release de produção;
-- um gate humano não pode ser falsificado por script.
+Classes de rota respondem: "que tipo de trabalho é este?" Motores de método respondem: "como este tipo de trabalho deve ser tratado?" Áreas operacionais respondem: "que parte da fábrica é dona desta capacidade?"
 
-## Registry de operating systems
+Isso permite que a fábrica se adapte sem ficar vaga. Ela consegue tratar criação de produto, bug, incidente, release, segurança, analytics, UX, migração e qualidade de agente sem fingir que tudo é a mesma tarefa.
 
-A fábrica agrupa áreas críticas em entradas de operating system:
+## Workers e perfis
 
-- **Deterministic Control Plane OS** (`deterministic_control_plane_os`): dono `factory-orchestrator`, status `active`. Own the reducer-first factory spine: phase graph, commands, events, decision outbox, replay and promotion boundaries.
-- **Product Truth and Research OS** (`product_truth_research_os`): dono `source-ledger-worker`, status `active`. Own deep product starts before Product SOT: sources, claims, conflicts, brownfield study, research decisions and operator understanding.
-- **Method OS** (`method_os`): dono `factory-orchestrator`, status `active`. Turn method routing into deterministic method engines rather than broad method-family labels.
-- **Product Architecture OS** (`product_architecture_os`): dono `product-architect`, status `active`. Own architecture candidates, trust boundaries, integration shape, data boundaries and technical decisions before decomposition.
-- **Product Experience, Design and Brand OS** (`product_experience_design_brand_os`): dono `product-face`, status `active`. Own UX, information architecture, brand/identity, design system, component proof, accessibility and visual regression for product surfaces.
-- **Work Unit and Execution Dispatch OS** (`work_unit_execution_dispatch_os`): dono `decomposition-planner`, status `active`. Own vertical work units, dispatch readiness, Hermes materialization plans, worker packets and execution ordering.
-- **Authority and Autonomy OS** (`authority_autonomy_os`): dono `factory-orchestrator`, status `active`. Decide when the factory proceeds, repairs, asks the operator, blocks or escalates without turning speed into unsafe YOLO.
-- **Hermes Worker Runtime OS** (`hermes_worker_runtime_os`): dono `factory-orchestrator`, status `blocked_pending_runtime_proof`. Own live worker operability: profile readiness, Hermes binding freshness, dispatch, no-idle, worker results and reconciliation.
-- **Evidence and Receipt OS** (`evidence_receipt_os`): dono `evidence-reconciler`, status `active`. Own proof tiers, evidence freshness, artifact readback, Receipt Five reconciliation and product-specific proof bundles.
-- **Capability Pack and Provider OS** (`capability_provider_os`): dono `factory-orchestrator`, status `active`. Own domain detection, capability pack activation, provider readiness, specialist acquisition and fail-closed pack execution.
-- **Agent and Profile Authority OS** (`agent_profile_authority_os`): dono `factory-orchestrator`, status `active`. Own worker identity, permissions, profile linting, binding readiness and the rule that agents execute contracts instead of deciding the line.
-- **Security OS** (`security_os`): dono `security-orchestrator`, status `active`. Own threat modeling, secrets, supply chain, privacy, runtime hardening, specialist security routing and risk evidence.
-- **Quality and Verification OS** (`quality_verification_os`): dono `qa-verification-worker`, status `active`. Own tests, QA plans, repair loops, visual verification, accessibility, product quality and independent evidence before done.
-- **Operator Experience OS** (`operator_experience_os`): dono `overkill-factory-gerente`, status `active`. Make one manager interface enough for Telegram-first operation: start, status, decisions, changes, briefings and proof.
-- **Release and Operations OS** (`release_operations_os`): dono `release-ops-worker`, status `active`. Own production readiness, release decision, rollback, monitoring, incident support and human R4 authority.
-- **Velocity, Cost and Throughput OS** (`velocity_cost_throughput_os`): dono `factory-orchestrator`, status `active`. Govern throughput, parallel lanes, retry budgets, token and time budgets, batching, dedupe and status cadence.
-- **Factory Learning OS** (`factory_learning_os`): dono `skill-eval-distiller`, status `hardened_existing`. Turn learnback, Hermes /learn drafts and repeated findings into inactive, reviewable, testable factory improvements.
+O registro público lista hoje 40 workers públicos. O nome do worker não basta. Um worker precisa de perfil, binding, expectativa de resultado, skill refs, política de evidência e limite de autoridade.
 
-Essas entradas não são categorias de marketing. Elas declaram dono, contratos, prova exigida e fronteiras de falha.
+Por isso o repositório tem registries de worker, perfis, bindings Hermes, readiness ledgers e validadores. Worker não deve ser personagem de prompt. Deve ser um papel operável com contrato.
 
-## Method engines
+## Referência gerada
 
-Method engines ligam uma rota a provas. Uma família de método não autoriza execução sozinha. A engine escolhida precisa produzir artefatos e gates corretos para o trabalho.
+A referência completa do kernel é produzida por `factory/scripts/generate_factory_reference_docs.py`. A saída gerada agora vive em `factory/legacy-docs/generated/`, porque o manual público precisa continuar legível. O arquivo gerado ainda é útil para maintainers e validadores.
 
-- `spec_first_sdd` — Spec-First SDD Engine: família `spec_first`; usado por product_creation, feature_delivery, critical_integration, migration_execution.
-- `test_first_tdd` — Test-First TDD Engine: família `test_first`; usado por feature_delivery, bug_repair, critical_integration, migration_execution.
-- `behavior_first_bdd` — Behavior-First BDD Engine: família `behavior_first`; usado por product_creation, feature_delivery, ux_product_experience.
-- `discovery_research` — Discovery and Research Engine: família `discovery_first`; usado por product_creation, research_validation, brownfield_discovery.
-- `security_first_threat_model` — Security-First Threat Model Engine: família `security_first`; usado por security_remediation, release_promotion, critical_integration, agent_quality_change.
-- `design_first_product_experience` — Design-First Product Experience Engine: família `design_first`; usado por ux_product_experience, product_creation, feature_delivery.
-- `legacy_diagnosis` — Legacy Diagnosis Engine: família `legacy_diagnosis`; usado por brownfield_discovery, migration_execution, bug_repair.
-- `incident_first` — Incident-First Engine: família `incident_first`; usado por incident_response, bug_repair, security_remediation.
+## Pilha de validação
+
+A implementação é guardada por validadores de JSON público, checks de public surface sync, promise-to-implementation, validação de perfis de worker, public safety scan, secret safety scan, build estrito do MkDocs e a suíte de testes Python.
+
+A documentação pública deve ser lida por humanos, mas continua presa a esses checks. É isso que impede o manual de virar uma história solta do produto.
+
+## Como um pedido vira estado
+
+A fábrica não confia num pedido só porque ele apareceu no chat. Primeiro ela registra a fonte. Depois transforma essa fonte em artefatos estruturados. Esses artefatos escolhem a rota, o método, os gates e os pacotes de worker. Só depois a execução de runtime deveria começar.
+
+Essa ordem é proposital. Se um worker começa a partir de uma instrução vaga, o sistema não tem uma forma estável de decidir se a resposta está certa. Se o pedido vira estado antes, cada passo depois consegue apontar para a mesma fonte. O worker ainda pode errar, mas a fábrica tem algo concreto para comparar.
+
+## O que deve ser gerado e o que deve ser escrito para gente
+
+Algumas coisas são melhores quando geradas a partir do código: catálogos completos de comando, cobertura de schemas, inventário de workers e tabelas grandes de referência. Escrever isso à mão, de cabeça, é o caminho mais curto para documentação velha.
+
+Outras coisas precisam ser escritas para gente: este manual, o modelo operacional, o modelo de confiança e o caminho de uso. Um operador novo não precisa receber uma referência gerada de mil linhas como primeira explicação. Ele precisa entender a história em linguagem simples e depois ver comandos exatos quando estiver pronto.
+
+O repositório atual mantém as duas camadas. O material gerado continua existindo para validação e manutenção. O manual público continua legível.
+
+## O que pode dar errado
+
+O modelo técnico é rígido porque as falhas são sutis. Um caminho pode existir, mas apontar para documentação legada. Um manifest público pode citar um arquivo que foi movido. Um perfil de worker pode parecer configurado enquanto o binding aponta para docs antigas. Uma prova local pode passar enquanto o Hermes vivo não foi checado. Uma claim pública pode ser verdadeira para o kernel e falsa para uma execução privada de produto.
+
+Os validadores existem para pegar essas divergências. Eles não substituem julgamento, mas removem muitas formas fáceis de enganar a nós mesmos.
+
+## Como mudar a fábrica com segurança
+
+Uma mudança segura normalmente mexe em três camadas ao mesmo tempo: a explicação humana, o contrato executável e os testes ou validadores. Se você muda só a doc, talvez melhore a comunicação sem mudar comportamento. Se muda só o código, a superfície pública pode mentir. Se muda só o teste, talvez esteja protegendo um modelo antigo.
+
+Para documentação pública, a regra mais segura é simples: escreva a partir do código atual e da saída real dos comandos, não de memória. Depois rode os validadores. Se eles reclamarem, trate isso como sinal de produto, não como incômodo.

--- a/docs/pt-BR/trust-and-evidence.md
+++ b/docs/pt-BR/trust-and-evidence.md
@@ -1,58 +1,63 @@
-# Confiança e Evidência
+# Confiança e evidência
 
-A fábrica parte de uma regra direta: processo parecendo vivo não é a mesma coisa que progresso.
+A Overkill Factory parte de uma verdade incômoda: processo parecendo vivo não é a mesma coisa que progresso.
 
-Isso importa porque sistemas com agentes podem produzir status convincente enquanto fazem o trabalho errado, pulam verdade de fonte, escondem bloqueios ou declaram conclusão sem evidência. A Overkill Factory trata isso como falha de produto, não como problema de estilo de comunicação.
+Agentes podem escrever arquivos, mover cards, produzir resumos confiantes e ainda errar o produto. Um painel pode mostrar atividade enquanto o bloqueio real continua parado. Uma revisão pode dizer pass sem ler o artefato. Um humano pode ser chamado para aprovar algo sem receber o material que está aprovando.
+
+A fábrica trata tudo isso como falha de produto.
 
 ## Evidência antes de confiança
 
-Declaração de worker não basta. A fábrica espera evidência que possa ser inspecionada depois: arquivos, comandos, saída de testes, registros de readback, screenshots, receipts, registros de revisão ou artefatos estruturados.
+A fábrica prefere evidência a tom de voz. Um worker dizendo "done" só ajuda se os artefatos existem, podem ser relidos e batem com o trabalho pedido. Um teste só ajuda se testa o comportamento certo. Uma revisão só ajuda se verifica o artefato certo e volta para a tarefa original.
 
-A evidência mais forte tem três propriedades:
-
-1. aponta para um artefato real;
-2. pode ser lida de volta depois que o worker termina;
-3. se conecta à verdade de produto ou ao método que diz satisfazer.
-
-## Readback
-
-Readback significa que a fábrica verifica se os artefatos declarados ainda existem e contêm o conteúdo esperado. Isso impede que um worker cite arquivos que nunca foram criados, foram criados no workspace errado ou sumiram depois da execução.
-
-Para artefatos críticos, readback não é burocracia. É a diferença entre "o agente disse" e "o sistema consegue provar".
-
-## Revisão independente
-
-Execução e revisão são trabalhos diferentes. Um builder pode terminar uma tarefa, mas um reviewer precisa inspecionar se o resultado satisfaz o contrato. Em trabalho material, a mesma identidade não deve ser executor e reviewer.
-
-Um resultado de revisão precisa ser reduzido de volta no estado original do runtime. Se a revisão passa mas o card original fica bloqueado para sempre, a fábrica ainda está falhando.
-
-## No-idle
-
-No-idle não deve ser autoridade normal de rota. Ele é uma proteção. Sua função é perceber quando o board está parado, quando um worker declarou artefatos que não podem ser lidos, quando trabalho ready não é despachado ou quando um loop de reparo está se duplicando.
-
-Um sistema no-idle válido precisa falhar alto quando ainda existe trabalho incompleto. Heartbeat não é progresso.
-
-## Bloqueios
-
-A fábrica separa bloqueios em dois tipos amplos:
-
-- bloqueios não humanos que a fábrica deve reparar ou re-rotear;
-- gates de autoridade humana que exigem decisão real do operador.
-
-Artefato faltando, worker stale, readback falhando ou revisão interna necessária não devem ser jogados no operador. Acesso de produção, fundos, autoridade de signer, aprovação de release ou aceite de risco podem exigir humano.
+É por isso que muitos registros da fábrica parecem rígidos. Eles não são rígidos porque o projeto gosta de papelada. Eles são rígidos porque evidência frouxa cria progresso falso.
 
 ## Receipt Five
 
-Receipt Five é o pacote final de evidência. Ele deve incluir pedido, evidência de artefato, evidência de verificação, evidência de revisão, decisão de release/bloqueio e riscos restantes.
+Receipt Five é o recibo de conclusão. Ele precisa responder cinco tipos de pergunta:
 
-Um Receipt Five não é resumo decorativo. É a fronteira de prova entre trabalho em andamento e uma afirmação que a fábrica consegue defender.
+1. O que foi pedido?
+2. O que foi feito ou decidido?
+3. Que evidência prova isso?
+4. Quem revisou e o que a revisão disse?
+5. O que continua bloqueado, arriscado ou pendente?
+
+Se o Receipt Five não consegue responder isso, o estado honesto não é pronto. Pode ser pronto para revisão, bloqueado, parcialmente completo ou aguardando decisão humana. Mas não é pronto.
+
+## Readback
+
+Readback quer dizer que a fábrica confere o artefato que o worker disse ter produzido. Não basta o worker dizer "escrevi o SOT" ou "adicionei o teste". A fábrica precisa ler o arquivo, confirmar que ele existe e decidir se ele tem qualidade para alimentar a próxima fase.
+
+Isso protege contra uma falha muito comum: processo correto com produto ruim. O worker pode ter seguido o card, mas a entrega pode estar rasa, errada ou ausente.
+
+## Revisão independente
+
+Trabalho material deve ser revisado por outra identidade quando o risco pede. O executor pode explicar o que fez. Ele não deveria ser o juiz final.
+
+A revisão pode passar, falhar ou pedir reparo. Se passa, precisa destravar ou fechar a tarefa original. Se falha, precisa gerar trabalho de reparo. Revisão parada, sem ser consumida, também é progresso falso.
+
+## No-idle e bloqueios
+
+No-idle não é truque de produtividade. É um guard contra paradas silenciosas. Se o board tem trabalho que deveria andar, mas nada material muda, a fábrica deve reparar o estado, despachar o próximo worker seguro ou falhar de forma visível.
+
+Bloqueio também precisa ser honesto. Alguns bloqueios são decisões humanas reais. Muitos não são. Se a fábrica precisa de revisão interna, readback, artefato faltando ou reparo, isso é trabalho da própria fábrica. Não deveria chegar ao operador como se o humano tivesse que resolver.
+
+## Gates humanos
+
+Gate humano é coisa séria. Ele pertence a decisões em que a autoridade é do operador: release em produção, mainnet, fundos, segredos, orçamento, risco relevante ou uma fronteira explícita de aprovação.
+
+Um bom gate humano é legível. Ele diz qual decisão precisa ser tomada, que evidência existe, o que pode dar errado e o que cada opção significa. O operador não deveria ter que decifrar JSON cru ou reconstruir a história por comentários espalhados.
 
 ## Segurança e risco
 
-Segurança não é checklist tardio. É questão de rota e arquitetura. Risco material pode exigir threat modeling, trust boundaries, identidade/autorização, supply chain, segredos, privacidade, incident response e dono de risco residual.
+Segurança não é checklist no fim. É rota e arquitetura. Risco material pode exigir threat modeling, fronteiras de confiança, identidade e autorização, supply chain, segredos, privacidade, incidente e dono explícito para risco residual.
 
-A fábrica não deve prometer segurança perfeita. Ela deve prometer a melhor postura possível sustentada por evidência, gates e decisões explícitas sobre risco residual.
+A fábrica não deve prometer segurança perfeita. Ela deve prometer a melhor postura possível com evidência, gates e decisão explícita sobre risco residual.
 
-## Fronteira honesta de afirmação
+A matriz pública de segurança agora faz parte deste modelo de confiança, em vez de ficar num arquivo operacional separado. Os domínios checáveis incluem `networking`, `linux-systems`, `web-security`, `application-security`, `ethical-hacking`, `security-tools`, `cloud-security`, `detection-monitoring`, `security-operations`, `cryptography`, `key-management`, `future-security`, `supply-chain` e `onchain-solana-quasar`.
 
-Validação local pode provar que o kernel público está coerente. Não pode provar que uma execução privada de produto está pronta para produção. Readiness de produto exige estado de runtime, evidência específica do produto, revisão, Receipt Five e aprovação humana quando o risco exigir.
+## A fronteira honesta
+
+Checks locais provam que o kernel público está coerente. Eles não provam que uma execução privada entregou um produto. Conclusão real de produto exige estado vivo no Hermes, evidência específica do produto, revisão e aprovação humana quando o risco pede.
+
+Essa fronteira não é fraqueza. É o jeito da fábrica continuar honesta.

--- a/docs/pt-BR/trust-and-evidence.md
+++ b/docs/pt-BR/trust-and-evidence.md
@@ -61,3 +61,27 @@ A matriz pública de segurança agora faz parte deste modelo de confiança, em v
 Checks locais provam que o kernel público está coerente. Eles não provam que uma execução privada entregou um produto. Conclusão real de produto exige estado vivo no Hermes, evidência específica do produto, revisão e aprovação humana quando o risco pede.
 
 Essa fronteira não é fraqueza. É o jeito da fábrica continuar honesta.
+
+## Pacote de decisão antes da decisão
+
+Um gate humano sem artefato é inválido. Se a fábrica pede aprovação para Product SOT, arquitetura, segurança, release ou Product Face, ela precisa entregar o material que está sendo aprovado ou uma projeção fiel com referência completa.
+
+A primeira mensagem deve caber na cabeça do operador: decisão pedida, resumo em português claro, o que aprovar autoriza, o que não autoriza, opções de resposta, consequência e urgência. O anexo pode carregar o documento completo. O JSON é evidência interna, não experiência primária do operador.
+
+## Blocos tipados e fronteira com o humano
+
+Nem todo bloqueio é pergunta para o operador. `dependency_wait` é espera de dependência. `capability` é busca ou ativação de pack. `transient` é retry ou reparo. `needs_input` só chega ao operador quando existe pacote de decisão completo.
+
+Essa separação evita um vício comum: transformar qualquer falha de processo em “preciso que o humano decida”. Muitas vezes a decisão correta é a fábrica reparar o próprio estado.
+
+## Evidência local, evidência viva e evidência pública
+
+Um comando local passando prova coerência do checkout. Um worker result prova que um worker rodou naquele escopo. Um Receipt Five prova fechamento quando consegue apontar para pedido, mudança, evidência, review e próximo estado. Uma publicação pública precisa ainda passar segurança de superfície e segredo.
+
+Essas provas não são intercambiáveis. Não se deve usar smoke local para afirmar entrega de produto vivo, nem usar artifact existence como se fosse readback, nem usar uma aprovação humana genérica como waiver de release, segurança, fundos ou mainnet.
+
+## Prontidão de implementação
+
+Product Implementation Readiness é o ponto em que a fábrica pergunta: “já temos SOT, método, pesquisa, arquitetura, packs, acesso, workers, reviewers e prova suficiente para deixar a execução material começar?”.
+
+Se essa resposta é fraca, a fábrica deve bloquear antes de gastar worker. Isso é mais barato do que descobrir no Receipt Five que o produto inteiro foi construído em cima de uma lacuna antiga.

--- a/docs/pt-BR/usage.md
+++ b/docs/pt-BR/usage.md
@@ -1,12 +1,10 @@
 # Uso
 
-Esta página é o primeiro caminho prático para um checkout local.
+Esta página é o caminho prático para um checkout local. Ela não finge que um checkout local é a mesma coisa que um runtime Hermes vivo, do operador. Primeiro ela dá uma prova segura. Depois mostra os checks que deveriam rodar antes de mexer em documentação pública ou em claims públicas.
 
 ## Requisitos
 
-- Python 3.11 ou mais novo.
-- Um checkout deste repositório.
-- Opcional: runtime Hermes se você quiser execução real com operador/workers. Checks locais do kernel não exigem runtime Hermes vivo.
+Você precisa de Python 3.11 ou mais novo e de um checkout do repositório. Um runtime Hermes vivo é opcional para validar o kernel local. Ele só vira obrigatório quando você quer execução real com operador e workers.
 
 ## Doctor local
 
@@ -15,7 +13,7 @@ cd factory
 python3 scripts/factoryctl.py doctor
 ```
 
-Um doctor passando checa metadata do pacote, estrutura do repositório, caminho mínimo de exemplo, superfície pública de CLI e prova local de V3 production activation. Ele pode avisar que o runtime Hermes não foi checado. Esse aviso é honesto: validação local não é prova E2E Hermes viva.
+Um doctor passando checa metadata do pacote, estrutura do repositório, exemplo mínimo, superfície pública de CLI e prova local de ativação V3. O comando pode avisar que o runtime Hermes não foi checado. Esse aviso está certo: validação local não é prova E2E Hermes viva.
 
 ## Minimal run
 
@@ -31,7 +29,21 @@ Wrote .tmp/quickstart-result.json
 PASS: wrote .tmp/quickstart-result.json
 ```
 
-Isso prova que o caminho público mínimo consegue materializar um artefato local válido.
+Isso prova que o caminho público mínimo consegue escrever um artefato local válido. Não prova que um produto real foi entregue.
+
+## Inspecione a fábrica em vez de chutar
+
+Use os registries executáveis quando quiser fatos:
+
+```bash
+cd factory
+python3 scripts/factoryctl.py route-registry
+python3 scripts/factoryctl.py method-engines
+python3 scripts/factoryctl.py operating-systems
+python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
+```
+
+Esses comandos são melhores do que ler prosa antiga, porque vêm da superfície real de implementação.
 
 ## Build do site de documentação
 
@@ -41,47 +53,42 @@ Da raiz do repositório:
 python3 -m mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/overkill-docs-site
 ```
 
-A documentação nasce para GitHub e já está estruturada para MkDocs.
-
-## Inspecionar o sistema de rotas
-
-```bash
-cd factory
-python3 scripts/factoryctl.py route-registry
-python3 scripts/factoryctl.py method-engines
-python3 scripts/factoryctl.py operating-systems
-```
-
-Use estes comandos quando quiser fatos da superfície executável em vez de prosa.
-
-## Compilar o workflow
-
-```bash
-cd factory
-python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
-```
-
-Isso produz o plano de fases usado pela documentação do ciclo.
+O site é pequeno de propósito: inglês, português e assets públicos. O arquivo técnico antigo fica em `factory/legacy-docs/` e não faz parte da navegação principal.
 
 ## Checks de segurança pública
 
-Antes de alterar docs ou claims públicas, rode pelo menos:
+Antes de alterar docs públicas ou claims públicas, rode:
 
 ```bash
 cd factory
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py
+python3 scripts/validate_worker_profiles.py
 python3 scripts/public_safety_scan.py
 python3 scripts/secret_safety_scan.py
+python3 scripts/generate_factory_reference_docs.py --check
 ```
 
-Se um check falhar, não descreva a superfície pública como pronta. Corrija o mismatch ou reporte a fronteira honestamente.
+`validate_public_surface_sync.py` checa se as superfícies públicas continuam alinhadas ao manifest. `validate_promise_implementation_map.py` checa se promessas públicas ainda têm referência de implementação e fronteira. `public_safety_scan.py` e `secret_safety_scan.py` protegem a fronteira pública do repositório.
 
-Saídas geradas em `.tmp/`, snapshots de validação, registros de piloto e provas locais são evidência de execução. Elas não devem ser commitadas como fonte pública, salvo quando um contrato público específico declarar que o artefato faz parte da superfície do repositório.
+Se um check falhar, não descreva a superfície pública como pronta. Corrija a divergência ou explique a fronteira honestamente.
+
+Saídas geradas em `.tmp/`, snapshots de validação, registros de piloto e provas locais são evidência de execução. Elas não devem ser commitadas como fonte pública, salvo quando um contrato público específico declarar que o artefato faz parte do repositório.
+
+## Validação local completa
+
+Para uma passada local mais profunda:
+
+```bash
+cd factory
+python3 -m unittest discover -s tests -p 'test_*.py' -q
+```
+
+É mais pesado do que o smoke público, mas é o check certo antes de uma mudança ampla em docs ou contratos.
 
 ## Uso com Hermes vivo
 
-Uma execução real exige um runtime Hermes do operador. O kernel público pode preparar e validar contratos, mas cards vivos, workers, comentários, workspaces, evidências e transições vivem no Hermes.
+Uma execução real exige um runtime Hermes do operador. O kernel público pode preparar contratos e validar caminhos locais de prova, mas cards vivos, workers, comentários, workspaces, evidências e transições vivem no Hermes.
 
-Não trate `doctor` ou `run minimal` como prova de que um produto real foi entregue.
+Não trate `doctor` ou `run minimal` como prova de que um produto foi entregue. Trate como prova de que este checkout está coerente o bastante para começar.

--- a/docs/pt-BR/usage.md
+++ b/docs/pt-BR/usage.md
@@ -92,3 +92,43 @@ python3 -m unittest discover -s tests -p 'test_*.py' -q
 Uma execução real exige um runtime Hermes do operador. O kernel público pode preparar contratos e validar caminhos locais de prova, mas cards vivos, workers, comentários, workspaces, evidências e transições vivem no Hermes.
 
 Não trate `doctor` ou `run minimal` como prova de que um produto foi entregue. Trate como prova de que este checkout está coerente o bastante para começar.
+
+## Checagem de um card real
+
+Depois do smoke mínimo, o próximo passo útil é validar um card específico. O exemplo público fica em `factory/examples/minimal-hermes-project/card.md`.
+
+```bash
+cd factory
+python3 scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
+python3 scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+python3 scripts/factoryctl.py status-snapshot --card examples/minimal-hermes-project/card.md --out .tmp/factory-status-snapshot.json
+```
+
+Isso mostra se o card tem campos obrigatórios, como risco e superfície foram roteados, que workers seriam exigidos e qual estado o operador veria. Ainda não é execução viva; é prova de contrato.
+
+## Antes de release público
+
+Mudança pública precisa de mais do que build de docs. Use os checks públicos, gere a referência quando necessário e não commite `.tmp` como prova pública. Para release real, a fronteira é mais alta: preflight, produção, rollback, published surface e evidência Hermes atual quando a claim falar de runtime vivo.
+
+O comando `validate_public_surface_sync.py --check-published` só deve ser usado quando o objeto público já foi publicado ou atualizado. Antes disso, ele pode corretamente dizer que o publicado está fora de sync.
+
+## Uso com Telegram ou Control Tower
+
+Telegram e Control Tower são interfaces de operador. Eles podem mostrar status, entregar pacote de decisão e receber resposta. Eles não aprovam release sozinhos, não substituem Hermes e não transformam evento de worker em conclusão.
+
+Se o operador usa português, status, cards visíveis e pacotes de decisão também devem falar português natural. Chaves de schema, logs e IDs internos podem continuar em inglês.
+
+## Preflight de release e produção
+
+Quando a pergunta deixa de ser “o checkout está coerente?” e vira “posso publicar ou promover?”, use uma camada mais forte:
+
+```bash
+cd factory
+python3 scripts/release_integration_preflight.py --out .tmp/release-check.json
+python3 scripts/factory_production_gate_receipts.py
+python3 scripts/factory_production_readiness.py --out .tmp/readiness-check.json
+python3 scripts/worktree_release_inventory.py --out .tmp/inventory-check.json
+```
+
+Esses comandos podem gerar recibos `BLOCKED`. Isso não é erro por si só. Muitas vezes é o resultado correto quando Hermes vivo, evidência privada, published surface, rollback ou readiness ainda não sustentam uma claim de produção.

--- a/docs/public-surface.manifest.json
+++ b/docs/public-surface.manifest.json
@@ -98,23 +98,6 @@
       }
     },
     {
-      "surface_id": "visual-map-v1.0.3-svg",
-      "path": "docs/assets/public-map/overkill-factory-map-v1.0.3.svg",
-      "surface_type": "static_visual_preview",
-      "authority_level": "conceptual_supporting_surface",
-      "source_refs": [
-        "docs/assets/public-map/overkill-factory-map-v1.0.3.html",
-        "docs/public-surface.manifest.json",
-        "docs/en/reference.md"
-      ],
-      "claim_checks": [
-        "metadata",
-        "source_refs_exist",
-        "risk_tiers",
-        "no_runtime_proof_claim"
-      ]
-    },
-    {
       "surface_id": "root-readme",
       "path": "README.md",
       "surface_type": "root_readme",

--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -38,7 +38,7 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Method engines | 8 | `templates/method-engine-registry.json` |
 | JSON schemas | 244 | `schemas/*.json` |
 | Templates | 161 | `templates/*` |
-| Public surfaces | 20 | `docs/public-surface.manifest.json` |
+| Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
 


### PR DESCRIPTION
## Summary
- Deepens the public bilingual product manual using the preserved legacy docs as factual input.
- Reworks the lifecycle page so each phase explains purpose, artifacts, gates, workers, shortcuts prevented, and operator view.
- Enriches the operating model with source resolution, five factory layers, Product SOT coverage, method contracts, capability packs, Product Face, Hermes graph rules, no-idle, bridge modes, and human gates.
- Improves Portuguese style so it reads as natural Brazilian Portuguese rather than literal technical translation.
- Adds clearer trust/evidence, usage, reference, and technical-model boundaries for local proof vs live Hermes/product delivery.

## Validation
- `git diff --check`
- `python3 -m mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/overkill-docs-legacy-depth-check3`
- `cd factory && python3 scripts/generate_factory_reference_docs.py --check`
- `cd factory && python3 scripts/validate_public_json_artifacts.py`
- `cd factory && python3 scripts/validate_public_surface_sync.py`
- `cd factory && python3 scripts/validate_promise_implementation_map.py`
- `cd factory && python3 scripts/validate_worker_profiles.py`
- `cd factory && python3 scripts/public_safety_scan.py`
- `cd factory && python3 scripts/secret_safety_scan.py`
- `cd factory && python3 scripts/factoryctl.py doctor`
- `cd factory && python3 scripts/factoryctl.py run minimal`
- `cd factory && python3 -m unittest tests.test_factory_bridge tests.test_open_source_docs tests.test_public_surface_sync tests.test_promise_implementation_map tests.test_generated_factory_reference_docs -q`
- `cd factory && python3 -m unittest discover -s tests -p 'test_*.py' -q` — 1225 tests OK, 1 skipped
