### PR TITLE
docs: rewrite Portuguese product manual voice

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,9 +21,9 @@ nav:
   - Português:
       - Início: pt-BR/index.md
       - Manual: pt-BR/manual.md
-      - Modelo Operacional: pt-BR/operating-model.md
-      - Ciclo da Fábrica: pt-BR/lifecycle.md
-      - Confiança e Evidência: pt-BR/trust-and-evidence.md
-      - Modelo Técnico: pt-BR/technical-model.md
+      - Como a fábrica trabalha: pt-BR/operating-model.md
+      - Confiança e prova: pt-BR/trust-and-evidence.md
+      - Ciclo simples: pt-BR/lifecycle.md
       - Uso: pt-BR/usage.md
+      - Modelo técnico: pt-BR/technical-model.md
       - Referência: pt-BR/reference.md

--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -1,34 +1,49 @@
 # Overkill Factory
 
-A Overkill Factory é uma fábrica de produto para trabalho com agentes. Não é um prompt grande, não é uma lista de tarefas e não é só uma casca em volta de um agente de código. Ela pega um pedido ainda meio cru e transforma isso em produção controlada: fonte, definição do produto, método, pacotes de trabalho, execução no Hermes, revisão, evidência, entrega ou bloqueio, e depois aprendizado.
+A Overkill Factory é uma fábrica para trabalho com agentes. Ela existe para uma situação bem concreta: você pede algo importante, o agente começa a trabalhar, tudo parece andar, mas ninguém consegue provar com segurança que o produto certo ficou pronto.
 
-O kernel público atual está na versão `3.0.2`. Ele expõe 26 fases compiladas, 14 classes de rota, 8 motores de método, 17 áreas de sistema operacional da fábrica, 40 workers públicos, 244 schemas JSON, 156 templates JSON e 97 arquivos de teste. Esses números não estão aqui para enfeitar. Eles mostram que esta documentação está presa ao repositório que roda, não a uma narrativa bonita.
+A fábrica tenta resolver isso sem transformar o operador em fiscal. O pedido entra. A fonte é preservada. A fábrica entende o produto, escolhe o caminho, divide o trabalho, roda pelo Hermes, cobra prova, revisa e só então entrega, bloqueia ou aprende.
 
-## Por que isso existe
+O objetivo é tornar a velocidade confiável. Não é fazer o agente correr mais; é fazer a corrida deixar rastro, prova e responsabilidade.
 
-Trabalho com agente costuma falhar de jeitos bem comuns. O agente começa cedo demais. O briefing está frouxo. O worker errado assume a tarefa. Um revisor diz "parece bom" sem reler a evidência. Um gate humano vira uma pergunta vaga no chat. Uma execução é marcada como pronta porque um arquivo existe, não porque o produto pedido ficou realmente usável.
+Isso é produção controlada.
 
-A Overkill Factory existe para tornar esses erros mais difíceis.
+## Leia como uma conversa
 
-O objetivo é tornar a velocidade confiável. Não adianta o agente ser rápido se a fábrica não sabe exatamente o que ele deve fazer, quem tem autoridade para fazer, qual prova precisa voltar e o que acontece quando a prova não aparece.
+Se você só quer entender o produto, leia assim:
 
-## A imagem simples
+1. [Manual](manual.md): o que é a fábrica e por que ela existe.
+2. [Como a fábrica trabalha](operating-model.md): o que acontece com um pedido por dentro.
+3. [Confiança e evidência](trust-and-evidence.md): como saber que "pronto" não é teatro.
+4. [Ciclo da fábrica](lifecycle.md): o caminho simples da ideia até entrega, bloqueio ou aprendizado.
 
-Um pedido entra na fábrica. Antes de sair fazendo, a fábrica protege a fonte: o que o operador pediu de verdade, que material existe, o que falta e o que não pode ser inventado. Depois ela cria a verdade do produto, escolhe um método, divide o trabalho em unidades pequenas, manda os workers certos pelo Hermes, checa os resultados e decide: entrega, bloqueia ou aprende.
+Depois disso, se quiser rodar ou manter o projeto:
 
-Por dentro isso é complexo. Tem que ser. Criar produto de verdade é complexo. Mas a experiência do operador deveria ser simples: pedir, ver o estado, receber decisões claras e exigir prova quando alguém disser que terminou.
+- [Uso](usage.md): comandos locais e fronteira do que eles provam.
+- [Modelo técnico](technical-model.md): como Hermes, workers, bindings, schemas e validadores se encaixam.
+- [Referência](reference.md): nomes, caminhos e comandos para consulta rápida.
 
-## Por onde começar
+## A versão curta
 
-Leia nesta ordem:
+A fábrica não deixa um agente sair fazendo só porque a tarefa parece clara.
 
-1. [Manual](manual.md), para entender a ideia sem jargão.
-2. [Modelo operacional](operating-model.md), para ver o que acontece numa execução.
-3. [Ciclo da fábrica](lifecycle.md), para acompanhar fase por fase.
-4. [Confiança e evidência](trust-and-evidence.md), para entender como a fábrica evita progresso falso.
-5. [Uso](usage.md), para rodar comandos agora.
+Ela precisa saber:
 
-Quem vai contribuir no código pode seguir para [Modelo técnico](technical-model.md) e [Referência](reference.md). Quem só quer entender o produto consegue parar no manual e no modelo operacional sem ficar perdido.
+- qual era a fonte;
+- que produto está sendo construído;
+- que tipo de trabalho é;
+- quem pode executar;
+- quem pode aprovar;
+- que prova precisa voltar;
+- o que acontece se a prova não vier.
+
+Sem isso, velocidade vira chute.
+
+## A fronteira honesta
+
+O kernel público atual está na versão `3.0.2`. Ele expõe 26 fases compiladas, 14 classes de rota, 8 motores de método, 17 áreas de sistema operacional da fábrica, 40 workers públicos, 244 schemas JSON, 156 templates JSON e 97 arquivos de teste.
+
+Esses números não são promessa de que qualquer produto privado foi entregue. Eles provam que existe um kernel público testável. Entrega real ainda precisa de Hermes vivo, worker results atuais, evidência específica do produto, revisão consumida e decisão humana quando o risco pedir.
 
 ## Primeira prova local
 
