### PR TITLE
Add Factory 15-point hardening scope lock

### DIFF
--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 244 | `schemas/*.json` |
-| Templates | 161 | `templates/*` |
+| JSON schemas | 245 | `schemas/*.json` |
+| Templates | 162 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
@@ -241,6 +241,7 @@ These are the public JSON schemas the factory exposes. They are not decoration; 
 - `schemas/discovery-brief.schema.json`
 - `schemas/evidence-graph.schema.json`
 - `schemas/execution-learnback-record.schema.json`
+- `schemas/factory-15-point-hardening-program.schema.json`
 - `schemas/factory-automation-run-record.schema.json`
 - `schemas/factory-automation-run-target.schema.json`
 - `schemas/factory-battery-result.schema.json`
@@ -479,6 +480,7 @@ Templates are starter records paired with schemas. They are examples of valid sh
 - `templates/discord-control-tower-owner-setup.json`
 - `templates/doc-implementation-obligations.json`
 - `templates/execution-learnback-record.json`
+- `templates/factory-15-point-hardening-program.json`
 - `templates/factory-automation-run-record.json`
 - `templates/factory-automation-run-target.json`
 - `templates/factory-bridge-decision.json`

--- a/factory/schemas/factory-15-point-hardening-program.schema.json
+++ b/factory/schemas/factory-15-point-hardening-program.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-15-point-hardening-program.schema.json",
+  "title": "Factory 15-point hardening program",
+  "type": "object",
+  "required": [
+    "$schema",
+    "program_id",
+    "record_type",
+    "status",
+    "master_issue_ref",
+    "scope_lock",
+    "global_completion_bar",
+    "points"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "program_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "record_type": {
+      "const": "factory_15_point_hardening_program"
+    },
+    "status": {
+      "enum": [
+        "active",
+        "complete",
+        "partial",
+        "blocked"
+      ]
+    },
+    "master_issue_ref": {
+      "type": "string",
+      "pattern": "^github:issue:[0-9]+$"
+    },
+    "scope_lock": {
+      "type": "object",
+      "required": [
+        "expected_point_count",
+        "partial_must_not_be_reported_done",
+        "negative_closeout_counts_as_progress",
+        "factory_owned_blocker_requires_repair_loop",
+        "human_stop_requires_exact_external_authority"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "expected_point_count": {
+          "const": 15
+        },
+        "partial_must_not_be_reported_done": {
+          "const": true
+        },
+        "negative_closeout_counts_as_progress": {
+          "const": false
+        },
+        "factory_owned_blocker_requires_repair_loop": {
+          "const": true
+        },
+        "human_stop_requires_exact_external_authority": {
+          "const": true
+        }
+      }
+    },
+    "global_completion_bar": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "contains": {
+        "const": "no_factory_owned_blocker_left_as_passive_bureaucracy"
+      }
+    },
+    "points": {
+      "type": "array",
+      "minItems": 15,
+      "maxItems": 15,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "problem",
+          "required_behavior",
+          "workstream",
+          "issue_refs",
+          "required_artifact_classes",
+          "verification"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^P(0[1-9]|1[0-5])$"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "problem": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required_behavior": {
+            "type": "string",
+            "minLength": 1
+          },
+          "workstream": {
+            "enum": [
+              "control_plane_invariants",
+              "discovery_preflight_capability",
+              "operator_ux",
+              "architecture_quality",
+              "worker_safety_accountability"
+            ]
+          },
+          "issue_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required_artifact_classes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "verification": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "implementation_status": {
+            "enum": [
+              "complete",
+              "partial",
+              "blocked",
+              "not_yet_claimed_complete"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/factory/scripts/factory_15_point_hardening_audit.py
+++ b/factory/scripts/factory_15_point_hardening_audit.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Audit the Factory 15-point hardening program scope lock.
+
+This audit is intentionally not a completion claim. It proves that the program
+tracks every required point and that partial work cannot be reported as done.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_POINT_IDS = [f"P{i:02d}" for i in range(1, 16)]
+REQUIRED_COMPLETION_BAR = {
+    "public_issue_or_mapped_issue_section",
+    "kanban_or_runtime_task_result_artifact",
+    "productized_code_schema_template_or_doc_update",
+    "regression_test_or_validator_coverage",
+    "green_ci_and_merge_when_repo_changes",
+    "live_or_simulated_behavior_proof",
+    "no_factory_owned_blocker_left_as_passive_bureaucracy",
+}
+REQUIRED_WORKSTREAMS = {
+    "control_plane_invariants",
+    "discovery_preflight_capability",
+    "operator_ux",
+    "architecture_quality",
+    "worker_safety_accountability",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def audit_program(program: dict[str, Any], *, require_complete: bool = False) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if program.get("record_type") != "factory_15_point_hardening_program":
+        errors.append("record_type must be factory_15_point_hardening_program")
+
+    raw_scope_lock = program.get("scope_lock")
+    scope_lock: dict[str, Any] = raw_scope_lock if isinstance(raw_scope_lock, dict) else {}
+    if scope_lock.get("expected_point_count") != 15:
+        errors.append("scope_lock.expected_point_count must be exactly 15")
+    if scope_lock.get("partial_must_not_be_reported_done") is not True:
+        errors.append("scope_lock.partial_must_not_be_reported_done must be true")
+    if scope_lock.get("negative_closeout_counts_as_progress") is not False:
+        errors.append("scope_lock.negative_closeout_counts_as_progress must be false")
+    if scope_lock.get("factory_owned_blocker_requires_repair_loop") is not True:
+        errors.append("scope_lock.factory_owned_blocker_requires_repair_loop must be true")
+    if scope_lock.get("human_stop_requires_exact_external_authority") is not True:
+        errors.append("scope_lock.human_stop_requires_exact_external_authority must be true")
+
+    completion_bar = set(program.get("global_completion_bar") or [])
+    missing_bar = sorted(REQUIRED_COMPLETION_BAR - completion_bar)
+    if missing_bar:
+        errors.append("global_completion_bar missing: " + ", ".join(missing_bar))
+
+    points = program.get("points")
+    if not isinstance(points, list):
+        errors.append("points must be a list")
+        points = []
+    if len(points) != 15:
+        errors.append(f"points must contain exactly 15 entries, found {len(points)}")
+
+    ids = [str(point.get("id") or "") for point in points if isinstance(point, dict)]
+    if ids != EXPECTED_POINT_IDS:
+        errors.append(f"points must be ordered exactly {EXPECTED_POINT_IDS}, found {ids}")
+
+    seen_workstreams: set[str] = set()
+    incomplete_points: list[str] = []
+    for expected_id, point in zip(EXPECTED_POINT_IDS, points):
+        if not isinstance(point, dict):
+            errors.append(f"{expected_id} must be an object")
+            continue
+        point_id = str(point.get("id") or "")
+        for field in ("title", "problem", "required_behavior", "workstream"):
+            if not str(point.get(field) or "").strip():
+                errors.append(f"{point_id or expected_id}.{field} is required")
+        workstream = str(point.get("workstream") or "")
+        if workstream:
+            seen_workstreams.add(workstream)
+            if workstream not in REQUIRED_WORKSTREAMS:
+                errors.append(f"{point_id}.workstream has unknown value {workstream}")
+        for field in ("issue_refs", "required_artifact_classes", "verification"):
+            value = point.get(field)
+            if not isinstance(value, list) or not value or not all(str(item).strip() for item in value):
+                errors.append(f"{point_id or expected_id}.{field} must be a non-empty string list")
+        implementation_status = str(point.get("implementation_status") or "not_yet_claimed_complete")
+        if implementation_status != "complete":
+            incomplete_points.append(point_id or expected_id)
+
+    missing_workstreams = sorted(REQUIRED_WORKSTREAMS - seen_workstreams)
+    if missing_workstreams:
+        errors.append("missing workstreams: " + ", ".join(missing_workstreams))
+
+    program_status = str(program.get("status") or "")
+    if incomplete_points and program_status == "complete":
+        errors.append("program status cannot be complete while points lack implementation_status=complete")
+    if require_complete and incomplete_points:
+        errors.append("require-complete failed; incomplete points: " + ", ".join(incomplete_points))
+    if incomplete_points:
+        warnings.append("implementation incomplete for: " + ", ".join(incomplete_points))
+
+    result = "FAIL" if errors else ("PASS_COMPLETE" if not incomplete_points else "PASS_SCOPE_LOCK_PARTIAL_IMPLEMENTATION")
+    return {
+        "result": result,
+        "program_id": program.get("program_id"),
+        "point_count": len(points),
+        "expected_point_count": 15,
+        "incomplete_point_ids": incomplete_points,
+        "workstreams": sorted(seen_workstreams),
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def markdown_report(audit: dict[str, Any]) -> str:
+    lines = [
+        "# Factory 15-point hardening audit",
+        "",
+        f"Result: `{audit['result']}`",
+        f"Program: `{audit.get('program_id')}`",
+        f"Points: {audit['point_count']}/{audit['expected_point_count']}",
+        "",
+    ]
+    if audit["errors"]:
+        lines.append("## Errors")
+        lines.extend(f"- {item}" for item in audit["errors"])
+        lines.append("")
+    if audit["warnings"]:
+        lines.append("## Warnings")
+        lines.extend(f"- {item}" for item in audit["warnings"])
+        lines.append("")
+    lines.append("## Incomplete point IDs")
+    if audit["incomplete_point_ids"]:
+        lines.extend(f"- {item}" for item in audit["incomplete_point_ids"])
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audit Factory 15-point hardening scope lock")
+    parser.add_argument("program", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--markdown", type=Path)
+    parser.add_argument("--require-complete", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    audit = audit_program(load_json(args.program), require_complete=args.require_complete)
+    text = json.dumps(audit, indent=2, sort_keys=True)
+    if args.out:
+        args.out.write_text(text + "\n", encoding="utf-8")
+    if args.markdown:
+        args.markdown.write_text(markdown_report(audit), encoding="utf-8")
+    print(text)
+    return 1 if audit["result"] == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/factory/templates/factory-15-point-hardening-program.json
+++ b/factory/templates/factory-15-point-hardening-program.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-15-point-hardening-program.schema.json",
+  "program_id": "factory-15-point-hardening-2026-07",
+  "record_type": "factory_15_point_hardening_program",
+  "status": "active",
+  "master_issue_ref": "github:issue:595",
+  "scope_lock": {
+    "expected_point_count": 15,
+    "partial_must_not_be_reported_done": true,
+    "negative_closeout_counts_as_progress": false,
+    "factory_owned_blocker_requires_repair_loop": true,
+    "human_stop_requires_exact_external_authority": true
+  },
+  "global_completion_bar": [
+    "public_issue_or_mapped_issue_section",
+    "kanban_or_runtime_task_result_artifact",
+    "productized_code_schema_template_or_doc_update",
+    "regression_test_or_validator_coverage",
+    "green_ci_and_merge_when_repo_changes",
+    "live_or_simulated_behavior_proof",
+    "no_factory_owned_blocker_left_as_passive_bureaucracy"
+  ],
+  "points": [
+    {
+      "id": "P01",
+      "title": "Real effectiveness rule",
+      "problem": "The factory can count ritual as progress.",
+      "required_behavior": "Separate product/material progress from process ritual; done counts only when product outcome advances or executable repair is created.",
+      "workstream": "control_plane_invariants",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["validator", "regression_test", "runtime_policy"],
+      "verification": ["process_pass_readback_pass_quality_pass_product_progress_pass_are_distinct"]
+    },
+    {
+      "id": "P02",
+      "title": "Universal automatic repair loop",
+      "problem": "Blockers can become passive or negative closeout.",
+      "required_behavior": "Every factory-owned blocker loops repair -> audit -> rerun -> reconcile until resolved or true external/human authority remains.",
+      "workstream": "control_plane_invariants",
+      "issue_refs": ["github:issue:594", "github:issue:595"],
+      "required_artifact_classes": ["reducer_rule", "no_idle_rule", "regression_test"],
+      "verification": ["downstream_final_phases_are_gated_on_reconciliation"]
+    },
+    {
+      "id": "P03",
+      "title": "Interactive factory start/discovery OS",
+      "problem": "Factory start can be too mechanical and under-aligned.",
+      "required_behavior": "Gerente-led discovery captures intent, scope, non-goals, UX, architecture preview, access/capability needs, risks and success criteria before material execution.",
+      "workstream": "discovery_preflight_capability",
+      "issue_refs": ["github:issue:593", "github:issue:595"],
+      "required_artifact_classes": ["product_understanding_packet", "deferred_decision_ledger", "gerente_flow"],
+      "verification": ["material_execution_requires_understanding_packet_or_explicit_deferred_ledger"]
+    },
+    {
+      "id": "P04",
+      "title": "Hermes environment preflight",
+      "problem": "Factory starts without proving Hermes environment readiness.",
+      "required_behavior": "Run doctor/preflight for profiles, bindings, skills, toolsets, browser, computer use, terminal/file/web, cron, gateway, PDF/video/media, domain providers and access readiness.",
+      "workstream": "discovery_preflight_capability",
+      "issue_refs": ["github:issue:588", "github:issue:595"],
+      "required_artifact_classes": ["doctor_command", "schema", "regression_test"],
+      "verification": ["preflight_status_ready_ready_with_deferred_or_blocked_with_exact_human_input"]
+    },
+    {
+      "id": "P05",
+      "title": "Gerente as proactive manager",
+      "problem": "Gerente is not yet a proactive human relationship manager.",
+      "required_behavior": "Gerente owns status, asks, summaries, progress and artifact delivery; cron/watchdog wakes gerente, not human directly.",
+      "workstream": "operator_ux",
+      "issue_refs": ["github:issue:589", "github:issue:595"],
+      "required_artifact_classes": ["operator_notification_policy", "status_contract", "delivery_receipt"],
+      "verification": ["cron_to_gerente_to_human_path_is_enforced"]
+    },
+    {
+      "id": "P06",
+      "title": "Human UX / artifact quality",
+      "problem": "Human can receive raw technical dumps.",
+      "required_behavior": "Human-facing gates/status use PDF/equivalent and video where configured/requested; JSON/Markdown are internal evidence only.",
+      "workstream": "operator_ux",
+      "issue_refs": ["github:issue:590", "github:issue:595"],
+      "required_artifact_classes": ["human_artifact_validator", "pdf_package_contract", "video_explainer_contract"],
+      "verification": ["raw_json_markdown_rejected_as_primary_material_gate_artifact"]
+    },
+    {
+      "id": "P07",
+      "title": "Architecture approval gate",
+      "problem": "Material execution can start without operator-readable architecture approval.",
+      "required_behavior": "Present architecture PDF/optional video with system shape, tradeoffs, rejected alternatives, boundaries, integrations, security, costs and operations before material execution.",
+      "workstream": "architecture_quality",
+      "issue_refs": ["github:issue:591", "github:issue:595"],
+      "required_artifact_classes": ["architecture_approval_package", "human_gate", "regression_test"],
+      "verification": ["material_execution_waits_for_architecture_gate_when_architecture_is_material"]
+    },
+    {
+      "id": "P08",
+      "title": "Domain-specialized capability requirement",
+      "problem": "Generic agents can handle specialized domains without capability proof.",
+      "required_behavior": "Mandatory capability/provider registry per domain; Solana/onchain requires Solana AI Kit or approved official Solana capability before generic execution.",
+      "workstream": "discovery_preflight_capability",
+      "issue_refs": ["github:issue:592", "github:issue:595"],
+      "required_artifact_classes": ["capability_registry", "routing_guard", "solana_ai_kit_receipt"],
+      "verification": ["generic_solana_execution_refused_without_solana_ai_kit_capability"]
+    },
+    {
+      "id": "P09",
+      "title": "Quality firewall",
+      "problem": "Shallow structured output can pass.",
+      "required_behavior": "Definition of Excellence per critical artifact; lazy/generic artifacts fail and route to repair.",
+      "workstream": "architecture_quality",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["quality_firewall", "definition_of_excellence", "review_regression_test"],
+      "verification": ["shallow_artifacts_route_to_repair_even_when_schema_valid"]
+    },
+    {
+      "id": "P10",
+      "title": "Real progress metric",
+      "problem": "Done counts are not meaningful to the human.",
+      "required_behavior": "Report product percent and critical path by gates/artifacts/readiness, not raw task counts.",
+      "workstream": "operator_ux",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["progress_model", "gerente_status_renderer", "evidence_reconciler_rule"],
+      "verification": ["status_reports_product_progress_with_uncertainty_and_blockers"]
+    },
+    {
+      "id": "P11",
+      "title": "Hard boundary between plan/proof/ready/release",
+      "problem": "Bounded evidence can look like readiness.",
+      "required_behavior": "Plan, spec, bounded proof, report-only pass, QA pass, release readiness, production readiness and Receipt Five are distinct machine states.",
+      "workstream": "control_plane_invariants",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["state_model", "validator", "regression_test"],
+      "verification": ["report_only_or_negative_results_cannot_masquerade_as_approval"]
+    },
+    {
+      "id": "P12",
+      "title": "Capability acquisition lane",
+      "problem": "Missing tools/providers can stop the factory instead of acquisition.",
+      "required_behavior": "Missing factory-acquirable capabilities create acquisition/eval/smoke/promotion path before human block except true external authority.",
+      "workstream": "discovery_preflight_capability",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["capability_acquisition_lane", "smoke_test", "promotion_demote_policy"],
+      "verification": ["missing_factory_acquirable_capability_creates_acquisition_task"]
+    },
+    {
+      "id": "P13",
+      "title": "Worker accountability",
+      "problem": "Bad workers can keep being trusted.",
+      "required_behavior": "Track worker quality, failure and rework; demote or route review/repair when repeated poor output occurs.",
+      "workstream": "worker_safety_accountability",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["worker_accountability_ledger", "routing_consequence", "eval_policy"],
+      "verification": ["repeated_worker_quality_failures_change_routing_or_require_review"]
+    },
+    {
+      "id": "P14",
+      "title": "Public/private/security boundary automation",
+      "problem": "Safety boundaries rely on humans remembering rules.",
+      "required_behavior": "Automated checks for secrets, private paths, raw internal artifacts, Mainnet/funds/signing/custody boundaries and human artifact leaks.",
+      "workstream": "worker_safety_accountability",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["safety_scan", "boundary_validator", "ci_gate"],
+      "verification": ["unsafe_public_or_operator_artifact_fails_before_delivery_or_publication"]
+    },
+    {
+      "id": "P15",
+      "title": "Adaptive system, not blind linear phase rail",
+      "problem": "F1..F27 can become a dumb conveyor.",
+      "required_behavior": "Phase graph supports lateral loops, re-entry, blocker-specific repair lanes, and downstream gating on reconciliation.",
+      "workstream": "control_plane_invariants",
+      "issue_refs": ["github:issue:595"],
+      "required_artifact_classes": ["phase_graph_rule", "board_reconciler_rule", "regression_test"],
+      "verification": ["lateral_repair_loop_blocks_downstream_final_phase_until_reconciled"]
+    }
+  ]
+}

--- a/factory/tests/test_factory_15_point_hardening_audit.py
+++ b/factory/tests/test_factory_15_point_hardening_audit.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "factory_15_point_hardening_audit.py"
+TEMPLATE_PATH = ROOT / "templates" / "factory-15-point-hardening-program.json"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("factory_15_point_hardening_audit", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_template() -> dict:
+    return json.loads(TEMPLATE_PATH.read_text(encoding="utf-8"))
+
+
+def test_template_is_complete_scope_lock_without_claiming_done() -> None:
+    module = load_module()
+    result = module.audit_program(load_template())
+
+    assert result["result"] == "PASS_SCOPE_LOCK_PARTIAL_IMPLEMENTATION"
+    assert result["point_count"] == 15
+    assert result["incomplete_point_ids"] == [f"P{i:02d}" for i in range(1, 16)]
+    assert not result["errors"]
+
+
+def test_missing_point_fails_loud() -> None:
+    module = load_module()
+    program = load_template()
+    program["points"] = program["points"][:-1]
+
+    result = module.audit_program(program)
+
+    assert result["result"] == "FAIL"
+    assert any("exactly 15" in error for error in result["errors"])
+
+
+def test_complete_status_is_rejected_until_every_point_is_complete() -> None:
+    module = load_module()
+    program = load_template()
+    program["status"] = "complete"
+
+    result = module.audit_program(program)
+
+    assert result["result"] == "FAIL"
+    assert any("cannot be complete" in error for error in result["errors"])
+
+
+def test_require_complete_fails_until_each_point_has_complete_status() -> None:
+    module = load_module()
+    program = load_template()
+
+    result = module.audit_program(program, require_complete=True)
+
+    assert result["result"] == "FAIL"
+    assert any("require-complete failed" in error for error in result["errors"])
+
+
+def test_complete_program_passes_when_all_points_are_marked_complete() -> None:
+    module = load_module()
+    program = load_template()
+    program["status"] = "complete"
+    for point in program["points"]:
+        point["implementation_status"] = "complete"
+
+    result = module.audit_program(program, require_complete=True)
+
+    assert result["result"] == "PASS_COMPLETE"
+    assert result["incomplete_point_ids"] == []
+    assert result["errors"] == []
+
+
+def test_point_order_is_enforced() -> None:
+    module = load_module()
+    program = load_template()
+    program["points"] = copy.deepcopy(program["points"])
+    program["points"][0], program["points"][1] = program["points"][1], program["points"][0]
+
+    result = module.audit_program(program)
+
+    assert result["result"] == "FAIL"
+    assert any("ordered exactly" in error for error in result["errors"])


### PR DESCRIPTION
## Summary
- adds a public Factory 15-point hardening program template covering P01..P15 exactly
- adds schema and audit script that fail loud if scope is incomplete, out of order, or partial work is claimed complete
- adds tests for scope lock, missing point failure, complete-status rejection, require-complete, and order enforcement

## Why
The factory must not simplify the operator mandate to a top-three subset or treat planning/issues/comments as completion. This creates the productized scope lock that future hardening work must satisfy.

## Validation
- python -m pytest tests/test_factory_15_point_hardening_audit.py tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_product_creation_repair_required_is_executable_loop_not_negative_bureaucracy -q
- python scripts/factory_15_point_hardening_audit.py templates/factory-15-point-hardening-program.json --out .tmp/factory-15-point-hardening-audit.json --markdown .tmp/factory-15-point-hardening-audit.md
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
This does not grant production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595.
