### PR TITLE
Stop release routing readback repair loops

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -1378,6 +1378,45 @@ def is_factory_materialization_contract_blocker(record: dict[str, Any]) -> bool:
     return not any(marker in text for marker in true_external_markers)
 
 
+def f16_release_readiness_readback_pass_after_routing(done: list[dict[str, Any]]) -> bool:
+    f16_producers: set[str] = set()
+    for item in done:
+        item_ref = task_record_id(item)
+        if not item_ref:
+            continue
+        text = task_record_text(item).lower()
+        body = task_body_json_object(item)
+        if (
+            "factory_f16_rerun_after_wu19_release_readiness_routing" in text
+            or "f16 rerun after" in text and "release/readiness routing" in text
+            or str(body.get("phase") or "").strip() == "F16" and "release_readiness" in text
+        ):
+            f16_producers.add(item_ref)
+    if not f16_producers:
+        return False
+    for item in done:
+        body = task_body_json_object(item)
+        producer = str(body.get("producer_task") or body.get("source_owner_task_ref") or "").strip()
+        text = task_record_text(item).lower()
+        if producer not in f16_producers and not any(ref in text for ref in f16_producers):
+            continue
+        if "pass_readback" in text and "f16 consolidated" in text:
+            return True
+        for run in item.get("runs") or []:
+            if not isinstance(run, dict):
+                continue
+            metadata = parse_json_object(run.get("metadata"))
+            if not isinstance(metadata, dict):
+                continue
+            review = metadata.get("independent_review_result") or metadata.get("independent_readback_review_result")
+            if not isinstance(review, dict):
+                continue
+            verdict = str(review.get("verdict") or review.get("result") or "").strip().upper()
+            if "PASS" in verdict and "READBACK" in verdict:
+                return True
+    return False
+
+
 def release_readiness_resolved_by_materialization_repair_refs(
     done: list[dict[str, Any]], blocked_refs: list[str]
 ) -> list[str]:
@@ -2954,6 +2993,27 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         done,
         materialization_contract_refs,
     )
