### PR TITLE
Add real operator progress model

### DIFF
--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 248 | `schemas/*.json` |
-| Templates | 165 | `templates/*` |
+| JSON schemas | 249 | `schemas/*.json` |
+| Templates | 166 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
@@ -271,6 +271,7 @@ These are the public JSON schemas the factory exposes. They are not decoration; 
 - `schemas/factory-method-excellence-registry.schema.json`
 - `schemas/factory-operating-system-registry.schema.json`
 - `schemas/factory-operating-system-scorecard.schema.json`
+- `schemas/factory-operator-progress-model.schema.json`
 - `schemas/factory-operator-ui-ux-excellence-registry.schema.json`
 - `schemas/factory-os-excellence-audit-registry.schema.json`
 - `schemas/factory-phase-engine-state.schema.json`
@@ -506,6 +507,7 @@ Templates are starter records paired with schemas. They are examples of valid sh
 - `templates/factory-maturity-scorecard.json`
 - `templates/factory-method-excellence-registry.json`
 - `templates/factory-operating-system-registry.json`
+- `templates/factory-operator-progress-model.json`
 - `templates/factory-operator-ui-ux-excellence-registry.json`
 - `templates/factory-os-excellence-audit-registry.json`
 - `templates/factory-phase-engine-state.json`

