### PR TITLE
Add universal repair loop contract

### DIFF
--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 246 | `schemas/*.json` |
-| Templates | 163 | `templates/*` |
+| JSON schemas | 247 | `schemas/*.json` |
+| Templates | 164 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases

--- a/factory/schemas/worker-result.schema.json
+++ b/factory/schemas/worker-result.schema.json
@@ -574,6 +574,41 @@
             "local_state_authority": { "const": false }
           },
           "additionalProperties": true
+        },
+        "automatic_repair_loop": {
+          "type": "object",
+          "properties": {
+            "required": { "type": "boolean" },
+            "factory_owned_repair_allowed": { "type": "boolean" },
+            "runtime_authority": { "const": "hermes_kanban" },
+            "local_state_authority": { "const": false },
+            "route_ref": { "type": "string", "minLength": 3 },
+            "stage_order": {
+              "type": "array",
+              "items": { "enum": ["repair", "audit", "rerun", "reconcile"] }
+            },
+            "stages": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stage": { "enum": ["repair", "audit", "rerun", "reconcile"] },
+                  "owner_worker": { "type": "string", "minLength": 3 },
+                  "command_or_route": { "type": "string", "minLength": 3 },
+                  "expected_output_ref": { "type": "string", "minLength": 3 },
+                  "exit_condition": { "type": "string", "minLength": 3 }
+                },
+                "additionalProperties": true
+              }
+            },
+            "post_repair_reconciliation_required": { "type": "boolean" },
+            "fresh_review_required": { "type": "boolean" },
+            "stop_classes": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 3 }
+            }
+          },
+          "additionalProperties": true
         }
       },
       "additionalProperties": true,

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -2702,6 +2702,89 @@ def is_human_gate_recovery(*, blocker_type: str, repair_owner_worker: str) -> bo
     return blocker_type == "human_gate" or repair_owner_worker == "human-gate-clerk"
 
 
+AUTOMATIC_REPAIR_LOOP_STAGES = ["repair", "audit", "rerun", "reconcile"]
+
+
+def automatic_repair_loop_contract(
+    *,
+    route_id: str,
+    repair_owner_worker: str,
+    output_field: str,
+    human_gate_required: bool,
+) -> dict[str, Any]:
+    """Materialize the repair→audit→rerun→reconcile loop for factory-owned blockers.
+
+    Human gates deliberately do not get a factory-owned automatic loop: they stop
+    at the human gate record. Every non-human blocked worker result or generated
+    recovery route must name the same deterministic Hermes/Kanban loop so no-idle,
+    reducers, transition hooks and closeout can all reason over one contract.
+    """
+    if human_gate_required:
+        return {
+            "required": False,
+            "reason": "human_gate_record_required",
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        }
+    worker_slug = sanitize_slug(repair_owner_worker, fallback="worker")
+    field_slug = sanitize_slug(output_field, fallback="worker-result")
+    return {
+        "required": True,
+        "factory_owned_repair_allowed": True,
+        "runtime_authority": "hermes_kanban",
+        "local_state_authority": False,
+        "route_ref": route_id,
+        "loop_id": f"automatic-repair:{sanitize_slug(route_id, fallback='recovery-route')}",
+        "stage_order": list(AUTOMATIC_REPAIR_LOOP_STAGES),
+        "stages": [
+            {
+                "stage": "repair",
+                "owner_worker": repair_owner_worker,
+                "expected_output_ref": f"worker-result:{output_field}:fresh-repair",
+                "exit_condition": "repair worker produces a fresh replacement artifact/result in Hermes Kanban",
+            },
+            {
+                "stage": "audit",
+                "owner_worker": "independent-reviewer",
+                "expected_output_ref": f"worker-result:{output_field}:fresh-review-pass",
+                "exit_condition": "independent review records PASS against the replacement artifact/result",
+            },
+            {
+                "stage": "rerun",
+                "owner_worker": repair_owner_worker,
+                "expected_output_ref": f"worker-result:{output_field}:fresh-pass-or-waiver",
+                "exit_condition": "original worker route is rerun or explicitly waived under Hermes task history",
+            },
+            {
+                "stage": "reconcile",
+                "owner_worker": "evidence-reconciler",
+                "command_or_route": "reconcile-ready-work-units",
+                "expected_output_ref": f"reconcile-ready-work-units:{field_slug}",
+                "exit_condition": "Hermes/Kanban readback confirms stale blockers remain blocked and eligible downstream work unblocks",
+            },
+        ],
+        "native_primitives": [
+            "kanban_task",
+            "parent_link",
+            "blocked_state",
+            "comment_metadata",
+            "run_history",
+            "reclaim_reassign",
+        ],
+        "retry_attempt_source": "hermes_task_history",
+        "post_repair_reconciliation_required": True,
+        "fresh_review_required": True,
+        "no_idle_visible_marker": f"factory_recovery_attempt:{worker_slug}:{field_slug}",
+        "stop_classes": [
+            "human_gate",
+            "secret_or_access_required",
+            "external_mutation_required",
+            "ambiguous_product_decision",
+            "repeated_failed_recovery",
+        ],
+    }
+
+
 def recovery_recommendation_for_worker(
     *,
     worker_id: str,
@@ -2737,6 +2820,12 @@ def recovery_recommendation_for_worker(
         "unblock_authority_ref": "Hermes blocked event plus fresh review PASS" if not human_gate_required else "human_gate_record",
         "retry_policy": recovery_retry_policy(attempt_number=attempt_number),
         "hermes_runtime_boundary": recovery_runtime_boundary(),
+        "automatic_repair_loop": automatic_repair_loop_contract(
+            route_id=route_id,
+            repair_owner_worker=worker_id,
+            output_field=output_field,
+            human_gate_required=human_gate_required,
+        ),
     }
 
 
@@ -16959,6 +17048,12 @@ def recovery_route_from_action(card: dict[str, Any], action: dict[str, Any], ind
             "comments_metadata_policy": "Store blocker type, invalidation refs, retry attempt and unblock authority in Hermes comments/metadata.",
             "local_state_authority": False,
         },
+        "automatic_repair_loop": automatic_repair_loop_contract(
+            route_id=route_id,
+            repair_owner_worker=worker_id,
+            output_field=field,
+            human_gate_required=human_gate_required,
+        ),
     }
 
 
