### PR TITLE
docs: rebuild Portuguese product docs from reader questions

### DIFF
--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -1,60 +1,44 @@
 # Overkill Factory
 
-A Overkill Factory é uma fábrica para trabalho com agentes. Ela existe para uma situação bem concreta: você pede algo importante, o agente começa a trabalhar, tudo parece andar, mas ninguém consegue provar com segurança que o produto certo ficou pronto.
+A Overkill Factory é uma resposta para um problema que aparece rápido quando começamos a usar agentes para trabalho sério.
 
-A fábrica tenta resolver isso sem transformar o operador em fiscal. O pedido entra. A fonte é preservada. A fábrica entende o produto, escolhe o caminho, divide o trabalho, roda pelo Hermes, cobra prova, revisa e só então entrega, bloqueia ou aprende.
+Você pede uma coisa importante. O agente entende uma parte, completa outra parte com palpite, faz bastante barulho, talvez abra arquivos, talvez passe testes, talvez diga que terminou. Só que, no fim, você ainda precisa perguntar: "isso entregou mesmo o produto que eu pedi?".
 
-O objetivo é tornar a velocidade confiável. Não é fazer o agente correr mais; é fazer a corrida deixar rastro, prova e responsabilidade.
+A fábrica existe para tirar essa pergunta do improviso.
 
-Isso é produção controlada.
+Ela pega um pedido e transforma em produção controlada: fonte preservada, verdade do produto, caminho escolhido, trabalho dividido, execução no Hermes, prova, revisão, decisão humana quando precisa e fechamento honesto.
 
-## Leia como uma conversa
+O objetivo é tornar a velocidade confiável. Não é fazer agente correr mais. É fazer cada avanço deixar rastro suficiente para alguém confiar, revisar ou bloquear.
 
-Se você só quer entender o produto, leia assim:
+## O que ler primeiro
 
-1. [Manual](manual.md): o que é a fábrica e por que ela existe.
-2. [Como a fábrica trabalha](operating-model.md): o que acontece com um pedido por dentro.
-3. [Confiança e evidência](trust-and-evidence.md): como saber que "pronto" não é teatro.
-4. [Ciclo da fábrica](lifecycle.md): o caminho simples da ideia até entrega, bloqueio ou aprendizado.
+Se você está chegando agora, não comece pelo modelo técnico. Comece pela pergunta que você tem na cabeça.
 
-Depois disso, se quiser rodar ou manter o projeto:
+- [Manual](manual.md): "o que é essa fábrica e por que ela existe?"
+- [Como a fábrica trabalha](operating-model.md): "o que acontece depois que eu mando um pedido?"
+- [Confiança e prova](trust-and-evidence.md): "como eu sei que isso não é só teatro de agente?"
+- [Ciclo simples](lifecycle.md): "qual é o caminho do começo ao fim?"
 
-- [Uso](usage.md): comandos locais e fronteira do que eles provam.
-- [Modelo técnico](technical-model.md): como Hermes, workers, bindings, schemas e validadores se encaixam.
-- [Referência](reference.md): nomes, caminhos e comandos para consulta rápida.
+Depois, se você for operar ou manter o repo:
+
+- [Uso](usage.md): comandos para provar o checkout local.
+- [Modelo técnico](technical-model.md): como Hermes, workers, schemas, adapters e validadores se encaixam.
+- [Referência](reference.md): nomes e caminhos para consulta rápida.
 
 ## A versão curta
 
-A fábrica não deixa um agente sair fazendo só porque a tarefa parece clara.
+A fábrica não confia em frase bonita. Ela confia em fonte, escopo, método, trabalho pequeno e prova.
 
-Ela precisa saber:
+Um pedido não deveria virar código antes de virar entendimento. Um release não deveria sair porque alguém escreveu "pass". Um gate humano não deveria ser uma pergunta vaga no chat. Um worker não deveria julgar o próprio trabalho. E um bloqueio interno da fábrica não deveria cair no colo do operador como se fosse decisão humana.
 
-- qual era a fonte;
-- que produto está sendo construído;
-- que tipo de trabalho é;
-- quem pode executar;
-- quem pode aprovar;
-- que prova precisa voltar;
-- o que acontece se a prova não vier.
+Se a fábrica funciona, o operador não fica caçando evidência. Ele recebe estado claro, decisão clara e recibo claro.
 
-Sem isso, velocidade vira chute.
+## O que esta documentação prova
 
-## A fronteira honesta
+O kernel público atual está na versão `3.0.2`. Ele tem workflow compilado, rotas, métodos, schemas, workers, exemplos, validadores e testes.
 
-O kernel público atual está na versão `3.0.2`. Ele expõe 26 fases compiladas, 14 classes de rota, 8 motores de método, 17 áreas de sistema operacional da fábrica, 40 workers públicos, 244 schemas JSON, 156 templates JSON e 97 arquivos de teste.
+Isso prova uma coisa específica: o repositório público tem um contrato verificável.
 
-Esses números não são promessa de que qualquer produto privado foi entregue. Eles provam que existe um kernel público testável. Entrega real ainda precisa de Hermes vivo, worker results atuais, evidência específica do produto, revisão consumida e decisão humana quando o risco pedir.
+Não prova que uma execução privada terminou. Não prova que um produto vivo foi entregue. Não prova aprovação humana em produção. Para isso, precisa de estado real no Hermes, resultados atuais de workers, evidência do produto, revisão consumida e autorização explícita quando houver risco.
 
-## Primeira prova local
-
-```bash
-cd factory
-python3 scripts/factoryctl.py doctor
-python3 scripts/factoryctl.py run minimal
-```
-
-Se isso passa, o checkout local está coerente. Ainda não significa que uma execução real terminou.
-
-## O que ficou fora da navegação principal
-
-A documentação antiga continua em `factory/legacy-docs/`. Ela tem histórico e detalhe técnico útil, mas não é mais a explicação pública principal. A ideia desta seção em português é ser legível primeiro. O detalhe vem depois.
+Essa fronteira é parte do produto. A fábrica só vale se souber dizer o que sabe e o que ainda não sabe.

--- a/docs/pt-BR/lifecycle.md
+++ b/docs/pt-BR/lifecycle.md
@@ -1,14 +1,10 @@
-# Ciclo da fábrica
+# Ciclo simples
 
-Esta página estava complicada demais. O ciclo da fábrica não deveria parecer uma tabela técnica com inglês vazando por todos os lados.
+O workflow compilado é a fonte factual para a máquina. Ele tem fases, gates, workers e artefatos.
 
-O workflow compilado é a fonte factual para a máquina. Para o leitor, ele precisa virar uma história simples.
+Mas a pessoa que está tentando entender a fábrica não deveria começar decorando fase.
 
-A ideia é mais simples: um pedido entra cru e só pode virar entrega depois de passar por alguns momentos de proteção.
-
-Não decore fase. Entenda o movimento.
-
-## O ciclo em linguagem humana
+O ciclo humano é este:
 
 ```text
 pedido
@@ -16,156 +12,135 @@ pedido
 -> entendimento
 -> verdade do produto
 -> caminho escolhido
--> trabalho dividido
+-> trabalho pequeno
 -> execução no Hermes
--> prova e revisão
--> decisão humana, se precisar
+-> prova
+-> revisão
+-> decisão humana, se houver
 -> entrega, bloqueio ou aprendizado
 ```
 
-É isso.
+## 1. Pedido
 
-Por baixo existem fases, gates, workers e schemas. Eles importam para a máquina. Para o leitor, o mais importante é entender por que cada momento existe.
+Tudo começa com um sinal.
 
-## 1. Antes de começar: proteger a fonte
+Pode ser uma frase, um bug, um repo, um documento, uma conversa, uma tela, um incidente, um pedido de release.
 
-A fábrica começa antes da execução.
+A fábrica ainda não sabe se isso é produto, correção, operação, risco, pesquisa ou decisão. Então ela não deveria sair executando.
 
-O operador pode mandar uma ideia, um documento, um bug, um link, um repo, uma conversa ou um pedido de release. A fábrica precisa guardar isso sem deformar.
+## 2. Fonte protegida
 
-O erro comum é resumir cedo demais. Um resumo curto vira plano. O plano vira execução. Depois todo mundo descobre que a primeira interpretação estava errada.
+Antes de interpretar, a fábrica preserva a fonte.
 
