### PR TITLE
Enforce real effectiveness proof

### DIFF
--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 245 | `schemas/*.json` |
-| Templates | 162 | `templates/*` |
+| JSON schemas | 246 | `schemas/*.json` |
+| Templates | 163 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
@@ -396,6 +396,7 @@ These are the public JSON schemas the factory exposes. They are not decoration; 
 - `schemas/readiness-truth-ledger.schema.json`
 - `schemas/ready-work-unit-hermes-materialization-plan.schema.json`
 - `schemas/ready-work-unit-packets.schema.json`
+- `schemas/real-effectiveness-proof.schema.json`
 - `schemas/reasoning-policy.schema.json`
 - `schemas/receipt-five.schema.json`
 - `schemas/reference-derived-negative-fixture.schema.json`
@@ -580,6 +581,7 @@ Templates are starter records paired with schemas. They are examples of valid sh
 - `templates/qa-verification-plan.json`
 - `templates/ready-work-unit-hermes-materialization-plan.json`
 - `templates/ready-work-unit-packets.json`
+- `templates/real-effectiveness-proof.json`
 - `templates/reasoning-policy.json`
 - `templates/receipt-five.json`
 - `templates/reference-quality-packet.json`

--- a/factory/legacy-docs/public-docs-before-product-manual/operations/real-effectiveness-rule.md
+++ b/factory/legacy-docs/public-docs-before-product-manual/operations/real-effectiveness-rule.md
@@ -1,0 +1,20 @@
+# Real effectiveness rule
+
+A Kanban comment, Receipt Five entry, `done` transition, or phase advancement is process evidence only. It does not count as real progress unless a `real_effectiveness_proof` ties that ritual to at least one material effect:
+
+- `product_progress`: a product/SOT/acceptance delta exists and is traced.
+- `blocker_resolution`: a named blocker is resolved with evidence.
+- `usable_artifact`: an operator/product artifact exists and has validation evidence.
+- `human_delivery`: the right human/operator received a usable delivery artifact.
+- `executable_repair`: executable code/runtime/config was repaired and validated.
+
+Use `factory/templates/real-effectiveness-proof.json` as the starting packet and validate it with:
+
+```sh
+python factory/scripts/factoryctl.py validate-real-effectiveness factory/templates/real-effectiveness-proof.json
+python factory/scripts/work_product_quality_firewall.py real_effectiveness factory/templates/real-effectiveness-proof.json
+```
+
+For cards that must enforce this boundary at done promotion, set `real_effectiveness_required: true` on the card or completion metadata and attach `real_effectiveness_proof` beside `receipt_five` and `kanban_transition_event`.
+
+Process-only evidence belongs in `ritual_refs`; material evidence belongs in `evidence_refs` plus the effect-specific refs. If every evidence ref is just a comment, receipt, status/done transition, or phase move, validation fails closed.