@@ -38,8 +53,8 @@ python3 scripts/factoryctl.py doctor
 python3 scripts/factoryctl.py run minimal
 ```
 
-Um teste local passando significa que o kernel público está coerente. Não significa que um produto privado foi entregue, que um runtime Hermes vivo está configurado, nem que um humano aprovou uma decisão de risco. A documentação deixa essa fronteira visível de propósito.
+Se isso passa, o checkout local está coerente. Ainda não significa que uma execução real terminou.
 
-## O que mudou nesta documentação
+## O que ficou fora da navegação principal
 
-A documentação antiga tinha valor para manutenção, mas parecia um conjunto de departamentos internos. A documentação atual é um manual de produto. O material antigo foi preservado em `factory/legacy-docs/` por histórico e compatibilidade. A árvore pública `docs/` agora é a explicação canônica.
+A documentação antiga continua em `factory/legacy-docs/`. Ela tem histórico e detalhe técnico útil, mas não é mais a explicação pública principal. A ideia desta seção em português é ser legível primeiro. O detalhe vem depois.

--- a/docs/pt-BR/lifecycle.md
+++ b/docs/pt-BR/lifecycle.md
@@ -1,447 +1,171 @@
 # Ciclo da fábrica
 
-O workflow compilado é a fonte factual desta página. Hoje ele contém `26` fases em `docs/factory-workflow.catalog.json`.
+Esta página estava complicada demais. O ciclo da fábrica não deveria parecer uma tabela técnica com inglês vazando por todos os lados.
 
-Esta página não deve ser lida como uma cachoeira rígida. Ela é um mapa do que a fábrica protege. Hermes, dependências, bloqueios, risco e evidência ainda decidem o que pode andar numa execução viva.
+O workflow compilado é a fonte factual para a máquina. Para o leitor, ele precisa virar uma história simples.
 
-A leitura prática é simples: cada fase responde uma pergunta, exige alguns artefatos, bloqueia atalhos perigosos e entrega ao operador uma visão mais clara do próximo passo.
+A ideia é mais simples: um pedido entra cru e só pode virar entrega depois de passar por alguns momentos de proteção.
+
+Não decore fase. Entenda o movimento.
+
+## O ciclo em linguagem humana
+
+```text
+pedido
+-> fonte protegida
+-> entendimento
+-> verdade do produto
+-> caminho escolhido
+-> trabalho dividido
+-> execução no Hermes
+-> prova e revisão
+-> decisão humana, se precisar
+-> entrega, bloqueio ou aprendizado
+```
+
+É isso.
+
+Por baixo existem fases, gates, workers e schemas. Eles importam para a máquina. Para o leitor, o mais importante é entender por que cada momento existe.
+
+## 1. Antes de começar: proteger a fonte
+
+A fábrica começa antes da execução.
+
+O operador pode mandar uma ideia, um documento, um bug, um link, um repo, uma conversa ou um pedido de release. A fábrica precisa guardar isso sem deformar.
+
+O erro comum é resumir cedo demais. Um resumo curto vira plano. O plano vira execução. Depois todo mundo descobre que a primeira interpretação estava errada.
+
+Então o começo da fábrica protege a fonte, cria o pedido inicial e diz qual runtime vai carregar o trabalho.
+
+Nome interno que aparece no workflow: F0 — Pre-Start / Sealed Source Envelope.
+
+## 2. Entender o que entrou
+
+Depois a fábrica pergunta: "que tipo de sinal é esse?"
+
+É produto novo? Bug? Incidente? Release? Segurança? UI? Integração? Migração? Trabalho em agente? Documentação?
+
+Ela também separa fato, palpite, decisão, conflito e lacuna. Isso é chato de fazer, mas salva a execução. Se essa separação não acontece, o agente começa a construir em cima de uma mistura perigosa.
+
+O operador deveria enxergar algo simples: "entendemos isto, falta aquilo, isso não podemos assumir".
+
+Aqui vivem as fases de entrada, source ledger, source resolution e descoberta.
+
+## 3. Definir a verdade do produto
+
+Antes de construir produto, a fábrica precisa dizer que produto é esse.
+
+Essa é a fase do Product SOT. Em português: a verdade do produto.
+
+Ela define escopo, não escopo, usuário, problema, critério de aceite, risco e prova. Se o trabalho é grande, também precisa cobrir o escopo inteiro. A primeira fatia não pode fingir ser o todo.
+
+O atalho perigoso aqui é executar a partir de uma conversa ou de um paper sem transformar aquilo em verdade revisável.
+
+Se a verdade do produto está fraca, o resto pode ficar bonito e ainda assim errado.
+
+## 4. Escolher a rota e o método
+
+Com a verdade na mesa, a fábrica escolhe o caminho.
+
+Bug não anda como release. Release não anda como tela. Segurança não anda como docs. Produto com interface não anda como backend puro. Mainnet, fundos e segredo não andam como tarefa comum.
+
+Rota responde: "que tipo de trabalho é esse?"
+
+Método responde: "como esse trabalho deve ser feito e provado?"
+
+O operador não precisa escolher engine interno. A fábrica escolhe e explica o suficiente para o humano confiar na direção.
+
+O atalho perigoso é começar arquitetura, PR ou worker packet antes de método claro.
+
+## 5. Checar capacidade, risco e autoridade
+
+Antes de execução material, a fábrica precisa perguntar:
+
+Temos o tipo certo de worker?
+
+Temos acesso?
+
+Tem orçamento?
+
+Tem risco de produção, mainnet, segredo, privacidade, carteira, assinatura ou dinheiro?
+
+Tem pacote de capacidade para esse tipo de produto?
+
+Se falta capacidade, bloqueia. Se a decisão é humana, prepara pacote. Se a decisão é da fábrica, a fábrica trabalha.
+
+Essa parte existe para impedir falsa competência. É melhor dizer "não tenho cobertura ainda" do que fingir especialista.
+
+## 6. Planejar o trabalho de verdade
+
+Agora o produto vira unidades pequenas.
+
+Uma unidade boa tem dono, reviewer, prova, dependência e regra de pronto. Se não tem isso, ainda é desejo, não trabalho.
+
+Aqui entram planos de desenvolvimento, grafo de specs, plano de loop, plano de criação do produto e prontidão de implementação.
+
+O atalho perigoso é mandar agentes trabalharem em paralelo sem saber quem depende de quem e que prova fecha cada pedaço.
+
+## 7. Rodar no Hermes
+
+Hermes é o chão da fábrica.
+
+Quando a execução começa, ela precisa aparecer como cards, dependências, workers, workspaces, comentários, bloqueios e transições no Hermes. A fábrica pode reconciliar e reparar, mas não pode esconder um segundo estado por fora.
+
+Se tem trabalho pronto, Hermes despacha. Se tem dependência, espera. Se o board fica silencioso sem motivo, no-idle repara ou falha de forma visível.
+
+O atalho perigoso é deixar um agente operar numa lista privada e depois tentar sincronizar a verdade no fim.
+
+## 8. Provar o que foi feito
+
+Worker que executa precisa devolver resultado com evidência.
+
+Dependendo do trabalho, evidência pode ser teste, diff, screenshot, transcript, log, scan, auditoria, simulação, pacote de release, proof remoto ou documento revisado.
+
+Produto visível precisa de prova visível. CLI precisa de transcript. Documentação precisa provar que leva o leitor ao primeiro sucesso. Segurança precisa de evidência de risco. Release precisa de rollback e prontidão.
+
+O atalho perigoso é tratar existência de arquivo ou pacote de worker como prova.
+
+## 9. Revisar e reconciliar
+
+Depois da execução vem a parte que muita gente pula: consumir a revisão.
+
+Revisão boa não é comentário solto. Ela passa ou falha algo específico. Se passa, destrava. Se falha, cria reparo. Se sobra risco, registra dono e decisão.
+
+Depois vem o Receipt Five, que amarra pedido, mudança, evidência, revisão e próximo estado.
+
+Sem isso, "feito" ainda é frágil.
+
+## 10. Chamar o humano quando a decisão é humana
+
+Algumas coisas não podem ser decididas por worker.
+
+Produção. Mainnet. Fundos. Segredos. Orçamento. Risco residual. Release. Waiver.
+
+Nesses casos, a fábrica precisa entregar um pacote de decisão. A pessoa recebe o material, a escolha, o risco, o que aprovar autoriza e o que não autoriza.
+
+O atalho perigoso é pedir "posso seguir?" sem entregar o artefato sob revisão.
+
+## 11. Entregar, bloquear ou aprender
+
+No final, só existem três saídas honestas.
+
+Entrega: a prova existe, a revisão foi consumida, os gates passaram e o próximo estado está claro.
+
+Bloqueio: falta prova, acesso, autoridade, capacidade ou segurança. O bloqueio precisa ter dono e próximo passo.
+
+Aprendizado: a execução mostrou que a própria fábrica precisa melhorar. Isso pode virar teste, doc, skill, worker, gate, issue ou mudança de processo.
+
+A fábrica não deve chamar tudo de sucesso. Às vezes a melhor resposta é um bloqueio bem explicado.
+
+## Onde entram as fases internas
+
+O workflow compilado ainda tem fases internas. Elas existem para a máquina e para os maintainers.
+
+A versão atual expõe 26 fases em `docs/factory-workflow.catalog.json`. Você pode inspecionar com:
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
 
-## F0 — Pre-Start / Sealed Source Envelope
-
-A fábrica separa conversa de execução. O material entra num envelope de fonte antes de virar card, para o primeiro resumo não destruir a intenção original.
-
-O que precisa existir: `factory_bridge_source_envelope`, `factory_bridge_start_request`.
-
-Gates que seguram o avanço: `Start Boundary`.
-
-Workers normalmente envolvidos: `overkill-factory-gerente`, `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- summarize or reinterpret source material in the bridge.
-- create Hermes board/card directly from bridge.
-- start without explicit runtime target policy.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F1 — Intake
-
-Aqui o pedido vira sinal classificado. A interface do operador, a conversa inicial e a resolução da fonte impedem que a fábrica comece com um chute bonito.
-
-O que precisa existir: `operator_interface_profile`, `factory_start_conversation`, `universal_signal_intake`, `source_refs`, `source_resolution_packet`.
-
-Gates que seguram o avanço: `Source Gate`.
-
-Workers normalmente envolvidos: `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- route implementation before source resolution.
-- create Product SOT from raw input.
-- require the operator to poll for status.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F2 — Source Ledger
-
-O source ledger diz de onde veio cada afirmação. Fato, inferência, decisão, conflito e lacuna não podem virar uma massa só.
-
-O que precisa existir: `source_refs`, `product_source_ledger`, `operator_understanding_confirmation`.
-
-Gates que seguram o avanço: `Source Gate`.
-
-Workers normalmente envolvidos: `source-ledger-worker`.
-
-Atalhos que esta fase impede:
-
-- ask user to reconcile internal source bookkeeping.
-- create outcome contract or Product SOT before understanding is confirmed.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F3 — Source Resolution
-
-A fábrica transforma fonte em entendimento operacional. Se ainda falta descoberta, ela segura o avanço em vez de deixar o worker preencher buraco com imaginação.
-
-O que precisa existir: `discovery_brief`.
-
-Gates que seguram o avanço: `Discovery Gate`.
-
-Workers normalmente envolvidos: `source-ledger-worker`, `product-sot-planner`.
-
-Atalhos que esta fase impede:
-
-- turn unresolved gaps into execution scope.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F4 — Product Outcome And Discovery
-
-O resultado esperado, o usuário, o problema e as hipóteses ficam explícitos. O operador precisa conseguir corrigir a direção antes de virar plano.
-
-O que precisa existir: `operator_understanding_confirmation`, `operator_briefing_package`, `outcome_contract`, `discovery_brief`.
-
-Gates que seguram o avanço: `Outcome Gate`, `Discovery Gate`.
-
-Workers normalmente envolvidos: `product-sot-planner`.
-
-Atalhos que esta fase impede:
-
-- treat outcome candidate as approved Product SOT.
-- draft Product SOT before operator understanding confirmation.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F5 — Product SOT
-
-O Product SOT vira a verdade do produto. Ele protege escopo, não-escopo, critérios de aceitação e cobertura completa antes de execução material.
-
-O que precisa existir: `product_sot`, `operator_briefing_package`, `full_product_sot_scope_coverage`, `factory_phase_lock`.
-
-Gates que seguram o avanço: `Product SOT Gate`.
-
-Workers normalmente envolvidos: `product-sot-planner`.
-
-Atalhos que esta fase impede:
-
-- execute from paper instead of Product SOT.
-- ask operator to approve Product SOT from a short chat summary only.
-- start architecture, repo cleanup, human gate or worker packet while Product SOT owner package is missing.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F6 — Agentic Method Router
-
-A rota escolhe o tipo de caminho: produto, bug, release, incidente, segurança, UX, analytics, integração ou agente. A fábrica para de tratar tudo como tarefa genérica.
-
-O que precisa existir: `factory_phase_lock`, `method_contract`.
-
-Gates que seguram o avanço: `Method Gate`.
-
-Workers normalmente envolvidos: `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- ask user to choose internal method machinery.
-- start architecture or repo cleanup before Method Contract.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F7 — Method Contract
-
-O método registra como o trabalho será feito e provado. Não basta dizer TDD, security-first ou design-first; o contrato precisa mudar artefatos, gates e evidência.
-
-O que precisa existir: `factory_phase_lock`, `method_contract`.
-
-Gates que seguram o avanço: `Method Gate`.
-
-Workers normalmente envolvidos: `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- start implementation with undocumented process choices.
-- materialize future-phase cards while active frontier is still product_sot or method_contract.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F8 — Pack And Product Experience Selection
-
-A fábrica confere se tem pacote de capacidade e prova de superfície para o tipo de produto. Web, CLI, docs, agente, Solana, mobile ou fintech não pedem a mesma prova.
-
-O que precisa existir: `capability_pack_contract`, `product_experience_plan`, `product_face_packet`, `project_design_system`, `professional_design_process`, `surface_evidence_profile`, `product_delivery_quality_profile`.
-
-Gates que seguram o avanço: `Pack Gate`, `Product Experience Gate`, `Surface Pack Gate`.
-
-Workers normalmente envolvidos: `product-face`, `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- activate a pack without proof or coverage.
-- start product-facing implementation before surface state coverage.
-- treat generic UI proof as Product Experience proof.
-- move to implementation with unnamed surface pack or proof profile.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F9 — Risk And Authority Gates
-
-Autoridade, acesso, orçamento e risco entram antes da execução sensível. Se a decisão pertence ao operador, a fábrica prepara pacote de decisão; se é reparo interno, não joga no humano.
-
-O que precisa existir: `access_capability`, `budget_contract`.
-
-Gates que seguram o avanço: `Access Gate`, `Budget Gate`, `Human Gate when required`.
-
-Workers normalmente envolvidos: `human-gate-clerk`.
-
-Atalhos que esta fase impede:
-
-- infer approval from silence.
-- ask for planning-only continuation approval.
-- ask for architecture or repo cleanup approval while downstream is frozen.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F10 — Security Architecture
-
-Segurança entra como arquitetura, não como scan no fim. Trust boundary, segredo, chave, supply chain, privacidade, onchain e rollback precisam aparecer cedo quando importam.
-
-O que precisa existir: `factory_phase_lock`, `security_architecture_plan`.
-
-Gates que seguram o avanço: `Security Architecture Gate`.
-
-Workers normalmente envolvidos: `security-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- build material risk before architecture.
-- start security architecture while Product SOT or Method Contract is still missing.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F11 — Executable Plans
-
-A arquitetura e os riscos viram plano de desenvolvimento. O objetivo é sair da ideia para unidades executáveis sem perder dependências e critérios de parada.
-
-O que precisa existir: `software_development_plan`, `spec_graph`, `loop_plan`, `product_creation_plan`.
-
-Gates que seguram o avanço: `Ready Gate`.
-
-Workers normalmente envolvidos: `decomposition-planner`.
-
-Atalhos que esta fase impede:
-
-- execute before plans, coverage review and stop criteria exist.
-- mark decomposition review as passed from the planner that created the decomposition.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F12 — Autonomy Readiness
-
-O produto é quebrado em work units. Cada pedaço precisa de dono, reviewer, prova, dependência e regra de pronto; do contrário vira fila de agente solta.
-
-O que precisa existir: `decomposition_coverage_review`, `product_implementation_readiness`, `autonomy_readiness_packet`.
-
-Gates que seguram o avanço: `Decomposition Coverage Gate`, `Access & Capability Gate`.
-
-Workers normalmente envolvidos: `independent-reviewer`, `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- start autonomous work with missing review, access or limits.
-- let a single reviewer approve the complete decomposition alone.
-- create Product Implementation Readiness from a failed or missing decomposition coverage review.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F13 — Ready Gate
-
-Antes de rodar, a fábrica checa prontidão de implementação: SOT, método, research, arquitetura, packs, acesso, workers e provas necessárias.
-
-O que precisa existir: `gate_report`.
-
-Gates que seguram o avanço: `Ready Gate`.
-
-Workers normalmente envolvidos: `factory-orchestrator`.
-
-Atalhos que esta fase impede:
-
-- dispatch blocked workers.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F15 — Runtime Execution
-
-Workers executam escopos pequenos e devolvem resultado estruturado. O resultado precisa trazer evidência, limite de autoridade e próximo estado.
-
-O que precisa existir: `worker_packets`.
-
-Gates que seguram o avanço: `Runtime Gate`.
-
-Workers normalmente envolvidos: `implementation-worker`, `qa-verification-worker`.
-
-Atalhos que esta fase impede:
-
-- spawn without route readiness.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F16 — Worker Results
-
-A fábrica roda verificação objetiva: testes, scans, screenshots, jornadas, logs, contratos ou provas remotas, conforme o tipo de trabalho.
-
-O que precisa existir: `worker_results`.
-
-Gates que seguram o avanço: `Done Gate`.
-
-Workers normalmente envolvidos: `evidence-reconciler`.
-
-Atalhos que esta fase impede:
-
-- treat packet existence as proof.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F17 — Verification
-
-Revisão independente consome o artefato real. Pass sem leitura, reviewer igual executor ou achado sem reparo são progresso falso.
-
-O que precisa existir: `verification_plan`, `verification_result`.
-
-Gates que seguram o avanço: `Verification Gate`.
-
-Workers normalmente envolvidos: `qa-verification-worker`.
-
-Atalhos que esta fase impede:
-
-- claim done without command evidence.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F18 — Independent Review
-
-Receipt Five reconcilia pedido, mudança, evidência, revisão e pendências. É a passagem entre “mexeu” e “provou”.
-
-O que precisa existir: `review_result`.
-
-Gates que seguram o avanço: `Review Gate`.
-
-Workers normalmente envolvidos: `independent-reviewer`.
-
-Atalhos que esta fase impede:
-
-- allow executor to self-approve.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F20 — Closure Summary
-
-Handoff guarda estado reproduzível para pausa, troca de operador ou retomada. Não é aprovação; é transferência honesta de contexto e evidência.
-
-O que precisa existir: `closure_summary`.
-
-Gates que seguram o avanço: `Closure Gate`.
-
-Workers normalmente envolvidos: `handoff-packer`.
-
-Atalhos que esta fase impede:
-
-- hide unresolved blockers in prose.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F21 — Receipt Five
-
-A auditoria de conclusão compara obrigações com provas entregues. Ela fecha quando bate e bloqueia quando falta algo.
-
-O que precisa existir: `receipt_five`.
-
-Gates que seguram o avanço: `Done Gate`.
-
-Workers normalmente envolvidos: `evidence-reconciler`.
-
-Atalhos que esta fase impede:
-
-- mark done without Receipt Five.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F22 — Completion Audit
-
-Operações de produção verificam dono, ambiente, monitoramento, rollback, incidentes e canal de release. Produto vivo precisa chão operacional.
-
-O que precisa existir: `completion_audit`.
-
-Gates que seguram o avanço: `Completion Audit`.
-
-Workers normalmente envolvidos: `evidence-reconciler`.
-
-Atalhos que esta fase impede:
-
-- close skipped method or evidence requirements.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F23 — Production Operations
-
-Release só acontece com promoção, evidência e autoridade. Se a prova não sustenta, a decisão correta é bloquear.
-
-O que precisa existir: `production_readiness_plan`.
-
-Gates que seguram o avanço: `Release Gate`.
-
-Workers normalmente envolvidos: `release-ops-worker`.
-
-Atalhos que esta fase impede:
-
-- release without owner, rollback or approval.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F24 — Release Or Block
-
-Depois da entrega, monitoramento e suporte mantêm o produto observável. Incidente não vira improviso; vira rota.
-
-O que precisa existir: `release_decision`.
-
-Gates que seguram o avanço: `Release Gate`, `Human Gate when required`.
-
-Workers normalmente envolvidos: `release-ops-worker`, `human-gate-clerk`.
-
-Atalhos que esta fase impede:
-
-- promote without production-strict evidence.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F25 — Monitoring Support
-
-Learnback transforma falhas repetidas em docs, testes, skills, gates ou issues. A fábrica aprende, mas não se altera em silêncio.
-
-O que precisa existir: `incident_support_plan`.
-
-Gates que seguram o avanço: `Support Gate`.
-
-Workers normalmente envolvidos: `release-ops-worker`.
-
-Atalhos que esta fase impede:
-
-- ship without support owner when support is material.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F26 — Learnback
-
-A auditoria de maturidade pergunta se o método escolhido foi bom o bastante. É a defesa contra uma fábrica que segue processo e mesmo assim escolhe processo fraco.
-
-O que precisa existir: `factory_learning_proposal`.
-
-Gates que seguram o avanço: `Learning Gate`.
-
-Workers normalmente envolvidos: `skill-eval-distiller`.
-
-Atalhos que esta fase impede:
-
-- auto-activate critical factory changes.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
-
-## F27 — Factory Maturity Audit
-
-A auditoria final olha a própria fábrica: cobertura, gaps, confiabilidade, operadores, workers e regras que precisam evoluir.
-
-O que precisa existir: `factory_maturity_scorecard`.
-
-Gates que seguram o avanço: `Maturity Gate`.
-
-Workers normalmente envolvidos: `skill-eval-distiller`.
-
-Atalhos que esta fase impede:
-
-- commit raw study or private evidence.
-
-O operador não deveria precisar ler o JSON dessa fase para entender a situação. A projeção humana precisa dizer o que já está claro, o que falta, quem é dono do próximo passo e qual prova destrava o avanço.
+Mas para ler o produto, use o ciclo simples desta página. As fases internas são o mecanismo. O movimento humano é: entender, organizar, executar, provar e fechar.