-Então o começo da fábrica protege a fonte, cria o pedido inicial e diz qual runtime vai carregar o trabalho.
+Isso impede que a primeira versão resumida vire verdade oficial.
 
-Nome interno que aparece no workflow: F0 — Pre-Start / Sealed Source Envelope.
+Se o operador mandou contexto longo, a fábrica não pode amputar o contexto e depois construir sobre o pedaço que sobrou.
 
-## 2. Entender o que entrou
+## 3. Entendimento
 
-Depois a fábrica pergunta: "que tipo de sinal é esse?"
+A fábrica separa fato, inferência, decisão, conflito e lacuna.
 
-É produto novo? Bug? Incidente? Release? Segurança? UI? Integração? Migração? Trabalho em agente? Documentação?
+Aqui ela deve conseguir dizer em português claro: "sabemos isso, achamos aquilo, falta isto, este ponto conflita".
 
-Ela também separa fato, palpite, decisão, conflito e lacuna. Isso é chato de fazer, mas salva a execução. Se essa separação não acontece, o agente começa a construir em cima de uma mistura perigosa.
+Se essa leitura está fraca, o resto ainda não deveria andar.
 
-O operador deveria enxergar algo simples: "entendemos isto, falta aquilo, isso não podemos assumir".
+## 4. Verdade do produto
 
-Aqui vivem as fases de entrada, source ledger, source resolution e descoberta.
+Agora o pedido vira definição.
 
-## 3. Definir a verdade do produto
+Qual é o produto? Para quem? Que problema resolve? O que entra? O que fica fora? Que risco importa? Que prova conta?
 
-Antes de construir produto, a fábrica precisa dizer que produto é esse.
+A fábrica chama isso de Product SOT, mas a ideia é só esta: ninguém deveria construir antes de saber o que está construindo.
 
-Essa é a fase do Product SOT. Em português: a verdade do produto.
+## 5. Caminho escolhido
 
-Ela define escopo, não escopo, usuário, problema, critério de aceite, risco e prova. Se o trabalho é grande, também precisa cobrir o escopo inteiro. A primeira fatia não pode fingir ser o todo.
+A fábrica escolhe rota e método.
 
-O atalho perigoso aqui é executar a partir de uma conversa ou de um paper sem transformar aquilo em verdade revisável.
+Bug, release, incidente, segurança, interface, integração, docs, agente, Solana e produto novo não andam do mesmo jeito.
 
-Se a verdade do produto está fraca, o resto pode ficar bonito e ainda assim errado.
+A rota escolhe a régua. O método escolhe como provar.
 
-## 4. Escolher a rota e o método
+## 6. Capacidade e autoridade
 
-Com a verdade na mesa, a fábrica escolhe o caminho.
+Antes de mandar worker, a fábrica pergunta se tem capacidade e autoridade.
 
-Bug não anda como release. Release não anda como tela. Segurança não anda como docs. Produto com interface não anda como backend puro. Mainnet, fundos e segredo não andam como tarefa comum.
+Tem worker certo? Tem acesso? Tem pack para essa superfície? Toca segredo? Toca produção? Toca mainnet? Toca fundos? Precisa de humano?
 
-Rota responde: "que tipo de trabalho é esse?"
+Se falta capacidade, bloqueia. Se precisa de decisão humana, prepara pacote. Se é problema interno, repara.
 
-Método responde: "como esse trabalho deve ser feito e provado?"
+## 7. Trabalho pequeno
 
-O operador não precisa escolher engine interno. A fábrica escolhe e explica o suficiente para o humano confiar na direção.
+O produto vira unidades menores.
 
-O atalho perigoso é começar arquitetura, PR ou worker packet antes de método claro.
+Cada unidade precisa ter entrada, saída, dono, dependência, evidência, reviewer e regra de pronto.
 
-## 5. Checar capacidade, risco e autoridade
+Sem isso, não é trabalho. É desejo.
 
-Antes de execução material, a fábrica precisa perguntar:
+## 8. Execução no Hermes
 
-Temos o tipo certo de worker?
+Hermes é onde o trabalho vivo aparece.
 
-Temos acesso?
+Cards, dependências, workers, comentários, workspaces, anexos, bloqueios e transições precisam estar no runtime. A fábrica não deveria manter uma verdade paralela escondida.
 
-Tem orçamento?
+Se algo depende de outra coisa, a dependência precisa estar no grafo.
 
-Tem risco de produção, mainnet, segredo, privacidade, carteira, assinatura ou dinheiro?
+## 9. Prova
 
-Tem pacote de capacidade para esse tipo de produto?
+Cada worker devolve evidência.
 
-Se falta capacidade, bloqueia. Se a decisão é humana, prepara pacote. Se a decisão é da fábrica, a fábrica trabalha.
+Para código, pode ser teste, diff, build, scan.
 
-Essa parte existe para impedir falsa competência. É melhor dizer "não tenho cobertura ainda" do que fingir especialista.
+Para interface, tela, jornada, estado, console, viewport.
 
-## 6. Planejar o trabalho de verdade
+Para CLI, transcript, instalação, help, erro.
 
-Agora o produto vira unidades pequenas.
+Para release, prontidão, rollback, dono.
 
-Uma unidade boa tem dono, reviewer, prova, dependência e regra de pronto. Se não tem isso, ainda é desejo, não trabalho.
+Para docs, clareza, navegação, primeiro sucesso.
 
-Aqui entram planos de desenvolvimento, grafo de specs, plano de loop, plano de criação do produto e prontidão de implementação.
+A prova precisa bater com o pedido.
 
-O atalho perigoso é mandar agentes trabalharem em paralelo sem saber quem depende de quem e que prova fecha cada pedaço.
+## 10. Revisão
 
-## 7. Rodar no Hermes
+A revisão olha o artefato real.
 
-Hermes é o chão da fábrica.
+Ela passa, falha, pede reparo ou registra risco. Depois a fábrica precisa consumir esse resultado.
 
-Quando a execução começa, ela precisa aparecer como cards, dependências, workers, workspaces, comentários, bloqueios e transições no Hermes. A fábrica pode reconciliar e reparar, mas não pode esconder um segundo estado por fora.
+Revisão que não muda nada é só comentário.
 
-Se tem trabalho pronto, Hermes despacha. Se tem dependência, espera. Se o board fica silencioso sem motivo, no-idle repara ou falha de forma visível.
+## 11. Decisão humana
 
-O atalho perigoso é deixar um agente operar numa lista privada e depois tentar sincronizar a verdade no fim.
+Algumas decisões pertencem ao operador.
 
-## 8. Provar o que foi feito
+Produção, mainnet, fundos, segredos, orçamento, risco residual, release, waiver.
 
-Worker que executa precisa devolver resultado com evidência.
+Nesses casos, a fábrica prepara um pacote de decisão. O humano aprova ou bloqueia sabendo exatamente o que está autorizando.
 
-Dependendo do trabalho, evidência pode ser teste, diff, screenshot, transcript, log, scan, auditoria, simulação, pacote de release, proof remoto ou documento revisado.
+## 12. Fechamento
 
-Produto visível precisa de prova visível. CLI precisa de transcript. Documentação precisa provar que leva o leitor ao primeiro sucesso. Segurança precisa de evidência de risco. Release precisa de rollback e prontidão.
+No fim, a fábrica não escolhe uma palavra bonita. Ela escolhe um estado honesto.
 
-O atalho perigoso é tratar existência de arquivo ou pacote de worker como prova.
+Entregue, se há prova suficiente.
 
-## 9. Revisar e reconciliar
+Bloqueado, se falta algo material.
 
-Depois da execução vem a parte que muita gente pula: consumir a revisão.
+Aprendizado, se a execução mostrou que a fábrica precisa mudar.
 
-Revisão boa não é comentário solto. Ela passa ou falha algo específico. Se passa, destrava. Se falha, cria reparo. Se sobra risco, registra dono e decisão.
+Esse é o ciclo. O resto são mecanismos para garantir que ele não vire teatro.
 
-Depois vem o Receipt Five, que amarra pedido, mudança, evidência, revisão e próximo estado.
+## Nomes internos que você pode encontrar
 