--- a/factory/schemas/real-effectiveness-proof.schema.json
+++ b/factory/schemas/real-effectiveness-proof.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/real-effectiveness-proof.schema.json",
+  "title": "Real Effectiveness Proof",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "record_type",
+    "effect_type",
+    "claim",
+    "evidence_refs",
+    "operator_or_product_impact"
+  ],
+  "properties": {
+    "$schema": {"type": "string"},
+    "record_type": {"const": "real_effectiveness_proof"},
+    "effect_type": {
+      "type": "string",
+      "enum": [
+        "product_progress",
+        "blocker_resolution",
+        "usable_artifact",
+        "human_delivery",
+        "executable_repair"
+      ]
+    },
+    "claim": {"type": "string", "minLength": 20},
+    "operator_or_product_impact": {"type": "string", "minLength": 20},
+    "evidence_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "ritual_refs": {"type": "array", "items": {"type": "string"}},
+    "product_delta_refs": {"type": "array", "items": {"type": "string"}},
+    "acceptance_refs": {"type": "array", "items": {"type": "string"}},
+    "blocker_refs": {"type": "array", "items": {"type": "string"}},
+    "resolution_refs": {"type": "array", "items": {"type": "string"}},
+    "artifact_refs": {"type": "array", "items": {"type": "string"}},
+    "validation_refs": {"type": "array", "items": {"type": "string"}},
+    "delivery_refs": {"type": "array", "items": {"type": "string"}},
+    "recipient_or_channel": {"type": "string"},
+    "repair_refs": {"type": "array", "items": {"type": "string"}}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"effect_type": {"const": "product_progress"}}},
+      "then": {"required": ["product_delta_refs", "acceptance_refs"]}
+    },
+    {
+      "if": {"properties": {"effect_type": {"const": "blocker_resolution"}}},
+      "then": {"required": ["blocker_refs", "resolution_refs"]}
+    },
+    {
+      "if": {"properties": {"effect_type": {"const": "usable_artifact"}}},
+      "then": {"required": ["artifact_refs", "validation_refs"]}
+    },
+    {
+      "if": {"properties": {"effect_type": {"const": "human_delivery"}}},
+      "then": {"required": ["delivery_refs", "recipient_or_channel"]}
+    },
+    {
+      "if": {"properties": {"effect_type": {"const": "executable_repair"}}},
+      "then": {"required": ["repair_refs", "validation_refs"]}
+    }
+  ],
+  "description": "Proof that a completion/receipt/comment/phase advancement represents material product/runtime progress, not only process ritual. Comments, Receipt Five, done labels and phase moves are ritual_refs unless tied to one of the allowed effect_type classes."
+}

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -15796,6 +15796,75 @@ def product_face_result_required(card: dict[str, Any]) -> bool:
     )
 
 
