### PR TITLE
Add adaptive phase graph repair loops

### DIFF
--- a/factory/schemas/factory-phase-engine-state.schema.json
+++ b/factory/schemas/factory-phase-engine-state.schema.json
@@ -25,13 +25,30 @@
     "decision_basis"
   ],
   "properties": {
-    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-phase-engine-state.schema.json" },
-    "record_type": { "const": "factory_phase_engine_state" },
-    "engine_version": { "type": "string", "minLength": 1 },
-    "deterministic": { "const": true },
-    "agent_route_authority": { "const": false },
-    "card_phase_id": { "type": "string", "minLength": 1 },
-    "computed_phase_id": { "type": "string", "pattern": "^F[0-9]+[A-Z]?$" },
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-phase-engine-state.schema.json"
+    },
+    "record_type": {
+      "const": "factory_phase_engine_state"
+    },
+    "engine_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "deterministic": {
+      "const": true
+    },
+    "agent_route_authority": {
+      "const": false
+    },
+    "card_phase_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "computed_phase_id": {
+      "type": "string",
+      "pattern": "^F[0-9]+[A-Z]?$"
+    },
     "computed_frontier": {
       "enum": [
         "pre_start",
@@ -53,27 +70,60 @@
         "factory_maturity"
       ]
     },
-    "next_required_artifact": { "type": "string", "minLength": 1 },
+    "next_required_artifact": {
+      "type": "string",
+      "minLength": 1
+    },
     "allowed_current_worker_ids": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "blocked_downstream_phase_ids": {
       "type": "array",
-      "items": { "type": "string", "pattern": "^F[0-9]+[A-Z]?$" }
+      "items": {
+        "type": "string",
+        "pattern": "^F[0-9]+[A-Z]?$"
+      }
     },
-    "phase_mismatch": { "type": "boolean" },
-    "lock_phase_mismatch": { "type": "boolean" },
-    "lock_frontier_mismatch": { "type": "boolean" },
-    "human_gate_allowed": { "type": "boolean" },
-    "human_gate_reason": { "type": "string" },
-    "human_gate_blocked_until_artifact": { "type": "string" },
+    "phase_mismatch": {
+      "type": "boolean"
+    },
+    "lock_phase_mismatch": {
+      "type": "boolean"
+    },
+    "lock_frontier_mismatch": {
+      "type": "boolean"
+    },
+    "human_gate_allowed": {
+      "type": "boolean"
+    },
+    "human_gate_reason": {
+      "type": "string"
+    },
+    "human_gate_blocked_until_artifact": {
+      "type": "string"
+    },
     "artifacts": {
       "type": "object",
-      "additionalProperties": { "type": "boolean" }
+      "additionalProperties": {
+        "type": "boolean"
+      }
     },
-    "decision_basis": { "type": "string", "minLength": 1 }
+    "decision_basis": {
+      "type": "string",
+      "minLength": 1
+    },
+    "active_repair_loop": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    }
   },
   "additionalProperties": false
 }

--- a/factory/schemas/factory-phase-graph.schema.json
+++ b/factory/schemas/factory-phase-graph.schema.json
@@ -12,28 +12,79 @@
     "gate_events",
     "projections",
     "legacy_aliases",
+    "adaptive_transition_policy",
     "taxonomy_policy"
   ],
   "properties": {
-    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-phase-graph.schema.json" },
-    "record_type": { "const": "factory_phase_graph" },
-    "graph_id": { "type": "string", "minLength": 3 },
-    "factory_method_version": { "const": "OVERKILL_VFINAL" },
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-phase-graph.schema.json"
+    },
+    "record_type": {
+      "const": "factory_phase_graph"
+    },
+    "graph_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "factory_method_version": {
+      "const": "OVERKILL_VFINAL"
+    },
     "product_phases": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["phase_id", "phase_index", "name", "kind", "frontier", "entry_contract_refs", "exit_contract_refs", "next_phase_id"],
+        "required": [
+          "phase_id",
+          "phase_index",
+          "name",
+          "kind",
+          "frontier",
+          "entry_contract_refs",
+          "exit_contract_refs",
+          "next_phase_id"
+        ],
         "properties": {
-          "phase_id": { "type": "string", "pattern": "^F[0-9]+$" },
-          "phase_index": { "type": "integer", "minimum": 0 },
-          "name": { "type": "string", "minLength": 3 },
-          "kind": { "const": "product_phase" },
-          "frontier": { "type": "string", "minLength": 3 },
-          "entry_contract_refs": { "type": "array", "items": { "type": "string", "minLength": 3 } },
-          "exit_contract_refs": { "type": "array", "items": { "type": "string", "minLength": 3 } },
-          "next_phase_id": { "type": ["string", "null"], "pattern": "^F[0-9]+$" }
+          "phase_id": {
+            "type": "string",
+            "pattern": "^F[0-9]+$"
+          },
+          "phase_index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3
+          },
+          "kind": {
+            "const": "product_phase"
+          },
+          "frontier": {
+            "type": "string",
+            "minLength": 3
+          },
+          "entry_contract_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "exit_contract_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "next_phase_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^F[0-9]+$"
+          }
         },
         "additionalProperties": false
       }
@@ -42,13 +93,40 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["event_id", "event_type", "trigger", "required_packet_refs", "forbidden_as_phase"],
+        "required": [
+          "event_id",
+          "event_type",
+          "trigger",
+          "required_packet_refs",
+          "forbidden_as_phase"
+        ],
         "properties": {
-          "event_id": { "type": "string", "minLength": 3 },
-          "event_type": { "enum": ["human_gate_event", "release_gate_event", "security_gate_event"] },
-          "trigger": { "type": "string", "minLength": 3 },
-          "required_packet_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 3 } },
-          "forbidden_as_phase": { "const": true }
+          "event_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "event_type": {
+            "enum": [
+              "human_gate_event",
+              "release_gate_event",
+              "security_gate_event"
+            ]
+          },
+          "trigger": {
+            "type": "string",
+            "minLength": 3
+          },
+          "required_packet_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          },
+          "forbidden_as_phase": {
+            "const": true
+          }
         },
         "additionalProperties": false
       }
@@ -57,12 +135,31 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["projection_id", "projection_type", "source_of_truth", "forbidden_as_phase"],
+        "required": [
+          "projection_id",
+          "projection_type",
+          "source_of_truth",
+          "forbidden_as_phase"
+        ],
         "properties": {
-          "projection_id": { "type": "string", "minLength": 3 },
-          "projection_type": { "enum": ["operator_projection", "status_snapshot", "control_tower_view"] },
-          "source_of_truth": { "type": "string", "minLength": 3 },
-          "forbidden_as_phase": { "const": true }
+          "projection_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "projection_type": {
+            "enum": [
+              "operator_projection",
+              "status_snapshot",
+              "control_tower_view"
+            ]
+          },
+          "source_of_truth": {
+            "type": "string",
+            "minLength": 3
+          },
+          "forbidden_as_phase": {
+            "const": true
+          }
         },
         "additionalProperties": false
       }