-Sem isso, "feito" ainda é frágil.
+Se você abrir o workflow compilado, vai ver nomes como `F0 — Pre-Start / Sealed Source Envelope`. Não precisa gostar do nome nem ler isso como copy de produto. Esse nome existe para a máquina e para os testes: ele marca o momento em que a fábrica sela a fonte antes de qualquer interpretação.
 
-## 10. Chamar o humano quando a decisão é humana
+A regra de leitura é esta: quando aparecer um nome interno em inglês, traduza mentalmente para a proteção que ele oferece. `Sealed Source Envelope` quer dizer "não destrua a fonte original". `Product SOT` quer dizer "defina a verdade do produto". `Receipt Five` quer dizer "não chame de pronto sem recibo".
 
-Algumas coisas não podem ser decididas por worker.
+## Como ver o workflow interno
 
-Produção. Mainnet. Fundos. Segredos. Orçamento. Risco residual. Release. Waiver.
-
-Nesses casos, a fábrica precisa entregar um pacote de decisão. A pessoa recebe o material, a escolha, o risco, o que aprovar autoriza e o que não autoriza.
-
-O atalho perigoso é pedir "posso seguir?" sem entregar o artefato sob revisão.
-
-## 11. Entregar, bloquear ou aprender
-
-No final, só existem três saídas honestas.
-
-Entrega: a prova existe, a revisão foi consumida, os gates passaram e o próximo estado está claro.
-
-Bloqueio: falta prova, acesso, autoridade, capacidade ou segurança. O bloqueio precisa ter dono e próximo passo.
-
-Aprendizado: a execução mostrou que a própria fábrica precisa melhorar. Isso pode virar teste, doc, skill, worker, gate, issue ou mudança de processo.
-
-A fábrica não deve chamar tudo de sucesso. Às vezes a melhor resposta é um bloqueio bem explicado.
-
-## Onde entram as fases internas
-
-O workflow compilado ainda tem fases internas. Elas existem para a máquina e para os maintainers.
-
-A versão atual expõe 26 fases em `docs/factory-workflow.catalog.json`. Você pode inspecionar com:
+Para inspecionar a versão compilada usada pelos testes:
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
 
-Mas para ler o produto, use o ciclo simples desta página. As fases internas são o mecanismo. O movimento humano é: entender, organizar, executar, provar e fechar.
+Esse comando ajuda maintainers. Para entender o produto, o ciclo acima é o mapa certo.

--- a/docs/pt-BR/manual.md
+++ b/docs/pt-BR/manual.md
@@ -1,204 +1,155 @@
-# Manual do produto
+# Manual
 
-Se você me perguntasse no chat "o que é a Overkill Factory?", eu não começaria falando de schema, worker, registry ou fase.
+A Overkill Factory é mais fácil de entender se você esquecer, por um minuto, os nomes internos.
 
-Eu começaria assim: é uma forma de fazer agentes trabalharem sem virar bagunça.
+Pense numa conversa normal.
 
-Você pede uma coisa. Pode ser um produto novo, uma correção, um release, uma revisão de segurança, uma tela, um fluxo, uma integração, uma operação em produção. Um agente comum tenta resolver direto. Às vezes acerta. Muitas vezes ele parece ocupado, escreve bastante, move alguma coisa, entrega um resumo bonito e deixa o problema real no mesmo lugar.
+Você diz: "quero criar esse produto". Ou: "esse release pode ir?". Ou: "corrige esse bug sem quebrar o resto". Ou: "tem algo errado nesse board, os agentes parecem ocupados, mas nada anda".
 
-A Overkill Factory existe para evitar esse teatro.
+Um agente comum tenta responder fazendo. Ele pode ser útil, mas trabalha com um risco enorme: ele quer avançar antes de ter certeza do que está avançando.
 
-Ela transforma um pedido em produção controlada. Primeiro entende a fonte. Depois define o produto. Depois escolhe o caminho. Depois divide o trabalho. Depois manda os workers certos pelo Hermes. Depois cobra prova. Depois revisa. Depois fecha, bloqueia ou aprende.
+A fábrica existe para colocar um processo entre o pedido e a execução.
 
-Isso é a fábrica.
+Não processo no sentido ruim, de burocracia. Processo no sentido de chão firme. Antes de alguém mexer no produto, a fábrica precisa saber o que foi pedido, o que é fato, o que é suposição, qual é o produto, que tipo de trabalho é, quem tem autoridade, que prova vai contar e o que acontece se a prova não aparecer.
 
-## O problema que ela resolve
+Isso é produção controlada.
 
-O problema não é "agente erra". Isso todo mundo já sabe.
+## Por que isso importa
 
-O problema é pior: agente erra de um jeito que parece certo.
+O erro mais perigoso de um agente não é falhar claramente.
 
-Ele escreve um arquivo, mas o arquivo não resolve o pedido. Ele passa um teste, mas o teste não cobre o comportamento importante. Ele diz que revisou, mas não leu o artefato certo. Ele marca uma tarefa como pronta, mas a evidência não existe. Ele pede aprovação humana, mas não entrega o material que a pessoa precisa aprovar.
+Falha clara é fácil. O comando quebrou. O arquivo não existe. A API recusou. O teste falhou.
 
-Aí o operador vira fiscal. Tem que perguntar: isso está mesmo pronto? Quem revisou? Onde está a prova? Esse bloqueio é meu ou é trabalho da fábrica? Esse "pass" vale alguma coisa?
+O erro perigoso é a entrega que parece certa.
 
-Esse é o trabalho que a fábrica precisa tirar das costas do operador.
+O agente cria um documento, mas o documento não responde à pergunta. Cria uma tela, mas não cobre os estados importantes. Escreve um teste, mas testa o caminho feliz e ignora o risco. Faz uma revisão, mas não relê o artefato. Diz que precisa do humano, mas na verdade faltou readback, faltou anexar prova, faltou rodar um worker.
 
-## A ideia em uma frase
+Aí o operador vira fiscal de tudo.
 
-A fábrica não deixa um pedido virar execução antes de virar verdade, método, trabalho pequeno e prova.
+Ele precisa perguntar onde está a prova. Precisa notar que o card andou sem dependência. Precisa perceber que o reviewer só carimbou. Precisa descobrir que o bloqueio era interno. Precisa virar gerente, QA, auditor e detetive.
 
-Essa frase é o centro do produto.
+A fábrica foi desenhada para impedir isso.
 
-Sem verdade, o agente constrói em cima de mal-entendido.
+## O que a fábrica promete
 
-Sem método, todo pedido vira a mesma tarefa genérica.
+A promessa não é "agentes nunca erram".
 
-Sem trabalho pequeno, ninguém sabe revisar.
+A promessa é melhor: quando a fábrica está funcionando, erro vira estado visível. Lacuna vira lacuna. Risco vira risco. Bloqueio vira bloqueio com dono. Pronto vira pronto com prova.
 
-Sem prova, "pronto" é só uma opinião.
+O operador não precisa acreditar no tom do agente. Ele olha o recibo.
 
-## O que entra na fábrica
+## O caminho de um pedido
 
-Pode entrar quase qualquer sinal de trabalho:
+Um pedido entra quase sempre meio torto. Isso é normal. Produto real começa assim mesmo.
 
-- "cria esse produto";
-- "corrige esse bug";
-- "prepara esse release";
-- "revisa essa mudança perigosa";
-- "descobre por que isso parou";
-- "transforma esse repo em algo publicável";
-- "faz essa tela ficar usável";
-- "prepara um fluxo com carteira, assinatura ou dinheiro";
-- "melhora esse worker porque ele está sendo raso".
+"Cria o onboarding".
 
-A fábrica não deveria responder a tudo com a mesma receita. Bug precisa de reprodução. Release precisa de rollback. Interface precisa de prova visual. Segurança precisa de arquitetura. Produto novo precisa de verdade de produto. Mainnet, fundos, segredos e produção precisam de autoridade humana explícita.
+Certo. Mas onboarding de quem? Com que conta? Com carteira? Com permissão? Com KYC? Com trial? Com pagamento? Com convite? Com dados sensíveis? O sucesso é chegar numa tela? É fazer a primeira ação? É depositar dinheiro? É assinar uma transação? É convidar alguém?
 