--- a/docs/pt-BR/manual.md
+++ b/docs/pt-BR/manual.md
@@ -1,99 +1,204 @@
 # Manual do produto
 
-A Overkill Factory fica mais fácil de entender quando começamos pelo problema que ela resolve.
+Se você me perguntasse no chat "o que é a Overkill Factory?", eu não começaria falando de schema, worker, registry ou fase.
 
-Uma pessoa pede alguma coisa: criar um produto, corrigir um bug, revisar uma mudança arriscada, preparar um release, tratar um incidente, melhorar um worker ou transformar uma ideia num sistema funcionando. Em muitos fluxos com agentes, isso vira uma instrução grande. O agente tenta ajudar, começa a trabalhar e vai mandando status. Às vezes dá certo. Muitas vezes vira movimento sem controle.
+Eu começaria assim: é uma forma de fazer agentes trabalharem sem virar bagunça.
 
-A Overkill Factory trata trabalho de produto como produção controlada. A fábrica não joga um "se vira" para o agente. Ela preserva a fonte, define o produto, escolhe o método, divide o trabalho, executa pelo Hermes, verifica evidência e fecha com recibo.
+Você pede uma coisa. Pode ser um produto novo, uma correção, um release, uma revisão de segurança, uma tela, um fluxo, uma integração, uma operação em produção. Um agente comum tenta resolver direto. Às vezes acerta. Muitas vezes ele parece ocupado, escreve bastante, move alguma coisa, entrega um resumo bonito e deixa o problema real no mesmo lugar.
 