@@ -71,11 +168,23 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["legacy_id", "canonical_ref", "allowed_for_compatibility_only"],
+        "required": [
+          "legacy_id",
+          "canonical_ref",
+          "allowed_for_compatibility_only"
+        ],
         "properties": {
-          "legacy_id": { "type": "string", "minLength": 2 },
-          "canonical_ref": { "type": "string", "minLength": 2 },
-          "allowed_for_compatibility_only": { "const": true }
+          "legacy_id": {
+            "type": "string",
+            "minLength": 2
+          },
+          "canonical_ref": {
+            "type": "string",
+            "minLength": 2
+          },
+          "allowed_for_compatibility_only": {
+            "const": true
+          }
         },
         "additionalProperties": false
       }
@@ -87,14 +196,152 @@
         "gate_event_is_not_phase",
         "projection_is_not_phase",
         "legacy_suffix_phase_ids_forbidden",
-        "single_active_product_phase_required"
+        "single_active_product_phase_required",
+        "adaptive_transition_policy_required",
+        "blind_linear_rail_forbidden"
       ],
       "properties": {
-        "frontier_is_not_phase": { "const": true },
-        "gate_event_is_not_phase": { "const": true },
-        "projection_is_not_phase": { "const": true },
-        "legacy_suffix_phase_ids_forbidden": { "const": true },
-        "single_active_product_phase_required": { "const": true }
+        "frontier_is_not_phase": {
+          "const": true
+        },
+        "gate_event_is_not_phase": {
+          "const": true
+        },
+        "projection_is_not_phase": {
+          "const": true
+        },
+        "legacy_suffix_phase_ids_forbidden": {
+          "const": true
+        },
+        "single_active_product_phase_required": {
+          "const": true
+        },
+        "adaptive_transition_policy_required": {
+          "const": true
+        },
+        "blind_linear_rail_forbidden": {
+          "const": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "adaptive_transition_policy": {
+      "type": "object",
+      "required": [
+        "linear_next_links_are_default_only",
+        "lateral_repair_loops_required",
+        "reentry_requires_reconciliation",
+        "downstream_final_phases_block_on_unresolved_repair",
+        "lateral_edges",
+        "reentry_gates"
+      ],
+      "properties": {
+        "linear_next_links_are_default_only": {
+          "const": true
+        },
+        "lateral_repair_loops_required": {
+          "const": true
+        },
+        "reentry_requires_reconciliation": {
+          "const": true
+        },
+        "downstream_final_phases_block_on_unresolved_repair": {
+          "const": true
+        },
+        "lateral_edges": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "edge_id",
+              "from_phase_id",
+              "to_phase_id",
+              "trigger",
+              "repair_owner_worker",
+              "reentry_gate_refs",
+              "blocks_downstream_phase_ids"
+            ],
+            "properties": {
+              "edge_id": {
+                "type": "string",
+                "minLength": 3
+              },
+              "from_phase_id": {
+                "type": "string",
+                "pattern": "^F[0-9]+$"
+              },
+              "to_phase_id": {
+                "type": "string",
+                "pattern": "^F[0-9]+$"
+              },
+              "trigger": {
+                "type": "string",
+                "minLength": 10
+              },
+              "repair_owner_worker": {
+                "type": "string",
+                "minLength": 3
+              },
+              "reentry_gate_refs": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 3
+                }
+              },
+              "blocks_downstream_phase_ids": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "pattern": "^F[0-9]+$"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "reentry_gates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "gate_id",
+              "gate_type",
+              "required_evidence_refs",
+              "required_result"
+            ],
+            "properties": {
+              "gate_id": {
+                "type": "string",
+                "minLength": 3
+              },
+              "gate_type": {
+                "enum": [
+                  "repair_reconciliation",
+                  "fresh_review",
+                  "human_decision"
+                ]
+              },
+              "required_evidence_refs": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 3
+                }
+              },
+              "required_result": {
+                "type": "string",
+                "minLength": 3
+              }
+            },
+            "additionalProperties": false
+          }
+        }
       },
       "additionalProperties": false
     }

--- a/factory/schemas/factory-workflow-compiled-plan.schema.json
+++ b/factory/schemas/factory-workflow-compiled-plan.schema.json
@@ -15,13 +15,32 @@
     "compiler_guards"
   ],
   "properties": {
-    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-workflow-compiled-plan.schema.json" },
-    "record_type": { "const": "factory_workflow_compiled_plan" },
-    "plan_id": { "type": "string", "minLength": 3 },
-    "compiled_at": { "type": "string", "minLength": 10 },
-    "catalog_ref": { "type": "string", "minLength": 3 },
-    "catalog_version": { "type": "string", "minLength": 1 },
-    "phase_count": { "type": "integer", "minimum": 1 },
+    "$schema": {
+      "const": "https://overkill-factory.dev/schemas/factory-workflow-compiled-plan.schema.json"
+    },
+    "record_type": {
+      "const": "factory_workflow_compiled_plan"
+    },
+    "plan_id": {
+      "type": "string",
+      "minLength": 3
+    },
+    "compiled_at": {
+      "type": "string",
+      "minLength": 10
+    },
+    "catalog_ref": {
+      "type": "string",
+      "minLength": 3
+    },
+    "catalog_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "phase_count": {
+      "type": "integer",
+      "minimum": 1
+    },
     "phases": {
       "type": "array",
       "minItems": 1,
@@ -40,12 +59,36 @@
           "auto_pass_allowed"
         ],
         "properties": {
-          "phase_id": { "type": "string", "minLength": 2 },
-          "phase_index": { "type": "integer", "minimum": 1 },
-          "phase_name": { "type": "string", "minLength": 3 },
-          "required_artifacts": { "type": "array", "items": { "type": "string" } },
-          "required_gates": { "type": "array", "items": { "type": "string" } },
-          "required_workers": { "type": "array", "items": { "type": "string" } },
+          "phase_id": {
+            "type": "string",
+            "minLength": 2
+          },
+          "phase_index": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "phase_name": {
+            "type": "string",
+            "minLength": 3
+          },
+          "required_artifacts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "required_gates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "required_workers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "allowed_commands": {
             "type": "array",
             "minItems": 1,
@@ -61,9 +104,22 @@
               ]
             }
           },
-          "blocked_actions": { "type": "array", "items": { "type": "string" } },
-          "next_phase_id": { "type": ["string", "null"], "minLength": 2 },
-          "auto_pass_allowed": { "type": "boolean" }
+          "blocked_actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "next_phase_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 2
+          },
+          "auto_pass_allowed": {
+            "type": "boolean"
+          }
         },
         "additionalProperties": false
       }
