### PR TITLE
fix: bound no-idle enrichment timeouts

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -79,6 +79,7 @@ NO_IDLE_OWNER_GATE_DELIVERY_MARKER = "factory_no_idle_owner_gate_delivery"
 NO_IDLE_DECLARED_ARTIFACT_REPAIR_SUPERSEDED_MARKER = "factory_no_idle_declared_artifact_repair_superseded"
 NO_IDLE_STALE_REMEDIATION_REPLACEMENT_LIMIT = 8
 NO_IDLE_RUNNING_RESULT_CLOSEOUT_TIMEOUT_SECONDS = 5 * 60
+NO_IDLE_DONE_ENRICHMENT_LIMIT = int(os.environ.get("NO_IDLE_DONE_ENRICHMENT_LIMIT", "40"))
 REL007_REDUCER_COMPLETION_MARKER = "rel007_bounded_reducer_completion"
 REL007_REDUCER_DECISION = "REDUCE_CHILD_BLOCKERS_AS_BOUNDED_EVIDENCE_ONLY"
 REL007_BANKRUN_CHILD_ROLE = "bankrun_child"
@@ -537,6 +538,9 @@ WORKER_MATERIALIZATION_CONTRACT_FIELDS = (
 )
 
 
+HERMES_ADAPTER_SUBPROCESS_TIMEOUT_SECONDS = int(os.environ.get("HERMES_ADAPTER_SUBPROCESS_TIMEOUT_SECONDS", "45"))
+
+
 def default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.setdefault("HOME", str(Path.home()))
@@ -547,6 +551,7 @@ def default_runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
         env=env,
         encoding="utf-8",
         errors="replace",
+        timeout=HERMES_ADAPTER_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
 
@@ -2287,6 +2292,29 @@ def running_result_closeout_candidates(rows: dict[str, list[dict[str, Any]]]) ->
     ]
 
 
+def no_idle_record_timestamp(record: dict[str, Any], fallback: float = 0.0) -> float:
+    for key in ("completed_at", "updated_at", "created_at", "started_at", "last_heartbeat_at"):
+        parsed = parse_timestamp_seconds(record.get(key))
+        if parsed is not None:
+            return parsed
+    return fallback
+
+
+def limit_no_idle_done_enrichment_rows(rows: dict[str, list[dict[str, Any]]], *, limit: int = NO_IDLE_DONE_ENRICHMENT_LIMIT) -> dict[str, list[dict[str, Any]]]:
+    if limit <= 0:
+        return rows
+    done_rows = rows.get("done") or []
+    if len(done_rows) <= limit:
+        return rows
+    indexed = list(enumerate(done_rows))
+    indexed.sort(key=lambda pair: no_idle_record_timestamp(pair[1], fallback=float(pair[0])), reverse=True)
+    selected_indexes = {index for index, _ in indexed[:limit]}
+    next_rows = dict(rows)
+    next_rows["done"] = [item for index, item in enumerate(done_rows) if index in selected_indexes]
+    next_rows["done_omitted_from_enrichment"] = done_rows[: max(0, len(done_rows) - limit)]
+    return next_rows
+
+
 def enrich_no_idle_rows(
     *,
     hermes_bin: str,
@@ -2327,7 +2355,12 @@ def enrich_no_idle_rows(
             merged["comments"] = task_readback_comments(shown)[-3:]
             merged["events"] = task_readback_events(shown)[-5:]
             if status in {"running", "done"}:
-                runs = task_run_records(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+                try:
+                    runs = task_run_records(hermes_bin=hermes_bin, board=board, task_id=task_id, runner=runner)
+                except (RuntimeError, subprocess.TimeoutExpired) as exc:
+                    merged["runs_unavailable"] = True
+                    merged["runs_unavailable_reason"] = type(exc).__name__
+                    runs = []
                 if runs:
                     merged["runs"] = runs[-3:]
             if status == "done":
@@ -11831,6 +11864,7 @@ def no_idle(args: argparse.Namespace, runner: Runner = default_runner) -> dict[s
         )
         for status in ("ready", "running", "todo", "blocked", "triage", "done")
     }
+    rows = limit_no_idle_done_enrichment_rows(rows)
     rows = enrich_no_idle_rows(hermes_bin=args.hermes_bin, board=args.board, rows=rows, runner=runner)
     rows = suppress_missing_declared_artifacts_with_readback_pass(rows)
     initial_reconcile_plan = build_board_reconcile_plan_from_rows(board=args.board, rows=rows)

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -350,6 +350,13 @@ class FakeHermes:
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="unexpected command")
 
 
+class TimeoutRunsHermes(FakeHermes):
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "runs":
+            raise subprocess.TimeoutExpired(argv, timeout=1)
+        return super().__call__(argv)
+
+
 class UnsafePromotionHermes(FakeHermes):
     def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
         if len(argv) >= 5 and argv[0:3] == ["hermes", "kanban", "--board"] and argv[4] == "show":
@@ -1084,6 +1091,22 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         assert_route_readiness_schema(self, result)
         self.assertEqual(result["result"], "BLOCKED")
         self.assertIn("credential_not_proven", result["checks"][0]["blocked_reasons"])
+
+    def test_no_idle_enrichment_survives_hung_runs_lookup(self) -> None:
+        fake = TimeoutRunsHermes()
+        fake.tasks["done-task"] = {
+            "id": "done-task",
+            "title": "Completed producer",
+            "status": "done",
+            "events": [],
+            "comments": [],
+        }
+        rows = {"done": [{"id": "done-task", "status": "done"}], "running": [], "todo": [], "blocked": [], "triage": []}
+
+        enriched = adapter.enrich_no_idle_rows(hermes_bin="hermes", board=TEST_BOARD, rows=rows, runner=fake)
+
+        self.assertEqual(enriched["done"][0]["id"], "done-task")
+        self.assertTrue(enriched["done"][0]["runs_unavailable"])
 
     def test_materialize_reducer_completion_completes_exact_bounded_rel007_children(self) -> None:
         fake = FakeHermes()


### PR DESCRIPTION
## Summary
- bounds Hermes subprocess calls used by the live adapter
- makes no-idle run-history enrichment fail open when hermes kanban runs hangs
- limits done-task enrichment before expensive per-task show/runs scans so no-idle remains a fast control-plane diagnosis
- adds regression coverage for hung runs lookup

## Live Proof
- reproduced no-idle hang with faulthandler at enrich_no_idle_rows -> task_run_records/show_task
- after patch, live no-idle returned within timeout and created/remediated active KAXIS work
- KAXIS board advanced to running F17 plus a missing-declared-artifact repair task

## Test Plan
- /srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check