-## A primeira obrigação: entender antes de fazer
+A fábrica não deveria pular essas perguntas. Também não deveria jogar tudo de volta para o operador se ela consegue resolver com a fonte que já existe.
 
-Quando o pedido entra, a fábrica precisa proteger a fonte.
+O primeiro trabalho é preservar a fonte e separar o que é sabido do que é palpite.
 
-Isso quer dizer: guardar o que foi pedido de verdade, separar fato de suposição, marcar conflito, listar lacuna e dizer o que ainda não pode ser assumido.
+Depois vem a verdade do produto. Internamente isso aparece como Product SOT. Em português simples: é o acordo sobre o que está sendo construído.
 
-Parece básico. Não é. É onde muito trabalho com agente começa a morrer.
+Só depois faz sentido escolher método, criar tarefas e mandar workers.
 
-Um resumo malfeito vira plano. Um plano malfeito vira execução. Uma execução malfeita vira uma entrega que parece pronta, mas nasceu torta.
+## O que é verdade do produto
 
-A fábrica tenta quebrar essa sequência logo no começo.
+Verdade do produto não é um resumo bonito.
 
-## A verdade do produto
+É o lugar onde a fábrica registra:
 
-Depois da fonte vem a verdade do produto. O nome interno é Product SOT. Pode esquecer o nome por um segundo. A pergunta é simples:
+- qual é o pedido;
+- quem é o usuário ou operador afetado;
+- que problema precisa ser resolvido;
+- o que entra no escopo;
+- o que fica fora;
+- que riscos importam;
+- que decisões já foram tomadas;
+- que decisões ainda dependem do humano;
+- que prova vai contar como aceite.
 
-"Que produto estamos construindo, exatamente?"
+Sem isso, qualquer plano parece razoável. Com isso, o plano pode ser cobrado.
 
-Não basta dizer "um dashboard", "um app", "um onboarding" ou "um agente". A fábrica precisa saber para quem é, que problema resolve, o que entra, o que fica fora, quais promessas precisam ser cumpridas, que risco existe e que prova vai contar.
+A fábrica também precisa cuidar de uma armadilha comum: transformar a primeira fatia executável no produto inteiro. Se o produto é maior, cada parte importante precisa ter destino. Pode estar planejada, bloqueada, fora de escopo, delegada ao humano ou provada. Não pode simplesmente sumir.
 
-Sem isso, um worker pode trabalhar muito e ainda entregar a coisa errada.
+## Método não é enfeite
 
-Quando o trabalho é um produto inteiro, a fábrica também precisa olhar a cobertura do escopo. A primeira fatia prática não pode virar "o produto" só porque foi a parte mais fácil de executar. Cada promessa importante precisa ter destino: planejada, bloqueada com dono, fora de escopo com justificativa, decidida pelo humano ou provada.
+Trabalhos diferentes precisam de caminhos diferentes.
 
-## A fábrica escolhe o caminho
+Bug pede reprodução e regressão.
 
-Depois de entender o produto, a fábrica escolhe o caminho.
+Release pede prontidão, rollback, dono e monitoramento.
 
-Um bug não anda como um release. Um release não anda como uma tela. Uma tela não anda como uma mudança de chave. Uma integração crítica não anda como uma alteração de texto.
+Interface pede jornada, estados, tela, erro, carregamento, acessibilidade básica e prova visual.
 
-A fábrica tem rotas e métodos para isso. O leitor não precisa decorar os nomes. O ponto é outro: a fábrica precisa escolher a régua certa antes de distribuir trabalho.
+Segurança pede fronteira, ameaça, segredo, permissão, supply chain, revisão e decisão sobre risco residual.
 
-Se é bug, cadê a reprodução?
+Incidente pede contenção, causa, comunicação e aprendizado.
 
-Se é produto, cadê a definição?
+Produto novo pede verdade do produto, decomposição, workers, revisão e aceite.
 
-Se é interface, cadê a jornada e os estados?
+Se a fábrica trata tudo igual, ela é só uma fila de tarefas com nome bonito.
 
-Se é segurança, cadê a ameaça e a fronteira?
+## O papel do Hermes
 
-Se é produção, cadê rollback, dono e monitoramento?
+Hermes é o chão da fábrica.
 
-Essa escolha muda o que será pedido aos workers e muda o que vai contar como prova.
+É onde ficam os cards, dependências, status, workers, comentários, workspaces, anexos, bloqueios e transições.
 
-## Workers não são personagens
+A Overkill Factory não deveria criar outro estado escondido. Ela define o contrato do trabalho: que artefatos precisam existir, que gates bloqueiam, que worker entra, que prova volta, que decisão é humana e que atalhos são proibidos.
 
-Um worker não deveria ser "um agente esperto com um prompt bom".
+Hermes mostra o trabalho vivo. A fábrica diz o que esse trabalho precisa respeitar.
 
-Na fábrica, worker é papel com limite. Ele recebe um pacote pequeno dizendo o que fazer, o que não fazer, o que devolver e que autoridade ele não tem.
+## O que é um worker bom
 
-Isso vale para quem planeja, quem constrói, quem testa, quem revisa, quem faz segurança, quem prepara release, quem reconcilia evidência e quem registra decisão humana.
+Um worker bom não recebe "faz o produto".
 
-O worker pode ter autonomia dentro da faixa. Fora da faixa, ele bloqueia.
+Recebe um pacote pequeno.
 
-Esse limite é o que permite velocidade sem entregar o volante inteiro para o agente.
+O pacote diz: faça isto, usando esta fonte, dentro deste limite, sem essa autoridade, devolvendo esta evidência. Se faltar algo, bloqueie deste jeito.
 
-## Hermes é o chão da fábrica
+Isso parece simples, mas muda a qualidade da autonomia. O worker pode andar rápido porque a faixa está marcada. E a revisão consegue olhar uma entrega pequena em vez de tentar julgar uma missão nebulosa.
 
-O Hermes guarda o estado vivo: cards, dependências, workers, comentários, workspaces, bloqueios e transições.
+## Onde o humano entra
 
-A Overkill Factory não tenta substituir isso. Ela define o contrato de produção: que artefatos precisam existir, que gates bloqueiam, que worker entra, que prova precisa voltar, que decisão é humana e o que não pode ser autorizado por um agente.
+O humano não deveria ser chamado para limpar bagunça da fábrica.
 
-Essa separação é saudável.
+Se falta arquivo, readback, evidência, revisão, PDF, link, hash, screenshot, worker result ou reparo interno, a fábrica trabalha.
 
-Hermes mostra o que está acontecendo.
+O humano entra quando a autoridade é dele: produção, mainnet, fundos, segredos, orçamento, release, risco material, waiver, mudança de poder.
 
-A fábrica diz o que pode acontecer com segurança.
+E quando entra, a fábrica precisa respeitar o tempo dele. Nada de "aprova?" sem contexto. Nada de JSON cru. Nada de caminho local como se fosse decisão.
 
-## Pronto quer dizer provado
+Um gate humano bom entrega uma decisão clara:
 
-Aqui está a regra mais importante: pronto quer dizer provado.
+"Você está aprovando este artefato, com estes riscos, para permitir este próximo passo. Você não está aprovando aquilo. Se recusar, o caminho seguro é este".
 
-Não quer dizer "o worker disse que terminou".
+## O que significa pronto
 
-Não quer dizer "um arquivo apareceu".
+Pronto quer dizer provado.
 
-Não quer dizer "o teste que ele mesmo escolheu passou".
+Não quer dizer que o agente ficou confiante. Não quer dizer que um arquivo apareceu. Não quer dizer que um teste qualquer passou. Não quer dizer que alguém falou "ok" no chat.
 
-Não quer dizer "alguém aprovou no chat sem ver o material".
+A fábrica precisa conseguir contar a história:
 
-Pronto quer dizer que a fábrica consegue apontar para o pedido, para a mudança, para a evidência, para a revisão e para o próximo estado.
+"O pedido era este. A fonte usada foi esta. O produto definido foi este. O método escolhido foi este. Estes workers rodaram. Estas provas voltaram. Esta revisão foi consumida. Este gate humano autorizou isto. O que ainda falta é aquilo".
 