--- a/factory/schemas/factory-operator-progress-model.schema.json
+++ b/factory/schemas/factory-operator-progress-model.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-operator-progress-model.schema.json",
+  "title": "Factory Operator Progress Model",
+  "type": "object",
+  "required": ["record_type", "gates"],
+  "additionalProperties": true,
+  "properties": {
+    "record_type": {"const": "factory_operator_progress_model"},
+    "language": {"type": "string"},
+    "manager_profile": {"type": "string"},
+    "process_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "done": {"type": "number", "minimum": 0},
+        "total": {"type": "number", "minimum": 1}
+      }
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "label", "weight", "readiness"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "label": {"type": "string", "minLength": 1},
+          "weight": {"type": "number", "minimum": 0.000001},
+          "readiness": {
+            "type": "string",
+            "enum": ["ready", "approved", "complete", "completed", "usable", "pass", "partial", "in_progress", "draft", "needs_review", "blocked", "not_started", "missing", "failed", "fail", "unknown"]
+          },
+          "critical": {"type": "boolean"},
+          "gate_ref": {"type": "string"},
+          "evidence_refs": {"type": "array", "items": {"type": "string"}},
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "status"],
+              "additionalProperties": true,
+              "properties": {
+                "id": {"type": "string"},
+                "status": {
+                  "type": "string",
+                  "enum": ["usable", "ready", "approved", "complete", "completed", "pass", "partial", "in_progress", "draft", "needs_review", "blocked", "not_started", "missing", "failed", "fail", "unknown"]
+                },
+                "evidence_ref": {"type": "string"}
+              }
+            }
+          },
+          "blockers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "kind", "summary"],
+              "additionalProperties": true,
+              "properties": {
+                "id": {"type": "string"},
+                "kind": {"type": "string"},
+                "summary": {"type": "string"},
+                "owner": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "uncertainty": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "range_percent": {
+          "type": "array",
+          "items": {"type": "number", "minimum": 0, "maximum": 100},
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "unknowns": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/factory/scripts/factory_operator_progress_card.py
+++ b/factory/scripts/factory_operator_progress_card.py
@@ -1,10 +1,192 @@
 #!/usr/bin/env python3
-"""Render an operator progress card so users do not need to inspect Kanban."""
+"""Render a gerente/operator progress card from product gates, artifacts and readiness.
+
+The progress percent is intentionally not a raw Kanban done/total count.  The
+operator-facing card reports material product progress: weighted gates backed by
+artifacts, readiness, critical-path blockers and uncertainty.
+"""
 from __future__ import annotations
 
 import argparse
 import json
 from pathlib import Path
+from typing import Any
+
+
+READINESS_SCORES = {
+    "complete": 1.0,
+    "completed": 1.0,
+    "approved": 1.0,
+    "ready": 1.0,
+    "usable": 1.0,
+    "pass": 1.0,
+    "partial": 0.5,
+    "in_progress": 0.5,
+    "draft": 0.5,
+    "needs_review": 0.5,
+    "blocked": 0.0,
+    "not_started": 0.0,
+    "missing": 0.0,
+    "failed": 0.0,
+    "fail": 0.0,
+    "unknown": 0.0,
+}
+
+
+def _score(value: Any) -> float:
+    return READINESS_SCORES.get(str(value or "unknown").strip().lower(), 0.0)
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _round_percent(value: float) -> int:
+    return max(0, min(100, int(round(value))))
+
+
+def _process_done_percent(process_counts: dict[str, Any]) -> int | None:
+    done = process_counts.get("done")
+    total = process_counts.get("total")
+    if not isinstance(done, (int, float)) or not isinstance(total, (int, float)) or total <= 0:
+        return None
+    return _round_percent((float(done) / float(total)) * 100.0)
+
+
+def _gate_score(gate: dict[str, Any]) -> tuple[float, float | None]:
+    readiness_score = _score(gate.get("readiness"))
+    artifacts = [item for item in _as_list(gate.get("artifacts")) if isinstance(item, dict)]
+    if not artifacts:
+        return readiness_score, None
+    artifact_score = sum(_score(item.get("status")) for item in artifacts) / len(artifacts)
+    # A gate is only as real as both its declared readiness and its artifacts.
+    # This prevents a ready-looking gate with missing proof from counting as
+    # product progress.
+    return min(readiness_score, artifact_score), artifact_score
+
+
+def _normalize_uncertainty(model: dict[str, Any], progress_percent: int, incomplete_weight: float, total_weight: float) -> dict[str, Any]:
+    supplied = _as_dict(model.get("uncertainty"))
+    confidence = supplied.get("confidence")
+    if not isinstance(confidence, (int, float)):
+        unresolved_ratio = incomplete_weight / total_weight if total_weight else 1.0
+        confidence = max(0.2, min(0.95, 1.0 - (unresolved_ratio * 0.6)))
+    range_percent = supplied.get("range_percent")
+    if not (
+        isinstance(range_percent, list)
+        and len(range_percent) == 2
+        and all(isinstance(item, (int, float)) for item in range_percent)
+    ):
+        spread = max(5, _round_percent((1.0 - float(confidence)) * 20))
+        range_percent = [max(0, progress_percent - spread), min(100, progress_percent + spread)]
+    unknowns = [str(item) for item in _as_list(supplied.get("unknowns"))]
+    return {
+        "confidence": round(float(confidence), 2),
+        "range_percent": [int(range_percent[0]), int(range_percent[1])],
+        "unknowns": unknowns,
+    }
+
+
+def build_card_from_model(model: dict[str, Any]) -> dict[str, Any]:
+    """Build an operator progress card from weighted gates/artifacts/readiness."""
+    gates = [item for item in _as_list(model.get("gates")) if isinstance(item, dict)]
+    if not gates:
+        raise ValueError("progress model requires at least one gate")
+
+    gate_progress: dict[str, dict[str, Any]] = {}
+    critical_path: list[dict[str, Any]] = []
+    blockers: list[dict[str, Any]] = []
+    weighted_complete = 0.0
+    total_weight = 0.0
+    incomplete_weight = 0.0
+
+    for index, gate in enumerate(gates):
+        gate_id = str(gate.get("id") or f"gate-{index + 1}")
+        label = str(gate.get("label") or gate_id)
+        weight_value = gate.get("weight", 1)
+        weight = float(weight_value) if isinstance(weight_value, (int, float)) and weight_value > 0 else 1.0
+        score, artifact_score = _gate_score(gate)
+        percent = _round_percent(score * 100.0)
+        total_weight += weight
+        weighted_complete += score * weight
+        if score < 1.0:
+            incomplete_weight += weight
+
+        gate_blockers = [item for item in _as_list(gate.get("blockers")) if isinstance(item, dict)]
+        for blocker in gate_blockers:
+            normalized = dict(blocker)
+            normalized.setdefault("gate_id", gate_id)
+            normalized.setdefault("gate_label", label)
+            blockers.append(normalized)
+
+        gate_progress[gate_id] = {
+            "label": label,
+            "weight": weight,
+            "readiness": str(gate.get("readiness") or "unknown"),
+            "artifact_percent": None if artifact_score is None else _round_percent(artifact_score * 100.0),
+            "percent": percent,
+            "gate_ref": gate.get("gate_ref"),
+            "evidence_refs": [str(item) for item in _as_list(gate.get("evidence_refs"))],
+            "artifacts": _as_list(gate.get("artifacts")),
+            "blocked": bool(gate_blockers) or str(gate.get("readiness") or "").lower() == "blocked",
+        }
+
+        if score < 1.0 and (gate.get("critical") is True or not any(item.get("critical") is True for item in gates)):
+            critical_path.append(
+                {
+                    "gate_id": gate_id,
+                    "label": label,
+                    "percent": percent,
+                    "readiness": str(gate.get("readiness") or "unknown"),
+                    "gate_ref": gate.get("gate_ref"),
+                    "blocked": bool(gate_blockers) or str(gate.get("readiness") or "").lower() == "blocked",
+                }
+            )
+
+    progress_percent = _round_percent((weighted_complete / total_weight) * 100.0) if total_weight else 0
+    process_counts = _as_dict(model.get("process_counts"))
+    process_done_percent = _process_done_percent(process_counts)
+    uncertainty = _normalize_uncertainty(model, progress_percent, incomplete_weight, total_weight)
+    next_critical_gate = critical_path[0]["gate_id"] if critical_path else None
+    current_phase = critical_path[0]["label"] if critical_path else "Product gates complete"
+    status = "blocked" if blockers else "running" if critical_path else "ready_for_next_gate"
+
+    card = {
+        "record_type": "operator_progress_card",
+        "result": "PASS",
+        "language": str(model.get("language") or "pt-BR"),
+        "manager_profile": str(model.get("manager_profile") or "overkill-factory-gerente"),
+        "kanban_dump_required": False,
+        "progress_basis": "weighted_gates_artifacts_readiness",
+        "progress_percent": progress_percent,
+        "process_counts": process_counts,
+        "process_done_percent": process_done_percent,
+        "process_counts_used_for_product_percent": False,
+        "current_phase": current_phase,
+        "status": status,
+        "next_critical_gate": next_critical_gate,
+        "next_safe_action": str(model.get("next_safe_action") or _default_next_action(status)),
+        "next_possible_gate": next_critical_gate or str(model.get("next_possible_gate") or "receipt-five"),
+        "worker_visibility_policy": "workers never contact the operator directly",
+        "gate_progress": gate_progress,
+        "critical_path": critical_path,
+        "blockers": blockers,
+        "uncertainty": uncertainty,
+    }
+    card["human_text"] = render_model_text(card)
+    return card
+
+
+def _default_next_action(status: str) -> str:
+    if status == "blocked":
+        return "Gerente resolve ou encaminha o bloqueio do caminho crítico antes de contar progresso novo."
+    if status == "ready_for_next_gate":
+        return "Gerente prepara o próximo gate com evidências e incerteza residual."
+    return "Gerente continua o caminho crítico e atualiza evidências de produto."
 
 
 def build_card(percent: int = 42, phase: str = "F5 Product SOT", blocker: str = "aguardando confirmação do escopo") -> dict:
@@ -14,6 +196,7 @@ def build_card(percent: int = 42, phase: str = "F5 Product SOT", blocker: str = 
         "language": "pt-BR",
         "manager_profile": "overkill-factory-gerente",
         "kanban_dump_required": False,
+        "progress_basis": "legacy_explicit_percent",
         "progress_percent": percent,
         "current_phase": phase,
         "status": "blocked_needs_input" if blocker else "running",
@@ -23,6 +206,46 @@ def build_card(percent: int = 42, phase: str = "F5 Product SOT", blocker: str = 
         "worker_visibility_policy": "workers never contact the operator directly",
         "human_text": render_text(percent, phase, blocker),
     }
+
+
+def render_model_text(card: dict[str, Any]) -> str:
+    lines = [
+        "Progresso da fábrica",
+        f"Progresso de produto: {card['progress_percent']}%",
+        "Base: gates ponderados por artefatos e prontidão; contagem bruta de tarefas não muda este percentual.",
+    ]
+    if card.get("process_done_percent") is not None:
+        lines.append(f"Contagem operacional observada: {card['process_done_percent']}% (não usada como progresso de produto).")
+    lines.append("")
+    lines.append("Gates / artefatos / prontidão:")
+    for gate in card.get("gate_progress", {}).values():
+        artifact = gate.get("artifact_percent")
+        artifact_text = "sem artefatos declarados" if artifact is None else f"artefatos {artifact}%"
+        lines.append(f"- {gate['label']}: {gate['percent']}% ({gate['readiness']}, {artifact_text})")
+    lines.append("")
+    if card.get("critical_path"):
+        path = " -> ".join(str(item["label"]) for item in card["critical_path"])
+        lines.append(f"Caminho crítico: {path}")
+    else:
+        lines.append("Caminho crítico: nenhum gate crítico pendente")
+    if card.get("blockers"):
+        lines.append("Bloqueadores:")
+        for blocker in card["blockers"]:
+            lines.append(f"- {blocker.get('summary', blocker.get('id', 'bloqueio sem resumo'))}")
+    else:
+        lines.append("Bloqueadores: nenhum bloqueio real no momento")
+    uncertainty = card.get("uncertainty", {})
+    lines.append(
+        "Incerteza: "
+        f"confiança {uncertainty.get('confidence')}, intervalo {uncertainty.get('range_percent')}"
+    )
+    unknowns = uncertainty.get("unknowns") if isinstance(uncertainty, dict) else []
+    if unknowns:
+        lines.append("Desconhecidos:")
+        for unknown in unknowns:
+            lines.append(f"- {unknown}")
+    lines.append(f"Próxima ação: {card['next_safe_action']}")
+    return "\n".join(lines) + "\n"
 
 
 def render_text(percent: int, phase: str, blocker: str) -> str:
@@ -39,13 +262,17 @@ def render_text(percent: int, phase: str, blocker: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, help="Progress model JSON with weighted gates/artifacts/readiness.")
     parser.add_argument("--percent", type=int, default=42)
     parser.add_argument("--phase", default="F5 Product SOT")
     parser.add_argument("--blocker", default="aguardando confirmação do escopo")
     parser.add_argument("--out", type=Path, default=Path(".tmp/operator-progress-card.json"))
     parser.add_argument("--text-out", type=Path, default=Path(".tmp/operator-progress-card.txt"))
     args = parser.parse_args()
-    card = build_card(args.percent, args.phase, args.blocker)
+    if args.model:
+        card = build_card_from_model(json.loads(args.model.read_text(encoding="utf-8")))
+    else:
+        card = build_card(args.percent, args.phase, args.blocker)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.text_out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(card, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -24846,7 +24846,12 @@ def command_manager_profile_live_smoke(args: argparse.Namespace) -> int:
 
 def command_operator_progress_card(args: argparse.Namespace) -> int:
     script = ROOT / "scripts" / "factory_operator_progress_card.py"
-    return _run_python_script(script, ["--percent", str(args.percent), "--phase", str(args.phase), "--blocker", str(args.blocker), "--out", str(args.out), "--text-out", str(args.text_out)])
+    argv = ["--out", str(args.out), "--text-out", str(args.text_out)]
+    if args.model:
+        argv.extend(["--model", str(args.model)])
+    else:
+        argv.extend(["--percent", str(args.percent), "--phase", str(args.phase), "--blocker", str(args.blocker)])
+    return _run_python_script(script, argv)
 
 
 def command_operator_delivery_receipt(args: argparse.Namespace) -> int:
@@ -25719,6 +25724,7 @@ def build_parser() -> argparse.ArgumentParser:
     manager_live_parser.set_defaults(func=command_manager_profile_live_smoke)
 
     progress_parser = sub.add_parser("operator-progress-card", help="Render a gerente-facing progress card so the operator does not need Kanban.")
+    progress_parser.add_argument("--model", type=Path, help="Progress model JSON with weighted gates/artifacts/readiness.")
     progress_parser.add_argument("--percent", type=int, default=42)
     progress_parser.add_argument("--phase", default="F5 Product SOT")
     progress_parser.add_argument("--blocker", default="aguardando confirmação do escopo")

--- a/factory/templates/factory-operator-progress-model.json
+++ b/factory/templates/factory-operator-progress-model.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-operator-progress-model.schema.json",
+  "record_type": "factory_operator_progress_model",
+  "language": "pt-BR",
+  "manager_profile": "overkill-factory-gerente",
+  "process_counts": {
+    "done": 0,
+    "total": 1
+  },
+  "gates": [
+    {
+      "id": "discovery",
+      "label": "Discovery",
+      "weight": 15,
+      "readiness": "not_started",
+      "critical": true,
+      "gate_ref": "gate:product-understanding-confirmed",
+      "evidence_refs": [],
+      "artifacts": [
+        {
+          "id": "product_understanding_packet",
+          "status": "missing"
+        }
+      ],
+      "blockers": []
+    },
+    {
+      "id": "architecture",
+      "label": "Architecture",
+      "weight": 25,
+      "readiness": "not_started",
+      "critical": true,
+      "gate_ref": "gate:architecture-approved",
+      "evidence_refs": [],
+      "artifacts": [
+        {
+          "id": "architecture_package",
+          "status": "missing"
+        }
+      ],
+      "blockers": []
+    },
+    {
+      "id": "execution",
+      "label": "Execution",
+      "weight": 30,
+      "readiness": "not_started",
+      "critical": true,
+      "gate_ref": "gate:material-execution-complete",
+      "evidence_refs": [],
+      "artifacts": [
+        {
+          "id": "working_product",
+          "status": "missing"
+        }
+      ],
+      "blockers": []
+    },
+    {
+      "id": "proof",
+      "label": "Proof",
+      "weight": 20,
+      "readiness": "not_started",
+      "critical": true,
+      "gate_ref": "gate:receipt-five-ready",
+      "evidence_refs": [],
+      "artifacts": [
+        {
+          "id": "receipt_five",
+          "status": "missing"
+        }
+      ],
+      "blockers": []
+    },
+    {
+      "id": "release",
+      "label": "Release",
+      "weight": 10,
+      "readiness": "not_started",
+      "critical": true,
+      "gate_ref": "gate:release-ready",
+      "evidence_refs": [],
+      "artifacts": [
+        {
+          "id": "release_packet",
+          "status": "missing"
+        }
+      ],
+      "blockers": []
+    }
+  ],
+  "uncertainty": {
+    "confidence": 0.4,
+    "range_percent": [0, 10],
+    "unknowns": ["No gate evidence has been reconciled yet."]
+  }
+}

--- a/factory/tests/test_factory_operator_progress_model.py
+++ b/factory/tests/test_factory_operator_progress_model.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factory_operator_progress_card.py"
+SPEC = importlib.util.spec_from_file_location("factory_operator_progress_card", MODULE_PATH)
+assert SPEC is not None
+progress_card = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["factory_operator_progress_card"] = progress_card
+SPEC.loader.exec_module(progress_card)
+
+
+def sample_progress_model() -> dict:
+    return {
+        "record_type": "factory_operator_progress_model",
+        "manager_profile": "overkill-factory-gerente",
+        "process_counts": {"done": 96, "total": 100},
+        "gates": [
+            {
+                "id": "discovery",
+                "label": "Discovery",
+                "weight": 15,
+                "readiness": "ready",
+                "gate_ref": "gate:product-understanding-confirmed",
+                "evidence_refs": ["reports/discovery/product-understanding-packet.json"],
+                "artifacts": [
+                    {"id": "product_understanding_packet", "status": "usable", "evidence_ref": "reports/discovery/product-understanding-packet.json"}
+                ],
+            },
+            {
+                "id": "architecture",
+                "label": "Architecture",
+                "weight": 25,
+                "readiness": "blocked",
+                "critical": True,
+                "gate_ref": "gate:architecture-approved",
+                "evidence_refs": ["reports/architecture/package-draft.json"],
+                "artifacts": [
+                    {"id": "architecture_package", "status": "partial", "evidence_ref": "reports/architecture/package-draft.json"}
+                ],
+                "blockers": [
+                    {
+                        "id": "arch-approval",
+                        "kind": "human_gate",
+                        "summary": "Architecture package has not been approved by the operator.",
+                        "owner": "overkill-factory-gerente",
+                    }
+                ],
+            },
+            {
+                "id": "execution",
+                "label": "Execution",
+                "weight": 30,
+                "readiness": "not_started",
+                "critical": True,
+                "gate_ref": "gate:material-execution-complete",
+                "artifacts": [{"id": "working_product", "status": "missing"}],
+            },
+            {
+                "id": "proof",
+                "label": "Proof",
+                "weight": 20,
+                "readiness": "not_started",
+                "critical": True,
+                "gate_ref": "gate:receipt-five-ready",
+                "artifacts": [{"id": "receipt_five", "status": "missing"}],
+            },
+            {
+                "id": "release",
+                "label": "Release",
+                "weight": 10,
+                "readiness": "not_started",
+                "critical": True,
+                "gate_ref": "gate:release-ready",
+                "artifacts": [{"id": "release_packet", "status": "missing"}],
+            },
+        ],
+        "uncertainty": {
+            "confidence": 0.72,
+            "range_percent": [12, 18],
+            "unknowns": ["Proof artifacts have not been audited yet."],
+        },
+    }
+
+
+class OperatorProgressModelTest(unittest.TestCase):
+    def test_product_percent_uses_weighted_gates_not_raw_done_counts(self) -> None:
+        card = progress_card.build_card_from_model(sample_progress_model())
+
+        self.assertEqual(card["record_type"], "operator_progress_card")
+        self.assertEqual(card["progress_basis"], "weighted_gates_artifacts_readiness")
+        self.assertEqual(card["progress_percent"], 15)
+        self.assertEqual(card["process_counts"], {"done": 96, "total": 100})
+        self.assertEqual(card["process_done_percent"], 96)
+        self.assertFalse(card["process_counts_used_for_product_percent"])
+        self.assertLess(card["progress_percent"], card["process_done_percent"])
+        self.assertEqual(card["gate_progress"]["discovery"]["percent"], 100)
+        self.assertEqual(card["gate_progress"]["architecture"]["percent"], 0)
+
+    def test_critical_path_blockers_and_uncertainty_are_operator_visible(self) -> None:
+        card = progress_card.build_card_from_model(sample_progress_model())
+
+        self.assertEqual([item["gate_id"] for item in card["critical_path"]], ["architecture", "execution", "proof", "release"])
+        self.assertEqual(card["blockers"][0]["id"], "arch-approval")
+        self.assertEqual(card["uncertainty"]["confidence"], 0.72)
+        self.assertEqual(card["uncertainty"]["range_percent"], [12, 18])
+        self.assertIn("Architecture", card["human_text"])
+        self.assertIn("Execution", card["human_text"])
+        self.assertIn("Proof", card["human_text"])
+        self.assertIn("Release", card["human_text"])
+        self.assertIn("15%", card["human_text"])
+        self.assertIn("incerteza", card["human_text"].lower())
+        self.assertIn("Architecture package has not been approved", card["human_text"])
+
+    def test_cli_accepts_progress_model_and_factoryctl_passes_it_through(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            model = tmp / "progress-model.json"
+            out = tmp / "operator-progress-card.json"
+            text_out = tmp / "operator-progress-card.txt"
+            model.write_text(json.dumps(sample_progress_model(), indent=2) + "\n", encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/factoryctl.py",
+                    "operator-progress-card",
+                    "--model",
+                    str(model),
+                    "--out",
+                    str(out),
+                    "--text-out",
+                    str(text_out),
+                ],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            text = text_out.read_text(encoding="utf-8")
+
+        self.assertEqual(payload["progress_percent"], 15)
+        self.assertEqual(payload["next_critical_gate"], "architecture")
+        self.assertIn("Caminho crítico", text)
+        self.assertIn("Discovery: 100%", text)
+        self.assertIn("Release: 0%", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds a real operator progress model for gerente status
- computes product percent from weighted gates, readiness, artifacts, blockers, critical path, and uncertainty
- keeps raw process/Kanban done counts separate as process-only metrics
- adds schema/template/tests and factoryctl model input

## Why
The human status surface must not use raw done counts as product progress. The gerente needs product readiness, blockers, uncertainty, and critical path.

## Validation
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_factory_operator_progress_model.py tests/test_factoryctl.py -q
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P10.