+def validate_real_effectiveness_proof(proof: dict[str, Any], *, prefix: str = "real_effectiveness_proof") -> list[str]:
+    errors: list[str] = []
+    if not isinstance(proof, dict) or not proof:
+        return [f"{prefix} is required"]
+    schemas = bundled_schemas()
+    schema = schemas.get("real-effectiveness-proof.schema.json")
+    if schema:
+        errors.extend(validate_node(schema, proof, prefix, schemas=schemas, root_schema=schema))
+    allowed_effects = {
+        "product_progress": ("product_delta_refs", "acceptance_refs"),
+        "blocker_resolution": ("blocker_refs", "resolution_refs"),
+        "usable_artifact": ("artifact_refs", "validation_refs"),
+        "human_delivery": ("delivery_refs", "recipient_or_channel"),
+        "executable_repair": ("repair_refs", "validation_refs"),
+    }
+    process_ritual_effects = {
+        "process_ritual",
+        "comment",
+        "receipt",
+        "done_transition",
+        "phase_advancement",
+        "status_update",
+        "board_motion",
+    }
+    process_markers = (
+        "comment",
+        "receipt",
+        "done",
+        "phase",
+        "advance",
+        "advanced",
+        "transition",
+        "status",
+        "kanban",
+    )
+    if proof.get("record_type") not in {None, "real_effectiveness_proof"}:
+        errors.append(f"{prefix}.record_type must be real_effectiveness_proof")
+    effect_type = str(proof.get("effect_type") or proof.get("real_effect_type") or "").strip()
+    claim = str(proof.get("claim") or proof.get("summary") or "").strip()
+    evidence_refs = _list_items(proof.get("evidence_refs"))
+    ritual_refs = set(_list_items(proof.get("ritual_refs")))
+    if not claim:
+        errors.append(f"{prefix}.claim is required")
+    if effect_type not in allowed_effects:
+        errors.append(
+            f"{prefix}.effect_type must be product_progress, blocker_resolution, usable_artifact, human_delivery or executable_repair"
+        )
+    if not evidence_refs:
+        errors.append(f"{prefix}.evidence_refs must be a non-empty array")
+    ritual_claim = effect_type in process_ritual_effects or any(marker in claim.lower() for marker in process_markers)
+    if ritual_claim:
+        material_refs = [
+            ref
+            for ref in evidence_refs
+            if ref not in ritual_refs and not any(marker in ref.lower() for marker in process_markers)
+        ]
+        if not material_refs:
+            errors.append(f"{prefix} must include material evidence refs beyond process ritual refs")
+    if effect_type in allowed_effects:
+        for field in allowed_effects[effect_type]:
+            value = proof.get(field)
+            valid = _list_items(value) if isinstance(value, list) else _non_empty_text(value)
+            if not valid:
+                errors.append(f"{prefix}.{field} is required for {effect_type}")
+        if not _non_empty_text(proof.get("operator_or_product_impact")):
+            errors.append(f"{prefix}.operator_or_product_impact is required")
+    return errors
+
+
 def validate_receipt(data: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     receipt = data.get("receipt_five")
@@ -16022,9 +16091,19 @@ def validate_completion(
     from_status: str | None = None,
     to_status: str | None = None,
 ) -> list[str]:
+    card = card if isinstance(card, dict) else {}
+    metadata = metadata if isinstance(metadata, dict) else {}
     errors = validate_receipt(metadata)
     errors.extend(done_promotion_errors(metadata, card=card, from_status=from_status, to_status=to_status))
     receipt = metadata.get("receipt_five") if isinstance(metadata.get("receipt_five"), dict) else {}
+    if card.get("real_effectiveness_required") is True or metadata.get("real_effectiveness_required") is True:
+        proof = metadata.get("real_effectiveness_proof")
+        if not isinstance(proof, dict):
+            errors.append("real_effectiveness_proof is required for real-effectiveness done promotion")
+        else:
+            errors.extend(validate_real_effectiveness_proof(proof))
+    elif isinstance(metadata.get("real_effectiveness_proof"), dict):
+        errors.extend(validate_real_effectiveness_proof(metadata["real_effectiveness_proof"]))
     if receipt.get("reviewer_required") is True and str(receipt.get("reviewer_result") or "").strip().upper() != "PASS":
         errors.append("reviewer_result must be PASS when reviewer_required=true")
     if receipt.get("reviewer_required") is True and "independent_review_result" not in metadata:
@@ -22978,6 +23057,16 @@ def command_validate_receipt(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_real_effectiveness(args: argparse.Namespace) -> int:
+    errors = validate_real_effectiveness_proof(load_json_like(args.path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def command_validate_completion(args: argparse.Namespace) -> int:
     errors = validate_completion(load_json_like(args.card), load_json_like(args.receipt))
     if errors:
@@ -24343,6 +24432,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_receipt_parser = sub.add_parser("validate-receipt")
     validate_receipt_parser.add_argument("path", type=Path)
     validate_receipt_parser.set_defaults(func=command_validate_receipt)
+
+    validate_real_effectiveness_parser = sub.add_parser("validate-real-effectiveness")
+    validate_real_effectiveness_parser.add_argument("path", type=Path)
+    validate_real_effectiveness_parser.set_defaults(func=command_validate_real_effectiveness)
 
     validate_completion_parser = sub.add_parser("validate-completion")
     validate_completion_parser.add_argument("--card", type=Path, required=True)

--- a/factory/scripts/work_product_quality_firewall.py
+++ b/factory/scripts/work_product_quality_firewall.py
@@ -187,6 +187,99 @@ def validate_completion_readback(completion: Mapping[str, Any], root: str | Path
     return QualityResult("completion_readback", process_pass, readback_pass, quality_pass, findings)
 
 
+REAL_EFFECTIVENESS_TYPES = {
+    "product_progress",
+    "blocker_resolution",
+    "usable_artifact",
+    "human_delivery",
+    "executable_repair",
+}
+PROCESS_RITUAL_TYPES = {
+    "process_ritual",
+    "comment",
+    "receipt",
+    "done_transition",
+    "phase_advancement",
+    "status_update",
+    "board_motion",
+}
+PROCESS_RITUAL_MARKERS = (
+    "comment",
+    "receipt",
+    "done",
+    "phase",
+    "advance",
+    "advanced",
+    "transition",
+    "status",
+    "kanban",
+)
+EFFECTIVENESS_REQUIRED_FIELDS = {
+    "product_progress": ("product_delta_refs", "acceptance_refs"),
+    "blocker_resolution": ("blocker_refs", "resolution_refs"),
+    "usable_artifact": ("artifact_refs", "validation_refs"),
+    "human_delivery": ("delivery_refs", "recipient_or_channel"),
+    "executable_repair": ("repair_refs", "validation_refs"),
+}
+
+
+def _items(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def validate_real_effectiveness_proof(proof: Mapping[str, Any]) -> QualityResult:
+    """Validate that claimed progress changed the product/runtime, not just the board ritual.
+
+    The five allowed effects are deliberately concrete: product progress, blocker
+    resolution, usable artifact, human delivery, or executable repair. Comments,
+    Receipt Five entries, done labels, and phase moves are process evidence only;
+    by themselves they cannot satisfy real-effectiveness claims.
+    """
+    data = _as_mapping(proof)
+    findings: list[QualityFinding] = []
+    effect_type = str(data.get("effect_type") or data.get("real_effect_type") or "").strip()
+    claim = str(data.get("claim") or data.get("summary") or "").strip()
+    evidence_refs = _items(data.get("evidence_refs"))
+    ritual_refs = set(_items(data.get("ritual_refs")))
+
+    process_pass = _nonempty(data) and _nonempty(claim)
+    if data.get("record_type") not in {None, "real_effectiveness_proof"}:
+        findings.append(_finding("invalid_record_type", "Real effectiveness proof must use record_type=real_effectiveness_proof."))
+    if not claim:
+        findings.append(_finding("missing_claim", "Real effectiveness proof must state the concrete effect claim."))
+    if effect_type not in REAL_EFFECTIVENESS_TYPES:
+        findings.append(_finding(
+            "process_ritual_not_material_progress",
+            "Comments, receipts, done labels and phase advancement are process rituals, not material progress.",
+        ))
+    if effect_type in PROCESS_RITUAL_TYPES or any(marker in claim.lower() for marker in PROCESS_RITUAL_MARKERS):
+        material_refs = [ref for ref in evidence_refs if ref not in ritual_refs and not any(marker in ref.lower() for marker in PROCESS_RITUAL_MARKERS)]
+        if not material_refs:
+            findings.append(_finding(
+                "missing_material_evidence",
+                "Real effectiveness proof needs material evidence beyond comment/receipt/done/phase refs.",
+            ))
+    if not evidence_refs:
+        findings.append(_finding("missing_evidence_refs", "Real effectiveness proof must include evidence_refs."))
+    if effect_type in REAL_EFFECTIVENESS_TYPES:
+        for field in EFFECTIVENESS_REQUIRED_FIELDS[effect_type]:
+            if not _nonempty(data.get(field)):
+                findings.append(_finding("missing_" + field, f"{effect_type} proof must include {field}."))
+        if not _nonempty(data.get("operator_or_product_impact")):
+            findings.append(_finding(
+                "missing_operator_or_product_impact",
+                "Real effectiveness proof must explain the operator or product impact.",
+            ))
+
+    readback_pass = bool(evidence_refs) and not [f for f in findings if f.code == "missing_material_evidence"]
+    quality_pass = process_pass and readback_pass and not [f for f in findings if f.severity == "error"]
+    return QualityResult("real_effectiveness_proof", process_pass, readback_pass, quality_pass, findings)
+
+
 def can_promote(result: QualityResult | Iterable[QualityResult]) -> bool:
     if isinstance(result, QualityResult):
         results = [result]
@@ -236,12 +329,22 @@ def validate_artifact(artifact_type: str, path: Path, *, root: Path | None = Non
                 findings=[_finding("invalid_completion_payload", "Completion readback input must be a JSON object.")],
             )
         return validate_completion_readback(payload, root or path.parent)
+    if artifact_type == "real_effectiveness":
+        if not isinstance(payload, Mapping):
+            return QualityResult(
+                "real_effectiveness_proof",
+                process_pass=False,
+                readback_pass=False,
+                quality_pass=False,
+                findings=[_finding("invalid_real_effectiveness_payload", "Real effectiveness proof must be a JSON object.")],
+            )
+        return validate_real_effectiveness_proof(payload)
     raise ValueError(f"unsupported artifact_type: {artifact_type}")
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate Overkill Factory work-product quality floor.")
-    parser.add_argument("artifact_type", choices=["product_sot", "human_gate", "completion_readback"])
+    parser.add_argument("artifact_type", choices=["product_sot", "human_gate", "completion_readback", "real_effectiveness"])
     parser.add_argument("path", type=Path)
     parser.add_argument("--root", type=Path, help="Root directory for completion readback artifact paths")
     parser.add_argument("--json", action="store_true", help="Emit JSON result")

--- a/factory/templates/real-effectiveness-proof.json
+++ b/factory/templates/real-effectiveness-proof.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/real-effectiveness-proof.schema.json",
+  "record_type": "real_effectiveness_proof",
+  "effect_type": "usable_artifact",
+  "claim": "Replace this with the concrete product/runtime effect, not the Kanban action performed.",
+  "operator_or_product_impact": "Explain what the operator can now decide/do or what product behavior/runtime is now repaired.",
+  "evidence_refs": [
+    "reports/example-artifact.md",
+    "reports/example-validation.json"
+  ],
+  "ritual_refs": [
+    "receipt_five",
+    "kanban_transition_event"
+  ],
+  "artifact_refs": [
+    "reports/example-artifact.md"
+  ],
+  "validation_refs": [
+    "python scripts/factoryctl.py validate-real-effectiveness reports/real-effectiveness-proof.json"
+  ]
+}

--- a/factory/tests/test_factoryctl.py
+++ b/factory/tests/test_factoryctl.py
@@ -2429,6 +2429,64 @@ class FactoryCtlTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_real_effectiveness_validator_rejects_comment_done_receipt_phase_ritual(self) -> None:
+        proof = {
+            "record_type": "real_effectiveness_proof",
+            "effect_type": "process_ritual",
+            "claim": "Commented status, wrote a receipt, set done, and advanced the phase.",
+            "ritual_refs": ["comment:status", "receipt_five", "kanban_transition_event", "phase:F12"],
+            "evidence_refs": ["comment:status"],
+        }
+
+        errors = factoryctl.validate_real_effectiveness_proof(proof)
+
+        self.assertIn(
+            "real_effectiveness_proof.effect_type must be product_progress, blocker_resolution, usable_artifact, human_delivery or executable_repair",
+            errors,
+        )
+        self.assertIn("real_effectiveness_proof must include material evidence refs beyond process ritual refs", errors)
+
+    def test_completion_real_effectiveness_required_blocks_process_ritual_receipt(self) -> None:
+        card = {"card_id": "REAL-EFFECTIVENESS-001", "real_effectiveness_required": True}
+        receipt = {
+            "receipt_five": {
+                "changed": "commented, wrote Receipt Five, and marked done",
+                "artifact_paths": ["reports/status-comment.md"],
+                "verification_commands": ["python scripts/factoryctl.py validate-receipt receipt.json"],
+                "verification_result": "PASS",
+                "reviewer_required": False,
+                "next_action": "advance phase",
+            },
+            "kanban_transition_event": {
+                "from_status": "review",
+                "to_status": "done",
+                "actor": "factory-orchestrator",
+                "worker": "factory-orchestrator",
+                "receipt_refs": ["receipt_five"],
+                "artifact_refs": ["reports/status-comment.md"],
+                "allowed": True,
+            },
+            "receipt_five_reconciliation_result": {
+                "result": "PASS",
+                "valid": True,
+                "promotion_authority": {"result": "PASS"},
+            },
+            "real_effectiveness_proof": {
+                "record_type": "real_effectiveness_proof",
+                "effect_type": "process_ritual",
+                "claim": "Comment and done transition only.",
+                "ritual_refs": ["receipt_five", "kanban_transition_event"],
+                "evidence_refs": ["receipt_five"],
+            },
+        }
+
+        errors = factoryctl.validate_completion(card, receipt, from_status="review", to_status="done")
+
+        self.assertIn(
+            "real_effectiveness_proof.effect_type must be product_progress, blocker_resolution, usable_artifact, human_delivery or executable_repair",
+            errors,
+        )
+
     def test_product_face_completion_requires_visual_result(self) -> None:
         card = factoryctl.load_json_like(ROOT / "examples" / "cards" / "v35_valid_product_face.md")
         card["product_face_result_required"] = True

--- a/factory/tests/test_work_product_quality_firewall.py
+++ b/factory/tests/test_work_product_quality_firewall.py
@@ -103,6 +103,43 @@ def test_quality_firewall_refuses_process_pass_without_quality_pass():
     assert quality.can_promote(result) is False
 
 
+def test_real_effectiveness_refuses_comment_done_receipt_and_phase_rituals():
+    proof = {
+        "record_type": "real_effectiveness_proof",
+        "effect_type": "process_ritual",
+        "claim": "Posted a comment, wrote Receipt Five, marked the phase done, and advanced the card.",
+        "ritual_refs": ["comment:kanban-update", "receipt_five", "kanban_transition_event"],
+        "evidence_refs": ["comment:kanban-update"],
+    }
+
+    result = quality.validate_real_effectiveness_proof(proof)
+
+    assert result.process_pass is True
+    assert result.quality_pass is False
+    codes = {finding.code for finding in result.findings}
+    assert "process_ritual_not_material_progress" in codes
+    assert "missing_material_evidence" in codes
+
+
+def test_real_effectiveness_accepts_usable_artifact_with_validation():
+    proof = {
+        "record_type": "real_effectiveness_proof",
+        "effect_type": "usable_artifact",
+        "claim": "Generated the operator PDF decision package and validated it against the delivery profile.",
+        "artifact_refs": ["reports/operator-decision-package.pdf"],
+        "evidence_refs": ["reports/operator-decision-package.pdf", "reports/operator-decision-package.validation.json"],
+        "validation_refs": ["pytest factory/tests/test_operator_experience.py"],
+        "operator_or_product_impact": "Operator can make the Product SOT gate decision without opening raw Kanban or JSON.",
+    }
+
+    result = quality.validate_real_effectiveness_proof(proof)
+
+    assert result.process_pass is True
+    assert result.readback_pass is True
+    assert result.quality_pass is True
+    assert result.findings == []
+
+
 def test_completion_readback_fails_missing_claimed_artifact():
     with TemporaryDirectory() as tmp:
         root = Path(tmp)


### PR DESCRIPTION
## Summary
- adds a `real_effectiveness_proof` schema/template and CLI validation
- teaches the quality firewall to reject process-only ritual as product progress
- adds tests proving comments, Receipt Five, done transitions, and phase moves do not count without material evidence
- documents the real-effectiveness rule for operators

## Why
The factory must not treat bureaucracy as progress. A card/phase/receipt only counts when tied to product progress, blocker resolution, usable artifact, human delivery, or executable repair evidence.

## Validation
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_factoryctl.py tests/test_work_product_quality_firewall.py -q
- python scripts/factoryctl.py validate-real-effectiveness templates/real-effectiveness-proof.json
- python scripts/work_product_quality_firewall.py real_effectiveness templates/real-effectiveness-proof.json
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P01.