-O nome interno desse recibo é Receipt Five. Ele não é burocracia. Ele é o freio contra conclusão falsa.
+Se essa história não existe, a entrega não está pronta. Ela pode estar em revisão, bloqueada, incompleta ou aguardando decisão. Mas pronta, não.
 
-## Quando o humano entra
+## O que falta quando a fábrica parece ruim
 
-O humano entra quando a decisão é realmente dele.
+Quando a documentação, o board ou a execução parecem ruins, normalmente é porque uma dessas coisas sumiu:
 
-Produção. Mainnet. Fundos. Segredos. Orçamento. Risco material. Release. Waiver. Mudança que pode afetar cliente, dinheiro, segurança ou reputação.
+- a dor do operador;
+- a verdade do produto;
+- o motivo de cada fase;
+- a fronteira entre Hermes e fábrica;
+- a diferença entre prova local e entrega viva;
+- a explicação de por que um humano está sendo chamado;
+- a ligação entre worker, evidência, revisão e recibo.
 
-Mas a fábrica não deveria chamar o humano para resolver bagunça interna. Se falta readback, se falta PDF, se falta artefato, se falta revisão, se um worker foi raso, isso é trabalho da fábrica.
+A fábrica não pode virar uma coleção de termos internos. Se o leitor precisa decorar nomes para entender o produto, a documentação falhou.
 
-Quando existe gate humano de verdade, ele precisa vir como pacote de decisão. Uma mensagem curta, em português claro, dizendo:
-
-- que decisão está sendo pedida;
-- que material está em revisão;
-- o que aprovar permite;
-- o que aprovar não permite;
-- quais são as opções;
-- qual é o risco;
-- qual é o próximo passo seguro.
-
-JSON cru não é gate humano. Pergunta vaga no chat também não.
-
-## Um exemplo simples
-
-Você pede: "cria o onboarding do cliente".
-
-Um agente comum pode começar a desenhar tela.
-
-A fábrica deveria parar e perguntar, mesmo que internamente:
-
-Quem é o cliente? O que ele precisa conseguir fazer no primeiro uso? Tem conta? Tem permissão? Tem carteira? Tem pagamento? Tem dado sensível? Tem design pronto? O que conta como sucesso? O que não entra agora?
-
-Depois disso, a fábrica separa o trabalho:
-
-- alguém define a verdade do fluxo;
-- alguém planeja a experiência;
-- alguém implementa a tela;
-- alguém implementa API ou dados, se houver;
-- alguém testa a jornada;
-- alguém olha a prova visual;
-- alguém revisa;
-- alguém fecha com evidência.
-
-O operador não deveria coordenar tudo isso na mão. Ele deveria receber o estado claro e ser chamado apenas quando houver decisão real.
-
-## O que a fábrica ainda precisa provar
-
-A documentação pública prova a intenção e o contrato do kernel. Os testes locais provam que o repositório está coerente.
-
-Isso não é a mesma coisa que dizer que uma execução privada, num Hermes vivo, entregou um produto específico.
-
-Para isso, precisa de estado real no Hermes, worker results atuais, evidência do produto, revisão consumida e decisão humana quando o risco pedir.
-
-Essa fronteira é importante. A fábrica não fica mais fraca por dizer isso. Ela fica mais confiável.
-
-## Se você só lembrar de uma coisa
-
-A Overkill Factory é uma tentativa de transformar agentes em linha de produção confiável.
-
-Não é mágica. Não é um agente único. Não é um prompt gigante.
-
-É um jeito de impedir que velocidade vire chute.
-
-Pedido entra. A fábrica entende, organiza, executa, prova, revisa e fecha.
-
-Quando não consegue provar, ela não finge. Ela bloqueia e diz o que falta.
+A versão boa precisa parecer uma conversa séria: simples na superfície, precisa por baixo, honesta sobre o que existe e o que ainda precisa ser provado.

--- a/docs/pt-BR/operating-model.md
+++ b/docs/pt-BR/operating-model.md
@@ -1,154 +1,163 @@
 # Como a fábrica trabalha
 
-A melhor forma de entender a Overkill Factory é acompanhar um pedido por dentro.
+Vamos acompanhar um pedido como ele deveria andar.
 
-Imagine que você manda uma mensagem: "quero transformar essa ideia num produto". Ou "esse release pode ir?". Ou "corrige esse fluxo". A fábrica não deveria sair correndo para codar. O primeiro trabalho dela é descobrir que tipo de pedido entrou e o que precisa ser verdade antes de qualquer agente tocar no produto.
+O operador manda: "quero transformar essa ideia em produto".
 
-## 1. Entrada não é execução
+A resposta errada é abrir uma tarefa gigante e deixar um agente tentar resolver. A resposta certa é a fábrica tratar o pedido como matéria-prima. Matéria-prima ainda não é produto.
 
-A conversa pode começar no Telegram, no Discord, no cockpit, no terminal ou em outro canal. Isso é só a porta de entrada.
+## A entrada é só a porta
 
-A porta recebe material, pergunta, arquivo, link, repo, imagem, bug, decisão. Mas ela não decide sozinha o que vai ser feito. Ela não é o runtime. Ela não é a verdade.
+O pedido pode chegar por Telegram, Discord, cockpit, CLI ou outro canal. O canal não manda na fábrica. Ele só recebe o sinal.
 
-A função da entrada é criar um começo seguro: guardar a fonte, registrar o objetivo, separar o que já está claro do que ainda precisa ser resolvido e impedir que a primeira interpretação vire plano definitivo.
+A primeira responsabilidade é guardar a fonte. A mensagem original, o documento, o repo, o link, a conversa, a imagem, o bug, a decisão. Tudo isso precisa existir antes da interpretação.
 
-É aqui que o gerente aparece. O gerente fala com o operador. Ele traduz estado, pede decisão quando precisa e entrega pacotes legíveis. Ele não substitui os workers nem o Hermes.
+Se a fábrica resume cedo demais, perde nuance. Se perde nuance, planeja errado. Se planeja errado, entrega algo convincente e inútil.
 
-## 2. A fábrica separa fato, palpite e decisão
+Por isso o começo é cuidadoso.
 
-Logo no começo, a fábrica precisa responder:
+## A fábrica separa o que sabe do que acha
 
-"O que sabemos de verdade?"
+Depois de guardar a fonte, a fábrica separa cinco coisas.
 
-Ela separa:
+Fato: veio da fonte.
 
-- o que veio da fonte;
-- o que é inferência;
-- o que já foi decidido;
-- o que está em conflito;
-- o que ainda está faltando.
+Inferência: parece razoável, mas não foi dito literalmente.
 
-Essa separação é o chão de tudo. Se a fábrica mistura essas coisas, o resto fica contaminado. Um palpite vira requisito. Uma lacuna vira escopo. Uma decisão antiga vira regra atual.
+Decisão: alguém com autoridade já decidiu.
 
-Quando a fábrica faz isso direito, o operador consegue corrigir cedo. Quando faz errado, o operador só percebe tarde, quando já tem código, docs, PR e desculpa.
+Conflito: duas fontes dizem coisas diferentes.
 
-## 3. Antes de plano, vem verdade do produto
+Lacuna: falta informação para seguir com segurança.
 
-A fábrica precisa montar a verdade do produto antes de mandar execução material.
+Essa etapa parece pequena. Não é. Ela impede que um palpite vire requisito e que uma lacuna vire trabalho escondido.
 
-O nome interno é Product SOT. Em português simples: é o documento que diz "é isto que estamos construindo".
+O operador deveria receber uma leitura simples: "entendi isso, falta aquilo, isso aqui não vou assumir".
 
-Ele precisa deixar claro:
+## A fábrica define o produto antes de planejar
 
-- qual é o produto ou fatia;
-- para quem serve;
-- que problema resolve;
-- o que entra;
-- o que não entra;
-- que risco existe;
-- que prova conta como aceite;
-- que decisão ainda depende do operador.
+O próximo passo é criar a verdade do produto.
 
-Se o trabalho é grande, a fábrica também precisa checar a cobertura do escopo inteiro. Isso evita uma armadilha comum: executar a primeira parte visível e fingir que o produto todo ficou planejado.
+Não é um texto bonito para justificar a execução. É o contrato do que será construído.
 