-## O que "fábrica" quer dizer aqui
+A Overkill Factory existe para evitar esse teatro.
 
-Fábrica não é sinônimo de burocracia. Quer dizer que existe uma linha de produção. O trabalho entra por um lado e precisa passar por estados que protegem o operador.
+Ela transforma um pedido em produção controlada. Primeiro entende a fonte. Depois define o produto. Depois escolhe o caminho. Depois divide o trabalho. Depois manda os workers certos pelo Hermes. Depois cobra prova. Depois revisa. Depois fecha, bloqueia ou aprende.
 
-Um pedido de produto não deveria pular direto para implementação se ninguém resolveu a fonte. Um release não deveria sair porque o executor disse que está pronto. Uma mudança sensível de segurança não deveria pular arquitetura. Um gate humano não deveria ficar escondido num comentário de chat. Um worker não deveria aprovar o próprio trabalho.
+Isso é a fábrica.
 
-Isso é produção controlada. É a diferença entre "um agente mexeu nisso" e "a fábrica consegue explicar o que aconteceu, por que aconteceu, quem tinha autoridade e qual evidência prova o resultado".
+## O problema que ela resolve
 
-## A experiência do operador
+O problema não é "agente erra". Isso todo mundo já sabe.
 
-O operador não deveria ter que cuidar da fábrica como babá. Ele não deveria precisar perceber que um worker foi raso, que uma revisão nunca foi consumida, ou que um bloqueio era na verdade trabalho da própria fábrica. A fábrica é dona do processo. O humano é dono das decisões reais.
+O problema é pior: agente erra de um jeito que parece certo.
 
-Uma boa execução se parece com isto:
+Ele escreve um arquivo, mas o arquivo não resolve o pedido. Ele passa um teste, mas o teste não cobre o comportamento importante. Ele diz que revisou, mas não leu o artefato certo. Ele marca uma tarefa como pronta, mas a evidência não existe. Ele pede aprovação humana, mas não entrega o material que a pessoa precisa aprovar.
 
-- o operador entrega um objetivo ou material de origem;
-- a fábrica diz o que entendeu e o que falta;
-- a fábrica cria uma definição de produto que pode ser revisada;
-- o trabalho é quebrado em partes pequenas o bastante para um worker terminar e provar;
-- o Hermes guarda o estado vivo;
-- revisões são independentes quando o risco pede;
-- gates humanos chegam como pacotes de decisão, não como interrupções vagas;
-- a conclusão vem com Receipt Five, não com uma mensagem animada dizendo "pronto".
+Aí o operador vira fiscal. Tem que perguntar: isso está mesmo pronto? Quem revisou? Onde está a prova? Esse bloqueio é meu ou é trabalho da fábrica? Esse "pass" vale alguma coisa?
 
-## A camada de verdade do produto
+Esse é o trabalho que a fábrica precisa tirar das costas do operador.
 
-O artefato mais importante é a verdade do produto. A fábrica chama isso de Product SOT, porque é a fonte de verdade do produto. O nome é técnico, mas a ideia é simples: antes de construir, todo mundo precisa saber que produto está sendo construído.
+## A ideia em uma frase
 
-Um Product SOT precisa dizer o que foi pedido, o que entra no escopo, o que fica fora, quais riscos importam, que evidência vai contar e o que tornaria o trabalho inaceitável. Sem isso, a fábrica não consegue escolher método nem distribuir workers com segurança.
+A fábrica não deixa um pedido virar execução antes de virar verdade, método, trabalho pequeno e prova.
 
-É aqui que muitos sistemas com agentes escorregam. Eles transformam um briefing grande num resumo curto e depois constroem a partir do resumo. A Overkill Factory foi desenhada para evitar isso. Resumo não é verdade do produto. Palpite útil não é verdade do produto. A verdade do produto precisa vir da fonte e precisa ser revisada quando o risco pede.
+Essa frase é o centro do produto.
 
-## Métodos são escolhidos, não improvisados
+Sem verdade, o agente constrói em cima de mal-entendido.
 
-Trabalhos diferentes pedem métodos diferentes. Bug precisa de reprodução e prova de regressão. Produto novo precisa de definição e cobertura de escopo. Release precisa de prontidão, rollback e aprovação. Mudança de segurança precisa de arquitetura, ameaça e evidência.
+Sem método, todo pedido vira a mesma tarefa genérica.
 
-O registro de rotas e os motores de método deixam isso explícito. Hoje a fábrica tem 14 classes de rota e 8 motores de método. A ideia não é impressionar com uma lista grande. A ideia é impedir que todo pedido seja tratado do mesmo jeito.
+Sem trabalho pequeno, ninguém sabe revisar.
 
-Quando o método está certo, o worker recebe um pacote limitado. Ele sabe a tarefa, os limites, a evidência esperada e a autoridade que ele não tem. Isso torna a autonomia mais segura. O worker pode andar rápido dentro da faixa porque a faixa está clara.
+Sem prova, "pronto" é só uma opinião.
+
+## O que entra na fábrica
+
+Pode entrar quase qualquer sinal de trabalho:
+
+- "cria esse produto";
+- "corrige esse bug";
+- "prepara esse release";
+- "revisa essa mudança perigosa";
+- "descobre por que isso parou";
+- "transforma esse repo em algo publicável";
+- "faz essa tela ficar usável";
+- "prepara um fluxo com carteira, assinatura ou dinheiro";
+- "melhora esse worker porque ele está sendo raso".
+
+A fábrica não deveria responder a tudo com a mesma receita. Bug precisa de reprodução. Release precisa de rollback. Interface precisa de prova visual. Segurança precisa de arquitetura. Produto novo precisa de verdade de produto. Mainnet, fundos, segredos e produção precisam de autoridade humana explícita.
+
+## A primeira obrigação: entender antes de fazer
+
+Quando o pedido entra, a fábrica precisa proteger a fonte.
+
+Isso quer dizer: guardar o que foi pedido de verdade, separar fato de suposição, marcar conflito, listar lacuna e dizer o que ainda não pode ser assumido.
+
+Parece básico. Não é. É onde muito trabalho com agente começa a morrer.
+
+Um resumo malfeito vira plano. Um plano malfeito vira execução. Uma execução malfeita vira uma entrega que parece pronta, mas nasceu torta.
+
+A fábrica tenta quebrar essa sequência logo no começo.
+
+## A verdade do produto
+
+Depois da fonte vem a verdade do produto. O nome interno é Product SOT. Pode esquecer o nome por um segundo. A pergunta é simples:
+
+"Que produto estamos construindo, exatamente?"
+
+Não basta dizer "um dashboard", "um app", "um onboarding" ou "um agente". A fábrica precisa saber para quem é, que problema resolve, o que entra, o que fica fora, quais promessas precisam ser cumpridas, que risco existe e que prova vai contar.
+
+Sem isso, um worker pode trabalhar muito e ainda entregar a coisa errada.
+
+Quando o trabalho é um produto inteiro, a fábrica também precisa olhar a cobertura do escopo. A primeira fatia prática não pode virar "o produto" só porque foi a parte mais fácil de executar. Cada promessa importante precisa ter destino: planejada, bloqueada com dono, fora de escopo com justificativa, decidida pelo humano ou provada.
+
+## A fábrica escolhe o caminho
+
+Depois de entender o produto, a fábrica escolhe o caminho.
+
+Um bug não anda como um release. Um release não anda como uma tela. Uma tela não anda como uma mudança de chave. Uma integração crítica não anda como uma alteração de texto.
+
+A fábrica tem rotas e métodos para isso. O leitor não precisa decorar os nomes. O ponto é outro: a fábrica precisa escolher a régua certa antes de distribuir trabalho.
+
+Se é bug, cadê a reprodução?
+
+Se é produto, cadê a definição?
+
+Se é interface, cadê a jornada e os estados?
+
+Se é segurança, cadê a ameaça e a fronteira?
+
+Se é produção, cadê rollback, dono e monitoramento?
+
+Essa escolha muda o que será pedido aos workers e muda o que vai contar como prova.
+
+## Workers não são personagens
+
+Um worker não deveria ser "um agente esperto com um prompt bom".
+
+Na fábrica, worker é papel com limite. Ele recebe um pacote pequeno dizendo o que fazer, o que não fazer, o que devolver e que autoridade ele não tem.
+
+Isso vale para quem planeja, quem constrói, quem testa, quem revisa, quem faz segurança, quem prepara release, quem reconcilia evidência e quem registra decisão humana.
+
+O worker pode ter autonomia dentro da faixa. Fora da faixa, ele bloqueia.
+
+Esse limite é o que permite velocidade sem entregar o volante inteiro para o agente.
 
 ## Hermes é o chão da fábrica
 
-O Hermes é onde o estado vivo mora. Cards, dependências, comentários, workspaces, workers, bloqueios e transições pertencem a ele. A Overkill Factory define o método de produção e os checks. O Hermes roda o chão da fábrica.
+O Hermes guarda o estado vivo: cards, dependências, workers, comentários, workspaces, bloqueios e transições.
 
-Essa separação é importante. Se a fábrica tentasse virar um segundo Hermes, ela criaria outro estado escondido. Se o Hermes guardasse o estado mas a fábrica ignorasse método e evidência, os workers moveriam cards sem disciplina de produto. O desenho é separado de propósito: Hermes controla o estado vivo; Overkill Factory controla o contrato de produção.
+A Overkill Factory não tenta substituir isso. Ela define o contrato de produção: que artefatos precisam existir, que gates bloqueiam, que worker entra, que prova precisa voltar, que decisão é humana e o que não pode ser autorizado por um agente.
+
+Essa separação é saudável.
+
+Hermes mostra o que está acontecendo.
+
+A fábrica diz o que pode acontecer com segurança.
 
 ## Pronto quer dizer provado
 
-A fábrica é rígida com conclusão porque trabalho com agente pode parecer convincente mesmo quando está errado. Um arquivo pode existir e não servir. Um teste pode passar e ainda não cobrir o produto. Um revisor pode aprovar sem checar a coisa certa. Um worker pode dizer que terminou e esquecer o artefato.
+Aqui está a regra mais importante: pronto quer dizer provado.
 
