### PR TITLE
Harden public-private safety scans

### DIFF
--- a/docs/en/trust-and-evidence.md
+++ b/docs/en/trust-and-evidence.md
@@ -76,7 +76,7 @@ This prevents a common failure: turning every process failure into “the human 
 
 ## Local evidence, live evidence, and public evidence
 
-A passing local command proves checkout coherence. A worker result proves a worker ran in that scope. Receipt Five proves closure when it points to request, change, evidence, review, and next state. Public publication also needs surface and secret safety.
+A passing local command proves checkout coherence. A worker result proves a worker ran in that scope. Receipt Five proves closure when it points to request, change, evidence, review, and next state. Public publication also needs surface, secret, public/private, sensitive-boundary, and human-artifact leak checks.
 
 These proofs are not interchangeable. Do not use local smoke to claim live product delivery, artifact existence as readback, or generic human approval as waiver for release, security, funds, or mainnet.
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -70,7 +70,7 @@ python3 scripts/secret_safety_scan.py
 python3 scripts/generate_factory_reference_docs.py --check
 ```
 
-`validate_public_surface_sync.py` checks that public surfaces still match their manifest. `validate_promise_implementation_map.py` checks that public promises still have implementation and boundary references. `public_safety_scan.py` and `secret_safety_scan.py` protect the public repo boundary.
+`validate_public_surface_sync.py` checks that public surfaces still match their manifest. `validate_promise_implementation_map.py` checks that public promises still have implementation and boundary references. `public_safety_scan.py` blocks private paths, raw internal artifact references, human artifact location leaks, and mainnet/funds/signing/custody overclaims in public artifacts. `secret_safety_scan.py` blocks obvious credentials, mnemonic/seed phrases, Solana-style key arrays, and high-entropy sensitive key assignments.
 
 If a check fails, do not describe the public surface as ready. Fix the mismatch or state the boundary honestly.
 

--- a/docs/promise-implementation-map.public.json
+++ b/docs/promise-implementation-map.public.json
@@ -316,7 +316,7 @@
     },
     {
       "claim_id": "public-release-readiness",
-      "public_promise": "Public release readiness is checked by preflight, public-surface sync, safety scans, worktree inventory, completion audit and Factory v1 Completion Gate.",
+      "public_promise": "Public release readiness is checked by preflight, public-surface sync, expanded public/private/security safety scans, worktree inventory, completion audit and Factory v1 Completion Gate.",
       "claim_level": "public_release_proof",
       "documentation_refs": [
         "README.md",

--- a/docs/pt-BR/trust-and-evidence.md
+++ b/docs/pt-BR/trust-and-evidence.md
@@ -126,6 +126,6 @@ Um Receipt Five bem formado prova que a conclusão foi reconciliada.
 
 Essas coisas não são iguais.
 
-Não dá para usar smoke local como prova de produto entregue. Não dá para usar arquivo existente como prova de readback. Não dá para usar aprovação genérica como autorização de mainnet.
+Não dá para usar smoke local como prova de produto entregue. Não dá para usar arquivo existente como prova de readback. Não dá para usar aprovação genérica como autorização de mainnet. Publicação pública também precisa bloquear vazamento de caminhos privados, artefatos humanos, referências internas brutas e segredos.
 
 A fábrica precisa manter essa fronteira visível, mesmo quando seria mais conveniente fingir que está tudo pronto.

--- a/docs/pt-BR/usage.md
+++ b/docs/pt-BR/usage.md
@@ -70,7 +70,7 @@ python3 scripts/secret_safety_scan.py
 python3 scripts/generate_factory_reference_docs.py --check
 ```
 
-`validate_public_surface_sync.py` checa se as superfícies públicas continuam alinhadas ao manifest. `validate_promise_implementation_map.py` checa se promessas públicas ainda têm referência de implementação e fronteira. `public_safety_scan.py` e `secret_safety_scan.py` protegem a fronteira pública do repositório.
+`validate_public_surface_sync.py` checa se as superfícies públicas continuam alinhadas ao manifest. `validate_promise_implementation_map.py` checa se promessas públicas ainda têm referência de implementação e fronteira. `public_safety_scan.py` bloqueia caminhos privados, referências a artefatos internos brutos, vazamentos de localização de artefatos humanos e overclaims de mainnet/fundos/assinatura/custódia em artefatos públicos. `secret_safety_scan.py` bloqueia credenciais óbvias, frases mnemonic/seed, arrays de chave estilo Solana e assignments sensíveis de alta entropia.
 
 Se um check falhar, não descreva a superfície pública como pronta. Corrija a divergência ou explique a fronteira honestamente.
 