-## 4. O caminho muda conforme o tipo de trabalho
+Ele responde: qual é o produto, para quem, com que promessa, dentro de que limite, com que risco e com que prova de aceite.
 
-A fábrica não deveria tratar tudo como "tarefa para agente".
+Se o pedido é pequeno, essa verdade pode ser curta. Se o pedido é grande, precisa cobrir o escopo inteiro. O importante é não deixar o worker decidir o produto no meio da execução.
 
-Um bug pede reprodução. Um incidente pede mitigação. Um release pede rollback. Uma tela pede prova de experiência. Uma mudança de segurança pede ameaça e fronteira. Um produto novo pede definição, decomposição e gates. Uma integração pede contrato e fallback. Um trabalho com Solana, carteira, assinatura ou dinheiro pede muito mais cuidado.
+Quando o produto não está definido, qualquer entrega pode parecer certa.
 
-Por isso existem rotas e métodos.
+## A rota escolhe a régua
 
-O operador não precisa decorar os nomes. O que importa é que a fábrica precisa escolher a régua certa. A pergunta não é "qual agente pega isso?". A pergunta é "que tipo de risco e prova esse pedido exige?".
+Com o produto definido, a fábrica escolhe a rota.
 
-## 5. A fábrica verifica capacidade antes de fingir especialista
+Rota é a resposta para: que tipo de trabalho é esse?
 
-Nem todo produto cabe no mesmo conjunto de workers.
+Bug, produto novo, release, incidente, segurança, UX, documentação, integração, migração, agente, Solana, operação viva. Cada um pede uma régua diferente.
 
-Web, API, CLI, cloud, agente, Solana, docs e onboarding têm cobertura mais madura no kernel público. Outros mundos, como mobile nativo, desktop, game, fintech, domínio regulado, analytics avançado, extensão de navegador e hardware, exigem pacotes de capacidade próprios antes de execução material.
+Se é bug, a fábrica precisa de reprodução e regressão.
 
-Isso é importante. Bloquear porque falta capacidade é melhor do que deixar um agente genérico fingir que é especialista.
+Se é release, precisa de prontidão, rollback e dono.
 
-A fábrica boa não promete "faço tudo". Ela diz: "para isso eu tenho cobertura" ou "para isso eu preciso instalar e provar um pacote antes".
+Se é interface, precisa de prova da experiência.
 
-## 6. O trabalho vira unidades pequenas
+Se é segurança, precisa de fronteira, ameaça e revisão.
 
-Depois da verdade e do método, a fábrica quebra o trabalho.
+Se é mainnet ou fundos, precisa de autoridade humana explícita.
 
-Uma unidade boa tem dono, escopo, entrada, saída, prova, reviewer, dependência e regra de pronto. Uma unidade ruim é algo como "construir o produto".
+A rota impede que tudo vire "manda um agente fazer".
 
-Essa diferença muda tudo. Trabalho pequeno pode ser executado, revisado, repetido e fechado. Trabalho grande demais vira uma aposta.
+## O método diz como provar
 
-Na prática, a fábrica transforma o produto em cards e pacotes de worker. Cada pacote diz o que o worker deve fazer e, principalmente, o que ele não pode fazer.
+Depois da rota vem o método.
 
-## 7. Hermes guarda o estado vivo
+Método bom não é slogan. Ele muda a prova.
 
-Hermes Kanban continua sendo a fonte de verdade do runtime. É lá que ficam cards, dependências, status, workers, workspaces, comentários, bloqueios e transições.
+Se o método é test-first, precisa ter teste que falha antes ou prova equivalente de regressão.
 
-A fábrica não deve criar um segundo Hermes por fora. Ela prepara o contrato e reconcilia o estado, mas o trabalho vivo precisa aparecer no runtime.
+Se é design-first, precisa de estados, jornada, superfície e evidência visual.
 
-Isso também vale para dependências. Se uma fase depende de uma unidade de trabalho, essa unidade precisa estar ligada no grafo. Se trabalho obrigatório aparece tarde, ele precisa entrar no grafo antes de a próxima fase andar.
+Se é security-first, precisa de fronteira, scan, revisão e decisão sobre risco.
 
-A fábrica não pode descobrir uma obrigação depois e fingir que a fase anterior estava completa.
+Se é incident-first, precisa de contenção, causa e aprendizado.
 
-## 8. No-idle é guarda, não motor principal
+Se o método não muda artefato, gate ou evidência, ele não está fazendo nada.
 
-No-idle existe para evitar silêncio perigoso.
+## A fábrica checa se tem capacidade
 
-Se tem coisa rodando, ele observa. Se tem coisa pronta, Hermes despacha. Se tem dependência, ele espera. Se precisa de decisão humana e o pacote está pronto, o gerente chama o operador. Se falta artefato, readback, PDF, revisão ou reparo interno, a fábrica repara.
+Nem todo tipo de produto está igualmente coberto.
 
-O que ele não pode fazer: virar um despachante paralelo, inventar fase, aprovar gate, completar tarefa ou jogar bloqueio interno no humano.
+Web, CLI, cloud, agentes, docs, onboarding e alguns caminhos Solana têm cobertura mais madura no kernel público. Outras áreas podem exigir pacote de capacidade antes: mobile nativo, desktop, game, fintech regulado, hardware, analytics avançado, extensão de navegador.
 
-No-idle bom não é barulho. É a garantia de que a fábrica não fica parada fingindo que está tudo bem.
+Isso não é fraqueza. É honestidade operacional.
 
-## 9. Produto visível precisa de prova visível
+Uma fábrica confiável não finge que sabe fazer tudo. Ela diz quando tem cobertura e quando precisa instalar, testar ou revisar um pack antes de execução material.
 
-Se o produto tem interface, não basta dizer que o backend está pronto.
+## O trabalho vira pacote pequeno
 
-A fábrica precisa de prova da cara do produto. Isso pode incluir tela, estados, jornada, erro, loading, viewport, acessibilidade básica, console, overflow, texto e comparação com o que foi prometido.
+Agora a fábrica quebra o produto em unidades de trabalho.
 
-Para CLI, a prova é diferente: instalação, help, transcript, erro, comportamento no terminal.
+Uma unidade boa tem entrada, saída, dono, dependência, evidência, reviewer e regra de pronto.
 
-Para docs, também é diferente: o leitor consegue chegar ao primeiro sucesso? Os links funcionam? O texto guia alguém de verdade?
+Uma unidade ruim diz "construir o produto".
 
-A regra é simples: cada superfície pede um tipo de prova. Uma screenshot bonita não prova um produto inteiro. Mas sem prova da experiência, produto visível não está pronto.
+A diferença é enorme. Trabalho pequeno pode ser executado, cobrado e refeito. Trabalho gigante vira aposta.
 
-## 10. Revisão precisa voltar para o trabalho
+O worker recebe só a parte dele. Ele não ganha autoridade para mudar escopo, aprovar risco, tocar segredo, decidir release ou encerrar o card inteiro.
 
-Review não é decoração.
+## Hermes Kanban continua sendo a fonte de verdade
 
-Se a revisão passa, ela precisa destravar ou fechar a tarefa certa. Se falha, precisa criar reparo. Se encontra risco, precisa registrar. Se fica parada num comentário, é só teatro.
+Hermes Kanban continua sendo a fonte de verdade do runtime.
 
-O executor não deve ser o juiz final do próprio trabalho quando o risco é material. A fábrica precisa consumir a revisão, não apenas gerar uma revisão.
+Cards, dependências, status, workers, comentários, workspaces, anexos, bloqueios e transições precisam aparecer ali.
 
-## 11. Gate humano é decisão, não interrupção
+A fábrica não pode manter um segundo estado escondido e depois tentar sincronizar no fim. Se uma unidade depende de outra, a dependência precisa estar no grafo. Se trabalho obrigatório aparece tarde, entra no grafo antes de a fase seguinte andar.
 
-A fábrica só deve chamar o humano quando a decisão é mesmo do humano.
+Isso evita uma mentira comum: dizer que a fase terminou enquanto ainda existe trabalho obrigatório fora do quadro.
 
-Produção. Mainnet. Fundos. Segredo. Orçamento. Release. Risco residual. Waiver. Mudança de autoridade.
+## No-idle observa silêncio perigoso
 
