### PR TITLE
Enforce repair loops before final closeout

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -10464,6 +10464,55 @@ def product_creation_next_route_contract(next_action: str, closeout: dict[str, A
                 "may_create_public_safe_issue": True,
             },
         }
+    if next_action in {"repair_required", "blocked_with_owner"}:
+        return {
+            **common,
+            "route_contract_type": "iterative_problem_resolution_loop",
+            "factory_invariant": (
+                "Any non-human/factory-owned problem must be advanced through repair, audit, rerun, "
+                "and reconciliation until resolved. Negative closeout is not progress."
+            ),
+            "done_definition": [
+                "create executable repair tasks",
+                "route each blocker to the owning worker or specialist with exact evidence and next action",
+                "audit the repair when safety/security/release semantics are involved",
+                "rerun the failed/blocked proof or worker path",
+                "reconcile the rerun result back into the original blocker",
+                "repeat the repair loop while blockers remain factory-owned",
+                "stop only for genuine human/external authority",
+                "gate final/production/release downstream on the reconciliation result",
+                "do not count a negative/no-Receipt-Five closeout as progress when repairable blockers remain",
+            ],
+            "evidence_expected": [
+                "blocker inventory with owners and next_repair_action",
+                "created repair task refs or exact reason no repair can be created",
+                "audit/review refs when the repair touches safety/security/release-sensitive paths",
+                "rerun command/results or exact remaining external blocker",
+                "reconciliation result linked to downstream gates",
+            ],
+            "output_contract": {
+                "receipt_field": "repair_loop_result",
+                "allowed_results": [
+                    "REPAIRED_AND_RECONCILED",
+                    "NEXT_REPAIR_CREATED",
+                    "HUMAN_OR_EXTERNAL_AUTHORITY_REQUIRED",
+                ],
+                "pass_requires": [
+                    "all factory-owned blockers resolved or next repair task created",
+                    "downstream final/release/production gates remain blocked until reconciliation passes",
+                    "evidence refs for repair, audit/rerun, and reconciliation",
+                ],
+                "human_stop_requires": [
+                    "specific unavailable external/human authority",
+                    "single exact question or required artifact",
+                    "why no factory-owned repair remains possible",
+                ],
+                "block_requires": ["owner", "reason", "next_repair_action", "repair_task_ref_or_human_stop_reason"],
+                "negative_closeout_counts_as_progress": False,
+                "production_promotion_allowed": False,
+                "complete_product_claim_allowed": False,
+            },
+        }
     if next_action == "release_readiness_required":
         return {
             **common,

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -1976,6 +1976,30 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         dispatch_calls = [call for call in fake.calls if len(call) >= 5 and call[4] == "dispatch"]
         self.assertEqual(dispatch_calls, [])
 
+    def test_product_creation_repair_required_is_executable_loop_not_negative_bureaucracy(self) -> None:
+        for next_action in ("repair_required", "blocked_with_owner"):
+            with self.subTest(next_action=next_action):
+                contract = adapter.product_creation_next_route_contract(
+                    next_action,
+                    {
+                        "blockers": [
+                            {
+                                "blocker_id": "any_factory_owned_problem",
+                                "owner": "factory-orchestrator",
+                                "reason": "something failed before final closeout",
+                                "next_repair_action": "repair, audit, rerun, and reconcile until resolved",
+                            }
+                        ]
+                    },
+                )
+
+                self.assertEqual(contract["route_contract_type"], "iterative_problem_resolution_loop")
+                self.assertIn("create executable repair tasks", contract["done_definition"])
+                self.assertIn("rerun the failed/blocked proof or worker path", contract["done_definition"])
+                self.assertIn("stop only for genuine human/external authority", contract["done_definition"])
+                self.assertFalse(contract["output_contract"]["negative_closeout_counts_as_progress"])
+                self.assertIn("repair_loop_result", contract["output_contract"]["receipt_field"])
+
     def test_close_product_creation_run_routes_learnback_with_worker_contract(self) -> None:
         fake = FakeHermes()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- makes repair_required / blocked_with_owner product closeout routes explicit iterative repair loops
- encodes the global factory invariant: factory-owned blockers must create repair/audit/rerun/reconcile work instead of counting negative closeout as progress
- adds regression coverage for both repair_required and blocked_with_owner route contracts

## Validation
- python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority is granted by this change.