@@ -74,13 +130,33 @@
         "duplicate_phase_ids_blocked",
         "unknown_next_phase_blocked",
         "human_gate_requires_decision_outbox",
-        "worker_materialization_requires_dispatch_readiness"
+        "worker_materialization_requires_dispatch_readiness",
+        "lateral_repair_loops_block_downstream",
+        "reentry_gate_reconciliation_required",
+        "blind_linear_rail_forbidden"
       ],
       "properties": {
-        "duplicate_phase_ids_blocked": { "const": true },
-        "unknown_next_phase_blocked": { "const": true },
-        "human_gate_requires_decision_outbox": { "const": true },
-        "worker_materialization_requires_dispatch_readiness": { "const": true }
+        "duplicate_phase_ids_blocked": {
+          "const": true
+        },
+        "unknown_next_phase_blocked": {
+          "const": true
+        },
+        "human_gate_requires_decision_outbox": {
+          "const": true
+        },
+        "worker_materialization_requires_dispatch_readiness": {
+          "const": true
+        },
+        "lateral_repair_loops_block_downstream": {
+          "const": true
+        },
+        "reentry_gate_reconciliation_required": {
+          "const": true
+        },
+        "blind_linear_rail_forbidden": {
+          "const": true
+        }
       },
       "additionalProperties": false
     }

--- a/factory/scripts/factory_v2_kernel.py
+++ b/factory/scripts/factory_v2_kernel.py
@@ -266,6 +266,9 @@ def compile_workflow_catalog(
             "unknown_next_phase_blocked": True,
             "human_gate_requires_decision_outbox": True,
             "worker_materialization_requires_dispatch_readiness": True,
+            "lateral_repair_loops_block_downstream": True,
+            "reentry_gate_reconciliation_required": True,
+            "blind_linear_rail_forbidden": True,
         },
     }
 
