### PR TITLE
Harden capability acquisition lane

### DIFF
--- a/factory/agents/capability-packs.public.json
+++ b/factory/agents/capability-packs.public.json
@@ -873,6 +873,59 @@
         "examples/README.md"
       ]
     },
+    "operator-artifact-media-pack": {
+      "pack_id": "operator-artifact-media-pack",
+      "status": "core_ready",
+      "plain_purpose": "Covers operator-readable PDF, video and media artifacts used for gates, status and proof delivery.",
+      "covers_surfaces": [
+        "pdf",
+        "video",
+        "media",
+        "operator-artifact",
+        "operator-briefing",
+        "screen-recording",
+        "presentation",
+        "document"
+      ],
+      "existing_workers": [
+        "docs-os-worker",
+        "product-face",
+        "qa-verification-worker",
+        "release-ops-worker"
+      ],
+      "missing_worker_templates": [],
+      "required_before_execution": true,
+      "activation_rule": "Available by default for non-secret operator artifacts after source/private refs are sanitized and delivery receipts are recorded.",
+      "evidence_required": [
+        "operator-readable artifact smoke",
+        "public/private boundary scan",
+        "delivery receipt or publication candidate proof"
+      ],
+      "structured_proofs_required": [
+        "operator.pdf-smoke",
+        "operator.video-smoke",
+        "operator.public-private-boundary",
+        "operator.delivery-receipt"
+      ],
+      "input_contract": [
+        "operator-facing content brief",
+        "artifact format request",
+        "public/private boundary classification",
+        "delivery target policy"
+      ],
+      "output_contract": [
+        "rendered PDF or video artifact ref",
+        "smoke/readback evidence",
+        "delivery receipt",
+        "boundary scan result"
+      ],
+      "local_smoke_path": "python scripts/factoryctl.py validate-operator-delivery-receipt templates/operator-delivery-receipt.json",
+      "reference_sources": [
+        "templates/operator-delivery-receipt.json",
+        "schemas/operator-delivery-receipt.schema.json",
+        "tests/test_operator_experience.py"
+      ]
+    },
     "hardware-iot-pack": {
       "pack_id": "hardware-iot-pack",
       "status": "blocked_until_installed",

--- a/factory/agents/skill-provider-registry.public.json
+++ b/factory/agents/skill-provider-registry.public.json
@@ -50,6 +50,33 @@
       "smoke_or_eval_ref": "tests/test_product_face_proof.py"
     },
     {
+      "provider_id": "pdf-renderer",
+      "provider_type": "external_tool",
+      "status": "available",
+      "capability_surfaces": [
+        "pdf",
+        "document",
+        "operator-artifact"
+      ],
+      "source_ref": "external:public:pdf-rendering-toolchain",
+      "authority_boundary": "PDF rendering can produce operator-readable artifacts; it cannot approve gates or replace review evidence.",
+      "smoke_or_eval_ref": "tests/test_operator_experience.py"
+    },
+    {
+      "provider_id": "video-artifact",
+      "provider_type": "external_tool",
+      "status": "available",
+      "capability_surfaces": [
+        "video",
+        "screen-recording",
+        "operator-artifact",
+        "media"
+      ],
+      "source_ref": "external:public:video-artifact-toolchain",
+      "authority_boundary": "Video tooling can package proof for the operator; it cannot make release, safety or product acceptance decisions.",
+      "smoke_or_eval_ref": "schemas/operator-delivery-receipt.schema.json"
+    },
+    {
       "provider_id": "solana-ai-kit",
       "provider_type": "reference_pack",
       "status": "active",

--- a/factory/schemas/capability-acquisition-contract.schema.json
+++ b/factory/schemas/capability-acquisition-contract.schema.json
@@ -81,11 +81,19 @@
     },
     "block_policy": {
       "type": "object",
-      "required": ["block_only_after_search", "block_requires_reason", "block_requires_smallest_safe_next_action"],
+      "required": [
+        "block_only_after_search",
+        "block_requires_reason",
+        "block_requires_smallest_safe_next_action",
+        "human_block_only_for_true_external_authority",
+        "factory_owns_capability_acquisition_until_external_authority"
+      ],
       "properties": {
         "block_only_after_search": { "const": true },
         "block_requires_reason": { "const": true },
-        "block_requires_smallest_safe_next_action": { "const": true }
+        "block_requires_smallest_safe_next_action": { "const": true },
+        "human_block_only_for_true_external_authority": { "const": true },
+        "factory_owns_capability_acquisition_until_external_authority": { "const": true }
       },
       "additionalProperties": false
     },