-O Receipt Five existe para evitar isso. Ele registra o que foi pedido, o que foi feito, qual evidência prova, quem revisou, o que ainda está arriscado ou bloqueado e qual é o próximo estado. Se essa evidência não existe, a resposta honesta não é "pronto". É bloqueado, incompleto ou pronto para revisão.
+Não quer dizer "o worker disse que terminou".
 
-## O que este projeto não é
+Não quer dizer "um arquivo apareceu".
 
-A Overkill Factory não tenta fingir que produto é simples. Ela tenta colocar a complexidade no lugar certo. O operador vê estado claro e decisões reais. Os workers recebem pacotes exatos. O código carrega schemas e testes. A documentação pública explica o suficiente para uma pessoa nova confiar no sistema sem ler cada arquivo interno.
+Não quer dizer "o teste que ele mesmo escolheu passou".
 
-Esse é o nível esperado do projeto: simples por fora, rigoroso por dentro e honesto na fronteira.
+Não quer dizer "alguém aprovou no chat sem ver o material".
 
-## Um exemplo concreto
+Pronto quer dizer que a fábrica consegue apontar para o pedido, para a mudança, para a evidência, para a revisão e para o próximo estado.
 
-Imagine que o operador diga: "Crie o fluxo de onboarding do cliente." Um sistema fraco com agentes talvez comece a desenhar telas imediatamente. A fábrica não deveria fazer isso.
+O nome interno desse recibo é Receipt Five. Ele não é burocracia. Ele é o freio contra conclusão falsa.
 
-Primeiro ela precisa entender o que "cliente" quer dizer naquele produto, o que o onboarding deve resolver, que contas ou permissões existem, o que o usuário precisa ver, o que precisa ser registrado e o que conta como uma primeira execução bem-sucedida. Se o produto já tem design system, a fábrica deve consumir isso. Se o fluxo toca dinheiro, identidade, custódia ou dados de produção, os gates de risco mudam.
+## Quando o humano entra
 
-Só depois implementação faz sentido. Um worker de frontend pode receber um pacote. Um worker de backend pode receber outro. Um worker de Product Face talvez precise devolver screenshots e prova por viewport. QA pode precisar de teste de jornada. Um reviewer pode precisar comparar o resultado com o Product SOT. O operador não deveria coordenar tudo isso na mão.
+O humano entra quando a decisão é realmente dele.
 
-Esse é o valor prático da fábrica. Ela transforma um pedido vago em pedaços pequenos, revisáveis e sustentados por evidência.
+Produção. Mainnet. Fundos. Segredos. Orçamento. Risco material. Release. Waiver. Mudança que pode afetar cliente, dinheiro, segurança ou reputação.
 
-## O que a fábrica tira das costas do operador
+Mas a fábrica não deveria chamar o humano para resolver bagunça interna. Se falta readback, se falta PDF, se falta artefato, se falta revisão, se um worker foi raso, isso é trabalho da fábrica.
 
-A promessa prática é autonomia com responsabilidade. O operador traz direção, contexto, restrições e decisões reais. Ele não deveria virar coordenador manual de source ledger, Product SOT, worker packet, review, proof, release e learnback.
+Quando existe gate humano de verdade, ele precisa vir como pacote de decisão. Uma mensagem curta, em português claro, dizendo:
 
-Quando a fábrica funciona bem, ela antecipa o que normalmente viraria cobrança humana:
+- que decisão está sendo pedida;
+- que material está em revisão;
+- o que aprovar permite;
+- o que aprovar não permite;
+- quais são as opções;
+- qual é o risco;
+- qual é o próximo passo seguro.
 
-- percebe que a fonte está incompleta antes de começar;
-- transforma o pedido em definição de produto revisável;
-- escolhe a rota certa para bug, feature, release, incidente, segurança, UX ou agente;
-- cria pacotes pequenos em vez de uma missão gigante;
-- cobra prova do worker que executou;
-- chama review independente quando o risco pede;
-- prepara gate humano com artefato legível quando a decisão é do operador;
-- bloqueia com motivo claro quando falta acesso, autoridade, evidência ou segurança.
+JSON cru não é gate humano. Pergunta vaga no chat também não.
 
-Isso muda a relação com agentes. O humano deixa de ser fiscal de preguiça do sistema e volta a ser dono do produto e das decisões importantes.
+## Um exemplo simples
 
-## A recepção pode ser simples; o contrato por trás não pode ser fraco
+Você pede: "cria o onboarding do cliente".
 
-Telegram, Discord, cockpit ou CLI podem ser a porta de entrada. O operador pode começar com uma frase curta, um documento, um repo, um bug ou um objetivo de negócio. A conversa deve ser simples.
+Um agente comum pode começar a desenhar tela.
 
-Mas simplicidade na entrada não significa informalidade na execução. Atrás da conversa, a fábrica precisa montar fonte, escopo, método, gates, workers e evidência. Se ela pula isso, só trocou formulário por chat e continua frágil.
+A fábrica deveria parar e perguntar, mesmo que internamente:
 
-Por isso a fábrica separa o gerente, que fala com o operador, do orquestrador, que cuida de rota e runtime. O operador recebe status e decisões em linguagem humana. O Hermes e os contratos guardam o estado real.
+Quem é o cliente? O que ele precisa conseguir fazer no primeiro uso? Tem conta? Tem permissão? Tem carteira? Tem pagamento? Tem dado sensível? Tem design pronto? O que conta como sucesso? O que não entra agora?
+
+Depois disso, a fábrica separa o trabalho:
+
+- alguém define a verdade do fluxo;
+- alguém planeja a experiência;
+- alguém implementa a tela;
+- alguém implementa API ou dados, se houver;
+- alguém testa a jornada;
+- alguém olha a prova visual;
+- alguém revisa;
+- alguém fecha com evidência.
+
+O operador não deveria coordenar tudo isso na mão. Ele deveria receber o estado claro e ser chamado apenas quando houver decisão real.
+
+## O que a fábrica ainda precisa provar
+
+A documentação pública prova a intenção e o contrato do kernel. Os testes locais provam que o repositório está coerente.
+
+Isso não é a mesma coisa que dizer que uma execução privada, num Hermes vivo, entregou um produto específico.
+
+Para isso, precisa de estado real no Hermes, worker results atuais, evidência do produto, revisão consumida e decisão humana quando o risco pedir.
+
+Essa fronteira é importante. A fábrica não fica mais fraca por dizer isso. Ela fica mais confiável.
+
+## Se você só lembrar de uma coisa
+
+A Overkill Factory é uma tentativa de transformar agentes em linha de produção confiável.
+
+Não é mágica. Não é um agente único. Não é um prompt gigante.
+
+É um jeito de impedir que velocidade vire chute.
+
+Pedido entra. A fábrica entende, organiza, executa, prova, revisa e fecha.
+
+Quando não consegue provar, ela não finge. Ela bloqueia e diz o que falta.

--- a/docs/pt-BR/operating-model.md
+++ b/docs/pt-BR/operating-model.md
@@ -1,130 +1,154 @@
-# Modelo operacional
+# Como a fábrica trabalha
 
-Esta página acompanha a vida de um pedido dentro da fábrica. A pergunta central não é “qual script roda?”, mas “como um pedido vira trabalho seguro, provado e revisável?”.
+A melhor forma de entender a Overkill Factory é acompanhar um pedido por dentro.
 
-Um pedido começa como sinal. Pode ser uma ideia de produto, um bug, um release, um incidente, uma tela, uma integração, uma auditoria, uma mudança em agente ou uma melhoria na própria fábrica. A resposta errada é sair fazendo. A resposta certa é preservar a fonte, entender o tipo de trabalho, escolher o método e só então executar.
+Imagine que você manda uma mensagem: "quero transformar essa ideia num produto". Ou "esse release pode ir?". Ou "corrige esse fluxo". A fábrica não deveria sair correndo para codar. O primeiro trabalho dela é descobrir que tipo de pedido entrou e o que precisa ser verdade antes de qualquer agente tocar no produto.
 
-## 1. O pedido entra pela porta certa
+## 1. Entrada não é execução
 
-A fábrica pode conversar com o operador por Telegram, Discord, cockpit, CLI ou outro canal. Mas o canal é só a recepção. Ele não é a fonte de verdade.
+A conversa pode começar no Telegram, no Discord, no cockpit, no terminal ou em outro canal. Isso é só a porta de entrada.
 
-O operador entrega material, objetivo, restrições e decisões quando elas são realmente dele. A fábrica deve cuidar do resto: registrar fonte, separar fato de inferência, montar Product SOT, escolher rota, criar worker packets, acompanhar Hermes, cobrar evidência, pedir review, preparar gates humanos e fechar com Receipt Five.
+A porta recebe material, pergunta, arquivo, link, repo, imagem, bug, decisão. Mas ela não decide sozinha o que vai ser feito. Ela não é o runtime. Ela não é a verdade.
 
-Isso tira trabalho das costas do operador. Ele não deveria ter que perceber que um worker foi raso, que a revisão não foi consumida, que o board parou por preguiça de processo ou que faltava pacote de decisão. Se isso acontece, é falha da fábrica.
+A função da entrada é criar um começo seguro: guardar a fonte, registrar o objetivo, separar o que já está claro do que ainda precisa ser resolvido e impedir que a primeira interpretação vire plano definitivo.
 
-## 2. A fonte é protegida antes do plano
+É aqui que o gerente aparece. O gerente fala com o operador. Ele traduz estado, pede decisão quando precisa e entrega pacotes legíveis. Ele não substitui os workers nem o Hermes.
 
-O primeiro artefato importante é o envelope de fonte. Ele preserva o que chegou antes da fábrica resumir, interpretar ou decompor. Depois vem o source ledger, que separa cinco coisas que agentes costumam misturar:
+## 2. A fábrica separa fato, palpite e decisão
 
-- fato vindo da fonte;
-- inferência razoável;
-- decisão já tomada;
-- conflito entre fontes;
-- lacuna que ainda precisa ser resolvida.
+Logo no começo, a fábrica precisa responder:
 
-Essa separação parece simples, mas muda tudo. Sem ela, um resumo curto vira “verdade” e o produto começa torto.
+"O que sabemos de verdade?"
 
-## 3. A fábrica trabalha em cinco camadas
+Ela separa:
 