@@ -17061,6 +17156,12 @@ def recovery_route_from_recommendation(
         ),
         "audit_trail_refs": audit_refs,
         "hermes_materialization": recovery_materialization_contract(route_id),
+        "automatic_repair_loop": automatic_repair_loop_contract(
+            route_id=route_id,
+            repair_owner_worker=repair_owner_worker,
+            output_field=field,
+            human_gate_required=human_gate_required,
+        ),
     }
 
 
@@ -17690,6 +17791,37 @@ def _record_specific_errors(data: dict[str, Any], evidence_kind: str) -> list[st
     return errors
 
 
+def automatic_repair_loop_errors(loop: Any, *, at: str) -> list[str]:
+    if not isinstance(loop, dict):
+        return [f"{at}.automatic_repair_loop is required for factory-owned blocked recovery"]
+    errors: list[str] = []
+    if loop.get("required") is not True:
+        errors.append(f"{at}.automatic_repair_loop.required must be true")
+    if loop.get("runtime_authority") != "hermes_kanban":
+        errors.append(f"{at}.automatic_repair_loop.runtime_authority must be hermes_kanban")
+    if loop.get("local_state_authority") is not False:
+        errors.append(f"{at}.automatic_repair_loop.local_state_authority must be false")
+    if loop.get("post_repair_reconciliation_required") is not True:
+        errors.append(f"{at}.automatic_repair_loop.post_repair_reconciliation_required must be true")
+    stage_order = string_list(loop.get("stage_order"))
+    if stage_order != AUTOMATIC_REPAIR_LOOP_STAGES:
+        errors.append(f"{at}.automatic_repair_loop.stage_order must be repair,audit,rerun,reconcile")
+    stages = loop.get("stages") if isinstance(loop.get("stages"), list) else []
+    stage_names = [str(stage.get("stage") or "") for stage in stages if isinstance(stage, dict)]
+    if stage_names != AUTOMATIC_REPAIR_LOOP_STAGES:
+        errors.append(f"{at}.automatic_repair_loop.stages must materialize repair,audit,rerun,reconcile")
+    reconcile = next((stage for stage in stages if isinstance(stage, dict) and stage.get("stage") == "reconcile"), {})
+    if not isinstance(reconcile, dict) or reconcile.get("command_or_route") != "reconcile-ready-work-units":
+        errors.append(f"{at}.automatic_repair_loop.reconcile must route through reconcile-ready-work-units")
+    audit = next((stage for stage in stages if isinstance(stage, dict) and stage.get("stage") == "audit"), {})
+    if not isinstance(audit, dict) or str(audit.get("owner_worker") or "") not in WORKERS:
+        errors.append(f"{at}.automatic_repair_loop.audit owner_worker must be a registered worker")
+    stop_classes = set(string_list(loop.get("stop_classes")))
+    if "human_gate" not in stop_classes or "repeated_failed_recovery" not in stop_classes:
+        errors.append(f"{at}.automatic_repair_loop.stop_classes must include human_gate and repeated_failed_recovery")
+    return errors
+
+
 def validate_worker_result_record(
     data: dict[str, Any],
     expected_field: str | None = None,
@@ -17751,6 +17883,16 @@ def validate_worker_result_record(
                         errors.append("human_gate recovery must not route through fresh review")
                     if recovery.get("unblock_authority_ref") != "human_gate_record":
                         errors.append("human_gate recovery unblock_authority_ref must be human_gate_record")
+                    human_loop = recovery.get("automatic_repair_loop") if isinstance(recovery.get("automatic_repair_loop"), dict) else {}
+                    if human_loop.get("required") is True:
+                        errors.append("human_gate recovery must not materialize an automatic factory-owned repair loop")
+                elif recovery.get("factory_owned_repair_allowed") is True:
+                    errors.extend(
+                        automatic_repair_loop_errors(
+                            recovery.get("automatic_repair_loop"),
+                            at="recovery_recommendation",
+                        )
+                    )
                 retry_policy = recovery.get("retry_policy") if isinstance(recovery.get("retry_policy"), dict) else None
                 if not isinstance(retry_policy, dict):
                     errors.append("recovery_recommendation.retry_policy is required")
@@ -19628,6 +19770,12 @@ def summarize_recovery_route_for_help(route: dict[str, Any]) -> dict[str, Any]:
     human_gate_required = route.get("human_gate_required") is True
     factory_owned = route.get("factory_owned_repair_allowed") is True and not human_gate_required
     retry_policy = route.get("retry_policy") if isinstance(route.get("retry_policy"), dict) else {}
+    automatic_loop = route.get("automatic_repair_loop") if isinstance(route.get("automatic_repair_loop"), dict) else automatic_repair_loop_contract(
+        route_id=route_id or "recovery:unknown",
+        repair_owner_worker=repair_owner or "human-gate-clerk",
+        output_field=WORKERS.get(repair_owner, WORKERS["factory-orchestrator"]).output_field if repair_owner in WORKERS else "worker_result",
+        human_gate_required=human_gate_required,
+    )
     summary = {
         "recovery_route_id": route_id,
         "route_digest": recovery_route_digest(route) if route_id else "",
@@ -19637,6 +19785,7 @@ def summarize_recovery_route_for_help(route: dict[str, Any]) -> dict[str, Any]:
         "repair_owner_worker": repair_owner,
         "unblock_authority_ref": str(route.get("unblock_authority_ref") or ""),
         "downstream_freeze_scope": _list_items(route.get("downstream_freeze_scope")),
+        "automatic_repair_loop": automatic_loop,
         "retry_state": {
             "attempt_number": int(retry_policy.get("attempt_number") or 1),
             "max_attempts": int(retry_policy.get("max_attempts") or 1),

--- a/factory/tests/test_factoryctl.py
+++ b/factory/tests/test_factoryctl.py
@@ -4189,6 +4189,14 @@ class FactoryCtlTest(unittest.TestCase):
         recovery = result["recovery_recommendation"]
         self.assertEqual(recovery["blocker_type"], "security")
         self.assertTrue(recovery["factory_owned_repair_allowed"])
+        loop = recovery["automatic_repair_loop"]
+        self.assertTrue(loop["required"])
+        self.assertEqual(loop["runtime_authority"], "hermes_kanban")
+        self.assertFalse(loop["local_state_authority"])
+        self.assertEqual(loop["stage_order"], ["repair", "audit", "rerun", "reconcile"])
+        self.assertEqual([stage["stage"] for stage in loop["stages"]], ["repair", "audit", "rerun", "reconcile"])
+        self.assertEqual(loop["stages"][-1]["command_or_route"], "reconcile-ready-work-units")
+        self.assertTrue(loop["post_repair_reconciliation_required"])
         self.assertEqual(recovery["hermes_runtime_boundary"]["runtime_authority"], "hermes_kanban")
         self.assertFalse(recovery["hermes_runtime_boundary"]["local_state_authority"])
         self.assertEqual(recovery["retry_policy"]["attempt_number"], 1)
@@ -4235,6 +4243,67 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn("recovery_recommendation.retry_policy.runtime_attempt_source must be hermes_task_history", errors)
         self.assertIn("recovery_recommendation.retry_policy must not claim local runtime state authority", errors)
 
+    def test_factory_owned_blocked_result_requires_automatic_repair_loop(self) -> None:
+        card = load_card("v35_valid_security_with_scan.md")
+        result = factoryctl.build_worker_result(
+            "codex-security",
+            card,
+            result="BLOCKED",
+            tool_or_profile="codex-security:security-scan",
+            executed_by="security-runner",
+            evidence_refs=["reports/security.md"],
+            blocking_findings=True,
+            findings_summary="Security finding blocks continuation.",
+            next_action="repair finding and rerun security scan",
+        )
+        bad = json.loads(json.dumps(result))
+        bad["recovery_recommendation"].pop("automatic_repair_loop")
+
+        errors = factoryctl.validate_worker_result_record(
+            bad,
+            expected_field="security_scan_result",
+            expected_worker_id="codex-security",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn(
+            "recovery_recommendation.automatic_repair_loop is required for factory-owned blocked recovery",
+            errors,
+        )
+
+    def test_factory_owned_recovery_loop_must_reconcile_after_rerun(self) -> None:
+        card = load_card("v35_valid_security_with_scan.md")
+        result = factoryctl.build_worker_result(
+            "codex-security",
+            card,
+            result="BLOCKED",
+            tool_or_profile="codex-security:security-scan",
+            executed_by="security-runner",
+            evidence_refs=["reports/security.md"],
+            blocking_findings=True,
+            findings_summary="Security finding blocks continuation.",
+            next_action="repair finding and rerun security scan",
+        )
+        bad = json.loads(json.dumps(result))
+        bad["recovery_recommendation"]["automatic_repair_loop"]["stage_order"] = ["repair", "rerun"]
+        bad["recovery_recommendation"]["automatic_repair_loop"]["stages"] = [
+            {"stage": "repair", "owner_worker": "codex-security"},
+            {"stage": "rerun", "owner_worker": "codex-security"},
+        ]
+
+        errors = factoryctl.validate_worker_result_record(
+            bad,
+            expected_field="security_scan_result",
+            expected_worker_id="codex-security",
+            card=card,
+            evidence_root=ROOT,
+        )
+
+        self.assertIn("recovery_recommendation.automatic_repair_loop.stage_order must be repair,audit,rerun,reconcile", errors)
+        self.assertIn("recovery_recommendation.automatic_repair_loop.stages must materialize repair,audit,rerun,reconcile", errors)
+        self.assertIn("recovery_recommendation.automatic_repair_loop.reconcile must route through reconcile-ready-work-units", errors)
+
     def test_human_gate_recovery_cannot_be_factory_owned_repair(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")
         recovery = factoryctl.recovery_recommendation_for_worker(
@@ -4259,6 +4328,8 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(recovery["blocker_type"], "human_gate")
         self.assertTrue(recovery["human_gate_required"])
         self.assertFalse(recovery["factory_owned_repair_allowed"])
+        self.assertFalse(recovery["automatic_repair_loop"]["required"])
+        self.assertEqual(recovery["automatic_repair_loop"]["reason"], "human_gate_record_required")
         self.assertFalse(recovery["fresh_review_required"])
         self.assertEqual(recovery["unblock_authority_ref"], "human_gate_record")
 
@@ -4629,6 +4700,9 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertFalse(route["retry_policy"]["local_state_authority"])
         self.assertEqual(route["hermes_materialization"]["runtime_authority"], "hermes_kanban")
         self.assertFalse(route["hermes_materialization"]["local_state_authority"])
+        self.assertTrue(route["automatic_repair_loop"]["required"])
+        self.assertEqual(route["automatic_repair_loop"]["stage_order"], ["repair", "audit", "rerun", "reconcile"])
+        self.assertEqual(route["automatic_repair_loop"]["stages"][-1]["command_or_route"], "reconcile-ready-work-units")
         self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_scheduler"])
         self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_dispatcher"])
         self.assertTrue(plan["hermes_runtime_boundary"]["no_shadow_dependency_engine"])
@@ -4678,6 +4752,9 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertIn(requirement["requirement_id"], route["dependency_edge_patch"]["old_edges"])
         self.assertEqual(route["hermes_materialization"]["runtime_authority"], "hermes_kanban")
         self.assertFalse(route["hermes_materialization"]["local_state_authority"])
+        self.assertTrue(route["automatic_repair_loop"]["required"])
+        self.assertEqual(route["automatic_repair_loop"]["stage_order"], ["repair", "audit", "rerun", "reconcile"])
+        self.assertEqual(route["automatic_repair_loop"]["stages"][-1]["command_or_route"], "reconcile-ready-work-units")
 
     def test_recovery_plan_reads_blocked_review_from_receipt_metadata(self) -> None:
         card = load_card("v35_valid_onchain_auditor_scan.md")

--- a/factory/tests/test_operator_experience.py
+++ b/factory/tests/test_operator_experience.py
@@ -95,6 +95,22 @@ def write_blocked_worker_result(tmp: Path, *, human_gate: bool = False) -> Path:
             "uses_native_kanban_primitives": True,
             "local_state_authority": False,
         },
+        "automatic_repair_loop": {
+            "required": not human_gate,
+            "factory_owned_repair_allowed": not human_gate,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+            "route_ref": route_id,
+            "stage_order": ["repair", "audit", "rerun", "reconcile"],
+            "stages": [
+                {"stage": "repair", "owner_worker": worker_id, "expected_output_ref": "worker-result:fresh-repair"},
+                {"stage": "audit", "owner_worker": "independent-reviewer", "expected_output_ref": "worker-result:fresh-review-pass"},
+                {"stage": "rerun", "owner_worker": worker_id, "expected_output_ref": "worker-result:fresh-pass-or-waiver"},
+                {"stage": "reconcile", "owner_worker": "evidence-reconciler", "command_or_route": "reconcile-ready-work-units"},
+            ],
+            "post_repair_reconciliation_required": not human_gate,
+            "stop_classes": ["human_gate", "repeated_failed_recovery"],
+        },
         "downstream_freeze_scope": ["next worker", "done promotion"],
     }
     if human_gate:
@@ -382,6 +398,9 @@ class OperatorExperienceTest(unittest.TestCase):
         self.assertTrue(route["factory_owned_repair_allowed"])
         self.assertFalse(route["human_gate_required"])
         self.assertEqual(route["repair_owner_worker"], "handoff-packer")
+        self.assertTrue(route["automatic_repair_loop"]["required"])
+        self.assertEqual(route["automatic_repair_loop"]["stage_order"], ["repair", "audit", "rerun", "reconcile"])
+        self.assertEqual(route["automatic_repair_loop"]["stages"][-1]["command_or_route"], "reconcile-ready-work-units")
         self.assertIn("next worker", route["downstream_freeze_scope"])
         self.assertIn("factoryctl recovery-plan", payload["factory_next_action"]["command_refs"])
         self.assertIn("recovery route recovery:test-card:handoff-repair", payload["factory_next_action"]["action"])
@@ -404,6 +423,7 @@ class OperatorExperienceTest(unittest.TestCase):
         self.assertEqual(route["recovery_route_id"], "recovery:test-card:human-gate")
         self.assertFalse(route["factory_owned_repair_allowed"])
         self.assertTrue(route["human_gate_required"])
+        self.assertFalse(route["automatic_repair_loop"]["required"])
         self.assertIn("human gate record", route["operator_visible_next_action"])
         self.assertTrue(
             any(decision["decision_type"] == "authority_required" for decision in payload["user_decision_required"])


### PR DESCRIPTION
## Summary
- adds a shared automatic repair loop contract for factory-owned blockers
- wires worker-result recovery recommendations and gate/block routes to executable repair/audit/rerun/reconcile loops
- keeps true external/human authority as the only valid operator-block path
- adds regression coverage for operator experience and factoryctl behavior

## Why
Factory-owned blockers must not become passive blocks or negative closeouts. They must route to an executable loop until repaired or proven to require true external authority.

## Validation
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_factoryctl.py tests/test_operator_experience.py -q
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P02.
