### PR TITLE
Add worker accountability routing ledger

### DIFF
--- a/docs/en/reference.md
+++ b/docs/en/reference.md
@@ -96,6 +96,8 @@ A worker is not a prompt character. To be operable it needs four layers:
 
 The worker executes inside received authority. It does not approve gates, invent evidence, touch production, handle keys, or change scope outside the contract.
 
+Worker accountability is separate from worker identity. Repeated bad output, failures, rework, shallow artifacts, review failures, or repair loops are aggregated into a `worker_accountability_ledger`. That ledger is public-safe and only records sanitized evidence refs. Its routing consequences are deterministic: watch, mandatory independent review, demotion to review queue, or escalation for profile review. It does not mutate Hermes Kanban directly; the factory reducer consumes the consequence and Hermes remains the runtime state authority.
+
 ## Core terms
 
 Product SOT is product truth.
@@ -130,6 +132,8 @@ python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compi
 python3 scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
 python3 scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
 python3 scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+python3 scripts/factoryctl.py build-worker-accountability-ledger .tmp/worker-accountability-events.json --out .tmp/worker-accountability-ledger.json
+python3 scripts/factoryctl.py validate-worker-accountability-ledger .tmp/worker-accountability-ledger.json
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py

--- a/docs/pt-BR/reference.md
+++ b/docs/pt-BR/reference.md
@@ -96,6 +96,8 @@ Worker não é personagem de prompt. Para ser operável, precisa de quatro camad
 
 O worker executa dentro da autoridade recebida. Ele não aprova gate, não inventa evidência, não toca produção, não mexe em chaves e não muda escopo fora do contrato.
 
+Accountability de worker é separada da identidade do worker. Saídas ruins repetidas, falhas, rework, artefatos rasos, reprovação em review ou loops de reparo entram em um `worker_accountability_ledger`. Esse ledger é public-safe e guarda apenas referências sanitizadas de evidência. As consequências de rota são determinísticas: observação, review independente obrigatório, rebaixamento para fila de review ou escalonamento para revisão de perfil. Ele não muta Hermes Kanban diretamente; o reducer da fábrica consome a consequência e Hermes continua sendo a autoridade de estado em runtime.
+
 ## Termos centrais
 
 Product SOT é a fonte de verdade do produto.
@@ -130,6 +132,8 @@ python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compi
 python3 scripts/factoryctl.py validate-card examples/minimal-hermes-project/card.md
 python3 scripts/factoryctl.py gate-report --card examples/minimal-hermes-project/card.md
 python3 scripts/factoryctl.py worker-packet --worker all --required-only --card examples/minimal-hermes-project/card.md --out .tmp/minimal-worker-packets
+python3 scripts/factoryctl.py build-worker-accountability-ledger .tmp/worker-accountability-events.json --out .tmp/worker-accountability-ledger.json
+python3 scripts/factoryctl.py validate-worker-accountability-ledger .tmp/worker-accountability-ledger.json
 python3 scripts/validate_public_json_artifacts.py
 python3 scripts/validate_public_surface_sync.py
 python3 scripts/validate_promise_implementation_map.py

--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 245 | `schemas/*.json` |
-| Templates | 162 | `templates/*` |
+| JSON schemas | 246 | `schemas/*.json` |
+| Templates | 163 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases

--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 244 | `schemas/*.json` |
-| Templates | 161 | `templates/*` |
+| JSON schemas | 245 | `schemas/*.json` |
+| Templates | 162 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
@@ -435,6 +435,7 @@ These are the public JSON schemas the factory exposes. They are not decoration; 
 - `schemas/visual-regression-proof.schema.json`
 - `schemas/work-unit-contract.schema.json`
 - `schemas/work-unit-dispatch-readiness.schema.json`
+- `schemas/worker-accountability-ledger.schema.json`
 - `schemas/worker-authority-contract.schema.json`
 - `schemas/worker-closure-summary.schema.json`
 - `schemas/worker-packet.schema.json`
@@ -609,6 +610,7 @@ Templates are starter records paired with schemas. They are examples of valid sh
 - `templates/visual-regression-proof.json`
 - `templates/work-unit-contract.json`
 - `templates/work-unit-dispatch-readiness.json`
+- `templates/worker-accountability-ledger.json`
 - `templates/worker-authority-contract.json`
 
 ## CLI Surface