-A documentação legada tinha um bom mapa que continua atual. A fábrica opera em cinco camadas:
+- o que veio da fonte;
+- o que é inferência;
+- o que já foi decidido;
+- o que está em conflito;
+- o que ainda está faltando.
 
-1. Camada de verdade: fonte, source resolution, Product SOT, decisões, conflitos e lacunas.
-2. Camada de método e planejamento: rota, método, arquitetura, Product Creation Plan, Product Experience Plan, dados, evals e loop plan.
-3. Camada de risco, autoridade, acesso e custo: risco, orçamento, segredos, produção, mainnet, privacidade, compliance e gates humanos.
-4. Camada de execução e evidência: Hermes, worker packets, worker results, Product Face, QA, review, proof remoto e Receipt Five.
-5. Camada de operação e aprendizado: release, monitoramento, suporte, incidente, learnback e auditoria de maturidade.
+Essa separação é o chão de tudo. Se a fábrica mistura essas coisas, o resto fica contaminado. Um palpite vira requisito. Uma lacuna vira escopo. Uma decisão antiga vira regra atual.
 
-A utilidade desse mapa é mostrar que “fazer a tarefa” é só uma parte. A fábrica também precisa saber se a tarefa certa foi escolhida, se havia autoridade, se o produto foi provado e se a própria fábrica aprendeu algo.
+Quando a fábrica faz isso direito, o operador consegue corrigir cedo. Quando faz errado, o operador só percebe tarde, quando já tem código, docs, PR e desculpa.
 
-## 4. A rota escolhe o peso certo
+## 3. Antes de plano, vem verdade do produto
 
-Rotas são a forma da fábrica dizer: este pedido não é igual aos outros.
+A fábrica precisa montar a verdade do produto antes de mandar execução material.
 
-Um bug precisa de reprodução e regressão. Um produto novo precisa de Product SOT e cobertura de escopo. Um release precisa de prontidão, rollback e dono. Um incidente precisa de severidade, mitigação e learnback. Uma integração crítica precisa de contrato, fallback e teste. Uma mudança de segurança precisa de arquitetura e review. Uma tela precisa de Product Face, estados, jornada e prova visual.
+O nome interno é Product SOT. Em português simples: é o documento que diz "é isto que estamos construindo".
 
-A fábrica tem quatorze classes de rota. O detalhe exato fica nos registries, mas a ideia pública é esta: cada tipo de trabalho ganha gates e provas diferentes. Isso impede que o mesmo agente genérico trate documentação, mainnet, UI, release e incidente como se fossem variações da mesma tarefa.
+Ele precisa deixar claro:
 
-## 5. Product SOT é verdade do produto, não papel bonito
+- qual é o produto ou fatia;
+- para quem serve;
+- que problema resolve;
+- o que entra;
+- o que não entra;
+- que risco existe;
+- que prova conta como aceite;
+- que decisão ainda depende do operador.
 
-Product SOT é a definição revisável do produto. Ele deve dizer o que entra, o que não entra, quais usuários importam, quais promessas precisam ser cumpridas, que riscos existem e que evidência vai contar como aceite.
+Se o trabalho é grande, a fábrica também precisa checar a cobertura do escopo inteiro. Isso evita uma armadilha comum: executar a primeira parte visível e fingir que o produto todo ficou planejado.
 
-A fábrica também precisa de Full Product SOT Scope Coverage quando o trabalho é produto completo. Isso impede que a primeira fatia prática seja confundida com o produto inteiro. Cada requisito importante precisa estar planejado, bloqueado com dono, fora de escopo com justificativa, delegado ao humano ou concluído com prova.
+## 4. O caminho muda conforme o tipo de trabalho
 
-Sem essa cobertura, workers podem trabalhar muito e ainda entregar uma versão estreita demais do produto.
+A fábrica não deveria tratar tudo como "tarefa para agente".
 
-## 6. Método liga intenção a prova
+Um bug pede reprodução. Um incidente pede mitigação. Um release pede rollback. Uma tela pede prova de experiência. Uma mudança de segurança pede ameaça e fronteira. Um produto novo pede definição, decomposição e gates. Uma integração pede contrato e fallback. Um trabalho com Solana, carteira, assinatura ou dinheiro pede muito mais cuidado.
 
-O Method Contract registra como aquele trabalho será feito. Ele pode puxar um caminho spec-first, test-first, behavior-first, discovery-first, security-first, design-first, legacy-diagnosis ou incident-first.
+Por isso existem rotas e métodos.
 
-O ponto não é o nome do método. O ponto é que o método muda a evidência:
+O operador não precisa decorar os nomes. O que importa é que a fábrica precisa escolher a régua certa. A pergunta não é "qual agente pega isso?". A pergunta é "que tipo de risco e prova esse pedido exige?".
 
-- test-first precisa de teste e regressão;
-- design-first precisa de Product Experience Plan, Product Face Packet e prova por superfície;
-- security-first precisa de ameaça, fronteira de confiança, scan e review;
-- discovery-first precisa transformar incerteza em decisão operacional;
-- legacy-diagnosis precisa baseline, rollback e proteção contra regressão;
-- incident-first precisa mitigação, status, causa e learnback.
+## 5. A fábrica verifica capacidade antes de fingir especialista
 
-Método que não muda artefato, gate ou prova é só slogan.
+Nem todo produto cabe no mesmo conjunto de workers.
 
+Web, API, CLI, cloud, agente, Solana, docs e onboarding têm cobertura mais madura no kernel público. Outros mundos, como mobile nativo, desktop, game, fintech, domínio regulado, analytics avançado, extensão de navegador e hardware, exigem pacotes de capacidade próprios antes de execução material.
 
+Isso é importante. Bloquear porque falta capacidade é melhor do que deixar um agente genérico fingir que é especialista.
 
-## Modos da ponte com o operador
+A fábrica boa não promete "faço tudo". Ela diz: "para isso eu tenho cobertura" ou "para isso eu preciso instalar e provar um pacote antes".
 
-A ponte pública com o operador é uma camada de interface. Ela traduz mensagens do operador para registros seguros da fábrica, mas não executa trabalho da fábrica sozinha. A execução continua pertencendo aos cards Hermes e aos workers atribuídos.
+## 6. O trabalho vira unidades pequenas
 
-Os modos da ponte são `status_bridge`, `start_bridge`, `question_bridge`, `decision_bridge`, `change_bridge`, `exception_bridge`, `handoff_bridge` e `learnback_forwarding`. Um pedido de início cria ou encaminha contexto de `factory_bridge_start_request`; ele não pula fonte, método nem gates de prontidão.
+Depois da verdade e do método, a fábrica quebra o trabalho.
 
-A ponte separa o `overkill-factory-gerente`, que conversa com o operador, do `factory-orchestrator`, que cuida de rota e controle de runtime. O Durable Operator Inbox preserva decisões, perguntas e handoffs no default Hermes store. O Factory Mechanic continua sendo o dono de self-improvement e learnback. A ponte não pode conceder autoridade, inventar aprovação, fechar gate ou declarar conclusão sem evidência.
+Uma unidade boa tem dono, escopo, entrada, saída, prova, reviewer, dependência e regra de pronto. Uma unidade ruim é algo como "construir o produto".
 
-## 7. Capability packs evitam falsa competência
+Essa diferença muda tudo. Trabalho pequeno pode ser executado, revisado, repetido e fechado. Trabalho grande demais vira uma aposta.
 
-A fábrica não deve fingir que um agente genérico cobre qualquer produto. Web SaaS, CLI/TUI, cloud, agente, Solana, mobile nativo, desktop, jogo, fintech, analytics, browser extension e hardware pedem provas diferentes.
+Na prática, a fábrica transforma o produto em cards e pacotes de worker. Cada pacote diz o que o worker deve fazer e, principalmente, o que ele não pode fazer.
 
-Os capability packs dizem o que já está pronto e o que ainda é template. Packs core como web, CLI/TUI, cloud, agent-runtime, Solana AI Kit, onboarding e public docs podem seguir quando a rota e os gates batem. Packs de mobile, desktop, game, AI/ML, fintech, regulated domain, analytics, browser extension e hardware precisam ser ativados com especialistas, bindings, smoke, eval e evidência antes de execução material.
+## 7. Hermes guarda o estado vivo
 
-Isso é uma fronteira de honestidade. Bloquear por falta de pack é melhor do que fingir especialista.
+Hermes Kanban continua sendo a fonte de verdade do runtime. É lá que ficam cards, dependências, status, workers, workspaces, comentários, bloqueios e transições.
 
-## 8. O trabalho vira worker packet pequeno
+A fábrica não deve criar um segundo Hermes por fora. Ela prepara o contrato e reconcilia o estado, mas o trabalho vivo precisa aparecer no runtime.
 
-Um worker packet é uma tarefa com bordas. Ele diz ao worker o que fazer, o que receber, o que devolver, que evidência anexar e que autoridade ele não tem.
+Isso também vale para dependências. Se uma fase depende de uma unidade de trabalho, essa unidade precisa estar ligada no grafo. Se trabalho obrigatório aparece tarde, ele precisa entrar no grafo antes de a próxima fase andar.
 
-Um bom packet consegue ser executado, revisado e refeito. Um packet ruim pede “construa o produto” e depois força o operador a adivinhar se ficou bom.
+A fábrica não pode descobrir uma obrigação depois e fingir que a fase anterior estava completa.
 
-Workers importantes incluem orquestração, source ledger, Product SOT, arquitetura, Product Face, builders, QA, segurança, review, release, handoff, evidence reconciler, human-gate clerk e skill/eval distiller. O nome não basta. Cada worker precisa de perfil, binding Hermes, receipt field, política de evidência e limite de autoridade.
+## 8. No-idle é guarda, não motor principal
 
-## 9. Hermes é o chão, a fábrica é o contrato
+No-idle existe para evitar silêncio perigoso.
 
-Hermes Kanban continua sendo a fonte de verdade do runtime. Ele guarda cards, dependências, status, workers, workspaces, comentários e transições. A fábrica não deve criar um segundo runtime escondido.
+Se tem coisa rodando, ele observa. Se tem coisa pronta, Hermes despacha. Se tem dependência, ele espera. Se precisa de decisão humana e o pacote está pronto, o gerente chama o operador. Se falta artefato, readback, PDF, revisão ou reparo interno, a fábrica repara.
 