-E quando chama, precisa entregar um pacote de decisão. Curto na frente, completo nos anexos. A pessoa precisa entender o que está aprovando sem abrir JSON cru ou caçar contexto no Kanban.
+No-idle não é outro Hermes.
 
-Um gate humano bom diz: "você está aprovando isto, com este risco, para permitir este próximo passo. Você não está aprovando aquilo".
+Ele serve para perceber quando o board está parado de um jeito suspeito. Se há trabalho pronto, despacha. Se há dependência, espera. Se falta pacote de decisão humana, prepara. Se falta readback, artefato ou revisão, repara. Se não consegue reparar, falha de forma visível.
 
-## 12. Fechar é reconciliar
+O que ele não pode fazer é inventar autoridade. Não aprova gate, não completa tarefa, não chama o humano por preguiça interna.
 
-No fim, a fábrica compara o que era obrigatório com o que foi entregue.
+## Produto visível precisa ser visto
 
-Ela olha pedido, Product SOT, método, workers, evidências, revisão, gates, risco residual, release e próximo estado.
+Quando o trabalho tem interface, a fábrica precisa provar a experiência.
 
-Se bate, fecha com Receipt Five.
+Para web, isso pode envolver telas, viewports, console, overflow, estados vazios, loading, erro, acessibilidade básica e comparação com a promessa do produto.
 
-Se não bate, bloqueia com motivo e dono.
+Para CLI, envolve instalação, help, comando real, saída, erro e comportamento no terminal.
 
-Se a execução revelou uma falha da própria fábrica, vira learnback: teste novo, doc nova, skill nova, gate novo, issue ou mudança de processo. Mas isso também precisa de validação. A fábrica não deve se reescrever no escuro.
+Para docs, envolve outra coisa: o texto realmente ajuda alguém a entender e chegar ao primeiro sucesso?
 
-## 13. O que o operador deveria sentir
+Uma prova de backend não prova interface. Uma screenshot não prova jornada inteira. Cada superfície precisa de prova própria.
 
-O operador não deveria sentir que está pilotando quarenta agentes.
+## Revisão só vale quando muda estado
 
-Deveria sentir que existe uma linha de produção: o pedido entrou, a fábrica entendeu, o estado está claro, os bloqueios têm dono, as decisões chegam bem explicadas e "pronto" vem com prova.
+Revisão que fica parada é decoração.
 
-Se a experiência vira cobrança manual, se o operador precisa detectar preguiça, se o humano precisa perguntar onde está a evidência, a fábrica falhou.
+Se passou, precisa destravar ou fechar a tarefa certa. Se falhou, precisa criar reparo. Se apontou risco, precisa registrar dono, consequência e decisão. Se o executor revisa a si mesmo num trabalho material, a fábrica está se enganando.
 
-Esse é o padrão certo para ler qualquer parte da Overkill Factory.
+A revisão precisa voltar para o fluxo.
+
+## Gate humano é pacote de decisão
+
+Quando a decisão é humana, a fábrica chama o humano.
+
+Mas chama direito.
+
+Ela entrega o artefato ou uma projeção fiel. Explica a decisão. Mostra opções. Diz o que cada opção autoriza. Diz o que não autoriza. Mostra o risco e o próximo passo seguro.
+
+O humano não deveria aprovar no escuro.
+
+## O fim tem três saídas
+
+Entrega: há prova, revisão consumida, gates resolvidos e próximo estado claro.
+
+Bloqueio: falta prova, acesso, autoridade, capacidade ou segurança. O bloqueio tem dono e menor próximo passo seguro.
+
+Aprendizado: a execução revelou que a própria fábrica precisa melhorar. Isso pode virar teste, doc, skill, worker, gate, issue ou mudança de processo.
+
+A fábrica boa não força final feliz. Ela fecha quando pode, bloqueia quando deve e aprende quando descobriu algo real.

--- a/docs/pt-BR/trust-and-evidence.md
+++ b/docs/pt-BR/trust-and-evidence.md
@@ -1,142 +1,131 @@
-# Confiança e evidência
+# Confiança e prova
 
-A pergunta desta página é simples:
-
-"Como eu sei que isso não é só um agente falando bonito?"
+A pergunta certa é: "como eu sei que isso não é só um agente falando bonito?"
 
 A resposta começa por uma verdade incômoda: processo parecendo vivo não é a mesma coisa que progresso.
 
-Essa pergunta precisa ficar no centro da Overkill Factory. Agente é muito bom em parecer confiante. Ele escreve. Ele resume. Ele cria arquivo. Ele move card. Ele diz que passou. Mas nada disso, sozinho, prova que o produto ficou certo.
+Um sistema pode ter cards andando, comentários novos, arquivos criados e mensagens confiantes. Ainda assim, o produto pode estar errado.
 
-A fábrica existe porque progresso falso é caro.
+## O que é teatro de progresso
 
-## O inimigo é o teatro de progresso
+Teatro de progresso é quando a aparência de trabalho substitui a entrega.
 
-Teatro de progresso é quando o sistema parece vivo, mas a entrega real não avançou.
+O worker diz "feito", mas não aponta evidência.
 
-Exemplos:
+O teste passa, mas não testa o risco.
 
-- o worker diz "feito", mas não entrega evidência;
-- o arquivo existe, mas não resolve o pedido;
-- o teste passa, mas testa a coisa errada;
-- o reviewer aprova sem ler o artefato;
-- o humano é chamado para aprovar sem receber o material;
-- o board fica cheio de atividade, mas o bloqueio real continua lá;
-- a fábrica pede decisão humana para algo que ela mesma deveria reparar.
+A tela existe, mas o fluxo quebra no segundo estado.
 
-Tudo isso deve ser tratado como falha de produto, não como detalhe de processo.
+A revisão aprova, mas não leu o artefato.
 
-## Evidência é mais importante que tom de voz
+O humano aprova, mas não recebeu o material.
 
-A fábrica não confia em confiança. Confia em prova.
+O board se move, mas a dependência real ficou de fora.
 
-Um worker bom não só diz o que fez. Ele aponta para o artefato, o comando, o resultado, a captura, o diff, o log, o teste, a revisão ou o pacote que prova.
+A fábrica foi criada para tratar isso como falha central, não como detalhe.
 
-Mesmo assim, evidência não pode ser qualquer coisa. Um caminho local perdido não serve. Um arquivo temporário não serve. Um print sem contexto quase nunca serve. Um pass sem escopo não serve. Uma aprovação humana genérica não serve para liberar produção, fundo, segredo ou mainnet.
+## Prova precisa ter ligação com o pedido
 
-A prova precisa ser atual, legível e ligada ao pedido.
+Evidência solta não basta.
 
-## Readback: ler o que foi entregue
+Um log, uma screenshot, um diff, um teste, um arquivo ou um link só vale se estiver ligado ao que foi pedido.
 
-Readback é uma palavra feia para uma coisa simples: a fábrica precisa reler o que o worker diz que entregou.
+Se o pedido era provar onboarding, a evidência precisa mostrar a jornada.
 
-Se ele diz que escreveu um Product SOT, a fábrica lê o SOT.
+Se era release, precisa mostrar prontidão, rollback e decisão.
 
-Se ele diz que anexou evidência, a fábrica confere se a evidência abre, se tem tamanho, se tem hash quando precisa, se pode ser lida depois e se não vaza segredo.
+Se era segurança, precisa mostrar risco, fronteira, revisão e o que ficou aceito.
 
-Se ele diz que criou um teste, a fábrica confere se o teste cobre o comportamento certo.
+Se era documentação, precisa mostrar que o leitor consegue entender e usar, não só que o Markdown compila.
 
-Sem readback, o processo pode estar correto e o produto errado.
+## Readback: a fábrica lê de volta
+
+Readback é simples: a fábrica confere o que foi entregue.
+
+Se um worker disse que criou um documento, a fábrica lê o documento.
+
+Se disse que anexou prova, a fábrica confere se a prova existe, abre, pode ser relida e não depende de um arquivo temporário.
+
+Se disse que rodou teste, a fábrica olha o teste e o resultado.
+
+Se disse que a interface está boa, a fábrica olha a superfície.
+
+Sem readback, a fábrica fica confiando no próprio processo. E processo pode estar correto enquanto o produto está ruim.
 
 ## Receipt Five: o recibo do pronto
 