--- a/factory/schemas/worker-accountability-ledger.schema.json
+++ b/factory/schemas/worker-accountability-ledger.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/worker-accountability-ledger.schema.json",
+  "title": "Overkill Factory Worker Accountability Ledger",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "ledger_version",
+    "generated_at",
+    "scope",
+    "runtime_authority",
+    "local_state_authority",
+    "routing_authority",
+    "source_refs",
+    "consequence_policy",
+    "worker_accountability",
+    "routing_summary",
+    "limits"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/worker-accountability-ledger.schema.json" },
+    "record_type": { "const": "worker_accountability_ledger" },
+    "ledger_version": { "type": "string", "minLength": 3 },
+    "generated_at": { "type": "string", "minLength": 10 },
+    "scope": { "const": "public-safe-routing-consequence-ledger" },
+    "runtime_authority": { "const": "hermes_kanban" },
+    "local_state_authority": { "const": false },
+    "routing_authority": { "const": "factory_reducer" },
+    "source_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    },
+    "consequence_policy": {
+      "type": "object",
+      "required": [
+        "watch_after_negative_events",
+        "mandatory_review_after_rework_or_shallow_events",
+        "demote_after_bad_output_failure_or_repair_loop_events",
+        "escalate_after_total_negative_events",
+        "positive_events_do_not_erase_negative_accountability_without_review"
+      ],
+      "properties": {
+        "watch_after_negative_events": { "type": "integer", "minimum": 1 },
+        "mandatory_review_after_rework_or_shallow_events": { "type": "integer", "minimum": 2 },
+        "demote_after_bad_output_failure_or_repair_loop_events": { "type": "integer", "minimum": 2 },
+        "escalate_after_total_negative_events": { "type": "integer", "minimum": 3 },
+        "positive_events_do_not_erase_negative_accountability_without_review": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "worker_accountability": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "worker_id",
+          "bad_output_count",
+          "failure_count",
+          "rework_count",
+          "shallow_artifact_count",
+          "review_fail_count",
+          "repair_loop_count",
+          "positive_signal_count",
+          "negative_total",
+          "event_refs",
+          "routing_consequence"
+        ],
+        "properties": {
+          "worker_id": { "type": "string", "minLength": 3 },
+          "bad_output_count": { "type": "integer", "minimum": 0 },
+          "failure_count": { "type": "integer", "minimum": 0 },
+          "rework_count": { "type": "integer", "minimum": 0 },
+          "shallow_artifact_count": { "type": "integer", "minimum": 0 },
+          "review_fail_count": { "type": "integer", "minimum": 0 },
+          "repair_loop_count": { "type": "integer", "minimum": 0 },
+          "positive_signal_count": { "type": "integer", "minimum": 0 },
+          "negative_total": { "type": "integer", "minimum": 0 },
+          "event_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 3 }
+          },
+          "routing_consequence": {
+            "type": "object",
+            "required": [
+              "action",
+              "accountability_state",
+              "queue_class",
+              "allowed_actions",
+              "reason"
+            ],
+            "properties": {
+              "action": {
+                "enum": [
+                  "normal_route",
+                  "watch",
+                  "mandatory_independent_review",
+                  "demote_to_review_queue",
+                  "escalate_for_profile_review"
+                ]
+              },
+              "accountability_state": {
+                "enum": ["healthy", "watch", "review_required", "demoted", "escalated"]
+              },
+              "queue_class": { "type": "string", "minLength": 3 },
+              "required_reviewer": {
+                "type": ["string", "null"],
+                "minLength": 3
+              },
+              "allowed_actions": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "minLength": 3 }
+              },
+              "reason": { "type": "string", "minLength": 12 }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "routing_summary": {
+      "type": "object",
+      "required": ["strongest_action", "affected_workers", "routing_authority"],
+      "properties": {
+        "strongest_action": {
+          "enum": [
+            "normal_route",
+            "watch",
+            "mandatory_independent_review",
+            "demote_to_review_queue",
+            "escalate_for_profile_review"
+          ]
+        },
+        "affected_workers": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 3 }
+        },
+        "routing_authority": { "const": "factory_reducer_consumes_this_ledger_hermes_kanban_executes_state" }
+      },
+      "additionalProperties": false
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 3 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -74,6 +74,11 @@ from factory_v2_kernel import (  # noqa: E402
     validate_factory_workflow_compiled_plan,
 )
 from validate_public_json_artifacts import load_schemas, validate_node  # noqa: E402
+from worker_accountability import (  # noqa: E402
+    build_accountability_ledger,
+    event_validation_errors,
+    validate_ledger as validate_worker_accountability_ledger,
+)
 
 
 def installed_asset_root() -> Path | None:
@@ -22704,6 +22709,26 @@ def command_validate_worker_authority_contract(args: argparse.Namespace) -> int:
     return _print_validation_result(validate_worker_authority_contract(load_json_like(args.path)))
 
 