@@ -280,6 +283,15 @@ def validate_factory_workflow_compiled_plan(plan: dict[str, Any], at: str = "fac
     if duplicate_phase_ids:
         errors.append(f"{at}.phases: duplicate phase ids {', '.join(str(item) for item in duplicate_phase_ids)}")
     known_phase_ids = {phase_id for phase_id in phase_ids if isinstance(phase_id, str)}
+    guard_value = plan.get("compiler_guards")
+    guards = guard_value if isinstance(guard_value, dict) else {}
+    for guard in (
+        "lateral_repair_loops_block_downstream",
+        "reentry_gate_reconciliation_required",
+        "blind_linear_rail_forbidden",
+    ):
+        if guards.get(guard) is not True:
+            errors.append(f"{at}.compiler_guards.{guard}: must be true")
     for index, phase in enumerate(phases):
         phase_at = f"{at}.phases[{index}]"
         expected_index = index + 1
@@ -335,9 +347,46 @@ def validate_factory_phase_graph(graph: dict[str, Any], at: str = "factory_phase
         "projection_is_not_phase",
         "legacy_suffix_phase_ids_forbidden",
         "single_active_product_phase_required",
+        "adaptive_transition_policy_required",
+        "blind_linear_rail_forbidden",
     ):
         if policy.get(field) is not True:
             errors.append(f"{at}.taxonomy_policy.{field}: must be true")
+    adaptive_value = graph.get("adaptive_transition_policy")
+    adaptive = adaptive_value if isinstance(adaptive_value, dict) else {}
+    gates = [gate for gate in _as_list(adaptive.get("reentry_gates")) if isinstance(gate, dict)]
+    gate_ids = {str(gate.get("gate_id") or "") for gate in gates}
+    lateral_edges = [edge for edge in _as_list(adaptive.get("lateral_edges")) if isinstance(edge, dict)]
+    if not lateral_edges:
+        errors.append(f"{at}.adaptive_transition_policy.lateral_edges: at least one lateral/re-entry repair edge is required")
+    if not gates:
+        errors.append(f"{at}.adaptive_transition_policy.reentry_gates: at least one re-entry gate is required")
+    has_non_forward_repair_edge = False
+    for index, edge in enumerate(lateral_edges):
+        edge_at = f"{at}.adaptive_transition_policy.lateral_edges[{index}]"
+        from_phase = str(edge.get("from_phase_id") or "")
+        to_phase = str(edge.get("to_phase_id") or "")
+        if from_phase not in product_phase_id_set:
+            errors.append(f"{edge_at}.from_phase_id: unknown product phase {from_phase}")
+        if to_phase not in product_phase_id_set:
+            errors.append(f"{edge_at}.to_phase_id: unknown product phase {to_phase}")
+        if from_phase in product_phase_id_set and to_phase in product_phase_id_set:
+            if product_phase_ids.index(to_phase) <= product_phase_ids.index(from_phase):
+                has_non_forward_repair_edge = True
+        for gate_ref in _as_list(edge.get("reentry_gate_refs")):
+            if str(gate_ref) not in gate_ids:
+                errors.append(f"{edge_at}.reentry_gate_refs: unknown gate {gate_ref}")
+        blocked = [str(item) for item in _as_list(edge.get("blocks_downstream_phase_ids"))]
+        unknown_blocked = sorted({phase_id for phase_id in blocked if phase_id not in product_phase_id_set})
+        if unknown_blocked:
+            errors.append(f"{edge_at}.blocks_downstream_phase_ids: unknown product phases {', '.join(unknown_blocked)}")
+        if blocked and from_phase in product_phase_id_set:
+            from_index = product_phase_ids.index(from_phase)
+            earlier_blocked = [phase_id for phase_id in blocked if phase_id in product_phase_id_set and product_phase_ids.index(phase_id) < from_index]
+            if earlier_blocked:
+                errors.append(f"{edge_at}.blocks_downstream_phase_ids: must not block phases before edge source {from_phase}")
+    if not has_non_forward_repair_edge:
+        errors.append(f"{at}.adaptive_transition_policy.lateral_edges: must include a non-forward repair/re-entry edge")
     return errors
 
 

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -5493,6 +5493,109 @@ def _phase_engine_any_materialized(
     )
 
 
+def _phase_repair_loop_phase_for_worker(worker_id: str) -> tuple[str, str, str]:
+    normalized = str(worker_id or "").strip()
+    if normalized in {"decomposition-planner", "supply-chain-gate"}:
+        return "ready_gate", "F12", "decomposition_coverage_review"
+    if normalized in {
+        "implementation-worker",
+        "frontend-builder",
+        "backend-api-builder",
+        "data-persistence-builder",
+        "solana-quasar-builder",
+        "solana-quasar-qa-engineer",
+        "wallet-transaction-builder",
+        "integration-builder",
+        "test-automation-builder",
+        "infra-devops-builder",
+        "agent-runtime-builder",
+    }:
+        return "execution", "F15", "worker_results"
+    if normalized in {"qa-verification-worker", "autoreview-gate"}:
+        return "verification", "F17", "qa_verification_plan"
+    if normalized in {"independent-reviewer", "handoff-packer"}:
+        return "review", "F18", "independent_review_result"
+    if normalized in {"release-ops-worker", "public-safety-gate"}:
+        return "release", "F23", "production_readiness_plan"
+    if normalized in {"security-orchestrator", "codex-security", "appsec-owasp-specialist", "agentic-ai-security-specialist", "cloud-infra-security-specialist", "crypto-key-management-specialist"}:
+        return "architecture", "F10", "architecture_packet"
+    if normalized == "product-sot-planner":
+        return "product_sot", "F5", "product_sot"
+    if normalized == "source-ledger-worker":
+        return "source_resolution", "F2", "product_source_ledger"
+    return "execution", "F15", "worker_results"
+
+
+_PHASE_REPAIR_LOOP_RESOLVED_STATUSES = {"pass", "passed", "resolved", "reconciled", "satisfied", "closed", "complete", "completed", "done"}
+
+
+def _phase_repair_loop_resolved(route: dict[str, Any]) -> bool:
+    for field in ("status", "reconciliation_status", "resolution_status", "repair_status"):
+        value = str(route.get(field) or "").strip().lower()
+        if value in _PHASE_REPAIR_LOOP_RESOLVED_STATUSES:
+            return True
+    reconciliation = route.get("reconciliation") if isinstance(route.get("reconciliation"), dict) else {}
+    result = str(reconciliation.get("result") or reconciliation.get("status") or "").strip().lower()
+    return result in _PHASE_REPAIR_LOOP_RESOLVED_STATUSES
+
+
+def active_factory_owned_repair_loop(card: dict[str, Any]) -> dict[str, Any] | None:
+    candidates: list[dict[str, Any]] = []
+    for field in ("active_recovery_routes", "recovery_routes"):
+        value = card.get(field)
+        if isinstance(value, list):
+            candidates.extend(item for item in value if isinstance(item, dict))
+    recovery_plan = card.get("factory_recovery_plan") if isinstance(card.get("factory_recovery_plan"), dict) else {}
+    plan_routes = recovery_plan.get("recovery_routes")
+    if isinstance(plan_routes, list):
+        candidates.extend(item for item in plan_routes if isinstance(item, dict))
+    single_loop = card.get("active_repair_loop") if isinstance(card.get("active_repair_loop"), dict) else None
+    if single_loop:
+        candidates.append(single_loop)
+
+    for route in candidates:
+        if _phase_repair_loop_resolved(route):
+            continue
+        if route.get("human_gate_required") is True:
+            continue
+        if route.get("factory_owned_repair_allowed") is False:
+            continue
+        blocker_type = str(route.get("blocker_type") or "").strip()
+        repair_owner = str(route.get("repair_owner_worker") or route.get("owner_worker") or "factory-orchestrator").strip()
+        frontier, phase_id, artifact = _phase_repair_loop_phase_for_worker(repair_owner)
+        explicit_phase = str(route.get("repair_phase_id") or route.get("reentry_phase_id") or "").strip().upper()
+        if explicit_phase and factory_phase_rank(explicit_phase) >= 0:
+            phase_id = explicit_phase
+            artifact = str(route.get("next_required_artifact") or artifact)
+            frontier = next(
+                (
+                    candidate_frontier
+                    for candidate_frontier, candidate_phase in FACTORY_PHASE_ENGINE_PHASE_BY_FRONTIER.items()
+                    if candidate_phase == phase_id
+                ),
+                frontier,
+            )
+        downstream = [
+            str(item).strip().upper()
+            for item in string_list(route.get("downstream_freeze_scope")) + string_list(route.get("blocks_downstream_phase_ids"))
+            if factory_phase_rank(str(item).strip().upper()) >= 0
+        ]
+        if not downstream:
+            downstream = [candidate for candidate in FACTORY_PRODUCT_PHASE_IDS if factory_phase_rank(candidate) > factory_phase_rank(phase_id)]
+        return {
+            "recovery_route_id": str(route.get("recovery_route_id") or route.get("route_id") or "active-repair-loop"),
+            "blocker_type": blocker_type or "dependency",
+            "repair_owner_worker": repair_owner,
+            "repair_phase_id": phase_id,
+            "repair_frontier": frontier,
+            "next_required_artifact": artifact,
+            "downstream_freeze_scope": downstream,
+            "reentry_gate_refs": string_list(route.get("reentry_gate_refs")) or ["fresh_review_required", str(route.get("unblock_authority_ref") or "reconciliation_pass")],
+            "fresh_review_required": route.get("fresh_review_required") is True,
+            "runtime_authority": "hermes_kanban",
+            "local_state_authority": False,
+        }
+    return None
 def _phase_engine_frontier_state(
     *,
     card: dict[str, Any],
@@ -5501,6 +5604,7 @@ def _phase_engine_frontier_state(
     next_required_artifact: str,
     reason: str,
     artifacts: dict[str, bool],
+    active_repair_loop: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     card_phase_id = str(card.get("phase") or "").strip() or "unknown"
     computed_rank = factory_phase_rank(phase_id)
@@ -5519,6 +5623,19 @@ def _phase_engine_frontier_state(
         and computed_frontier_rank >= factory_phase_engine_frontier_rank("method_contract")
     )
     allowed_workers = FACTORY_PHASE_ENGINE_WORKERS_BY_FRONTIER.get(frontier, ["factory-orchestrator"])
+    blocked_downstream_phase_ids = [
+        candidate
+        for candidate in FACTORY_PRODUCT_PHASE_IDS
+        if factory_phase_rank(candidate) > computed_rank
+    ]
+    if active_repair_loop:
+        repair_scope = [
+            str(item).strip().upper()
+            for item in string_list(active_repair_loop.get("downstream_freeze_scope"))
+            if factory_phase_rank(str(item).strip().upper()) >= 0
+        ]
+        if repair_scope:
+            blocked_downstream_phase_ids = repair_scope
     return {
         "$schema": "https://overkill-factory.dev/schemas/factory-phase-engine-state.schema.json",
         "record_type": "factory_phase_engine_state",
@@ -5530,11 +5647,7 @@ def _phase_engine_frontier_state(
         "computed_frontier": frontier,
         "next_required_artifact": next_required_artifact,
         "allowed_current_worker_ids": allowed_workers,
-        "blocked_downstream_phase_ids": [
-            candidate
-            for candidate in FACTORY_PRODUCT_PHASE_IDS
-            if factory_phase_rank(candidate) > computed_rank
-        ],
+        "blocked_downstream_phase_ids": blocked_downstream_phase_ids,
         "phase_mismatch": card_rank > computed_rank,
         "lock_phase_mismatch": bool(lock_phase_id and lock_phase_rank > computed_rank),
         "lock_frontier_mismatch": bool(
@@ -5543,6 +5656,7 @@ def _phase_engine_frontier_state(
         "human_gate_allowed": human_gate_allowed,
         "human_gate_reason": human_gate_reason,
         "human_gate_blocked_until_artifact": "" if human_gate_allowed else next_required_artifact,
+        "active_repair_loop": active_repair_loop,
         "artifacts": artifacts,
         "decision_basis": reason,
     }
@@ -5796,7 +5910,13 @@ def factory_phase_engine_state(
         "factory_maturity_scorecard": maturity_done,
     }
 
-    def state(frontier: str, phase_id: str, artifact: str, reason: str) -> dict[str, Any]:
+    def state(
+        frontier: str,
+        phase_id: str,
+        artifact: str,
+        reason: str,
+        active_repair_loop: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         return _phase_engine_frontier_state(
             card=card,
             frontier=frontier,
@@ -5804,6 +5924,17 @@ def factory_phase_engine_state(
             next_required_artifact=artifact,
             reason=reason,
             artifacts=artifacts,
+            active_repair_loop=active_repair_loop,
+        )
+
+    active_repair_loop = active_factory_owned_repair_loop(card)
+    if active_repair_loop:
+        return state(
+            str(active_repair_loop["repair_frontier"]),
+            str(active_repair_loop["repair_phase_id"]),
+            str(active_repair_loop["next_required_artifact"]),
+            f"unresolved factory-owned repair loop {active_repair_loop['recovery_route_id']} blocks downstream phases until re-entry gates reconcile",
+            active_repair_loop=active_repair_loop,
         )
 
     if not source_input and not product_sot:
@@ -19163,6 +19294,8 @@ def build_transition_plan(
 ) -> dict[str, Any]:
     card = normalize_transition_card(card)
     gate = gate_report_for_transition(card)
+    phase_engine = factory_phase_engine_state(card)
+    active_repair_loop = phase_engine.get("active_repair_loop") if isinstance(phase_engine, dict) else None
     normalized_to = to_status.strip().lower()
     blocked_reasons: list[str] = []
     worker_tasks = [
@@ -19205,6 +19338,13 @@ def build_transition_plan(
     if recovery_routes:
         attach_recovery_routes_to_tasks(worker_tasks, recovery_routes, card, source_path)
     downstream_authorizations = downstream_task_authorizations(graph_requirements, worker_tasks)
+    if isinstance(active_repair_loop, dict):
+        reason = (
+            "factory_phase_engine active repair loop "
+            f"{active_repair_loop.get('recovery_route_id')} blocks downstream transition until re-entry reconciliation"
+        )
+        if reason not in blocked_reasons:
+            blocked_reasons.append(reason)
 
     def append_unsatisfied_graph_requirement_blocks() -> None:
         for requirement in unsatisfied_graph_requirements:
@@ -19317,6 +19457,7 @@ def build_transition_plan(
         "transition_action": transition_action,
         "blocked_reasons": blocked_reasons,
         "gate_report": gate,
+        "phase_engine": phase_engine,
         "worker_tasks": worker_tasks,
         "graph_requirements": graph_requirements,
         "recovery_routes": recovery_routes,

--- a/factory/scripts/validate_public_json_artifacts.py
+++ b/factory/scripts/validate_public_json_artifacts.py
@@ -59,6 +59,10 @@ def default_root() -> Path:
         cwd / "examples" / "minimal-hermes-project" / "card.md"
     ).exists():
         return cwd
+    if (CODE_ROOT / "agents" / "hermes-profile-bindings.public.json").exists() and (
+        CODE_ROOT / "examples" / "minimal-hermes-project" / "card.md"
+    ).exists():
+        return CODE_ROOT
     installed_root = installed_asset_root()
     if installed_root is not None:
         return installed_root

--- a/factory/templates/factory-phase-graph.json
+++ b/factory/templates/factory-phase-graph.json
@@ -10,7 +10,9 @@
       "name": "Pre-Start / Sealed Source Envelope",
       "kind": "product_phase",
       "frontier": "pre_start",
-      "entry_contract_refs": ["schemas/factory-bridge-source-envelope.schema.json"],
+      "entry_contract_refs": [
+        "schemas/factory-bridge-source-envelope.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/factory-bridge-source-envelope.schema.json",
         "schemas/factory-bridge-start-request.schema.json",
@@ -24,7 +26,9 @@
       "name": "Intake",
       "kind": "product_phase",
       "frontier": "intake",
-      "entry_contract_refs": ["schemas/factory-start-conversation.schema.json"],
+      "entry_contract_refs": [
+        "schemas/factory-start-conversation.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/operator-interface-profile.schema.json",
         "schemas/factory-start-conversation.schema.json",
@@ -39,8 +43,13 @@
       "name": "Source Ledger",
       "kind": "product_phase",
       "frontier": "source_resolution",
-      "entry_contract_refs": ["schemas/source-resolution-packet.schema.json"],
-      "exit_contract_refs": ["schemas/product-source-ledger.schema.json", "schemas/operator-understanding-confirmation.schema.json"],
+      "entry_contract_refs": [
+        "schemas/source-resolution-packet.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/product-source-ledger.schema.json",
+        "schemas/operator-understanding-confirmation.schema.json"
+      ],
       "next_phase_id": "F3"
     },
     {
@@ -49,8 +58,12 @@
       "name": "Source Resolution",
       "kind": "product_phase",
       "frontier": "source_resolution",
-      "entry_contract_refs": ["schemas/product-source-ledger.schema.json"],
-      "exit_contract_refs": ["schemas/discovery-brief.schema.json"],
+      "entry_contract_refs": [
+        "schemas/product-source-ledger.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/discovery-brief.schema.json"
+      ],
       "next_phase_id": "F4"
     },
     {
@@ -59,7 +72,9 @@
       "name": "Product Outcome And Discovery",
       "kind": "product_phase",
       "frontier": "product_sot",
-      "entry_contract_refs": ["schemas/operator-understanding-confirmation.schema.json"],
+      "entry_contract_refs": [
+        "schemas/operator-understanding-confirmation.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/operator-understanding-confirmation.schema.json",
         "schemas/operator-briefing-package.schema.json",
@@ -74,7 +89,9 @@
       "name": "Product SOT",
       "kind": "product_phase",
       "frontier": "product_sot",
-      "entry_contract_refs": ["schemas/outcome-contract.schema.json"],
+      "entry_contract_refs": [
+        "schemas/outcome-contract.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/product-sot.schema.json",
         "schemas/operator-briefing-package.schema.json",
@@ -89,8 +106,13 @@
       "name": "Agentic Method Router",
       "kind": "product_phase",
       "frontier": "method_contract",
-      "entry_contract_refs": ["schemas/full-product-sot-scope-coverage.schema.json"],
-      "exit_contract_refs": ["schemas/factory-phase-lock.schema.json", "schemas/method-contract.schema.json"],
+      "entry_contract_refs": [
+        "schemas/full-product-sot-scope-coverage.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/factory-phase-lock.schema.json",
+        "schemas/method-contract.schema.json"
+      ],
       "next_phase_id": "F7"
     },
     {
@@ -99,8 +121,13 @@
       "name": "Method Contract",
       "kind": "product_phase",
       "frontier": "method_contract",
-      "entry_contract_refs": ["schemas/method-contract.schema.json"],
-      "exit_contract_refs": ["schemas/factory-phase-lock.schema.json", "schemas/method-contract.schema.json"],
+      "entry_contract_refs": [
+        "schemas/method-contract.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/factory-phase-lock.schema.json",
+        "schemas/method-contract.schema.json"
+      ],
       "next_phase_id": "F8"
     },
     {
@@ -109,7 +136,9 @@
       "name": "Pack And Product Experience Selection",
       "kind": "product_phase",
       "frontier": "pack_selection",
-      "entry_contract_refs": ["schemas/method-contract.schema.json"],
+      "entry_contract_refs": [
+        "schemas/method-contract.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/capability-pack-contract.schema.json",
         "schemas/product-experience-plan.schema.json",
@@ -126,8 +155,13 @@
       "name": "Risk And Authority Gates",
       "kind": "product_phase",
       "frontier": "authority",
-      "entry_contract_refs": ["schemas/capability-pack-contract.schema.json"],
-      "exit_contract_refs": ["schemas/access-capability.schema.json", "schemas/budget-contract.schema.json"],
+      "entry_contract_refs": [
+        "schemas/capability-pack-contract.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/access-capability.schema.json",
+        "schemas/budget-contract.schema.json"
+      ],
       "next_phase_id": "F10"
     },
     {
@@ -136,8 +170,13 @@
       "name": "Security Architecture",
       "kind": "product_phase",
       "frontier": "architecture",
-      "entry_contract_refs": ["schemas/method-contract.schema.json"],
-      "exit_contract_refs": ["schemas/factory-phase-lock.schema.json", "schemas/security-architecture-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/method-contract.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/factory-phase-lock.schema.json",
+        "schemas/security-architecture-plan.schema.json"
+      ],
       "next_phase_id": "F11"
     },
     {
@@ -146,7 +185,9 @@
       "name": "Executable Plans",
       "kind": "product_phase",
       "frontier": "ready_gate",
-      "entry_contract_refs": ["schemas/security-architecture-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/security-architecture-plan.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/software-development-plan.schema.json",
         "schemas/spec-graph.schema.json",
@@ -161,7 +202,9 @@
       "name": "Autonomy Readiness",
       "kind": "product_phase",
       "frontier": "ready_gate",
-      "entry_contract_refs": ["schemas/product-creation-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/product-creation-plan.schema.json"
+      ],
       "exit_contract_refs": [
         "schemas/decomposition-coverage-review.schema.json",
         "schemas/product-implementation-readiness.schema.json",
@@ -175,8 +218,13 @@
       "name": "Ready Gate",
       "kind": "product_phase",
       "frontier": "ready_gate",
-      "entry_contract_refs": ["schemas/product-implementation-readiness.schema.json", "schemas/autonomy-readiness-packet.schema.json"],
-      "exit_contract_refs": ["schemas/gate-report.schema.json"],
+      "entry_contract_refs": [
+        "schemas/product-implementation-readiness.schema.json",
+        "schemas/autonomy-readiness-packet.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/gate-report.schema.json"
+      ],
       "next_phase_id": "F15"
     },
     {
@@ -185,8 +233,12 @@
       "name": "Runtime Execution",
       "kind": "product_phase",
       "frontier": "execution",
-      "entry_contract_refs": ["schemas/ready-work-unit-packets.schema.json"],
-      "exit_contract_refs": ["schemas/worker-packet.schema.json"],
+      "entry_contract_refs": [
+        "schemas/ready-work-unit-packets.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/worker-packet.schema.json"
+      ],
       "next_phase_id": "F16"
     },
     {
@@ -195,8 +247,12 @@
       "name": "Worker Results",
       "kind": "product_phase",
       "frontier": "execution",
-      "entry_contract_refs": ["schemas/worker-packet.schema.json"],
-      "exit_contract_refs": ["schemas/worker-result.schema.json"],
+      "entry_contract_refs": [
+        "schemas/worker-packet.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/worker-result.schema.json"
+      ],
       "next_phase_id": "F17"
     },
     {
@@ -205,8 +261,12 @@
       "name": "Verification",
       "kind": "product_phase",
       "frontier": "verification",
-      "entry_contract_refs": ["schemas/worker-result.schema.json"],
-      "exit_contract_refs": ["schemas/qa-verification-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/worker-result.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/qa-verification-plan.schema.json"
+      ],
       "next_phase_id": "F18"
     },
     {
@@ -215,8 +275,12 @@
       "name": "Independent Review",
       "kind": "product_phase",
       "frontier": "review",
-      "entry_contract_refs": ["schemas/qa-verification-plan.schema.json"],
-      "exit_contract_refs": ["schemas/reviewer-selection-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/qa-verification-plan.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/reviewer-selection-plan.schema.json"
+      ],
       "next_phase_id": "F20"
     },
     {
@@ -225,8 +289,12 @@
       "name": "Closure Summary",
       "kind": "product_phase",
       "frontier": "completion",
-      "entry_contract_refs": ["schemas/worker-result.schema.json"],
-      "exit_contract_refs": ["schemas/worker-closure-summary.schema.json"],
+      "entry_contract_refs": [
+        "schemas/worker-result.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/worker-closure-summary.schema.json"
+      ],
       "next_phase_id": "F21"
     },
     {
@@ -235,8 +303,12 @@
       "name": "Receipt Five",
       "kind": "product_phase",
       "frontier": "completion",
-      "entry_contract_refs": ["schemas/worker-closure-summary.schema.json"],
-      "exit_contract_refs": ["schemas/receipt-five.schema.json"],
+      "entry_contract_refs": [
+        "schemas/worker-closure-summary.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/receipt-five.schema.json"
+      ],
       "next_phase_id": "F22"
     },
     {
@@ -245,8 +317,12 @@
       "name": "Completion Audit",
       "kind": "product_phase",
       "frontier": "completion",
-      "entry_contract_refs": ["schemas/receipt-five.schema.json"],
-      "exit_contract_refs": ["schemas/completion-audit.schema.json"],
+      "entry_contract_refs": [
+        "schemas/receipt-five.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/completion-audit.schema.json"
+      ],
       "next_phase_id": "F23"
     },
     {
@@ -255,8 +331,12 @@
       "name": "Production Operations",
       "kind": "product_phase",
       "frontier": "release",
-      "entry_contract_refs": ["schemas/completion-audit.schema.json"],
-      "exit_contract_refs": ["schemas/production-readiness-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/completion-audit.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/production-readiness-plan.schema.json"
+      ],
       "next_phase_id": "F24"
     },
     {
@@ -265,8 +345,12 @@
       "name": "Release Or Block",
       "kind": "product_phase",
       "frontier": "release",
-      "entry_contract_refs": ["schemas/production-readiness-plan.schema.json"],
-      "exit_contract_refs": ["schemas/factory-promotion-packet.schema.json"],
+      "entry_contract_refs": [
+        "schemas/production-readiness-plan.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/factory-promotion-packet.schema.json"
+      ],
       "next_phase_id": "F25"
     },
     {
@@ -275,8 +359,12 @@
       "name": "Monitoring Support",
       "kind": "product_phase",
       "frontier": "operations",
-      "entry_contract_refs": ["schemas/factory-promotion-packet.schema.json"],
-      "exit_contract_refs": ["schemas/incident-support-plan.schema.json"],
+      "entry_contract_refs": [
+        "schemas/factory-promotion-packet.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/incident-support-plan.schema.json"
+      ],
       "next_phase_id": "F26"
     },
     {
@@ -285,8 +373,12 @@
       "name": "Learnback",
       "kind": "product_phase",
       "frontier": "learnback",
-      "entry_contract_refs": ["schemas/receipt-five.schema.json"],
-      "exit_contract_refs": ["schemas/factory-learning-proposal.schema.json"],
+      "entry_contract_refs": [
+        "schemas/receipt-five.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/factory-learning-proposal.schema.json"
+      ],
       "next_phase_id": "F27"
     },
     {
@@ -295,8 +387,12 @@
       "name": "Factory Maturity Audit",
       "kind": "product_phase",
       "frontier": "factory_maturity",
-      "entry_contract_refs": ["schemas/factory-learning-proposal.schema.json"],
-      "exit_contract_refs": ["schemas/factory-maturity-scorecard.schema.json"],
+      "entry_contract_refs": [
+        "schemas/factory-learning-proposal.schema.json"
+      ],
+      "exit_contract_refs": [
+        "schemas/factory-maturity-scorecard.schema.json"
+      ],
       "next_phase_id": null
     }
   ],
@@ -317,7 +413,10 @@
       "event_id": "release_gate_event",
       "event_type": "release_gate_event",
       "trigger": "promotion from completion evidence to production or customer-visible release",
-      "required_packet_refs": ["schemas/factory-promotion-packet.schema.json", "schemas/production-readiness-plan.schema.json"],
+      "required_packet_refs": [
+        "schemas/factory-promotion-packet.schema.json",
+        "schemas/production-readiness-plan.schema.json"
+      ],
       "forbidden_as_phase": true
     }
   ],
@@ -357,6 +456,131 @@
     "gate_event_is_not_phase": true,
     "projection_is_not_phase": true,
     "legacy_suffix_phase_ids_forbidden": true,
-    "single_active_product_phase_required": true
+    "single_active_product_phase_required": true,
+    "adaptive_transition_policy_required": true,
+    "blind_linear_rail_forbidden": true
+  },
+  "adaptive_transition_policy": {
+    "linear_next_links_are_default_only": true,
+    "lateral_repair_loops_required": true,
+    "reentry_requires_reconciliation": true,
+    "downstream_final_phases_block_on_unresolved_repair": true,
+    "lateral_edges": [
+      {
+        "edge_id": "edge:F13-to-F12-decomposition-repair",
+        "from_phase_id": "F13",
+        "to_phase_id": "F12",
+        "trigger": "Ready Gate cannot pass because decomposition coverage review is missing or failed.",
+        "repair_owner_worker": "decomposition-planner",
+        "reentry_gate_refs": [
+          "gate:repair-reconciliation-pass",
+          "gate:fresh-review-pass"
+        ],
+        "blocks_downstream_phase_ids": [
+          "F13",
+          "F15",
+          "F17",
+          "F18",
+          "F20",
+          "F21",
+          "F22",
+          "F23",
+          "F24",
+          "F25",
+          "F26",
+          "F27"
+        ]
+      },
+      {
+        "edge_id": "edge:F15-worker-repair-loop",
+        "from_phase_id": "F15",
+        "to_phase_id": "F15",
+        "trigger": "Worker result is missing, invalid, blocked, stale, or rejected by review.",
+        "repair_owner_worker": "implementation-worker",
+        "reentry_gate_refs": [
+          "gate:repair-reconciliation-pass",
+          "gate:fresh-review-pass"
+        ],
+        "blocks_downstream_phase_ids": [
+          "F17",
+          "F18",
+          "F20",
+          "F21",
+          "F22",
+          "F23",
+          "F24",
+          "F25",
+          "F26",
+          "F27"
+        ]
+      },
+      {
+        "edge_id": "edge:F18-review-to-producer-repair",
+        "from_phase_id": "F18",
+        "to_phase_id": "F15",
+        "trigger": "Independent review returns BLOCKED or cannot consume the producer handoff.",
+        "repair_owner_worker": "implementation-worker",
+        "reentry_gate_refs": [
+          "gate:repair-reconciliation-pass",
+          "gate:fresh-review-pass"
+        ],
+        "blocks_downstream_phase_ids": [
+          "F18",
+          "F20",
+          "F21",
+          "F22",
+          "F23",
+          "F24",
+          "F25",
+          "F26",
+          "F27"
+        ]
+      },
+      {
+        "edge_id": "edge:F24-release-readiness-repair",
+        "from_phase_id": "F24",
+        "to_phase_id": "F23",
+        "trigger": "Release or production promotion evidence is missing, stale, or blocked.",
+        "repair_owner_worker": "release-ops-worker",
+        "reentry_gate_refs": [
+          "gate:repair-reconciliation-pass",
+          "gate:fresh-review-pass",
+          "gate:human-decision-when-required"
+        ],
+        "blocks_downstream_phase_ids": [
+          "F24",
+          "F25",
+          "F26",
+          "F27"
+        ]
+      }
+    ],
+    "reentry_gates": [
+      {
+        "gate_id": "gate:repair-reconciliation-pass",
+        "gate_type": "repair_reconciliation",
+        "required_evidence_refs": [
+          "schemas/factory-recovery-plan.schema.json",
+          "schemas/receipt-five.schema.json"
+        ],
+        "required_result": "PASS"
+      },
+      {
+        "gate_id": "gate:fresh-review-pass",
+        "gate_type": "fresh_review",
+        "required_evidence_refs": [
+          "schemas/worker-result.schema.json"
+        ],
+        "required_result": "PASS"
+      },
+      {
+        "gate_id": "gate:human-decision-when-required",
+        "gate_type": "human_decision",
+        "required_evidence_refs": [
+          "schemas/human-gate-record.schema.json"
+        ],
+        "required_result": "APPROVED_OR_REPAIR_REQUESTED"
+      }
+    ]
   }
 }

--- a/factory/templates/factory-workflow-compiled-plan.json
+++ b/factory/templates/factory-workflow-compiled-plan.json
@@ -702,6 +702,9 @@
     "duplicate_phase_ids_blocked": true,
     "unknown_next_phase_blocked": true,
     "human_gate_requires_decision_outbox": true,
-    "worker_materialization_requires_dispatch_readiness": true
+    "worker_materialization_requires_dispatch_readiness": true,
+    "lateral_repair_loops_block_downstream": true,
+    "reentry_gate_reconciliation_required": true,
+    "blind_linear_rail_forbidden": true
   }
 }

--- a/factory/tests/test_factory_v2_kernel.py
+++ b/factory/tests/test_factory_v2_kernel.py
@@ -143,6 +143,18 @@ class FactoryV2KernelTests(unittest.TestCase):
         self.assertNotIn("F19", product_phase_ids)
         self.assertIn("human_gate_event", {event["event_id"] for event in graph["gate_events"]})
         self.assertIn("operator_projection", {projection["projection_id"] for projection in graph["projections"]})
+        adaptive = graph["adaptive_transition_policy"]
+        self.assertTrue(adaptive["lateral_repair_loops_required"])
+        edge_pairs = {(edge["from_phase_id"], edge["to_phase_id"]) for edge in adaptive["lateral_edges"]}
+        self.assertIn(("F18", "F15"), edge_pairs)
+
+    def test_phase_graph_rejects_blind_linear_rail_without_repair_edges(self) -> None:
+        graph = json.loads((ROOT / "templates" / "factory-phase-graph.json").read_text(encoding="utf-8"))
+        graph["adaptive_transition_policy"]["lateral_edges"] = []
+
+        errors = kernel.validate_factory_phase_graph(graph)
+
+        self.assertTrue(any("lateral_edges" in error for error in errors), errors)
 
     def test_phase_graph_rejects_legacy_gate_or_projection_as_product_phase(self) -> None:
         graph = json.loads((ROOT / "templates" / "factory-phase-graph.json").read_text(encoding="utf-8"))
@@ -299,6 +311,9 @@ class FactoryV2KernelTests(unittest.TestCase):
         self.assertEqual(plan["phases"][0]["phase_id"], "F0")
         self.assertEqual(plan["phases"][0]["next_phase_id"], "F1")
         self.assertIn("F27", {phase["phase_id"] for phase in plan["phases"]})
+        self.assertTrue(plan["compiler_guards"]["lateral_repair_loops_block_downstream"])
+        self.assertTrue(plan["compiler_guards"]["reentry_gate_reconciliation_required"])
+        self.assertTrue(plan["compiler_guards"]["blind_linear_rail_forbidden"])
 
     def test_v2_study_traceability_uses_bounded_truth_levels(self) -> None:
         packet = json.loads((ROOT / "templates" / "v2-study-traceability.json").read_text(encoding="utf-8"))

--- a/factory/tests/test_factoryctl.py
+++ b/factory/tests/test_factoryctl.py
@@ -4862,6 +4862,58 @@ class FactoryCtlTest(unittest.TestCase):
         self.assertEqual(repair_task["packet"]["input_contract"]["recovery_routes"][0]["repair_owner_worker"], "handoff-packer")
         self.assertTrue(any("requires independent-reviewer PASS" in reason for reason in plan["blocked_reasons"]))
 
+    def test_phase_engine_routes_unresolved_factory_repair_loop_before_downstream(self) -> None:
+        card = load_card("v35_valid_product_face.md")
+        card["phase"] = "F18"
+        card["recovery_routes"] = [
+            {
+                "recovery_route_id": "recovery:blocked-review",
+                "blocker_type": "dependency",
+                "factory_owned_repair_allowed": True,
+                "human_gate_required": False,
+                "repair_owner_worker": "implementation-worker",
+                "fresh_review_required": True,
+                "unblock_authority_ref": "fresh_review_pass",
+                "downstream_freeze_scope": ["F18", "F20", "F21", "F22", "F23", "F24", "F25", "F26", "F27"],
+            }
+        ]
+
+        state = factoryctl.factory_phase_engine_state(card)
+
+        self.assertEqual(state["computed_phase_id"], "F15")
+        self.assertEqual(state["computed_frontier"], "execution")
+        self.assertEqual(state["active_repair_loop"]["recovery_route_id"], "recovery:blocked-review")
+        self.assertIn("F18", state["blocked_downstream_phase_ids"])
+        self.assertTrue(state["phase_mismatch"])
+
+    def test_transition_plan_blocks_downstream_when_repair_loop_is_active(self) -> None:
+        card = load_card("v35_valid_product_face.md")
+        card["phase"] = "F18"
+        card["recovery_routes"] = [
+            {
+                "recovery_route_id": "recovery:blocked-review",
+                "blocker_type": "dependency",
+                "factory_owned_repair_allowed": True,
+                "human_gate_required": False,
+                "repair_owner_worker": "implementation-worker",
+                "fresh_review_required": True,
+                "unblock_authority_ref": "fresh_review_pass",
+                "downstream_freeze_scope": ["F18", "F20", "F21", "F22", "F23", "F24", "F25", "F26", "F27"],
+            }
+        ]
+
+        plan = factoryctl.build_transition_plan(
+            card,
+            ROOT / "examples" / "cards" / "v35_valid_product_face.md",
+            from_status="review",
+            to_status="done",
+            receipt={"kanban_transition_event": {"allowed": True, "from_status": "review", "to_status": "done"}},
+        )
+
+        self.assertEqual(plan["transition_action"], "block_transition")
+        self.assertEqual(plan["phase_engine"]["active_repair_loop"]["recovery_route_id"], "recovery:blocked-review")
+        self.assertTrue(any("active repair loop recovery:blocked-review" in reason for reason in plan["blocked_reasons"]), plan["blocked_reasons"])
+
     def test_hermes_schemas_allow_before_ready_block_action(self) -> None:
         action = "block_and_create_before_ready_tasks"
         transition_plan_schema = json.loads((ROOT / "schemas" / "hermes-transition-plan.schema.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- makes phase graph transitions adaptive instead of a blind linear rail
- adds lateral repair/re-entry edges and gates so downstream phases wait on unresolved repair loops
- validates adaptive transition policy and compiled workflow metadata
- adds tests for V2 kernel/factoryctl behavior

## Why
The factory must route around unresolved factory-owned blockers through repair loops before re-entering downstream phases. Negative closeout or F1..F27 spine advancement must not substitute for repair.

## Validation
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_factory_v2_kernel.py tests/test_factoryctl.py -q
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P15.