--- a/factory/schemas/public-safety-scan-summary.schema.json
+++ b/factory/schemas/public-safety-scan-summary.schema.json
@@ -43,7 +43,10 @@
           "public_repository_tree",
           "private_run_evidence",
           "sanitized_report",
-          "publication_candidate"
+          "publication_candidate",
+          "human_artifact_metadata",
+          "raw_internal_artifact_markers",
+          "sensitive_boundary_claims"
         ]
       }
     },

--- a/factory/scripts/public_safety_scan.py
+++ b/factory/scripts/public_safety_scan.py
@@ -60,6 +60,47 @@ PATTERN_SPECS = [
     ("private_whimsical_board_marker", re.compile(r"--board-id\s+(?!<)[A-Za-z0-9_-]{4,}\b")),
 ]
 
+CONTEXT_PATTERN_SPECS = [
+    (
+        "raw_internal_artifact_marker",
+        re.compile(
+            r"\braw(?:[_ -](?:internal|private))?[_ -]"
+            r"(?:source[_ -]?extraction|study[_ -]?extraction|evidence|artifact|browser[_ -]?snapshot|"
+            r"session[_ -]?transcript|chat[_ -]?transcript|operator[_ -]?recording|screenshot)"
+            r"(?:[_ -]?(?:bundle|dump|json|file))?\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "human_artifact_private_ref",
+        re.compile(
+            r"\b(?:screenshot|transcript|recording|screen[_ -]?capture|browser[_ -]?capture)\b"
+            r".*(?:C:\\\\Users|C:\\Users|/srv/hermes|/(?:home|Users)/[A-Za-z0-9._-]+|file://)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "sensitive_boundary_claim",
+        re.compile(
+            r"\b(?:mainnet|funds?|signing|custody)\b(?!-).{0,80}"
+            r"\b(?:approved|authorized|released|ready|safe|complete|completed|waived)\b",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+RAW_ARTIFACT_LEAK_CONTEXT_RE = re.compile(
+    r"\b(?:publish|commit|embed|include|attach|upload|download|link|leak|expose|paste|ship|release|share|open)\b"
+    r"|(?:\.json|\.md|\.txt|\.zip|://|/srv|C:\\)",
+    re.IGNORECASE,
+)
+
+BOUNDARY_POLICY_RE = re.compile(
+    r"\b(?:not|never|no|cannot|must not|blocked|block|blocks|requires?|gate|human|"
+    r"forbidden|before|without|boundary|policy|public[- ]safe|private|redacted|by local tests only)\b",
+    re.IGNORECASE,
+)
+
 BYTE_PATTERN_SPECS = [
     ("private_product_marker", b"KAXIS"),
     ("private_product_marker", b"Kaxis"),
@@ -110,6 +151,17 @@ def is_allowed_public_repo_metadata_line(rel: str, line: str) -> bool:
     return PUBLIC_REPO_URL in line
 
 
+def is_boundary_policy_line(line: str) -> bool:
+    """Allow public policy statements while still blocking concrete unsafe claims.
+
+    The public repository can explain that mainnet, funds, signing, custody,
+    private evidence, screenshots or transcripts are sensitive. It must not
+    publish concrete statements that those boundaries are approved/safe/released
+    or attach raw/private artifact locations to human evidence.
+    """
+    return BOUNDARY_POLICY_RE.search(line) is not None
+
+
 def rel_parts(rel: str) -> tuple[str, ...]:
     return PurePosixPath(rel).parts
 
@@ -146,6 +198,16 @@ def scan_text(rel: str, text: str) -> list[str]:
             if category == "private_owner_marker" and is_allowed_public_repo_metadata_line(rel, line):
                 continue
             if pattern.search(line):
+                findings.append(f"{rel}:{lineno}: {category}")
+                break
+        else:
+            for category, pattern in CONTEXT_PATTERN_SPECS:
+                if not pattern.search(line):
+                    continue
+                if category == "raw_internal_artifact_marker" and not RAW_ARTIFACT_LEAK_CONTEXT_RE.search(line):
+                    continue
+                if category != "human_artifact_private_ref" and is_boundary_policy_line(line):
+                    continue
                 findings.append(f"{rel}:{lineno}: {category}")
                 break
     return findings
@@ -187,7 +249,12 @@ def safe_ref(value: str | None) -> str | None:
 def build_summary(findings: list[str], *, git_ref: str | None = None, created_at: str | None = None) -> dict[str, object]:
     categories = Counter(finding_category(finding) for finding in findings)
     target = {"kind": "git_ref", "ref": safe_ref(git_ref)} if git_ref else {"kind": "worktree"}
-    artifact_classes = ["public_repository_tree"]
+    artifact_classes = [
+        "human_artifact_metadata",
+        "public_repository_tree",
+        "raw_internal_artifact_markers",
+        "sensitive_boundary_claims",
+    ]
     if git_ref:
         artifact_classes.append("publication_candidate")
     return {
@@ -204,6 +271,9 @@ def build_summary(findings: list[str], *, git_ref: str | None = None, created_at
             "publication_candidate": "fail_closed_on_any_private_marker",
             "private_kanban_task_ids": f"replace_with_{PUBLIC_SAFE_KANBAN_REF}",
             "stable_issue_refs": "allowed",
+            "raw_internal_artifacts": "forbidden_unless_reduced_to_public_safe_refs",
+            "mainnet_funds_signing_custody": "must_remain_blocked_without_human_gate_evidence",
+            "human_artifact_locations": "must_use_public_safe_external_refs_not_private_paths_or_file_uris",
         },
         "forbidden_hits": [
             {"category": category, "count": count}

--- a/factory/scripts/secret_safety_scan.py
+++ b/factory/scripts/secret_safety_scan.py
@@ -20,7 +20,19 @@ from typing import Iterator
 CODE_ROOT = Path(__file__).resolve().parents[1]
 ROOT = CODE_ROOT.parent if (CODE_ROOT.parent / ".github").exists() else CODE_ROOT
 SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico", ".pdf", ".tgz", ".zip"}
-SKIP_PARTS = {".git", ".tmp", ".pytest_cache", ".venv", "__pycache__", "build", "dist", "node_modules", "site", "venv"}
+SKIP_PARTS = {
+    ".git",
+    ".tmp",
+    ".pytest_cache",
+    ".venv",
+    ".worktrees",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "site",
+    "venv",
+}
 SKIP_PART_SUFFIXES = (".egg-info",)
 
 SECRET_PATTERNS = [
@@ -33,10 +45,22 @@ SECRET_PATTERNS = [
         r"\b(?:api[_-]?key|secret|token|password|passwd)\b\s*(?::(?!:)|=)\s*['\"]?[^'\"\s]{16,}",
         re.IGNORECASE,
     ),
+    re.compile(
+        r"\b(?:mnemonic|seed[_ -]?phrase|recovery[_ -]?phrase)\b\s*(?::(?!:)|=)\s*['\"]?"
+        r"(?:[a-z]{3,12}\s+){11,23}[a-z]{3,12}",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:wallet[_-]?private[_-]?key|secret[_-]?key|signing[_-]?key|custody[_-]?key|"
+        r"mainnet[_-]?key|funds?[_-]?key)\b\s*(?::(?!:)|=)\s*\[[0-9,\s]{80,}\]",
+        re.IGNORECASE,
+    ),
 ]
 
 ASSIGNMENT_RE = re.compile(
-    r"\b(?:api[_-]?key|secret|token|password|passwd|private[_-]?key)\b\s*(?::(?!:)|=)\s*['\"]?([A-Za-z0-9_./+=-]{24,})",
+    r"\b(?:api[_-]?key|secret|token|password|passwd|private[_-]?key|signing[_-]?key|"
+    r"custody[_-]?key|mainnet[_-]?key|funds?[_-]?key|wallet[_-]?key)\b"
+    r"\s*(?::(?!:)|=)\s*['\"]?([A-Za-z0-9_./+=-]{24,})",
     re.IGNORECASE,
 )
 

--- a/factory/tests/test_public_safety_scan.py
+++ b/factory/tests/test_public_safety_scan.py
@@ -38,7 +38,7 @@ class PublicSafetyScanTest(unittest.TestCase):
         self.assertEqual(public_safety_scan.scan_text("tests/example.py", line), [])
 
     def test_negative_fixture_guard_allows_declared_status_snapshot_sample_only(self) -> None:
-        blocked_ref = '  "ref": "' + "C:" + "\\\\Users\\\\operator\\\\raw-evidence.json" + '"'
+        blocked_ref = '  "ref": "' + "C:" + "\\\\Users\\\\operator\\\\" + "raw" + "-evidence.json" + '"'
 
         self.assertEqual(
             public_safety_scan.scan_text(
@@ -211,6 +211,37 @@ class PublicSafetyScanTest(unittest.TestCase):
 
         self.assertEqual(summary["target"]["ref"], "kanban:<redacted>")
         self.assertNotIn(RAW_TASK_MARKER, summary_text)
+
+    def test_blocks_internal_artifact_publication_refs(self) -> None:
+        artifact_line = "publish " + "raw" + "_evidence_bundle.json from the operator run"
+        findings = public_safety_scan.scan_text("docs/example.md", artifact_line)
+
+        self.assertTrue(findings)
+        self.assertIn("raw_" + "internal_artifact_marker", findings[0])
+
+    def test_allows_policy_language_about_private_artifacts(self) -> None:
+        policy_line = "Do not publish raw evidence; reduce it to redacted public-safe refs."
+
+        self.assertEqual(public_safety_scan.scan_text("docs/example.md", policy_line), [])
+
+    def test_blocks_sensitive_boundary_overclaim(self) -> None:
+        claim = "The " + "main" + "net" + " launch is safe and released after local smoke only."
+        findings = public_safety_scan.scan_text("docs/example.md", claim)
+
+        self.assertTrue(findings)
+        self.assertIn("sensitive_boundary_claim", findings[0])
+
+    def test_allows_sensitive_boundary_policy(self) -> None:
+        policy = "Mainnet and funds remain blocked until human gate evidence exists."
+
+        self.assertEqual(public_safety_scan.scan_text("docs/example.md", policy), [])
+
+    def test_blocks_human_artifact_private_ref(self) -> None:
+        private_path = "file" + "://operator/run/screen.png"
+        findings = public_safety_scan.scan_text("docs/example.md", "screenshot saved at " + private_path)
+
+        self.assertTrue(findings)
+        self.assertIn("human_artifact_private_ref", findings[0])
 
     def test_cli_writes_public_safe_summary_for_failing_git_ref_scan(self) -> None:
         original_root = public_safety_scan.ROOT

--- a/factory/tests/test_secret_safety_scan.py
+++ b/factory/tests/test_secret_safety_scan.py
@@ -71,6 +71,48 @@ class SecretSafetyScanTest(unittest.TestCase):
 
         self.assertEqual([], findings)
 
+    def test_seed_phrase_assignment_matches(self):
+        scanner = load_scanner()
+        phrase = "abandon ability able about above absent absorb abstract absurd abuse access accident"
+        line = "seed_" + "phrase: " + phrase
+
+        self.assertTrue(any(pattern.search(line) for pattern in scanner.SECRET_PATTERNS))
+
+    def test_solana_keypair_array_matches(self):
+        scanner = load_scanner()
+        key_bytes = ", ".join(str((index * 7) % 255) for index in range(64))
+        line = "signing_" + "key: [" + key_bytes + "]"
+
+        self.assertTrue(any(pattern.search(line) for pattern in scanner.SECRET_PATTERNS))
+
+    def test_sensitive_key_assignment_matches_entropy_check(self):
+        scanner = load_scanner()
+        candidate = "Ab9/cD2+Ef3-Gh4_Ij5.Kl6/Mn7+Op8-Qr9_St0.Uv1/Wx2+Yz3"
+        line = "custody_" + "key = " + candidate
+
+        self.assertIsNotNone(scanner.ASSIGNMENT_RE.search(line))
+        self.assertGreaterEqual(scanner.entropy(candidate), 4.2)
+
+    def test_ignored_worktrees_are_not_scanned(self):
+        scanner = load_scanner()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ignored = root / ".worktrees" / "task" / "sample.env"
+            ignored.parent.mkdir(parents=True)
+            ignored.write_text("tok" + "en: " + "abcdefghijklmnopqrstuvwxyz123456\n", encoding="utf-8")
+            clean = root / "README.md"
+            clean.write_text("public docs only\n", encoding="utf-8")
+
+            original_root = scanner.ROOT
+            scanner.ROOT = root
+            try:
+                findings = scanner.scan()
+            finally:
+                scanner.ROOT = original_root
+
+        self.assertEqual([], findings)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand public safety scanning for raw internal artifact references, private human artifact locations, and mainnet/funds/signing/custody overclaims
- expand secret safety scanning for mnemonic/seed phrases, Solana-style key arrays, high-entropy sensitive key assignments, and .worktrees exclusions
- update public safety schema, public docs, promise map, and regression tests

## Validation
- python3 -m unittest factory.tests.test_public_safety_scan factory.tests.test_secret_safety_scan -q
- python3 -m unittest discover -s factory/tests -p 'test_*.py' -q (timed out after 300s after progressing through the suite; no task-related failure observed before timeout)\n- python3 factory/scripts/public_safety_scan.py\n- python3 factory/scripts/secret_safety_scan.py\n- python3 factory/scripts/validate_promise_implementation_map.py\n- python3 factory/scripts/generate_factory_reference_docs.py --check\n\n## Known existing validation blocker\n- python3 factory/scripts/validate_public_json_artifacts.py still fails on pre-existing missing public repo refs in templates/factory-operating-system-registry.json\n\nReview-required for kanban task t_985428c0.