-A fábrica prepara o contrato: que artefatos faltam, que gates bloqueiam, que workers entram, que tipo de evidência é aceitável e que aprovação humana é real. Hermes registra o trabalho vivo.
+O que ele não pode fazer: virar um despachante paralelo, inventar fase, aprovar gate, completar tarefa ou jogar bloqueio interno no humano.
 
-Quando a fábrica cria tarefas Hermes, ela deve usar dependências nativas. Se uma fase depende de work units, esses work units precisam ser pais da fase seguinte. Se aparecem tarde, entram no grafo antes do downstream andar. Não é aceitável descobrir trabalho obrigatório depois que a fase já está “done”.
+No-idle bom não é barulho. É a garantia de que a fábrica não fica parada fingindo que está tudo bem.
 
-## 10. No-idle não é despachante paralelo
+## 9. Produto visível precisa de prova visível
 
-No-idle existe para detectar silêncio perigoso. Se há trabalho rodando, ele observa. Se há ready, Hermes despacha. Se há dependency_wait, ele espera a dependência. Se há needs_input com pacote de decisão pronto, o gerente chama o operador. Se falta pacote, readback, PDF, artefato ou reparo interno, a fábrica corrige em vez de jogar no humano.
+Se o produto tem interface, não basta dizer que o backend está pronto.
 
-Essa regra importa muito. No-idle não pode virar um mini-Hermes. Ele é auditor de integridade do board, não fonte normal de autoridade.
+A fábrica precisa de prova da cara do produto. Isso pode incluir tela, estados, jornada, erro, loading, viewport, acessibilidade básica, console, overflow, texto e comparação com o que foi prometido.
 
-## 11. Product Face prova a cara do produto
+Para CLI, a prova é diferente: instalação, help, transcript, erro, comportamento no terminal.
 
-Produto com interface precisa provar experiência, não só backend ou arquitetura. Product Face cobre web visual, CLI/TUI, docs/onboarding, interface agentic, wallet UI e outros tipos de superfície.
+Para docs, também é diferente: o leitor consegue chegar ao primeiro sucesso? Os links funcionam? O texto guia alguém de verdade?
 
-Para web, a prova pode incluir screenshots, viewports, estados, jornada, console, acessibilidade básica, overflow e comparação com o Product Face Packet. Para CLI/TUI, precisa transcript, help, instalação, erro e comportamento de terminal. Para docs/onboarding, precisa replay do primeiro sucesso e critério de leitor. Para interface agentic, precisa controle do usuário, permissões, recuperação e limites.
+A regra é simples: cada superfície pede um tipo de prova. Uma screenshot bonita não prova um produto inteiro. Mas sem prova da experiência, produto visível não está pronto.
 
-Uma screenshot não prova produto inteiro. Product Face é uma parte da evidência, consumida junto com SOT, método, QA, review e Receipt Five.
+## 10. Revisão precisa voltar para o trabalho
 
-## 12. Gates humanos são pacotes, não perguntas soltas
+Review não é decoração.
 
-Gate humano só entra quando a decisão pertence ao operador: produção, mainnet, fundos, segredos, orçamento, autoridade, release, risco material ou waiver explícito.
+Se a revisão passa, ela precisa destravar ou fechar a tarefa certa. Se falha, precisa criar reparo. Se encontra risco, precisa registrar. Se fica parada num comentário, é só teatro.
 
-O gate deve ser artifact-first. O operador recebe o artefato ou uma projeção fiel, um resumo de uma tela, opções claras, consequência de cada opção, o que a aprovação autoriza e o que ela não autoriza. JSON cru, caminho local ou pergunta vaga no chat não são gate humano válido.
+O executor não deve ser o juiz final do próprio trabalho quando o risco é material. A fábrica precisa consumir a revisão, não apenas gerar uma revisão.
 
-A voz humana é o gerente. Worker, cron, evento Kanban e dump de artefato podem alimentar o estado interno, mas não deveriam notificar o operador diretamente.
+## 11. Gate humano é decisão, não interrupção
 
-## 13. Fechamento honesto
+A fábrica só deve chamar o humano quando a decisão é mesmo do humano.
 
-Uma execução termina em entregar, bloquear ou aprender.
+Produção. Mainnet. Fundos. Segredo. Orçamento. Release. Risco residual. Waiver. Mudança de autoridade.
 
-Entrega exige evidência atual, readback, review consumido, Receipt Five e gates satisfeitos. Bloqueio exige motivo claro, dono e menor próximo passo seguro. Learnback exige proposta, teste, review e promoção; a fábrica não deve se alterar em silêncio porque uma execução foi estranha.
+E quando chama, precisa entregar um pacote de decisão. Curto na frente, completo nos anexos. A pessoa precisa entender o que está aprovando sem abrir JSON cru ou caçar contexto no Kanban.
+
+Um gate humano bom diz: "você está aprovando isto, com este risco, para permitir este próximo passo. Você não está aprovando aquilo".
+
+## 12. Fechar é reconciliar
+
+No fim, a fábrica compara o que era obrigatório com o que foi entregue.
+
+Ela olha pedido, Product SOT, método, workers, evidências, revisão, gates, risco residual, release e próximo estado.
+
+Se bate, fecha com Receipt Five.
+
+Se não bate, bloqueia com motivo e dono.
+
+Se a execução revelou uma falha da própria fábrica, vira learnback: teste novo, doc nova, skill nova, gate novo, issue ou mudança de processo. Mas isso também precisa de validação. A fábrica não deve se reescrever no escuro.
+
+## 13. O que o operador deveria sentir
+
+O operador não deveria sentir que está pilotando quarenta agentes.
+
+Deveria sentir que existe uma linha de produção: o pedido entrou, a fábrica entendeu, o estado está claro, os bloqueios têm dono, as decisões chegam bem explicadas e "pronto" vem com prova.
+
+Se a experiência vira cobrança manual, se o operador precisa detectar preguiça, se o humano precisa perguntar onde está a evidência, a fábrica falhou.
+
+Esse é o padrão certo para ler qualquer parte da Overkill Factory.

--- a/docs/pt-BR/trust-and-evidence.md
+++ b/docs/pt-BR/trust-and-evidence.md
@@ -1,87 +1,142 @@
 # Confiança e evidência
 
-A Overkill Factory parte de uma verdade incômoda: processo parecendo vivo não é a mesma coisa que progresso.
+A pergunta desta página é simples:
 
-Agentes podem escrever arquivos, mover cards, produzir resumos confiantes e ainda errar o produto. Um painel pode mostrar atividade enquanto o bloqueio real continua parado. Uma revisão pode dizer pass sem ler o artefato. Um humano pode ser chamado para aprovar algo sem receber o material que está aprovando.
+"Como eu sei que isso não é só um agente falando bonito?"
 
-A fábrica trata tudo isso como falha de produto.
+A resposta começa por uma verdade incômoda: processo parecendo vivo não é a mesma coisa que progresso.
 
-## Evidência antes de confiança
+Essa pergunta precisa ficar no centro da Overkill Factory. Agente é muito bom em parecer confiante. Ele escreve. Ele resume. Ele cria arquivo. Ele move card. Ele diz que passou. Mas nada disso, sozinho, prova que o produto ficou certo.
 
-A fábrica prefere evidência a tom de voz. Um worker dizendo "done" só ajuda se os artefatos existem, podem ser relidos e batem com o trabalho pedido. Um teste só ajuda se testa o comportamento certo. Uma revisão só ajuda se verifica o artefato certo e volta para a tarefa original.
+A fábrica existe porque progresso falso é caro.
 
-É por isso que muitos registros da fábrica parecem rígidos. Eles não são rígidos porque o projeto gosta de papelada. Eles são rígidos porque evidência frouxa cria progresso falso.
+## O inimigo é o teatro de progresso
 
-## Receipt Five
+Teatro de progresso é quando o sistema parece vivo, mas a entrega real não avançou.
 
-Receipt Five é o recibo de conclusão. Ele precisa responder cinco tipos de pergunta:
+Exemplos:
+
+- o worker diz "feito", mas não entrega evidência;
+- o arquivo existe, mas não resolve o pedido;
+- o teste passa, mas testa a coisa errada;
+- o reviewer aprova sem ler o artefato;
+- o humano é chamado para aprovar sem receber o material;
+- o board fica cheio de atividade, mas o bloqueio real continua lá;
+- a fábrica pede decisão humana para algo que ela mesma deveria reparar.
+
+Tudo isso deve ser tratado como falha de produto, não como detalhe de processo.
+
+## Evidência é mais importante que tom de voz
+
+A fábrica não confia em confiança. Confia em prova.
+
+Um worker bom não só diz o que fez. Ele aponta para o artefato, o comando, o resultado, a captura, o diff, o log, o teste, a revisão ou o pacote que prova.
+
+Mesmo assim, evidência não pode ser qualquer coisa. Um caminho local perdido não serve. Um arquivo temporário não serve. Um print sem contexto quase nunca serve. Um pass sem escopo não serve. Uma aprovação humana genérica não serve para liberar produção, fundo, segredo ou mainnet.
+
+A prova precisa ser atual, legível e ligada ao pedido.
+
+## Readback: ler o que foi entregue
+
+Readback é uma palavra feia para uma coisa simples: a fábrica precisa reler o que o worker diz que entregou.
+
+Se ele diz que escreveu um Product SOT, a fábrica lê o SOT.
+
+Se ele diz que anexou evidência, a fábrica confere se a evidência abre, se tem tamanho, se tem hash quando precisa, se pode ser lida depois e se não vaza segredo.
+
+Se ele diz que criou um teste, a fábrica confere se o teste cobre o comportamento certo.
+
+Sem readback, o processo pode estar correto e o produto errado.
+
+## Receipt Five: o recibo do pronto
+
+Receipt Five é o jeito da fábrica dizer "pronto" sem depender de humor, pressa ou autoridade do executor.
+
+Ele precisa responder cinco perguntas:
 
 1. O que foi pedido?
 2. O que foi feito ou decidido?
 3. Que evidência prova isso?