+def command_build_worker_accountability_ledger(args: argparse.Namespace) -> int:
+    payload = load_json_like(args.events)
+    events = payload.get("events") if isinstance(payload, dict) else payload
+    if not isinstance(events, list):
+        return _print_validation_result(["worker-accountability events input must be a JSON array or object with events[]"])
+    event_errors = event_validation_errors(events)
+    if event_errors:
+        return _print_validation_result(event_errors)
+    ledger = build_accountability_ledger(events, source_refs=args.source_refs)
+    validation_errors = validate_worker_accountability_ledger(ledger)
+    if validation_errors:
+        return _print_validation_result(validation_errors)
+    write_json(args.out, ledger)
+    return 0
+
+
+def command_validate_worker_accountability_ledger(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_worker_accountability_ledger(load_json_like(args.path)))
+
+
 def validate_hermes_reducer_mutation_proof(packet: dict[str, Any]) -> list[str]:
     schemas = bundled_schemas()
     schema = schemas.get("hermes-reducer-mutation-proof.schema.json")
@@ -24255,6 +24280,19 @@ def build_parser() -> argparse.ArgumentParser:
     validate_worker_authority_parser = sub.add_parser("validate-worker-authority-contract")
     validate_worker_authority_parser.add_argument("path", type=Path)
     validate_worker_authority_parser.set_defaults(func=command_validate_worker_authority_contract)
+
+    build_worker_accountability_parser = sub.add_parser(
+        "build-worker-accountability-ledger",
+        help="Build public-safe worker accountability routing consequences from sanitized events.",
+    )
+    build_worker_accountability_parser.add_argument("events", type=Path)
+    build_worker_accountability_parser.add_argument("--source-ref", action="append", dest="source_refs")
+    build_worker_accountability_parser.add_argument("--out", type=Path)
+    build_worker_accountability_parser.set_defaults(func=command_build_worker_accountability_ledger)
+
+    validate_worker_accountability_parser = sub.add_parser("validate-worker-accountability-ledger")
+    validate_worker_accountability_parser.add_argument("path", type=Path)
+    validate_worker_accountability_parser.set_defaults(func=command_validate_worker_accountability_ledger)
 
     validate_hermes_reducer_parser = sub.add_parser("validate-hermes-reducer-mutation-proof")
     validate_hermes_reducer_parser.add_argument("path", type=Path)

