### PR TITLE
fix: consume proof authority and triage block loops

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -74,6 +74,7 @@ NO_IDLE_CANONICAL_FRONTIER_RESUME_MARKER = "factory_no_idle_canonical_frontier_r
 NO_IDLE_MATERIALIZATION_CONTRACT_REPAIR_MARKER = "factory_no_idle_materialization_contract_repair"
 NO_IDLE_RELEASE_READINESS_REPAIR_MARKER = "factory_no_idle_release_readiness_repair"
 NO_IDLE_RELEASE_REPLAN_MARKER = "factory_no_idle_release_replan"
+NO_IDLE_NONPRODUCTION_AUTHORITY_UNBLOCK_MARKER = "factory_no_idle_nonproduction_authority_unblock"
 NO_IDLE_OWNER_GATE_DELIVERY_MARKER = "factory_no_idle_owner_gate_delivery"
 NO_IDLE_DECLARED_ARTIFACT_REPAIR_SUPERSEDED_MARKER = "factory_no_idle_declared_artifact_repair_superseded"
 NO_IDLE_STALE_REMEDIATION_REPLACEMENT_LIMIT = 8
@@ -1418,6 +1419,25 @@ def f16_release_readiness_readback_pass_after_routing(done: list[dict[str, Any]]
     return False
 
 
+def nonproduction_proof_authority_unblock_refs(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
+    refs: list[str] = []
+    for item in rows.get("blocked", []):
+        item_ref = task_record_id(item)
+        if not item_ref:
+            continue
+        text = task_record_text(item).lower()
+        if "approved/non-production-proof-only" not in text:
+            continue
+        if not any(marker in text for marker in ("needs_input", "disposable devnet", "bankrun", "non-production proof", "rel-007")):
+            continue
+        if any(marker in text for marker in ("production", "mainnet", "real funds")) and "not production" not in text and "no production" not in text:
+            # Keep the guard conservative when the text does not clearly preserve the production ban.
+            continue
+        refs.append(item_ref)
+    return sorted(set(refs))
+
+
+
 def release_replan_consumed_blocker_refs(rows: dict[str, list[dict[str, Any]]]) -> set[str]:
     consumed: set[str] = set()
     blocked_refs = {
@@ -2401,6 +2421,19 @@ def human_gate_delivery_artifact_is_covered_by_receipt(record: dict[str, Any], a
     )
 
 
+def release_replan_duplicate_consumption_artifact(record: dict[str, Any], artifact_name: str) -> bool:
+    normalized_name = normalized_artifact_token(artifact_name)
+    if "releasereplanduplicateconsumption" not in normalized_name:
+        return False
+    text = task_record_text(record).lower()
+    return (
+        NO_IDLE_RELEASE_REPLAN_MARKER in text
+        or "duplicate_replan_consumed" in text
+        or "duplicate release replan" in text
+    )
+
+
+
 def missing_declared_local_artifacts(record: dict[str, Any]) -> list[dict[str, Any]]:
     missing: list[dict[str, Any]] = []
     suppress_self_evidenced_repair_refs = completed_declared_artifact_readback_repair_is_self_evidenced(record)
@@ -2409,6 +2442,8 @@ def missing_declared_local_artifacts(record: dict[str, Any]) -> list[dict[str, A
         if not path.is_absolute():
             continue
         if human_gate_delivery_artifact_is_covered_by_receipt(record, path.name):
+            continue
+        if release_replan_duplicate_consumption_artifact(record, path.name):
             continue
         if suppress_self_evidenced_repair_refs and path.name in {
             "declared-artifact-readback-repair.json",
@@ -2873,6 +2908,7 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
             "remediation_required": True,
             "human_gate_required": False,
             "operator_input_required": False,
+            "remediation_strategy": "create_typed_block_loop_triage_task",
             "next_action": (
                 "route the loop to deterministic triage/repair; do not re-block the same task "
                 "and do not ask the operator unless a delivered needs_input decision package exists"
@@ -3051,6 +3087,26 @@ def classify_no_idle_state(rows: dict[str, list[dict[str, Any]]]) -> dict[str, A
         done,
         materialization_contract_refs,
     )
+    nonproduction_authority_refs = nonproduction_proof_authority_unblock_refs(rows)
+    if nonproduction_authority_refs:
+        return {
+            "status": "remediation_required",
+            "classification": "nonproduction_proof_authority_unblock_required",
+            "blocked": True,
+            "remediation_required": True,
+            "remediation_strategy": "unblock_nonproduction_proof_authority_tasks",
+            "human_gate_required": False,
+            "operator_input_required": False,
+            "operator_input_task_refs": [],
+            "human_gate_task_refs": human_gate_refs,
+            "authority_unblock_task_refs": nonproduction_authority_refs,
+            "remediation_reason": (
+                "A blocked non-production proof task has an existing approved/non-production-proof-only operator "
+                "authority receipt. The factory must consume that receipt and rerun under guardrails instead of waiting."
+            ),
+            "next_action": "unblock the approved non-production proof task and run native Hermes dispatch",
+            "state": state,
+        }
     replan_requested_refs = release_replan_requested_blocker_refs(rows)
     if replan_requested_refs:
         return {
@@ -3670,6 +3726,67 @@ def create_release_readiness_repair_task(
         body=compact_json_argument(body),
         assignee="release-ops-worker",
         idempotency_key=f"overkill:no-idle-release-readiness-repair:{public_safe_slug(board, fallback='board')}:{digest}",
+        created_by=NO_IDLE_AUTHOR,
+        workspace=workspace,
+        blocked=False,
+        workflow_template_id=FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID,
+        current_step_key=FACTORY_KANBAN_DEFAULT_STEP_KEY,
+        runner=runner,
+    )
+
+
+
+def create_typed_block_loop_triage_task(
+    *,
+    hermes_bin: str,
+    board: str,
+    workspace: str,
+    classification: dict[str, Any],
+    runner: Runner,
+) -> str:
+    body = no_idle_remediation_body(board=board, classification=classification)
+    body["marker"] = "factory_no_idle_typed_block_loop_triage"
+    body["packet_type"] = "factory_no_idle_typed_block_loop_triage_request"
+    body["objective"] = (
+        "Resolve a Hermes typed block loop without re-blocking the same task. Read the looped task, decide whether "
+        "the next safe action is review, repair, exact human ask, or completion reduction, and create/record that path."
+    )
+    body["targeted_remediation"] = {
+        "plan_action": "triage_typed_block_loop",
+        "block_loop_task_refs": classification.get("block_loop_task_refs") or [],
+        "required_outputs": [
+            "loop_cause",
+            "safe_next_task_or_exact_human_ask",
+            "no_duplicate_reblock_proof",
+        ],
+        "native_dispatch_required_next": True,
+        "human_gate_required": False,
+        "operator_input_required": False,
+    }
+    body["human_gate_required"] = False
+    body["operator_input_required"] = False
+    body["allowed_actions"] = [
+        "inspect the looped task comments/events/runs and produced artifacts",
+        "create a review/repair task if the loop asks for auditor or independent review",
+        "complete or unblock only with concrete reducer evidence",
+        "deliver one exact human ask only if a true external input remains",
+    ]
+    body["forbidden_actions"].extend(
+        [
+            "re-block the same task with the same reason",
+            "treat triage as release approval",
+            "ask vague operator status questions",
+            "touch production, Mainnet, real funds, custody, signing, secrets, deploy or release",
+        ]
+    )
+    digest = idempotency_digest_fragment(contract_digest(body))
+    return create_task(
+        hermes_bin=hermes_bin,
+        board=board,
+        title="Triage Hermes typed block loop",
+        body=compact_json_argument(body),
+        assignee="factory-orchestrator",
+        idempotency_key=f"overkill:no-idle-typed-block-loop-triage:{public_safe_slug(board, fallback='board')}:{digest}",
         created_by=NO_IDLE_AUTHOR,
         workspace=workspace,
         blocked=False,
@@ -12312,9 +12429,33 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
         if args.out:
             write_json(args.out, public_envelope)
         return public_envelope
+    if legacy_classification.get("classification") == "hermes_typed_block_loop_detected" and not args.create_remediation:
+        envelope = {
+            "$schema": LIVE_ADAPTER_SCHEMA,
+            "mode": "no-idle",
+            "board": args.board,
+            "blocked": True,
+            "no_idle_state": legacy_classification,
+            "board_reconcile_plan": reconcile_plan,
+            "artifact_materialization": [],
+            "targeted_remediation_plan": None,
+            "remediation_task_id": None,
+            "hook": {
+                "runtime_authority": "hermes_kanban",
+                "local_state_authority": False,
+                "no_shadow_dispatcher": True,
+                "dispatch_called_by_this_command": False,
+                "reporting_policy": (
+                    "No-idle preserves native Hermes typed block-loop state unless create-remediation is explicit."
+                ),
+            },
+        }
+        public_envelope = sanitize_public_refs(envelope)
+        if args.out:
+            write_json(args.out, public_envelope)
+        return public_envelope
     if legacy_classification.get("classification") in {
         "hermes_native_dependency_wait",
-        "hermes_typed_block_loop_detected",
     }:
         envelope = {
             "$schema": LIVE_ADAPTER_SCHEMA,
@@ -12496,6 +12637,8 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
         return public_envelope
     legacy_remediation_strategy = str(legacy_classification.get("remediation_strategy") or "")
     targeted_legacy_repair_available = legacy_remediation_strategy in {
+        "create_typed_block_loop_triage_task",
+        "unblock_nonproduction_proof_authority_tasks",
         "create_release_replan_task",
         "create_owner_gate_delivery_task",
         "create_targeted_review_repair_task",
@@ -12640,6 +12783,78 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
                 "factory_repair_task_unlinked_and_promoted"
                 if released_repair_tasks
                 else "factory_repair_task_unlink_promote_failed"
+            )
+        elif classification.get("remediation_strategy") == "create_typed_block_loop_triage_task":
+            targeted_remediation_plan = {
+                "record_type": "factory_no_idle_targeted_repair_plan",
+                "plan_action": "triage_typed_block_loop",
+                "board": args.board,
+                "block_loop_task_refs": classification.get("block_loop_task_refs") or [],
+                "assignee": "factory-orchestrator",
+                "native_dispatch_required_next": True,
+                "human_gate_required": False,
+                "operator_input_required": False,
+            }
+            remediation_task_id = create_typed_block_loop_triage_task(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                workspace=args.workspace,
+                classification=classification,
+                runner=runner,
+            )
+            task_runtime = remediation_task_runtime_metadata(
+                hermes_bin=args.hermes_bin,
+                board=args.board,
+                task_id=remediation_task_id,
+                runner=runner,
+            )
+            classification["targeted_remediation_plan"] = targeted_remediation_plan
+            classification["remediation_task_ref"] = remediation_task_id
+            classification.update(task_runtime)
+            classification["native_dispatch_required_next"] = bool(
+                remediation_task_id
+                and targeted_remediation_plan.get("native_dispatch_required_next") is True
+                and task_runtime.get("native_dispatch_required_next") is True
+            )
+            classification["classification"] = (
+                "typed_block_loop_triage_task_created"
+                if remediation_task_id and not classification.get("remediation_task_stale")
+                else "typed_block_loop_triage_task_not_created"
+            )
+        elif classification.get("remediation_strategy") == "unblock_nonproduction_proof_authority_tasks":
+            authority_refs = [str(ref) for ref in (classification.get("authority_unblock_task_refs") or []) if str(ref).strip()]
+            unblocked_refs: list[str] = []
+            for task_ref in authority_refs:
+                run_checked(
+                    [
+                        args.hermes_bin,
+                        "kanban",
+                        "--board",
+                        args.board,
+                        "unblock",
+                        task_ref,
+                        "approved/non-production-proof-only authority already recorded; rerun under no-production/no-Mainnet/no-real-funds/no-secrets guardrails",
+                    ],
+                    runner=runner,
+                )
+                unblocked_refs.append(task_ref)
+            classification["targeted_remediation_plan"] = {
+                "record_type": "factory_no_idle_targeted_repair_plan",
+                "plan_action": "consume_nonproduction_proof_authority_and_unblock",
+                "board": args.board,
+                "authority_unblock_task_refs": authority_refs,
+                "unblocked_task_refs": unblocked_refs,
+                "native_dispatch_required_next": bool(unblocked_refs),
+                "human_gate_required": False,
+                "operator_input_required": False,
+                "authority_marker": NO_IDLE_NONPRODUCTION_AUTHORITY_UNBLOCK_MARKER,
+            }
+            classification["unblocked_task_refs"] = unblocked_refs
+            classification["native_dispatch_required_next"] = bool(unblocked_refs)
+            classification["classification"] = (
+                "nonproduction_proof_authority_unblocked"
+                if unblocked_refs
+                else "nonproduction_proof_authority_unblock_failed"
             )
         elif classification.get("remediation_strategy") == "create_release_replan_task":
             targeted_remediation_plan = {

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4717,6 +4717,105 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertFalse(created_body["operator_input_required"])
         self.assertNotIn("parents", created_tasks[0])
 
+    def test_no_idle_creates_triage_task_for_typed_block_loop(self) -> None:
+        fake = FakeHermes()
+        loop_id = "t_" + "looped"
+        fake.tasks[loop_id] = {
+            "id": loop_id,
+            "status": "triage",
+            "title": "REL-007 Solana/Quasar Bankrun/DevNet-safe proof packet",
+            "assignee": "solana-quasar-qa-engineer",
+            "body": json.dumps({"rel": "REL-007"}),
+            "events": [
+                {
+                    "type": "block_loop_detected",
+                    "payload": {
+                        "kind": "needs_input",
+                        "reason": "review-required/R3-onchain: auditor review required",
+                    },
+                }
+            ],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "typed_block_loop_triage_task_created")
+        self.assertEqual(state["remediation_strategy"], "create_typed_block_loop_triage_task")
+        self.assertTrue(state["native_dispatch_required_next"])
+        created_tasks = [task for task_id, task in fake.tasks.items() if task_id != loop_id]
+        self.assertEqual(len(created_tasks), 1)
+        created_body = json.loads(str(created_tasks[0]["body"]))
+        self.assertEqual(created_body["targeted_remediation"]["plan_action"], "triage_typed_block_loop")
+        self.assertEqual(created_body["targeted_remediation"]["block_loop_task_refs"], [loop_id])
+        self.assertFalse(created_body["operator_input_required"])
+
+    def test_no_idle_unblocks_nonproduction_proof_task_after_operator_authority_receipt(self) -> None:
+        fake = FakeHermes()
+        proof_id = "t_" + "rel007proof"
+        fake.tasks[proof_id] = {
+            "id": proof_id,
+            "status": "blocked",
+            "title": "REL-007 Solana/Quasar Bankrun/DevNet-safe proof packet",
+            "assignee": "solana-quasar-qa-engineer",
+            "body": json.dumps({"rel": "REL-007", "proof_scope": "Bankrun/disposable DevNet"}),
+            "comments": [
+                {
+                    "author": "human-gate-clerk",
+                    "body": (
+                        "OPERATOR DECISION / non-production proof authority confirmed. "
+                        "decision record: approved/non-production-proof-only. Safe proof/staging/Bankrun/"
+                        "disposable-DevNet validation only; no production, no Mainnet, no real funds, no secrets."
+                    ),
+                }
+            ],
+            "events": [{"type": "blocked", "payload": {"kind": "needs_input", "reason": "disposable DevNet authority required"}}],
+        }
+        args = adapter.build_parser().parse_args(
+            ["no-idle", "--board", TEST_BOARD, "--create-remediation", "--workspace", "scratch"]
+        )
+
+        result = adapter.no_idle(args, runner=fake)
+
+        state = result["no_idle_state"]
+        self.assertEqual(state["classification"], "nonproduction_proof_authority_unblocked")
+        self.assertEqual(state["remediation_strategy"], "unblock_nonproduction_proof_authority_tasks")
+        self.assertEqual(state["unblocked_task_refs"], [adapter.PUBLIC_SAFE_KANBAN_REF])
+        self.assertTrue(state["native_dispatch_required_next"])
+        self.assertEqual(fake.tasks[proof_id]["status"], "ready")
+        self.assertFalse(state["operator_input_required"])
+        self.assertFalse(state["human_gate_required"])
+
+    def test_release_replan_duplicate_consumption_artifacts_do_not_trigger_repair(self) -> None:
+        task_id = "t_" + "dupreplan"
+        record = {
+            "id": task_id,
+            "status": "done",
+            "title": "Replan actionable non-production release proof path",
+            "assignee": "release-ops-worker",
+            "body": json.dumps({"marker": adapter.NO_IDLE_RELEASE_REPLAN_MARKER}),
+            "runs": [
+                {
+                    "status": "done",
+                    "summary": "Consumed duplicate release replan without creating another proof graph.",
+                    "metadata": {
+                        "release_ops_result": {
+                            "verdict": "DUPLICATE_REPLAN_CONSUMED_BY_EXISTING_NATIVE_PATH__PROMOTION_STILL_BLOCKED",
+                            "artifacts": [
+                                f"/tmp/missing/{task_id}/release_replan_duplicate_consumption_{task_id}.json",
+                                f"/tmp/missing/{task_id}/release_replan_duplicate_consumption_{task_id}.md",
+                            ],
+                        }
+                    },
+                }
+            ],
+        }
+
+        self.assertEqual(adapter.missing_declared_local_artifacts(record), [])
+
     def test_missing_human_gate_artifacts_are_suppressed_when_delivery_receipt_exists(self) -> None:
         gate_id = "t_" + "humangate"
         missing_artifacts = [


### PR DESCRIPTION
## Summary
- consumes approved/non-production-proof-only receipts to unblock proof tasks under guardrails
- turns Hermes typed block-loop detection into an explicit triage task when create-remediation is requested
- keeps no-create no-idle read-only behavior intact
- suppresses duplicate release-replan consumption artifacts so they do not cause artifact repair loops

## Test Plan
- /srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check