### PR TITLE
fix: avoid duplicate no-idle release replan tasks

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -1418,11 +1418,34 @@ def f16_release_readiness_readback_pass_after_routing(done: list[dict[str, Any]]
     return False
 
 
+def release_replan_consumed_blocker_refs(rows: dict[str, list[dict[str, Any]]]) -> set[str]:
+    consumed: set[str] = set()
+    blocked_refs = {
+        task_record_id(item)
+        for item in rows.get("blocked", [])
+        if task_record_id(item)
+    }
+    if not blocked_refs:
+        return consumed
+    for bucket in ("ready", "running", "todo", "blocked", "done"):
+        for item in rows.get(bucket, []):
+            text = task_record_text(item)
+            lowered = text.lower()
+            if NO_IDLE_RELEASE_REPLAN_MARKER not in lowered and "replan_actionable_nonproduction_release_path" not in lowered:
+                continue
+            for ref in blocked_refs:
+                if ref and ref in text:
+                    consumed.add(ref)
+    return consumed
+
+
+
 def release_replan_requested_blocker_refs(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
     refs: list[str] = []
+    consumed_refs = release_replan_consumed_blocker_refs(rows)
     for item in rows.get("blocked", []):
         item_ref = task_record_id(item)
-        if not item_ref:
+        if not item_ref or item_ref in consumed_refs:
             continue
         text = task_record_text(item).lower()
         if "needs_replan" not in text:

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -5001,6 +5001,57 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(created_body["operator_input_required"])
         self.assertIn("do not ask the operator a vague question", " ".join(created_body["forbidden_actions"]).lower())
 
+    def test_no_idle_does_not_duplicate_consumed_manager_needs_replan(self) -> None:
+        fake = FakeHermes()
+        blocker_id = "t_" + "f17blocked"
+        replan_id = "t_" + "replanold"
+        fake.tasks[blocker_id] = {
+            "id": blocker_id,
+            "status": "blocked",
+            "title": "F17 - Verificacao",
+            "assignee": "qa-verification-worker",
+            "body": json.dumps({"phase_id": "F17", "runtime_contract": "present", "release_readiness_status": "blocked"}),
+            "comments": [
+                {
+                    "author": "overkill-factory-gerente",
+                    "body": "FACTORY DEFECT / needs_replan_not_consumed: ready=0 running=0 blocked=1; factory-owned routing gap.",
+                }
+            ],
+            "events": [{"type": "blocked", "payload": {"kind": "capability", "reason": "release/readiness proof gap"}}],
+        }
+        fake.tasks[replan_id] = {
+            "id": replan_id,
+            "status": "done",
+            "title": "Replan actionable non-production release proof path",
+            "assignee": "release-ops-worker",
+            "body": json.dumps(
+                {
+                    "marker": adapter.NO_IDLE_RELEASE_REPLAN_MARKER,
+                    "targeted_remediation": {
+                        "plan_action": "replan_actionable_nonproduction_release_path",
+                        "blocked_task_refs": [blocker_id],
+                    },
+                }
+            ),
+            "events": [{"type": "completed"}],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertNotEqual(state["classification"], "release_replan_task_created")
+        self.assertFalse(state.get("remediation_strategy") == "create_release_replan_task")
+        created_replans = [
+            task
+            for task_id, task in fake.tasks.items()
+            if task_id not in {blocker_id, replan_id}
+            and "Replan actionable non-production release proof path" in str(task.get("title") or "")
+        ]
+        self.assertEqual(created_replans, [])
+
     def test_declared_artifact_owner_rerun_candidate_from_done_readback_repair_missing_files(self) -> None:
         target_id = "t_" + "releasepkg"
         repair_id = "t_" + "readbackdone"


### PR DESCRIPTION
## Summary
- suppresses gerente needs_replan consumption when a release replan task already exists for the same blocked ref
- adds regression coverage so no-idle does not create repeated replan tasks for the same operator escalation

## Test Plan
- /srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_no_idle_consumes_manager_needs_replan_after_f16_readback_pass tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_no_idle_does_not_duplicate_consumed_manager_needs_replan -q
- /srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check