--- a/factory/scripts/worker_accountability.py
+++ b/factory/scripts/worker_accountability.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Build and validate worker accountability routing ledgers.
+
+This module turns repeated bad output, failures, rework, and shallow artifacts
+into deterministic routing consequences. It does not mutate Hermes Kanban. The
+ledger is a public-safe reducer input/output: Hermes remains the runtime
+authority, while the factory reducer can consume the consequence to route the
+next worker task to normal, review, demoted, or escalated handling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+RAW_KANBAN_TASK_RE = re.compile(r"\bt_[0-9a-f]{6,}\b", re.IGNORECASE)
+PRIVATE_REF_RE = re.compile(
+    r"((?<![A-Za-z])[A-Za-z]:[\\/]|\\\\|/home/|/Users/|/srv/|token|secret|webhook|guild[_-]?id|channel[_-]?id|message[_-]?id)",
+    re.IGNORECASE,
+)
+
+NEGATIVE_EVENT_TYPES = {
+    "bad_output",
+    "failure",
+    "failed_run",
+    "rework_required",
+    "shallow_artifact",
+    "review_fail",
+    "repair_loop",
+}
+POSITIVE_EVENT_TYPES = {"positive_review", "repair_pass", "quality_pass"}
+EVENT_TYPES = NEGATIVE_EVENT_TYPES | POSITIVE_EVENT_TYPES
+COUNT_FIELDS = {
+    "bad_output": "bad_output_count",
+    "failure": "failure_count",
+    "failed_run": "failure_count",
+    "rework_required": "rework_count",
+    "shallow_artifact": "shallow_artifact_count",
+    "review_fail": "review_fail_count",
+    "repair_loop": "repair_loop_count",
+}
+CONSEQUENCE_ORDER = {
+    "normal_route": 0,
+    "watch": 1,
+    "mandatory_independent_review": 2,
+    "demote_to_review_queue": 3,
+    "escalate_for_profile_review": 4,
+}
+
+
+@dataclass
+class WorkerCounters:
+    worker_id: str
+    bad_output_count: int = 0
+    failure_count: int = 0
+    rework_count: int = 0
+    shallow_artifact_count: int = 0
+    review_fail_count: int = 0
+    repair_loop_count: int = 0
+    positive_signal_count: int = 0
+    event_refs: list[str] = field(default_factory=list)
+
+    @property
+    def negative_total(self) -> int:
+        return (
+            self.bad_output_count
+            + self.failure_count
+            + self.rework_count
+            + self.shallow_artifact_count
+            + self.review_fail_count
+            + self.repair_loop_count
+        )
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def _clean_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _safe_ref(ref: Any) -> bool:
+    value = _clean_string(ref)
+    if not value:
+        return False
+    if RAW_KANBAN_TASK_RE.search(value) or PRIVATE_REF_RE.search(value):
+        return False
+    if value.startswith(("http://", "https://", "file://")):
+        return False
+    return True
+
+
+def event_validation_errors(events: Iterable[Mapping[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    for index, event in enumerate(events):
+        worker_id = _clean_string(event.get("worker_id"))
+        event_type = _clean_string(event.get("event_type"))
+        if not worker_id:
+            errors.append(f"events[{index}].worker_id is required")
+        if event_type not in EVENT_TYPES:
+            errors.append(f"events[{index}].event_type must be one of {sorted(EVENT_TYPES)}")
+        refs = _list(event.get("evidence_refs") or event.get("event_ref"))
+        if not refs:
+            errors.append(f"events[{index}].evidence_refs is required")
+        for ref_index, ref in enumerate(refs):
+            if not _safe_ref(ref):
+                errors.append(f"events[{index}].evidence_refs[{ref_index}] must be a public-safe sanitized ref")
+    return errors
+
+
+def aggregate_worker_events(events: Iterable[Mapping[str, Any]]) -> dict[str, WorkerCounters]:
+    workers: dict[str, WorkerCounters] = {}
+    for event in events:
+        worker_id = _clean_string(event.get("worker_id"))
+        event_type = _clean_string(event.get("event_type"))
+        if not worker_id or event_type not in EVENT_TYPES:
+            continue
+        counters = workers.setdefault(worker_id, WorkerCounters(worker_id=worker_id))
+        for ref in _list(event.get("evidence_refs") or event.get("event_ref")):
+            ref_text = _clean_string(ref)
+            if ref_text and ref_text not in counters.event_refs:
+                counters.event_refs.append(ref_text)
+        if event_type in POSITIVE_EVENT_TYPES:
+            counters.positive_signal_count += 1
+            continue
+        count_field = COUNT_FIELDS[event_type]
+        setattr(counters, count_field, getattr(counters, count_field) + 1)
+    return workers
+
+
+def consequence_for_counters(counters: WorkerCounters) -> dict[str, Any]:
+    reasons: list[str] = []
+    action = "normal_route"
+    accountability_state = "healthy"
+    queue_class = "normal"
+    allowed_actions = ["dispatch_normally"]
+    required_reviewer = None
+
+    if counters.negative_total >= 1:
+        action = "watch"
+        accountability_state = "watch"
+        queue_class = "normal_with_accountability_watch"
+        allowed_actions = ["dispatch_normally", "attach_accountability_context"]
+        reasons.append("negative accountability signal recorded")
+
+    if counters.rework_count >= 2 or counters.shallow_artifact_count >= 2 or counters.review_fail_count >= 1:
+        action = "mandatory_independent_review"
+        accountability_state = "review_required"
+        queue_class = "review-before-consumption"
+        allowed_actions = ["route_output_to_independent_review", "block_downstream_consumption_until_review_pass"]
+        required_reviewer = "independent-reviewer"
+        reasons.append("repeated rework/shallow output or review failure requires independent review")
+
+    if counters.bad_output_count >= 2 or counters.failure_count >= 2 or counters.repair_loop_count >= 2:
+        action = "demote_to_review_queue"
+        accountability_state = "demoted"
+        queue_class = "demoted-review-queue"
+        allowed_actions = ["route_output_to_independent_review", "prefer_alternate_worker_when_available"]
+        required_reviewer = "independent-reviewer"
+        reasons.append("repeated bad output/failures/repair loops demote worker routing")
+
+    if counters.negative_total >= 5 or (
+        counters.bad_output_count >= 3
+        or counters.failure_count >= 3
+        or counters.shallow_artifact_count >= 3
+        or counters.rework_count >= 3
+    ):
+        action = "escalate_for_profile_review"
+        accountability_state = "escalated"
+        queue_class = "blocked-profile-review"
+        allowed_actions = ["block_new_sensitive_assignments", "open_profile_eval_review", "prefer_alternate_worker_when_available"]
+        required_reviewer = "skill-eval-distiller"
+        reasons.append("high repeated negative count requires profile eval review before further sensitive routing")
+
+    if not reasons:
+        reasons.append("no repeated negative accountability pattern")
+
+    return {
+        "action": action,
+        "accountability_state": accountability_state,
+        "queue_class": queue_class,
+        "required_reviewer": required_reviewer,
+        "allowed_actions": allowed_actions,
+        "reason": "; ".join(reasons),
+    }
+
+
+def merge_consequences(worker_rows: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    strongest = "normal_route"
+    affected_workers: list[str] = []
+    for row in worker_rows:
+        consequence = row.get("routing_consequence") if isinstance(row.get("routing_consequence"), Mapping) else {}
+        action = _clean_string(consequence.get("action")) or "normal_route"
+        if CONSEQUENCE_ORDER.get(action, -1) > CONSEQUENCE_ORDER.get(strongest, -1):
+            strongest = action
+        if action != "normal_route":
+            affected_workers.append(_clean_string(row.get("worker_id")))
+    return {
+        "strongest_action": strongest,
+        "affected_workers": [worker for worker in affected_workers if worker],
+        "routing_authority": "factory_reducer_consumes_this_ledger_hermes_kanban_executes_state",
+    }
+
+
+def build_accountability_ledger(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    generated_at: str | None = None,
+    source_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    event_list = [dict(event) for event in events]
+    workers = aggregate_worker_events(event_list)
+    worker_rows: dict[str, Any] = {}
+    for worker_id, counters in sorted(workers.items()):
+        consequence = consequence_for_counters(counters)
+        worker_rows[worker_id] = {
+            "worker_id": worker_id,
+            "bad_output_count": counters.bad_output_count,
+            "failure_count": counters.failure_count,
+            "rework_count": counters.rework_count,
+            "shallow_artifact_count": counters.shallow_artifact_count,
+            "review_fail_count": counters.review_fail_count,
+            "repair_loop_count": counters.repair_loop_count,
+            "positive_signal_count": counters.positive_signal_count,
+            "negative_total": counters.negative_total,
+            "event_refs": counters.event_refs,
+            "routing_consequence": consequence,
+        }
+
+    return {
+        "$schema": "https://overkill-factory.dev/schemas/worker-accountability-ledger.schema.json",
+        "record_type": "worker_accountability_ledger",
+        "ledger_version": "factory-15-p13-worker-accountability-v1",
+        "generated_at": generated_at or utc_now(),
+        "scope": "public-safe-routing-consequence-ledger",
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+        "routing_authority": "factory_reducer",
+        "source_refs": source_refs or ["issues/595#point-13-worker-accountability"],
+        "consequence_policy": {
+            "watch_after_negative_events": 1,
+            "mandatory_review_after_rework_or_shallow_events": 2,
+            "demote_after_bad_output_failure_or_repair_loop_events": 2,
+            "escalate_after_total_negative_events": 5,
+            "positive_events_do_not_erase_negative_accountability_without_review": True,
+        },
+        "worker_accountability": worker_rows,
+        "routing_summary": merge_consequences(worker_rows.values()),
+        "limits": [
+            "Ledger refs must be public-safe sanitized refs, not raw Hermes task ids or private paths.",
+            "The ledger recommends routing consequences only; Hermes Kanban remains runtime state authority.",
+            "Demotion or escalation does not approve, reject, or waive a human/product/security gate.",
+        ],
+    }
+
+
+def validate_ledger(ledger: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if ledger.get("record_type") != "worker_accountability_ledger":
+        errors.append("record_type must be worker_accountability_ledger")
+    if ledger.get("runtime_authority") != "hermes_kanban":
+        errors.append("runtime_authority must be hermes_kanban")
+    if ledger.get("local_state_authority") is not False:
+        errors.append("local_state_authority must be false")
+    if ledger.get("routing_authority") != "factory_reducer":
+        errors.append("routing_authority must be factory_reducer")
+    for ref_index, ref in enumerate(_list(ledger.get("source_refs"))):
+        if not _safe_ref(ref):
+            errors.append(f"source_refs[{ref_index}] must be public-safe")
+    workers = ledger.get("worker_accountability")
+    if not isinstance(workers, Mapping) or not workers:
+        errors.append("worker_accountability must contain at least one worker row")
+        return errors
+    for worker_id, row in workers.items():
+        if not isinstance(row, Mapping):
+            errors.append(f"worker_accountability.{worker_id} must be an object")
+            continue
+        if row.get("worker_id") != worker_id:
+            errors.append(f"worker_accountability.{worker_id}.worker_id must match row key")
+        for field_name in (
+            "bad_output_count",
+            "failure_count",
+            "rework_count",
+            "shallow_artifact_count",
+            "review_fail_count",
+            "repair_loop_count",
+            "negative_total",
+        ):
+            value = row.get(field_name)
+            if not isinstance(value, int) or value < 0:
+                errors.append(f"worker_accountability.{worker_id}.{field_name} must be a non-negative integer")
+        for ref_index, ref in enumerate(_list(row.get("event_refs"))):
+            if not _safe_ref(ref):
+                errors.append(f"worker_accountability.{worker_id}.event_refs[{ref_index}] must be public-safe")
+        consequence = row.get("routing_consequence") if isinstance(row.get("routing_consequence"), Mapping) else {}
+        action = consequence.get("action")
+        if action not in CONSEQUENCE_ORDER:
+            errors.append(f"worker_accountability.{worker_id}.routing_consequence.action is invalid")
+        if action in {"mandatory_independent_review", "demote_to_review_queue", "escalate_for_profile_review"}:
+            if not consequence.get("required_reviewer"):
+                errors.append(f"worker_accountability.{worker_id}.routing_consequence.required_reviewer is required for {action}")
+    return errors
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build/validate worker accountability ledger routing consequences.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    build = sub.add_parser("build", help="Build a ledger from a JSON event list or object with events[]")
+    build.add_argument("events", type=Path)
+    build.add_argument("--out", type=Path)
+    build.add_argument("--source-ref", action="append", dest="source_refs")
+    validate = sub.add_parser("validate", help="Validate an existing worker accountability ledger")
+    validate.add_argument("ledger", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "build":
+        payload = load_json(args.events)
+        events = payload.get("events") if isinstance(payload, Mapping) else payload
+        if not isinstance(events, list):
+            print("events input must be a list or object with events[]", file=sys.stderr)
+            return 2
+        event_errors = event_validation_errors(events)
+        if event_errors:
+            print(json.dumps({"result": "BLOCKED", "errors": event_errors}, indent=2), file=sys.stderr)
+            return 1
+        ledger = build_accountability_ledger(events, source_refs=args.source_refs)
+        errors = validate_ledger(ledger)
+        if errors:
+            print(json.dumps({"result": "BLOCKED", "errors": errors}, indent=2), file=sys.stderr)
+            return 1
+        text = json.dumps(ledger, indent=2, ensure_ascii=False) + "\n"
+        if args.out:
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(text, encoding="utf-8")
+        else:
+            print(text, end="")
+        return 0
+    if args.command == "validate":
+        ledger = load_json(args.ledger)
+        if not isinstance(ledger, Mapping):
+            print(json.dumps({"result": "BLOCKED", "errors": ["ledger must be a JSON object"]}, indent=2), file=sys.stderr)
+            return 1
+        errors = validate_ledger(ledger)
+        result = "PASS" if not errors else "BLOCKED"
+        print(json.dumps({"result": result, "errors": errors}, indent=2))
+        return 0 if not errors else 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/factory/templates/worker-accountability-ledger.json
+++ b/factory/templates/worker-accountability-ledger.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/worker-accountability-ledger.schema.json",
+  "record_type": "worker_accountability_ledger",
+  "ledger_version": "factory-15-p13-worker-accountability-v1",
+  "generated_at": "2026-07-01T00:00:00Z",
+  "scope": "public-safe-routing-consequence-ledger",
+  "runtime_authority": "hermes_kanban",
+  "local_state_authority": false,
+  "routing_authority": "factory_reducer",
+  "source_refs": [
+    "issues/595#point-13-worker-accountability"
+  ],
+  "consequence_policy": {
+    "watch_after_negative_events": 1,
+    "mandatory_review_after_rework_or_shallow_events": 2,
+    "demote_after_bad_output_failure_or_repair_loop_events": 2,
+    "escalate_after_total_negative_events": 5,
+    "positive_events_do_not_erase_negative_accountability_without_review": true
+  },
+  "worker_accountability": {
+    "product-face": {
+      "worker_id": "product-face",
+      "bad_output_count": 1,
+      "failure_count": 0,
+      "rework_count": 1,
+      "shallow_artifact_count": 2,
+      "review_fail_count": 0,
+      "repair_loop_count": 0,
+      "positive_signal_count": 0,
+      "negative_total": 4,
+      "event_refs": [
+        "external:sanitized/accountability/product-face-p13-sample"
+      ],
+      "routing_consequence": {
+        "action": "mandatory_independent_review",
+        "accountability_state": "review_required",
+        "queue_class": "review-before-consumption",
+        "required_reviewer": "independent-reviewer",
+        "allowed_actions": [
+          "route_output_to_independent_review",
+          "block_downstream_consumption_until_review_pass"
+        ],
+        "reason": "repeated rework/shallow output or review failure requires independent review"
+      }
+    }
+  },
+  "routing_summary": {
+    "strongest_action": "mandatory_independent_review",
+    "affected_workers": [
+      "product-face"
+    ],
+    "routing_authority": "factory_reducer_consumes_this_ledger_hermes_kanban_executes_state"
+  },
+  "limits": [
+    "Ledger refs must be public-safe sanitized refs, not raw Hermes task ids or private paths.",
+    "The ledger recommends routing consequences only; Hermes Kanban remains runtime state authority.",
+    "Demotion or escalation does not approve, reject, or waive a human/product/security gate."
+  ]
+}

--- a/factory/tests/test_worker_accountability.py
+++ b/factory/tests/test_worker_accountability.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "worker_accountability.py"
+SPEC = importlib.util.spec_from_file_location("worker_accountability", MODULE_PATH)
+assert SPEC is not None
+accountability = importlib.util.module_from_spec(SPEC)
+sys.modules["worker_accountability"] = accountability
+assert SPEC.loader is not None
+SPEC.loader.exec_module(accountability)
+
+VALIDATOR_PATH = ROOT / "scripts" / "validate_public_json_artifacts.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location("validate_public_json_artifacts", VALIDATOR_PATH)
+assert VALIDATOR_SPEC is not None
+public_json_validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+sys.modules["validate_public_json_artifacts_for_accountability"] = public_json_validator
+assert VALIDATOR_SPEC.loader is not None
+VALIDATOR_SPEC.loader.exec_module(public_json_validator)
+
+
+class WorkerAccountabilityTest(unittest.TestCase):
+    def test_repeated_shallow_output_routes_to_mandatory_independent_review(self) -> None:
+        events = [
+            {
+                "worker_id": "product-face",
+                "event_type": "shallow_artifact",
+                "evidence_refs": ["external:sanitized/accountability/product-face-shallow-1"],
+            },
+            {
+                "worker_id": "product-face",
+                "event_type": "shallow_artifact",
+                "evidence_refs": ["external:sanitized/accountability/product-face-shallow-2"],
+            },
+        ]
+
+        ledger = accountability.build_accountability_ledger(events, generated_at="2026-07-01T00:00:00Z")
+        row = ledger["worker_accountability"]["product-face"]
+
+        self.assertEqual(row["shallow_artifact_count"], 2)
+        self.assertEqual(row["routing_consequence"]["action"], "mandatory_independent_review")
+        self.assertEqual(row["routing_consequence"]["required_reviewer"], "independent-reviewer")
+        self.assertIn("block_downstream_consumption_until_review_pass", row["routing_consequence"]["allowed_actions"])
+        self.assertEqual(ledger["routing_summary"]["strongest_action"], "mandatory_independent_review")
+        self.assertEqual(accountability.validate_ledger(ledger), [])
+
+    def test_repeated_failures_demote_worker_route(self) -> None:
+        events = [
+            {
+                "worker_id": "implementation-worker",
+                "event_type": "failed_run",
+                "evidence_refs": ["external:sanitized/accountability/impl-failure-1"],
+            },
+            {
+                "worker_id": "implementation-worker",
+                "event_type": "failure",
+                "evidence_refs": ["external:sanitized/accountability/impl-failure-2"],
+            },
+        ]
+
+        ledger = accountability.build_accountability_ledger(events, generated_at="2026-07-01T00:00:00Z")
+        consequence = ledger["worker_accountability"]["implementation-worker"]["routing_consequence"]
+
+        self.assertEqual(consequence["action"], "demote_to_review_queue")
+        self.assertEqual(consequence["accountability_state"], "demoted")
+        self.assertEqual(consequence["queue_class"], "demoted-review-queue")
+        self.assertIn("prefer_alternate_worker_when_available", consequence["allowed_actions"])
+
+    def test_high_repeated_negative_count_escalates_for_profile_review(self) -> None:
+        events = [
+            {
+                "worker_id": "product-sot-planner",
+                "event_type": event_type,
+                "evidence_refs": [f"external:sanitized/accountability/sot-{index}"],
+            }
+            for index, event_type in enumerate(
+                ["bad_output", "rework_required", "shallow_artifact", "review_fail", "repair_loop"],
+                start=1,
+            )
+        ]
+
+        ledger = accountability.build_accountability_ledger(events, generated_at="2026-07-01T00:00:00Z")
+        consequence = ledger["worker_accountability"]["product-sot-planner"]["routing_consequence"]
+
+        self.assertEqual(consequence["action"], "escalate_for_profile_review")
+        self.assertEqual(consequence["required_reviewer"], "skill-eval-distiller")
+        self.assertIn("block_new_sensitive_assignments", consequence["allowed_actions"])
+        self.assertEqual(ledger["routing_summary"]["strongest_action"], "escalate_for_profile_review")
+
+    def test_positive_signal_does_not_erase_negative_accountability(self) -> None:
+        events = [
+            {
+                "worker_id": "qa-verification-worker",
+                "event_type": "bad_output",
+                "evidence_refs": ["external:sanitized/accountability/qa-bad-output"],
+            },
+            {
+                "worker_id": "qa-verification-worker",
+                "event_type": "positive_review",
+                "evidence_refs": ["external:sanitized/accountability/qa-positive-review"],
+            },
+        ]
+
+        ledger = accountability.build_accountability_ledger(events, generated_at="2026-07-01T00:00:00Z")
+        row = ledger["worker_accountability"]["qa-verification-worker"]
+
+        self.assertEqual(row["positive_signal_count"], 1)
+        self.assertEqual(row["negative_total"], 1)
+        self.assertEqual(row["routing_consequence"]["action"], "watch")
+
+    def test_raw_kanban_task_refs_are_rejected_from_public_ledger_inputs(self) -> None:
+        events = [
+            {
+                "worker_id": "product-face",
+                "event_type": "shallow_artifact",
+                "evidence_refs": ["t_" + "123abc"],
+            }
+        ]
+
+        errors = accountability.event_validation_errors(events)
+
+        self.assertTrue(any("public-safe sanitized ref" in error for error in errors), errors)
+
+    def test_template_worker_accountability_ledger_matches_public_schema(self) -> None:
+        schema = json.loads((ROOT / "schemas" / "worker-accountability-ledger.schema.json").read_text(encoding="utf-8"))
+        schemas = {"worker-accountability-ledger.schema.json": schema}
+        template = json.loads((ROOT / "templates" / "worker-accountability-ledger.json").read_text(encoding="utf-8"))
+
+        errors = public_json_validator.validate_node(
+            schema,
+            template,
+            "$",
+            schemas=schemas,
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(accountability.validate_ledger(template), [])
+
+    def test_cli_builds_valid_ledger_from_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            tmp_path = Path(tempdir)
+            events_path = tmp_path / "events.json"
+            out_path = tmp_path / "ledger.json"
+            events_path.write_text(
+                json.dumps(
+                    {
+                        "events": [
+                            {
+                                "worker_id": "frontend-builder",
+                                "event_type": "rework_required",
+                                "evidence_refs": ["external:sanitized/accountability/frontend-rework-1"],
+                            },
+                            {
+                                "worker_id": "frontend-builder",
+                                "event_type": "rework_required",
+                                "evidence_refs": ["external:sanitized/accountability/frontend-rework-2"],
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code = accountability.main(["build", str(events_path), "--out", str(out_path)])
+            built = json.loads(out_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(
+                built["worker_accountability"]["frontend-builder"]["routing_consequence"]["action"],
+                "mandatory_independent_review",
+            )
+            self.assertEqual(accountability.main(["validate", str(out_path)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a public-safe worker accountability ledger builder/validator for issue #595 point 13.
- Adds deterministic routing consequences for repeated bad output, failures, rework, shallow artifacts, review failures, and repair loops.
- Wires factoryctl commands, schema/template/docs, generated reference, and regression coverage.

## Validation
- python3 -m unittest factory.tests.test_worker_accountability factory.tests.test_worker_profiles factory.tests.test_work_product_quality_firewall factory.tests.test_open_source_docs -q
- python3 factory/scripts/public_safety_scan.py --summary-json .tmp/public-safety-summary.json
- python3 factory/scripts/secret_safety_scan.py --summary-json .tmp/secret-safety-summary.json
- python3 -m py_compile factory/scripts/worker_accountability.py factory/scripts/factoryctl.py
- python3 factory/scripts/factoryctl.py build-worker-accountability-ledger .tmp/worker-accountability-events.json --out .tmp/worker-accountability-ledger.json && python3 factory/scripts/factoryctl.py validate-worker-accountability-ledger .tmp/worker-accountability-ledger.json

## Notes
Full `python3 factory/scripts/validate_public_json_artifacts.py` still fails on pre-existing missing docs refs in `templates/factory-operating-system-registry.json`; this PR did not introduce those refs.