+    if materialization_contract_refs and f16_release_readiness_readback_pass_after_routing(done):
+        return {
+            "status": "blocked",
+            "classification": "release_readiness_blocked_after_f16_readback_pass",
+            "blocked": True,
+            "remediation_required": False,
+            "human_gate_required": owner_gate_delivery_receipt_exists_for_blockers(rows, materialization_contract_refs),
+            "operator_input_required": False,
+            "operator_input_task_refs": [],
+            "human_gate_task_refs": human_gate_refs,
+            "release_readiness_task_refs": materialization_contract_refs,
+            "remediation_reason": (
+                "A release/readiness repair already routed a fresh F16 rerun and independent readback PASS. "
+                "Remaining REL blockers are real authority/proof blockers, not another factory repair loop."
+            ),
+            "next_action": (
+                "do not create another WU-19 release/readiness repair; keep F17 blocked until a new concrete "
+                "proof source or explicit operator authority exists"
+            ),
+            "state": state,
+        }
     if release_readiness_resolved_refs:
         release_readiness_task_refs = sorted(
             ref
@@ -4765,6 +4825,25 @@ def suppress_missing_declared_artifacts_with_readback_pass(
             pass_artifact_classes_by_phase.setdefault(phase, set()).update(artifact_classes)
     if not pass_targets and not pass_artifact_classes_by_phase and not pass_artifact_classes_all:
         return rows
+    routing_packet_refs_superseded_by_f16_readback: set[str] = set()
+    for record in rows.get("done", []):
+        record_ref = task_record_id(record)
+        if not record_ref or (record_ref not in pass_targets and record_ref not in pass_owner_refs):
+            continue
+        body = task_body_json_object(record)
+        record_text = task_record_text(record).lower()
+        if str(body.get("phase") or "").strip() != "F16" and "f16" not in record_text:
+            continue
+        for key in ("current_release_readiness_packet", "release_readiness_packet", "routing_packet"):
+            raw_value = str(body.get(key) or "").strip()
+            if not raw_value:
+                continue
+            ref_match = re.search(r"\b(t_[A-Za-z0-9_]+)\b", raw_value)
+            routing_ref = ref_match.group(1) if ref_match else raw_value
+            if routing_ref:
+                routing_packet_refs_superseded_by_f16_readback.add(routing_ref)
+        for match in re.finditer(r"release_readiness_routing_packet_(t_[A-Za-z0-9_]+)\.(?:json|md)", task_record_text(record)):
+            routing_packet_refs_superseded_by_f16_readback.add(match.group(1))
     next_rows = dict(rows)
     done_rows: list[dict[str, Any]] = []
     for item in rows.get("done", []):
@@ -4808,6 +4887,10 @@ def suppress_missing_declared_artifacts_with_readback_pass(
             and bool(missing_classes & pass_artifact_classes_by_phase[item_body_phase])
         )
         global_artifact_pass_match = bool(missing_classes & pass_artifact_classes_all)
+        routing_packet_superseded_match = (
+            item_ref in routing_packet_refs_superseded_by_f16_readback
+            and any(str(name).startswith("release_readiness_routing_packet") for name in missing_names)
+        )
         if missing_artifacts and (
             item_ref in pass_targets
             or item_ref in pass_owner_refs
@@ -4816,6 +4899,7 @@ def suppress_missing_declared_artifacts_with_readback_pass(
             or artifact_pass_match
             or phase_pass_match
             or global_artifact_pass_match
+            or routing_packet_superseded_match
         ):
             item = dict(item)
             item["suppressed_missing_declared_artifacts"] = item.pop("missing_declared_artifacts")

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4842,6 +4842,83 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertTrue(state["human_gate_required"])
         self.assertEqual(state["classification"], "human_gate_delivered_waiting_for_operator")
 
+    def test_missing_release_readiness_routing_artifacts_suppressed_after_f16_readback_pass(self) -> None:
+        routing_id = "t_" + "routingpkt"
+        f16_id = "t_" + "f16rerun"
+        review_id = "t_" + "f16readback"
+        rows = {
+            "ready": [],
+            "running": [],
+            "todo": [],
+            "blocked": [],
+            "done": [
+                {
+                    "id": routing_id,
+                    "status": "done",
+                    "title": "Repair WU-19 release/readiness blockers",
+                    "assignee": "release-ops-worker",
+                    "body": json.dumps({"marker": adapter.NO_IDLE_RELEASE_READINESS_REPAIR_MARKER}),
+                    "missing_declared_artifacts": [
+                        {
+                            "artifact_name": f"release_readiness_routing_packet_{routing_id}.json",
+                            "local_path": f"/tmp/scratch/{routing_id}/release_readiness_routing_packet_{routing_id}.json",
+                        },
+                        {
+                            "artifact_name": f"release_readiness_routing_packet_{routing_id}.md",
+                            "local_path": f"/tmp/scratch/{routing_id}/release_readiness_routing_packet_{routing_id}.md",
+                        },
+                    ],
+                },
+                {
+                    "id": f16_id,
+                    "status": "done",
+                    "title": "F16 rerun after release/readiness routing packet",
+                    "assignee": "evidence-reconciler",
+                    "body": json.dumps(
+                        {
+                            "phase": "F16",
+                            "marker": "factory_f16_rerun_after_wu19_release_readiness_routing",
+                            "current_durable_evidence": {
+                                "routing_packet": f"parent task {routing_id} workspace release_readiness_routing_packet_{routing_id}.json"
+                            },
+                        }
+                    ),
+                },
+                {
+                    "id": review_id,
+                    "status": "done",
+                    "title": f"Independent readback: F16 consolidated reconciliation packet {f16_id}",
+                    "assignee": "independent-reviewer",
+                    "body": json.dumps({"phase": "F16", "producer_task": f16_id}),
+                    "latest_summary": f"PASS_READBACK_ONLY for F16 consolidated reconciliation packet {f16_id}",
+                    "runs": [
+                        {
+                            "status": "done",
+                            "metadata": {
+                                "independent_review_result": {
+                                    "verdict": "PASS_READBACK_ONLY_NO_AUTHORITY_GRANT",
+                                    "evidence_reviewed": [
+                                        f"attachments/{f16_id}/f16_consolidated_reconciliation_packet_{f16_id}.json",
+                                        f"attachments/{f16_id}/f16_consolidated_reconciliation_packet_{f16_id}.md",
+                                    ],
+                                    "owner_reviewer_signoffs": {
+                                        "executor_task": f16_id,
+                                        "reviewer_task": review_id,
+                                    },
+                                }
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+
+        suppressed = adapter.suppress_missing_declared_artifacts_with_readback_pass(rows)
+        routing_record = next(item for item in suppressed["done"] if item["id"] == routing_id)
+
+        self.assertNotIn("missing_declared_artifacts", routing_record)
+        self.assertTrue(routing_record["missing_declared_artifacts_suppressed_by_readback_pass"])
+
     def test_declared_artifact_owner_rerun_candidate_from_done_readback_repair_missing_files(self) -> None:
         target_id = "t_" + "releasepkg"
         repair_id = "t_" + "readbackdone"


### PR DESCRIPTION
## Summary
- suppress stale local release_readiness_routing_packet artifacts after downstream F16 rerun + independent readback PASS
- stop no-idle from creating duplicate WU-19 release/readiness repair loops once fresh F16 readback already proves the current NOT_READY/BLOCKED state
- keep F17 blocked as a real authority/proof blocker instead of fabricating progress

## Tests
- python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check