### PR TITLE
Enforce Solana domain capability routing for generic builders

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -663,10 +663,14 @@ OPERATOR_BRIEFING_DECISION_ARTIFACTS = {
     "release_decision",
 }
 SOLANA_DOMAIN_BRAIN_WORKERS = {
+    "agent-runtime-builder",
     "backend-api-builder",
     "codex-security",
     "crypto-key-management-specialist",
+    "data-persistence-builder",
     "decomposition-planner",
+    "frontend-builder",
+    "infra-devops-builder",
     "implementation-worker",
     "integration-builder",
     "product-architect",
@@ -681,11 +685,15 @@ SOLANA_DOMAIN_BRAIN_WORKERS = {
     "wallet-transaction-builder",
 }
 SOLANA_DOMAIN_BRAIN_OUTPUT_FIELDS = {
+    "agent_runtime_result",
     "architecture_result",
     "backend_api_build_result",
     "crypto_key_management_result",
+    "data_persistence_result",
     "decomposition_result",
+    "frontend_build_result",
     "implementation_result",
+    "infra_devops_result",
     "integration_build_result",
     "product_face_result",
     "product_sot_result",

--- a/factory/tests/test_factoryctl.py
+++ b/factory/tests/test_factoryctl.py
@@ -80,6 +80,10 @@ def worker_result(
         "security_orchestration_result": "security-orchestrator",
         "crypto_key_management_result": "crypto-key-management-specialist",
         "backend_api_build_result": "backend-api-builder",
+        "frontend_build_result": "frontend-builder",
+        "data_persistence_result": "data-persistence-builder",
+        "infra_devops_result": "infra-devops-builder",
+        "agent_runtime_result": "agent-runtime-builder",
         "remote_proof_result": "remote-proof-runner",
         "handoff_packet_result": "handoff-packer",
         "solana_quasar_build_result": "solana-quasar-builder",
@@ -880,12 +884,16 @@ class FactoryCtlTest(unittest.TestCase):
             "product-architect",
             "decomposition-planner",
             "product-face",
+            "frontend-builder",
             "wallet-transaction-builder",
             "crypto-key-management-specialist",
             "codex-security",
             "security-orchestrator",
             "backend-api-builder",
+            "data-persistence-builder",
             "integration-builder",
+            "infra-devops-builder",
+            "agent-runtime-builder",
             "test-automation-builder",
         ]:
             with self.subTest(worker_id=worker_id):
@@ -1093,6 +1101,34 @@ class FactoryCtlTest(unittest.TestCase):
             "solana_ai_kit_usage_receipt object is required for real PASS Solana worker results",
             errors,
         )
+
+    def test_real_generic_builder_results_require_solana_ai_kit_receipt_on_solana_card(self) -> None:
+        card = load_card("v35_valid_onchain_auditor_scan.md")
+        card["surfaces"] = ["frontend", "database", "infra", "agent-runtime", "solana", "wallet", "token-2022"]
+
+        for record_type, worker_id in [
+            ("frontend_build_result", "frontend-builder"),
+            ("data_persistence_result", "data-persistence-builder"),
+            ("infra_devops_result", "infra-devops-builder"),
+            ("agent_runtime_result", "agent-runtime-builder"),
+        ]:
+            with self.subTest(record_type=record_type):
+                result = worker_result(record_type, source_card=card)
+                result["evidence_kind"] = "real"
+                result["reusable_for_product"] = True
+
+                errors = factoryctl.validate_worker_result_record(
+                    result,
+                    expected_field=record_type,
+                    expected_worker_id=worker_id,
+                    card=card,
+                    evidence_root=ROOT,
+                )
+
+                self.assertIn(
+                    "solana_ai_kit_usage_receipt object is required for real PASS Solana worker results",
+                    errors,
+                )
 
     def test_worker_packet_carries_sdlc_feedback_loop_ref(self) -> None:
         card_path = ROOT / "templates" / "vfinal-factory-card.json"


### PR DESCRIPTION
## Summary
- Extends the mandatory Solana AI Kit domain-brain route from explicit Solana/wallet workers to generic material builders that can execute Solana/onchain work: frontend, data persistence, infra/devops, and agent runtime.
- Requires real PASS results from those generic builders on Solana cards to include the Solana AI Kit usage receipt.
- Adds regression coverage for worker packet provider propagation and result receipt enforcement.

## Tests
- `python3 -m unittest factory.tests.test_capability_packs -q`
- `python3 -m unittest factory.tests.test_factoryctl.FactoryCtlTest.test_solana_domain_brain_reaches_lifecycle_wallet_and_security_workers factory.tests.test_factoryctl.FactoryCtlTest.test_solana_domain_brain_uses_inferred_surfaces_when_declared_surface_is_generic factory.tests.test_factoryctl.FactoryCtlTest.test_real_generic_builder_results_require_solana_ai_kit_receipt_on_solana_card factory.tests.test_factoryctl.FactoryCtlTest.test_real_wallet_worker_result_requires_solana_ai_kit_usage_receipt_on_solana_card factory.tests.test_factoryctl.FactoryCtlTest.test_vfinal_solana_f4_blocks_without_structured_solana_ai_kit_route -q`

## Notes
- A broader `python3 -m unittest factory.tests.test_capability_packs factory.tests.test_factoryctl -q` currently has unrelated existing failures in product-face reference resolution/source-card-ref expectations; the targeted Solana/capability routing tests pass.

Closes #592.
Refs #595.