-4. Quem revisou e o que a revisão disse?
-5. O que continua bloqueado, arriscado ou pendente?
+4. Quem revisou e o que a revisão concluiu?
+5. O que continua pendente, bloqueado ou arriscado?
 
-Se o Receipt Five não consegue responder isso, o estado honesto não é pronto. Pode ser pronto para revisão, bloqueado, parcialmente completo ou aguardando decisão humana. Mas não é pronto.
+Se uma dessas respostas falta, o estado honesto não é pronto. Pode ser pronto para revisão. Pode ser parcialmente completo. Pode ser bloqueado. Pode estar aguardando decisão humana.
 
-## Readback
+Mas não é pronto.
 
-Readback quer dizer que a fábrica confere o artefato que o worker disse ter produzido. Não basta o worker dizer "escrevi o SOT" ou "adicionei o teste". A fábrica precisa ler o arquivo, confirmar que ele existe e decidir se ele tem qualidade para alimentar a próxima fase.
+## Revisão independente não é carimbo
 
-Isso protege contra uma falha muito comum: processo correto com produto ruim. O worker pode ter seguido o card, mas a entrega pode estar rasa, errada ou ausente.
+Review de verdade precisa ser consumido.
 
-## Revisão independente
+Não basta gerar um relatório de revisão. A fábrica precisa usar o resultado. Se passou, destrava ou fecha o item certo. Se falhou, cria reparo. Se achou risco residual, registra dono e decisão. Se o reviewer é a mesma identidade que executou, não é revisão independente.
 
-Trabalho material deve ser revisado por outra identidade quando o risco pede. O executor pode explicar o que fez. Ele não deveria ser o juiz final.
+Revisão parada é só mais um artefato bonito.
 
-A revisão pode passar, falhar ou pedir reparo. Se passa, precisa destravar ou fechar a tarefa original. Se falha, precisa gerar trabalho de reparo. Revisão parada, sem ser consumida, também é progresso falso.
+## Bloqueio honesto
 
-## No-idle e bloqueios
+Bloqueio bom diz:
 
-No-idle não é truque de produtividade. É um guard contra paradas silenciosas. Se o board tem trabalho que deveria andar, mas nada material muda, a fábrica deve reparar o estado, despachar o próximo worker seguro ou falhar de forma visível.
+- o que falta;
+- por que falta;
+- quem é dono;
+- qual é o menor próximo passo seguro;
+- se precisa ou não do operador.
 
-Bloqueio também precisa ser honesto. Alguns bloqueios são decisões humanas reais. Muitos não são. Se a fábrica precisa de revisão interna, readback, artefato faltando ou reparo, isso é trabalho da própria fábrica. Não deveria chegar ao operador como se o humano tivesse que resolver.
+Nem todo bloqueio é humano.
 
-## Gates humanos
+Se a dependência ainda não terminou, é espera. Se falta capacidade, a fábrica precisa buscar ou ativar um pacote. Se é erro transitório, tenta reparar. Se falta artefato, readback, PDF ou revisão, a fábrica trabalha.
 
-Gate humano é coisa séria. Ele pertence a decisões em que a autoridade é do operador: release em produção, mainnet, fundos, segredos, orçamento, risco relevante ou uma fronteira explícita de aprovação.
+O operador só entra quando existe decisão real de autoridade.
 
-Um bom gate humano é legível. Ele diz qual decisão precisa ser tomada, que evidência existe, o que pode dar errado e o que cada opção significa. O operador não deveria ter que decifrar JSON cru ou reconstruir a história por comentários espalhados.
+## Gate humano precisa respeitar o humano
 
-## Segurança e risco
+Gate humano não é "posso seguir?" jogado no chat.
 
-Segurança não é checklist no fim. É rota e arquitetura. Risco material pode exigir threat modeling, fronteiras de confiança, identidade e autorização, supply chain, segredos, privacidade, incidente e dono explícito para risco residual.
+Um gate humano sério entrega o material sob revisão. Se é Product SOT, entrega o SOT. Se é arquitetura, entrega a arquitetura. Se é release, entrega o pacote de release. Se é segurança, entrega o risco e as opções.
 
-A fábrica não deve prometer segurança perfeita. Ela deve prometer a melhor postura possível com evidência, gates e decisão explícita sobre risco residual.
+A primeira mensagem precisa ser clara e curta:
 
-A matriz pública de segurança agora faz parte deste modelo de confiança, em vez de ficar num arquivo operacional separado. Os domínios checáveis incluem `networking`, `linux-systems`, `web-security`, `application-security`, `ethical-hacking`, `security-tools`, `cloud-security`, `detection-monitoring`, `security-operations`, `cryptography`, `key-management`, `future-security`, `supply-chain` e `onchain-solana-quasar`.
+- decisão pedida;
+- resumo em português normal;
+- o que aprovar permite;
+- o que aprovar não permite;
+- opções de resposta;
+- consequência;
+- evidência;
+- urgência.
 
-## A fronteira honesta
+O anexo pode ser grande. A pergunta não pode ser vaga.
 
-Checks locais provam que o kernel público está coerente. Eles não provam que uma execução privada entregou um produto. Conclusão real de produto exige estado vivo no Hermes, evidência específica do produto, revisão e aprovação humana quando o risco pede.
+## Segurança não fica para o fim
 
-Essa fronteira não é fraqueza. É o jeito da fábrica continuar honesta.
+Segurança não é um scan no final para deixar a PR bonita.
 
-## Pacote de decisão antes da decisão
+Se o trabalho toca autenticação, permissão, segredo, chave, produção, supply chain, privacidade, carteira, assinatura, Solana, fundos ou mainnet, a segurança entra no caminho desde cedo.
 
-Um gate humano sem artefato é inválido. Se a fábrica pede aprovação para Product SOT, arquitetura, segurança, release ou Product Face, ela precisa entregar o material que está sendo aprovado ou uma projeção fiel com referência completa.
+Às vezes isso significa arquitetura. Às vezes significa threat model. Às vezes significa worker especialista. Às vezes significa gate humano. Às vezes significa bloquear.
 
-A primeira mensagem deve caber na cabeça do operador: decisão pedida, resumo em português claro, o que aprovar autoriza, o que não autoriza, opções de resposta, consequência e urgência. O anexo pode carregar o documento completo. O JSON é evidência interna, não experiência primária do operador.
+A fábrica não promete segurança perfeita. Promete não fingir que risco desapareceu.
 
-## Blocos tipados e fronteira com o humano
+## Prova local, prova viva e prova pública
 
-Nem todo bloqueio é pergunta para o operador. `dependency_wait` é espera de dependência. `capability` é busca ou ativação de pack. `transient` é retry ou reparo. `needs_input` só chega ao operador quando existe pacote de decisão completo.
+Essas três coisas são diferentes.
 
-Essa separação evita um vício comum: transformar qualquer falha de processo em “preciso que o humano decida”. Muitas vezes a decisão correta é a fábrica reparar o próprio estado.
+Um comando local passando prova que o checkout está coerente.
 
-## Evidência local, evidência viva e evidência pública
+Um Hermes vivo com worker result prova que aquele worker rodou naquele contexto.
 
-Um comando local passando prova coerência do checkout. Um worker result prova que um worker rodou naquele escopo. Um Receipt Five prova fechamento quando consegue apontar para pedido, mudança, evidência, review e próximo estado. Uma publicação pública precisa ainda passar segurança de superfície e segredo.
+Um Receipt Five bem formado prova que a conclusão daquele trabalho está ligada a pedido, mudança, evidência, revisão e próximo estado.
 
-Essas provas não são intercambiáveis. Não se deve usar smoke local para afirmar entrega de produto vivo, nem usar artifact existence como se fosse readback, nem usar uma aprovação humana genérica como waiver de release, segurança, fundos ou mainnet.
+Uma publicação pública ainda precisa passar por segurança de superfície e segredo.
 
-## Prontidão de implementação
+Não dá para trocar uma pela outra. Smoke local não prova produto entregue. Arquivo existente não prova readback. Aprovação genérica não prova release. Print bonito não prova jornada.
 
-Product Implementation Readiness é o ponto em que a fábrica pergunta: “já temos SOT, método, pesquisa, arquitetura, packs, acesso, workers, reviewers e prova suficiente para deixar a execução material começar?”.
+## Quando confiar
 
-Se essa resposta é fraca, a fábrica deve bloquear antes de gastar worker. Isso é mais barato do que descobrir no Receipt Five que o produto inteiro foi construído em cima de uma lacuna antiga.
+Você pode começar a confiar quando a fábrica consegue contar a história inteira sem pular etapa:
+
+"O pedido era este. A fonte dizia isto. A verdade do produto ficou assim. O método escolhido foi este. Estes workers rodaram. Estas evidências voltaram. Esta revisão foi consumida. Este gate humano autorizou exatamente isto. O que ainda falta é aquilo."
+
+Essa história precisa estar nos artefatos, não só na memória de quem estava no chat.
+
+Esse é o padrão.


### PR DESCRIPTION
## Summary
- Rewrites the Portuguese public docs as conversational product documentation instead of technical registry prose.
- Reworks the PT navigation order and labels so the reader starts with manual, operating model, evidence, then lifecycle.
- Rewrites PT manual, operating model, trust/evidence, lifecycle, and index around the operator's experience: source, product truth, method, Hermes runtime, proof, review, gates, and honest closure.

## Validation
- `git diff --check`
- `python3 -m mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/overkill-docs-pt-human-check2`
- `cd factory && python3 scripts/generate_factory_reference_docs.py && python3 scripts/generate_factory_reference_docs.py --check`
- `cd factory && python3 scripts/validate_public_json_artifacts.py`
- `cd factory && python3 scripts/validate_public_surface_sync.py`
- `cd factory && python3 scripts/validate_promise_implementation_map.py`
- `cd factory && python3 scripts/validate_worker_profiles.py`
- `cd factory && python3 scripts/public_safety_scan.py`
- `cd factory && python3 scripts/secret_safety_scan.py`
- `cd factory && python3 -m unittest tests.test_open_source_docs tests.test_public_surface_sync tests.test_promise_implementation_map tests.test_generated_factory_reference_docs -q`
- `cd factory && python3 -m unittest discover -s tests -p 'test_*.py' -q` (1226 tests OK, 1 skipped)