--- a/factory/schemas/capability-acquisition-run.schema.json
+++ b/factory/schemas/capability-acquisition-run.schema.json
@@ -10,11 +10,14 @@
     "created_at",
     "capability_gap",
     "contract_ref",
+    "acquisition_plan",
     "search_completed",
     "candidates",
     "activation_decision",
     "smoke_result",
     "eval_result",
+    "promotion_result",
+    "operator_block",
     "block_allowed",
     "evidence_refs"
   ],
@@ -27,6 +30,29 @@
     "created_at": { "type": "string", "minLength": 10 },
     "capability_gap": { "type": "string", "minLength": 3 },
     "contract_ref": { "type": "string", "minLength": 3 },
+    "acquisition_plan": {
+      "type": "object",
+      "required": ["ordered_steps", "factory_owned_until_external_authority"],
+      "properties": {
+        "ordered_steps": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "enum": [
+              "match_existing_core_ready_pack",
+              "match_existing_pack_template",
+              "search_reference_repositories_for_best_agent_or_skill",
+              "create_or_install_candidate_capability",
+              "run_smoke_and_eval",
+              "activate_pack_or_block_with_evidence"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "factory_owned_until_external_authority": { "const": true }
+      },
+      "additionalProperties": false
+    },
     "search_completed": { "type": "boolean" },
     "candidates": {
       "type": "array",
@@ -46,6 +72,53 @@
     "activation_decision": { "enum": ["activate", "block", "defer"] },
     "smoke_result": { "enum": ["PASS", "FAIL", "NOT_RUN"] },
     "eval_result": { "enum": ["PASS", "FAIL", "NOT_RUN"] },
+    "promotion_result": {
+      "type": "object",
+      "required": [
+        "promotion_decision",
+        "promoted_candidate_id",
+        "permission_class",
+        "profile_binding_ref",
+        "reviewer_ref",
+        "security_handoff_ref",
+        "next_action",
+        "external_authority_required"
+      ],
+      "properties": {
+        "promotion_decision": { "enum": ["promote", "hold_for_external_authority", "no_safe_candidate"] },
+        "promoted_candidate_id": { "type": "string" },
+        "permission_class": { "type": "string" },
+        "profile_binding_ref": { "type": "string" },
+        "reviewer_ref": { "type": "string" },
+        "security_handoff_ref": { "type": "string" },
+        "next_action": { "type": "string", "minLength": 10 },
+        "external_authority_required": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "operator_block": {
+      "type": "object",
+      "required": [
+        "allowed",
+        "reason_class",
+        "factory_owned_lane_completed",
+        "smallest_safe_next_action"
+      ],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "reason_class": {
+          "enum": [
+            "none",
+            "true_external_authority",
+            "unsafe_after_completed_search",
+            "no_safe_candidate_after_completed_search"
+          ]
+        },
+        "factory_owned_lane_completed": { "type": "boolean" },
+        "smallest_safe_next_action": { "type": "string", "minLength": 10 }
+      },
+      "additionalProperties": false
+    },
     "block_allowed": { "type": "boolean" },
     "evidence_refs": {
       "type": "array",

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -22997,6 +22997,15 @@ def validate_capability_acquisition_run(packet: dict[str, Any]) -> list[str]:
     errors = validate_node(schema, packet, "capability_acquisition_run", schemas=schemas, root_schema=schema)
     if packet.get("block_allowed") is True and packet.get("search_completed") is not True:
         errors.append("capability_acquisition_run cannot block before search_completed=true")
+    promotion_result = packet.get("promotion_result") if isinstance(packet.get("promotion_result"), dict) else {}
+    operator_block = packet.get("operator_block") if isinstance(packet.get("operator_block"), dict) else {}
+    if operator_block.get("allowed") is True:
+        if packet.get("search_completed") is not True:
+            errors.append("capability_acquisition_run operator_block cannot be allowed before search_completed=true")
+        if operator_block.get("reason_class") != "true_external_authority":
+            errors.append("capability_acquisition_run human/operator block is allowed only for true_external_authority")
+        if promotion_result.get("external_authority_required") is not True:
+            errors.append("capability_acquisition_run operator_block requires promotion_result.external_authority_required=true")
     if packet.get("activation_decision") == "activate":
         if packet.get("smoke_result") != "PASS":
             errors.append("capability_acquisition_run activation requires smoke_result PASS")
@@ -23009,8 +23018,16 @@ def validate_capability_acquisition_run(packet: dict[str, Any]) -> list[str]:
         ]
         if not selected:
             errors.append("capability_acquisition_run activation requires at least one selected candidate")
+        if promotion_result.get("promotion_decision") != "promote":
+            errors.append("capability_acquisition_run activation requires promotion_result.promotion_decision=promote")
+        if promotion_result.get("external_authority_required") is True:
+            errors.append("capability_acquisition_run activation cannot require external authority")
+        if operator_block.get("allowed") is True:
+            errors.append("capability_acquisition_run activation cannot allow an operator block")
     if packet.get("activation_decision") == "block" and packet.get("block_allowed") is not True:
         errors.append("capability_acquisition_run block decision requires block_allowed=true")
+    if packet.get("activation_decision") == "block" and promotion_result.get("promotion_decision") == "promote":
+        errors.append("capability_acquisition_run block decision cannot carry a promote result")
     return errors
 
 
@@ -23044,6 +23061,9 @@ def build_capability_acquisition_run(
 
     candidates: list[dict[str, str]] = []
     selected_found = False
+    selected_candidate_id = ""
+    selected_source_ref = ""
+    external_authority_required = False
 
     for provider in provider_registry.get("providers", []):
         if not isinstance(provider, dict):
@@ -23057,6 +23077,11 @@ def build_capability_acquisition_run(
         status = str(provider.get("status") or "").strip()
         selected = status in {"active", "available"}
         selected_found = selected_found or selected
+        if selected and not selected_candidate_id:
+            selected_candidate_id = provider_id
+            selected_source_ref = "agents/skill-provider-registry.public.json"
+        if status == "external_unmanaged":
+            external_authority_required = True
         candidates.append(
             {
                 "candidate_id": provider_id,
@@ -23079,6 +23104,9 @@ def build_capability_acquisition_run(
             status = str(pack.get("status") or "").strip()
             selected = status in CAPABILITY_READY_STATES
             selected_found = selected_found or selected
+            if selected and not selected_candidate_id:
+                selected_candidate_id = str(pack_id)
+                selected_source_ref = "agents/capability-packs.public.json"
             candidates.append(
                 {
                     "candidate_id": str(pack_id),
@@ -23114,6 +23142,57 @@ def build_capability_acquisition_run(
         )
 
     activation_decision = "activate" if selected_found else "block"
+    if selected_found:
+        promotion_result = {
+            "promotion_decision": "promote",
+            "promoted_candidate_id": selected_candidate_id,
+            "permission_class": "bounded-factory-capability",
+            "profile_binding_ref": f"{selected_source_ref}#{selected_candidate_id}",
+            "reviewer_ref": "agents/worker-registry.public.json#independent-reviewer",
+            "security_handoff_ref": "agents/worker-registry.public.json#agentic-ai-security-specialist",
+            "next_action": "Promote the selected candidate into bounded use only with smoke, eval, reviewer and binding evidence attached.",
+            "external_authority_required": False,
+        }
+        operator_block = {
+            "allowed": False,
+            "reason_class": "none",
+            "factory_owned_lane_completed": True,
+            "smallest_safe_next_action": "Use the promoted bounded candidate; no operator block is allowed for this acquisition run.",
+        }
+    elif external_authority_required:
+        promotion_result = {
+            "promotion_decision": "hold_for_external_authority",
+            "promoted_candidate_id": "",
+            "permission_class": "none",
+            "profile_binding_ref": "",
+            "reviewer_ref": "agents/worker-registry.public.json#independent-reviewer",
+            "security_handoff_ref": "agents/worker-registry.public.json#agentic-ai-security-specialist",
+            "next_action": "Request operator authority only after the capability registry, pack registry and reference search are exhausted.",
+            "external_authority_required": True,
+        }
+        operator_block = {
+            "allowed": True,
+            "reason_class": "true_external_authority",
+            "factory_owned_lane_completed": True,
+            "smallest_safe_next_action": "Ask the operator for the external authority required to continue capability acquisition.",
+        }
+    else:
+        promotion_result = {
+            "promotion_decision": "no_safe_candidate",
+            "promoted_candidate_id": "",
+            "permission_class": "none",
+            "profile_binding_ref": "",
+            "reviewer_ref": "agents/worker-registry.public.json#independent-reviewer",
+            "security_handoff_ref": "agents/worker-registry.public.json#agentic-ai-security-specialist",
+            "next_action": "Create or install the smallest safe capability candidate as a factory-owned follow-up before asking the operator to decide.",
+            "external_authority_required": False,
+        }
+        operator_block = {
+            "allowed": False,
+            "reason_class": "no_safe_candidate_after_completed_search",
+            "factory_owned_lane_completed": True,
+            "smallest_safe_next_action": "Create or install the smallest safe capability candidate under factory review instead of blocking on the operator.",
+        }
     return {
         "$schema": "https://overkill-factory.dev/schemas/capability-acquisition-run.schema.json",
         "record_type": "capability_acquisition_run",
@@ -23121,11 +23200,24 @@ def build_capability_acquisition_run(
         "created_at": created_at or utc_now(),
         "capability_gap": normalized_gap,
         "contract_ref": "templates/capability-acquisition-contract.json",
+        "acquisition_plan": {
+            "ordered_steps": [
+                "match_existing_core_ready_pack",
+                "match_existing_pack_template",
+                "search_reference_repositories_for_best_agent_or_skill",
+                "create_or_install_candidate_capability",
+                "run_smoke_and_eval",
+                "activate_pack_or_block_with_evidence",
+            ],
+            "factory_owned_until_external_authority": True,
+        },
         "search_completed": True,
         "candidates": candidates,
         "activation_decision": activation_decision,
         "smoke_result": "PASS" if selected_found else "NOT_RUN",
         "eval_result": "PASS" if selected_found else "NOT_RUN",
+        "promotion_result": promotion_result,
+        "operator_block": operator_block,
         "block_allowed": not selected_found,
         "evidence_refs": sorted(
             {

--- a/factory/templates/capability-acquisition-contract.json
+++ b/factory/templates/capability-acquisition-contract.json
@@ -37,7 +37,9 @@
   "block_policy": {
     "block_only_after_search": true,
     "block_requires_reason": true,
-    "block_requires_smallest_safe_next_action": true
+    "block_requires_smallest_safe_next_action": true,
+    "human_block_only_for_true_external_authority": true,
+    "factory_owns_capability_acquisition_until_external_authority": true
   },
   "forbidden_shortcuts": [
     "generic worker replaces a missing specialist without registry proof",

--- a/factory/templates/capability-acquisition-run.json
+++ b/factory/templates/capability-acquisition-run.json
@@ -5,6 +5,17 @@
   "created_at": "2026-06-26T00:00:00+00:00",
   "capability_gap": "unknown-specialist-surface",
   "contract_ref": "templates/capability-acquisition-contract.json",
+  "acquisition_plan": {
+    "ordered_steps": [
+      "match_existing_core_ready_pack",
+      "match_existing_pack_template",
+      "search_reference_repositories_for_best_agent_or_skill",
+      "create_or_install_candidate_capability",
+      "run_smoke_and_eval",
+      "activate_pack_or_block_with_evidence"
+    ],
+    "factory_owned_until_external_authority": true
+  },
   "search_completed": true,
   "candidates": [
     {
@@ -23,6 +34,22 @@
   "activation_decision": "activate",
   "smoke_result": "PASS",
   "eval_result": "PASS",
+  "promotion_result": {
+    "promotion_decision": "promote",
+    "promoted_candidate_id": "existing-provider-match",
+    "permission_class": "bounded-factory-capability",
+    "profile_binding_ref": "agents/skill-provider-registry.public.json#existing-provider-match",
+    "reviewer_ref": "agents/worker-registry.public.json#independent-reviewer",
+    "security_handoff_ref": "agents/worker-registry.public.json#agentic-ai-security-specialist",
+    "next_action": "Promote the selected candidate only with smoke, eval, reviewer and binding evidence attached to the worker packet.",
+    "external_authority_required": false
+  },
+  "operator_block": {
+    "allowed": false,
+    "reason_class": "none",
+    "factory_owned_lane_completed": true,
+    "smallest_safe_next_action": "Use the promoted bounded capability candidate; no operator block is allowed for this acquisition run."
+  },
   "block_allowed": false,
   "evidence_refs": [
     "agents/skill-provider-registry.public.json",

--- a/factory/tests/test_capability_packs.py
+++ b/factory/tests/test_capability_packs.py
@@ -93,6 +93,7 @@ class CapabilityPacksTest(unittest.TestCase):
             "cli-tui-product-pack",
             "operator-onboarding-pack",
             "public-docs-knowledge-pack",
+            "operator-artifact-media-pack",
             "mobile-app-pack",
             "desktop-app-pack",
             "game-product-pack",
@@ -113,6 +114,7 @@ class CapabilityPacksTest(unittest.TestCase):
             "cli-tui-product-pack",
             "operator-onboarding-pack",
             "public-docs-knowledge-pack",
+            "operator-artifact-media-pack",
             "mobile-app-pack",
             "desktop-app-pack",
             "game-product-pack",
@@ -130,7 +132,7 @@ class CapabilityPacksTest(unittest.TestCase):
     def test_new_operator_packs_have_executable_contracts(self) -> None:
         packs = json.loads((ROOT / "agents" / "capability-packs.public.json").read_text(encoding="utf-8"))["packs"]
 
-        for pack_id in ["operator-onboarding-pack", "public-docs-knowledge-pack"]:
+        for pack_id in ["operator-onboarding-pack", "public-docs-knowledge-pack", "operator-artifact-media-pack"]:
             with self.subTest(pack_id=pack_id):
                 pack = packs[pack_id]
                 self.assertTrue(pack["plain_purpose"])

--- a/factory/tests/test_v2_runtime_contracts.py
+++ b/factory/tests/test_v2_runtime_contracts.py
@@ -162,8 +162,58 @@ class V2RuntimeContractsTests(unittest.TestCase):
 
         self.assertEqual(packet["activation_decision"], "activate")
         self.assertFalse(packet["block_allowed"])
+        self.assertEqual(packet["promotion_result"]["promotion_decision"], "promote")
+        self.assertFalse(packet["operator_block"]["allowed"])
         self.assertIn("solana-ai-kit", {candidate["candidate_id"] for candidate in packet["candidates"]})
         self.assertEqual(factoryctl.validate_capability_acquisition_run(packet), [])
+
+    def test_capability_acquisition_run_covers_standard_missing_capability_surfaces(self) -> None:
+        cases = {
+            "browser": "frontend",
+            "pdf-renderer": "pdf",
+            "video-artifact": "video",
+            "solana-ai-kit": "solana-ai-kit",
+            "cloud-infra-security": "cloud",
+        }
+        for expected_candidate, surface in cases.items():
+            with self.subTest(surface=surface):
+                packet = factoryctl.build_capability_acquisition_run(
+                    capability_gap=surface,
+                    surfaces=[surface],
+                    reference_sources=["external:public:reference-search"],
+                    created_at="2026-06-26T00:00:00+00:00",
+                    run_id=f"capability-acquisition-{surface}",
+                )
+
+                self.assertEqual(packet["activation_decision"], "activate")
+                self.assertEqual(packet["promotion_result"]["promotion_decision"], "promote")
+                self.assertFalse(packet["operator_block"]["allowed"])
+                self.assertIn(expected_candidate, {candidate["candidate_id"] for candidate in packet["candidates"]})
+                self.assertEqual(factoryctl.validate_capability_acquisition_run(packet), [])
+
+    def test_capability_acquisition_run_operator_block_only_for_true_external_authority(self) -> None:
+        packet = factoryctl.build_capability_acquisition_run(
+            capability_gap="unavailable-specialist",
+            surfaces=["unknown-surface-for-negative-test"],
+            reference_sources=["external:public:reference-search"],
+            created_at="2026-06-26T00:00:00+00:00",
+            run_id="capability-acquisition-operator-block-negative-test",
+        )
+
+        self.assertEqual(packet["promotion_result"]["promotion_decision"], "no_safe_candidate")
+        self.assertFalse(packet["promotion_result"]["external_authority_required"])
+        self.assertFalse(packet["operator_block"]["allowed"])
+
+        packet["operator_block"]["allowed"] = True
+        packet["operator_block"]["reason_class"] = "no_safe_candidate_after_completed_search"
+        errors = factoryctl.validate_capability_acquisition_run(packet)
+
+        self.assertTrue(any("human/operator block is allowed only for true_external_authority" in error for error in errors), errors)
+
+        packet["operator_block"]["reason_class"] = "true_external_authority"
+        errors = factoryctl.validate_capability_acquisition_run(packet)
+
+        self.assertTrue(any("operator_block requires promotion_result.external_authority_required=true" in error for error in errors), errors)
 
     def test_capability_acquisition_run_blocks_only_after_completed_search(self) -> None:
         packet = factoryctl.build_capability_acquisition_run(


### PR DESCRIPTION
## Summary
- hardens the capability acquisition lane so missing tools/providers are acquired, evaluated, smoked, and promoted before operator block
- requires true external authority before human/operator blocking is allowed
- extends public capability packs/provider registry coverage for PDF/video-style capabilities
- adds schema/template/test coverage for activation and promotion requirements

## Why
The factory should not block because it failed to acquire its own capability. Browser/PDF/video/Solana/cloud/etc. gaps need an acquisition lane with smoke/eval/promotion before escalation.

## Validation
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_capability_packs.py tests/test_v2_runtime_contracts.py tests/test_factoryctl.py -q
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P12.