-Receipt Five é o jeito da fábrica dizer "pronto" sem depender de humor, pressa ou autoridade do executor.
+Receipt Five é o recibo de conclusão.
 
-Ele precisa responder cinco perguntas:
+Ele responde cinco perguntas:
 
 1. O que foi pedido?
 2. O que foi feito ou decidido?
-3. Que evidência prova isso?
-4. Quem revisou e o que a revisão concluiu?
-5. O que continua pendente, bloqueado ou arriscado?
+3. Que prova sustenta isso?
+4. Quem revisou e o que a revisão disse?
+5. O que ainda falta, bloqueia ou fica como risco?
 
-Se uma dessas respostas falta, o estado honesto não é pronto. Pode ser pronto para revisão. Pode ser parcialmente completo. Pode ser bloqueado. Pode estar aguardando decisão humana.
+Se uma resposta importante está vazia, o estado não é pronto.
+
+Pode ser "pronto para revisão". Pode ser "bloqueado". Pode ser "parcial". Pode ser "aguardando humano".
 
 Mas não é pronto.
 
-## Revisão independente não é carimbo
+## Revisão independente precisa ser consumida
 
-Review de verdade precisa ser consumido.
+A revisão não existe para enfeitar o processo.
 
-Não basta gerar um relatório de revisão. A fábrica precisa usar o resultado. Se passou, destrava ou fecha o item certo. Se falhou, cria reparo. Se achou risco residual, registra dono e decisão. Se o reviewer é a mesma identidade que executou, não é revisão independente.
+Ela precisa mudar o estado do trabalho.
 
-Revisão parada é só mais um artefato bonito.
+Se passou, destrava. Se falhou, cria reparo. Se encontrou risco, registra. Se pediu decisão, vira pacote humano. Se não foi consumida, não serviu.
 
-## Bloqueio honesto
+E quando o risco é material, o executor não deveria ser o juiz final do próprio trabalho.
 
-Bloqueio bom diz:
+## Bloqueio precisa ser honesto
 
-- o que falta;
-- por que falta;
-- quem é dono;
-- qual é o menor próximo passo seguro;
-- se precisa ou não do operador.
+Bloqueio bom é específico.
 
-Nem todo bloqueio é humano.
+Ele diz o que falta, por que falta, quem é dono e qual é o menor próximo passo seguro.
 
-Se a dependência ainda não terminou, é espera. Se falta capacidade, a fábrica precisa buscar ou ativar um pacote. Se é erro transitório, tenta reparar. Se falta artefato, readback, PDF ou revisão, a fábrica trabalha.
+Também diz se precisa do humano ou não.
 
-O operador só entra quando existe decisão real de autoridade.
+Muita coisa não precisa do humano. Falta de readback, falta de anexo, falta de revisão, worker raso, artefato quebrado, prova insuficiente. Isso é trabalho da fábrica.
 
-## Gate humano precisa respeitar o humano
+O humano só deve ser chamado quando existe autoridade real a exercer.
 
-Gate humano não é "posso seguir?" jogado no chat.
+## Gate humano sem material é inválido
 
-Um gate humano sério entrega o material sob revisão. Se é Product SOT, entrega o SOT. Se é arquitetura, entrega a arquitetura. Se é release, entrega o pacote de release. Se é segurança, entrega o risco e as opções.
+Um gate humano não é "posso seguir?".
 
-A primeira mensagem precisa ser clara e curta:
+É uma decisão com artefato.
 
-- decisão pedida;
-- resumo em português normal;
-- o que aprovar permite;
-- o que aprovar não permite;
-- opções de resposta;
-- consequência;
-- evidência;
-- urgência.
+Se a fábrica pede aprovação de Product SOT, entrega o Product SOT. Se pede release, entrega o pacote de release. Se pede arquitetura, entrega a arquitetura. Se pede risco de segurança, entrega o risco, as opções e a consequência.
 
-O anexo pode ser grande. A pergunta não pode ser vaga.
+O operador precisa saber o que aprovar permite e o que aprovar não permite.
 
-## Segurança não fica para o fim
+A pergunta pode ser curta. O material não pode ser ausente.
 
-Segurança não é um scan no final para deixar a PR bonita.
+## Segurança entra cedo
 
-Se o trabalho toca autenticação, permissão, segredo, chave, produção, supply chain, privacidade, carteira, assinatura, Solana, fundos ou mainnet, a segurança entra no caminho desde cedo.
+Segurança não é maquiagem de fim de PR.
 
-Às vezes isso significa arquitetura. Às vezes significa threat model. Às vezes significa worker especialista. Às vezes significa gate humano. Às vezes significa bloquear.
+Se o trabalho toca segredo, permissão, produção, supply chain, privacidade, wallet, assinatura, Solana, fundos ou mainnet, segurança entra no caminho desde cedo.
 
-A fábrica não promete segurança perfeita. Promete não fingir que risco desapareceu.
+Às vezes isso vira arquitetura. Às vezes vira scan. Às vezes vira revisão. Às vezes vira gate humano. Às vezes vira bloqueio.
 
-## Prova local, prova viva e prova pública
+A fábrica não promete risco zero. Ela promete não esconder risco atrás de um "pass" genérico.
 
-Essas três coisas são diferentes.
+## Prova local não é entrega viva
 
 Um comando local passando prova que o checkout está coerente.
 
-Um Hermes vivo com worker result prova que aquele worker rodou naquele contexto.
+Um estado Hermes vivo prova que o trabalho existiu naquele runtime.
 
-Um Receipt Five bem formado prova que a conclusão daquele trabalho está ligada a pedido, mudança, evidência, revisão e próximo estado.
+Um worker result prova que um worker devolveu algo naquele escopo.
 
-Uma publicação pública ainda precisa passar por segurança de superfície e segredo.
+Um Receipt Five bem formado prova que a conclusão foi reconciliada.
 
-Não dá para trocar uma pela outra. Smoke local não prova produto entregue. Arquivo existente não prova readback. Aprovação genérica não prova release. Print bonito não prova jornada.
+Essas coisas não são iguais.
 
-## Quando confiar
+Não dá para usar smoke local como prova de produto entregue. Não dá para usar arquivo existente como prova de readback. Não dá para usar aprovação genérica como autorização de mainnet.
 
-Você pode começar a confiar quando a fábrica consegue contar a história inteira sem pular etapa:
-
-"O pedido era este. A fonte dizia isto. A verdade do produto ficou assim. O método escolhido foi este. Estes workers rodaram. Estas evidências voltaram. Esta revisão foi consumida. Este gate humano autorizou exatamente isto. O que ainda falta é aquilo."
-
-Essa história precisa estar nos artefatos, não só na memória de quem estava no chat.
-
-Esse é o padrão.
+A fábrica precisa manter essa fronteira visível, mesmo quando seria mais conveniente fingir que está tudo pronto.


### PR DESCRIPTION
## Summary
- Rebuilds the Portuguese public docs from a reader-question structure instead of another technical pass.
- Rewrites PT index, manual, operating model, trust/evidence, and lifecycle around operator pain, product truth, Hermes runtime, proof, review, gates, and honest closure.
- Keeps public manifest phrases and executable boundaries while reducing phase-table language and English-heavy copy.

## Validation
- `git diff --check`
- `python3 -m mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/overkill-docs-pt-zero-check2`
- `cd factory && python3 scripts/generate_factory_reference_docs.py && python3 scripts/generate_factory_reference_docs.py --check`
- `cd factory && python3 scripts/validate_public_json_artifacts.py`
- `cd factory && python3 scripts/validate_public_surface_sync.py`
- `cd factory && python3 scripts/validate_promise_implementation_map.py`
- `cd factory && python3 scripts/validate_worker_profiles.py`
- `cd factory && python3 scripts/public_safety_scan.py`
- `cd factory && python3 scripts/secret_safety_scan.py`
- `cd factory && python3 -m unittest tests.test_open_source_docs tests.test_public_surface_sync tests.test_promise_implementation_map tests.test_generated_factory_reference_docs -q`
- `cd factory && python3 -m unittest discover -s tests -p 'test_*.py' -q` (1230 tests OK, 1 skipped)
