### PR TITLE
docs: rewrite Portuguese guide with product voice

### DIFF
--- a/docs/pt-BR/index.md
+++ b/docs/pt-BR/index.md
@@ -1,44 +1,54 @@
 # Overkill Factory
 
-A Overkill Factory é uma resposta para um problema que aparece rápido quando começamos a usar agentes para trabalho sério.
+Sem a fábrica, você vira fiscal do agente.
 
-Você pede uma coisa importante. O agente entende uma parte, completa outra parte com palpite, faz bastante barulho, talvez abra arquivos, talvez passe testes, talvez diga que terminou. Só que, no fim, você ainda precisa perguntar: "isso entregou mesmo o produto que eu pedi?".
+Você pede uma coisa importante. O agente responde rápido, abre arquivo, move card, talvez passe teste, talvez diga que terminou. Só que ainda sobra a pergunta: entregou mesmo o que eu pedi ou só produziu movimento?
 
-A fábrica existe para tirar essa pergunta do improviso.
+A Overkill Factory existe para tirar essa pergunta do improviso.
 
-Ela pega um pedido e transforma em produção controlada: fonte preservada, verdade do produto, caminho escolhido, trabalho dividido, execução no Hermes, prova, revisão, decisão humana quando precisa e fechamento honesto.
+Você faz um pedido. A fábrica guarda o contexto original, entende o que é fato e o que é palpite, divide o trabalho em partes pequenas, manda os agentes trabalharem no Hermes e só chama de pronto quando existe prova.
 
-O objetivo é tornar a velocidade confiável. Não é fazer agente correr mais. É fazer cada avanço deixar rastro suficiente para alguém confiar, revisar ou bloquear.
+O objetivo é tornar a velocidade confiável. Em português direto: andar rápido sem obrigar você a conferir tudo na mão.
 
-## O que ler primeiro
+## A ideia em uma frase
 
-Se você está chegando agora, não comece pelo modelo técnico. Comece pela pergunta que você tem na cabeça.
+A Overkill Factory é uma camada de produção para trabalho com agentes: ela transforma pedidos vagos em trabalho pequeno, rastreável e provado.
 
-- [Manual](manual.md): "o que é essa fábrica e por que ela existe?"
-- [Como a fábrica trabalha](operating-model.md): "o que acontece depois que eu mando um pedido?"
-- [Confiança e prova](trust-and-evidence.md): "como eu sei que isso não é só teatro de agente?"
-- [Ciclo simples](lifecycle.md): "qual é o caminho do começo ao fim?"
+O agente pode executar. Ele não pode inventar escopo, esconder risco, aprovar a si mesmo ou dizer "pronto" sem evidência.
 
-Depois, se você for operar ou manter o repo:
+## Um exemplo em 30 segundos
 
-- [Uso](usage.md): comandos para provar o checkout local.
-- [Modelo técnico](technical-model.md): como Hermes, workers, schemas, adapters e validadores se encaixam.
-- [Referência](reference.md): nomes e caminhos para consulta rápida.
+Você escreve:
 
-## A versão curta
+> Quero lançar o onboarding novo amanhã.
 
-A fábrica não confia em frase bonita. Ela confia em fonte, escopo, método, trabalho pequeno e prova.
+A fábrica não deveria responder "ok, fazendo".
 
-Um pedido não deveria virar código antes de virar entendimento. Um release não deveria sair porque alguém escreveu "pass". Um gate humano não deveria ser uma pergunta vaga no chat. Um worker não deveria julgar o próprio trabalho. E um bloqueio interno da fábrica não deveria cair no colo do operador como se fosse decisão humana.
+Ela primeiro segura o pedido e devolve algo mais útil:
 
-Se a fábrica funciona, o operador não fica caçando evidência. Ele recebe estado claro, decisão clara e recibo claro.
+> Entendi que você quer lançar o onboarding novo. Antes de executar, preciso confirmar o usuário do fluxo, o que conta como sucesso e se isso toca pagamento, carteira, dados sensíveis ou produção. Enquanto isso, já preservei a fonte, localizei o repo e vou preparar a definição do produto.
+
+Essa é a diferença. A fábrica não tira a decisão do humano. Ela impede que um agente gaste horas construindo a coisa errada.
+
+## Por onde ler
+
+Se você quer entender o produto, leia assim:
+
+1. [Manual](manual.md): por que a fábrica existe e o que ela tira das suas costas.
+2. [Como a fábrica trabalha](operating-model.md): o que acontece depois que você manda um pedido.
+3. [Confiança e prova](trust-and-evidence.md): como separar entrega real de teatro de progresso.
+4. [Ciclo simples](lifecycle.md): o mapa curto do começo ao fim.
+
+Se você vai operar ou manter o repo:
+
+- [Uso](usage.md): comandos locais e o que eles provam.
+- [Modelo técnico](technical-model.md): como Hermes, Factory, scripts, schemas e workers se encaixam.
+- [Referência](reference.md): nomes e caminhos quando você já sabe o que procurar.
 
 ## O que esta documentação prova
 
-O kernel público atual está na versão `3.0.2`. Ele tem workflow compilado, rotas, métodos, schemas, workers, exemplos, validadores e testes.
+Ela prova o contrato público do repositório: workflow compilado, rotas, métodos, schemas, workers, exemplos, validadores e testes.
 
-Isso prova uma coisa específica: o repositório público tem um contrato verificável.
+Ela não prova que um produto privado foi entregue. Não prova que um Hermes vivo rodou um card real. Não prova aprovação humana em produção. Para isso, precisa de estado atual no Hermes, resultado de worker, evidência do produto, revisão consumida e autorização explícita quando houver risco.
 
-Não prova que uma execução privada terminou. Não prova que um produto vivo foi entregue. Não prova aprovação humana em produção. Para isso, precisa de estado real no Hermes, resultados atuais de workers, evidência do produto, revisão consumida e autorização explícita quando houver risco.
-
-Essa fronteira é parte do produto. A fábrica só vale se souber dizer o que sabe e o que ainda não sabe.
+Essa fronteira não é fraqueza. É o que impede a fábrica de virar mais um agente falando bonito.

--- a/docs/pt-BR/lifecycle.md
+++ b/docs/pt-BR/lifecycle.md
@@ -1,146 +1,102 @@
 # Ciclo simples
 
-O workflow compilado é a fonte factual para a máquina. Ele tem fases, gates, workers e artefatos.
+A máquina tem um workflow detalhado. Você não precisa começar por ele.
 
-Mas a pessoa que está tentando entender a fábrica não deveria começar decorando fase.
-
-O ciclo humano é este:
+O workflow compilado é a fonte factual para a máquina. Para entender o produto, o mapa humano é mais simples:
 
 ```text
-pedido
--> fonte protegida
--> entendimento
--> verdade do produto
--> caminho escolhido
--> trabalho pequeno
--> execução no Hermes
--> prova
--> revisão
--> decisão humana, se houver
--> entrega, bloqueio ou aprendizado
+pedido -> fonte -> entendimento -> verdade do produto -> caminho -> trabalho pequeno -> Hermes -> prova -> revisão -> decisão humana -> entrega, bloqueio ou aprendizado
 ```
 
-## 1. Pedido
+## Pedido
 
-Tudo começa com um sinal.
+Tudo começa com um sinal: frase, bug, repo, documento, incidente, tela, release ou decisão.
 
-Pode ser uma frase, um bug, um repo, um documento, uma conversa, uma tela, um incidente, um pedido de release.
+Nesse momento a fábrica ainda não sabe o suficiente. Executar direto seria chute.
 
-A fábrica ainda não sabe se isso é produto, correção, operação, risco, pesquisa ou decisão. Então ela não deveria sair executando.
+## Fonte
 
-## 2. Fonte protegida
+A fonte é preservada antes do resumo.
 
-Antes de interpretar, a fábrica preserva a fonte.
+Isso protege o pedido original contra uma primeira interpretação ruim. Se a fonte longa vira resumo curto cedo demais, a fábrica pode construir em cima de um erro.
 
-Isso impede que a primeira versão resumida vire verdade oficial.
+O nome interno que aparece no workflow é `F0 — Pre-Start / Sealed Source Envelope`. Esses nomes existem para a máquina e para os testes, não para vender o produto. Leia como: selar a fonte antes de mexer nela.
 
-Se o operador mandou contexto longo, a fábrica não pode amputar o contexto e depois construir sobre o pedaço que sobrou.
-
-## 3. Entendimento
+## Entendimento
 
 A fábrica separa fato, inferência, decisão, conflito e lacuna.
 
-Aqui ela deve conseguir dizer em português claro: "sabemos isso, achamos aquilo, falta isto, este ponto conflita".
+A saída humana deveria ser clara: isto sabemos, isto parece provável, isto foi decidido, isto conflita, isto falta.
 
-Se essa leitura está fraca, o resto ainda não deveria andar.
+Se esse entendimento está fraco, avançar é aposta.
 
-## 4. Verdade do produto
+## Verdade do produto
 
-Agora o pedido vira definição.
+Agora a fábrica define o que será construído.
 
-Qual é o produto? Para quem? Que problema resolve? O que entra? O que fica fora? Que risco importa? Que prova conta?
+Qual produto? Para quem? Com que escopo? Fora de que escopo? Com que risco? Que prova encerra a discussão?
 
-A fábrica chama isso de Product SOT, mas a ideia é só esta: ninguém deveria construir antes de saber o que está construindo.
+O nome interno é Product SOT. A tradução útil é: verdade do produto.
 
-## 5. Caminho escolhido
+## Caminho
 
-A fábrica escolhe rota e método.
+Com a verdade do produto na mesa, a fábrica escolhe rota e método.
 
-Bug, release, incidente, segurança, interface, integração, docs, agente, Solana e produto novo não andam do mesmo jeito.
+Bug, release, incidente, segurança, interface, documentação, agente, integração e Solana não pedem a mesma prova.
 
 A rota escolhe a régua. O método escolhe como provar.
 
-## 6. Capacidade e autoridade
+## Trabalho pequeno
 
-Antes de mandar worker, a fábrica pergunta se tem capacidade e autoridade.
+O produto vira unidades executáveis.
 
-Tem worker certo? Tem acesso? Tem pack para essa superfície? Toca segredo? Toca produção? Toca mainnet? Toca fundos? Precisa de humano?
+Cada unidade precisa de entrada, saída, dono, dependência, prova, reviewer e regra de pronto.
 
-Se falta capacidade, bloqueia. Se precisa de decisão humana, prepara pacote. Se é problema interno, repara.
+Sem isso, o agente recebe uma intenção, não uma tarefa.
 
-## 7. Trabalho pequeno
+## Hermes
 
-O produto vira unidades menores.
+Hermes é o chão vivo da execução.
 
-Cada unidade precisa ter entrada, saída, dono, dependência, evidência, reviewer e regra de pronto.
+Cards, dependências, workers, comentários, anexos, bloqueios e transições precisam aparecer ali. A Factory não deve manter um estado paralelo escondido.
 
-Sem isso, não é trabalho. É desejo.
+## Prova
 
-## 8. Execução no Hermes
+Cada worker devolve evidência adequada ao tipo de trabalho.
 
-Hermes é onde o trabalho vivo aparece.
-
-Cards, dependências, workers, comentários, workspaces, anexos, bloqueios e transições precisam estar no runtime. A fábrica não deveria manter uma verdade paralela escondida.
-
-Se algo depende de outra coisa, a dependência precisa estar no grafo.
-
-## 9. Prova
-
-Cada worker devolve evidência.
-
-Para código, pode ser teste, diff, build, scan.
-
-Para interface, tela, jornada, estado, console, viewport.
-
-Para CLI, transcript, instalação, help, erro.
-
-Para release, prontidão, rollback, dono.
-
-Para docs, clareza, navegação, primeiro sucesso.
+Código pede teste, diff, build ou scan. Interface pede superfície. CLI pede transcript. Release pede prontidão e rollback. Docs pedem clareza e caminho de uso.
 
 A prova precisa bater com o pedido.
 
-## 10. Revisão
+## Revisão
 
 A revisão olha o artefato real.
 
-Ela passa, falha, pede reparo ou registra risco. Depois a fábrica precisa consumir esse resultado.
+Se passa, destrava. Se falha, cria reparo. Se encontra risco, registra dono e decisão. Se não muda nada, não foi consumida.
 
-Revisão que não muda nada é só comentário.
+## Decisão humana
 
-## 11. Decisão humana
+Algumas decisões pertencem ao operador: produção, mainnet, fundos, segredos, orçamento, release, waiver, risco residual.
 
-Algumas decisões pertencem ao operador.
+Nesses casos, a fábrica prepara pacote de decisão. O humano não aprova no escuro.
 
-Produção, mainnet, fundos, segredos, orçamento, risco residual, release, waiver.
+## Fechamento
 
-Nesses casos, a fábrica prepara um pacote de decisão. O humano aprova ou bloqueia sabendo exatamente o que está autorizando.
-
-## 12. Fechamento
-
-No fim, a fábrica não escolhe uma palavra bonita. Ela escolhe um estado honesto.
+No fim, a fábrica escolhe um estado honesto.
 
 Entregue, se há prova suficiente.
 
 Bloqueado, se falta algo material.
 
-Aprendizado, se a execução mostrou que a fábrica precisa mudar.
+Aprendizado, se a execução revelou que a própria fábrica precisa mudar.
 
-Esse é o ciclo. O resto são mecanismos para garantir que ele não vire teatro.
+Esse ciclo é simples de ler e difícil de cumprir. O valor da Factory está em cumprir mesmo quando seria mais fácil dizer "pronto".
 
-## Nomes internos que você pode encontrar
+## Para maintainers
 
-Se você abrir o workflow compilado, vai ver nomes como `F0 — Pre-Start / Sealed Source Envelope`. Não precisa gostar do nome nem ler isso como copy de produto. Esse nome existe para a máquina e para os testes: ele marca o momento em que a fábrica sela a fonte antes de qualquer interpretação.
-
-A regra de leitura é esta: quando aparecer um nome interno em inglês, traduza mentalmente para a proteção que ele oferece. `Sealed Source Envelope` quer dizer "não destrua a fonte original". `Product SOT` quer dizer "defina a verdade do produto". `Receipt Five` quer dizer "não chame de pronto sem recibo".
-
-## Como ver o workflow interno
-
-Para inspecionar a versão compilada usada pelos testes:
+O workflow compilado continua existindo para validação, testes e manutenção. Para inspecionar:
 
 ```bash
 cd factory
 python3 scripts/factoryctl.py compile-workflow --out .tmp/factory-workflow-compiled-plan.json
 ```
-
-Esse comando ajuda maintainers. Para entender o produto, o ciclo acima é o mapa certo.

--- a/docs/pt-BR/manual.md
+++ b/docs/pt-BR/manual.md
@@ -1,155 +1,168 @@
 # Manual
 
-A Overkill Factory é mais fácil de entender se você esquecer, por um minuto, os nomes internos.
+A Overkill Factory é uma camada de produção para trabalho com agentes.
 
-Pense numa conversa normal.
+Ela transforma pedidos vagos em trabalho pequeno, rastreável e provado.
 
-Você diz: "quero criar esse produto". Ou: "esse release pode ir?". Ou: "corrige esse bug sem quebrar o resto". Ou: "tem algo errado nesse board, os agentes parecem ocupados, mas nada anda".
-
-Um agente comum tenta responder fazendo. Ele pode ser útil, mas trabalha com um risco enorme: ele quer avançar antes de ter certeza do que está avançando.
-
-A fábrica existe para colocar um processo entre o pedido e a execução.
-
-Não processo no sentido ruim, de burocracia. Processo no sentido de chão firme. Antes de alguém mexer no produto, a fábrica precisa saber o que foi pedido, o que é fato, o que é suposição, qual é o produto, que tipo de trabalho é, quem tem autoridade, que prova vai contar e o que acontece se a prova não aparecer.
+A ideia é simples: o agente pode executar, mas não pode inventar escopo, esconder risco, aprovar o próprio trabalho ou dizer "pronto" sem prova.
 
 Isso é produção controlada.
 
-## Por que isso importa
+## Para quem isso existe
 
-O erro mais perigoso de um agente não é falhar claramente.
+Existe para quem usa agentes em produto, código, release, revisão, operação, incidente ou documentação e cansou de virar fiscal do processo.
 
-Falha clara é fácil. O comando quebrou. O arquivo não existe. A API recusou. O teste falhou.
+Você não quer ficar perguntando toda hora:
 
-O erro perigoso é a entrega que parece certa.
+- ele entendeu o pedido?
+- isso era fato ou palpite?
+- quem revisou?
+- que teste prova o comportamento certo?
+- esse risco foi aceito por alguém?
+- esse bloqueio é meu ou é trabalho da fábrica?
 
-O agente cria um documento, mas o documento não responde à pergunta. Cria uma tela, mas não cobre os estados importantes. Escreve um teste, mas testa o caminho feliz e ignora o risco. Faz uma revisão, mas não relê o artefato. Diz que precisa do humano, mas na verdade faltou readback, faltou anexar prova, faltou rodar um worker.
+Se você precisa fazer essas perguntas manualmente, o agente pode até ajudar, mas a operação ainda depende demais de você.
 
-Aí o operador vira fiscal de tudo.
+A fábrica existe para mudar isso.
 
-Ele precisa perguntar onde está a prova. Precisa notar que o card andou sem dependência. Precisa perceber que o reviewer só carimbou. Precisa descobrir que o bloqueio era interno. Precisa virar gerente, QA, auditor e detetive.
+## O problema real
 
-A fábrica foi desenhada para impedir isso.
+Agente falhando claramente é fácil de lidar. O comando quebra. O teste falha. O arquivo não existe.
 
-## O que a fábrica promete
+O problema é o agente que erra com aparência de progresso.
 
-A promessa não é "agentes nunca erram".
+Ele entrega um plano bonito baseado num resumo ruim. Cria uma tela que não cobre erro, vazio, permissão ou mobile. Passa um teste que não prova o risco. Marca revisão como feita, mas ninguém consumiu o resultado. Pede aprovação humana com uma pergunta vaga: "posso seguir?".
 
-A promessa é melhor: quando a fábrica está funcionando, erro vira estado visível. Lacuna vira lacuna. Risco vira risco. Bloqueio vira bloqueio com dono. Pronto vira pronto com prova.
+Aí você vira gerente, QA, auditor e detetive.
 
-O operador não precisa acreditar no tom do agente. Ele olha o recibo.
+A Overkill Factory tenta impedir esse tipo de progresso falso.
 
-## O caminho de um pedido
+## O que ela faz antes de executar
 
-Um pedido entra quase sempre meio torto. Isso é normal. Produto real começa assim mesmo.
+Antes de deixar um agente sair fazendo, a fábrica precisa responder algumas perguntas.
 
-"Cria o onboarding".
+O que chegou como fonte original?
 
-Certo. Mas onboarding de quem? Com que conta? Com carteira? Com permissão? Com KYC? Com trial? Com pagamento? Com convite? Com dados sensíveis? O sucesso é chegar numa tela? É fazer a primeira ação? É depositar dinheiro? É assinar uma transação? É convidar alguém?
+O que é fato?
 
-A fábrica não deveria pular essas perguntas. Também não deveria jogar tudo de volta para o operador se ela consegue resolver com a fonte que já existe.
+O que é palpite?
 
-O primeiro trabalho é preservar a fonte e separar o que é sabido do que é palpite.
+Qual produto ou mudança está sendo pedido?
 
-Depois vem a verdade do produto. Internamente isso aparece como Product SOT. Em português simples: é o acordo sobre o que está sendo construído.
+Que tipo de trabalho é esse: bug, release, incidente, tela, segurança, integração, documentação, produto novo?
 
-Só depois faz sentido escolher método, criar tarefas e mandar workers.
+Quem pode executar?
 
-## O que é verdade do produto
+Quem pode aprovar?
 
-Verdade do produto não é um resumo bonito.
+Que prova vai contar?
 
-É o lugar onde a fábrica registra:
+Se essas respostas não existem, executar é aposta.
 
-- qual é o pedido;
-- quem é o usuário ou operador afetado;
-- que problema precisa ser resolvido;
-- o que entra no escopo;
-- o que fica fora;
-- que riscos importam;
-- que decisões já foram tomadas;
-- que decisões ainda dependem do humano;
-- que prova vai contar como aceite.
+## Um exemplo: onboarding novo
 
-Sem isso, qualquer plano parece razoável. Com isso, o plano pode ser cobrado.
+Você escreve:
 
-A fábrica também precisa cuidar de uma armadilha comum: transformar a primeira fatia executável no produto inteiro. Se o produto é maior, cada parte importante precisa ter destino. Pode estar planejada, bloqueada, fora de escopo, delegada ao humano ou provada. Não pode simplesmente sumir.
+> Cria o onboarding do cliente.
 
-## Método não é enfeite
+Um agente solto pode começar pela tela. Parece produtivo, mas pode estar errado desde o primeiro minuto.
 
-Trabalhos diferentes precisam de caminhos diferentes.
+A fábrica segura o pedido.
 
-Bug pede reprodução e regressão.
+Ela procura a fonte. Separa o que veio de você do que seria palpite. Pergunta ou descobre quem é "cliente" nesse contexto. Verifica se onboarding significa criar conta, conectar carteira, passar por KYC, assinar transação, fazer primeiro depósito ou só chegar a uma tela inicial.
 
-Release pede prontidão, rollback, dono e monitoramento.
+Ela também olha risco: toca pagamento? toca dados sensíveis? toca produção? toca mainnet? existe Figma? existe backend? existe design system? o que conta como sucesso?
 
-Interface pede jornada, estados, tela, erro, carregamento, acessibilidade básica e prova visual.
+Depois disso, o trabalho pode virar unidades menores:
 
-Segurança pede fronteira, ameaça, segredo, permissão, supply chain, revisão e decisão sobre risco residual.
+- definir a verdade do fluxo;
+- implementar a tela;
+- implementar API, se houver;
+- testar a jornada;
+- revisar risco e escopo;
+- anexar prova visual;
+- fechar com recibo.
 
-Incidente pede contenção, causa, comunicação e aprendizado.
+O operador não deveria coordenar tudo isso na mão.
 
-Produto novo pede verdade do produto, decomposição, workers, revisão e aceite.
+## O que você recebe
 
-Se a fábrica trata tudo igual, ela é só uma fila de tarefas com nome bonito.
+Quando a fábrica funciona, você recebe coisas que ajudam a decidir.
 
-## O papel do Hermes
+Uma leitura do pedido: o que foi entendido, o que falta e o que não será assumido.
 
-Hermes é o chão da fábrica.
+Uma definição do produto: o que será entregue, para quem, com quais limites e que prova vai contar. Internamente isso pode aparecer como Product SOT, mas o ponto é simples: é a verdade do produto.
 
-É onde ficam os cards, dependências, status, workers, comentários, workspaces, anexos, bloqueios e transições.
+Um plano pequeno: tarefas com dono, dependência, evidência e reviewer.
 
-A Overkill Factory não deveria criar outro estado escondido. Ela define o contrato do trabalho: que artefatos precisam existir, que gates bloqueiam, que worker entra, que prova volta, que decisão é humana e que atalhos são proibidos.
+Status no Hermes: cards, bloqueios, workspaces, anexos e transições visíveis.
 
-Hermes mostra o trabalho vivo. A fábrica diz o que esse trabalho precisa respeitar.
+Pedidos humanos bons: quando a decisão é sua, você recebe contexto, opções e consequência.
 
-## O que é um worker bom
+Um recibo final: o que foi pedido, o que foi feito, que prova existe, quem revisou e o que ainda falta.
 
-Um worker bom não recebe "faz o produto".
+## Quando a fábrica chama o humano
 
-Recebe um pacote pequeno.
+A fábrica chama o humano quando a autoridade é humana.
 
-O pacote diz: faça isto, usando esta fonte, dentro deste limite, sem essa autoridade, devolvendo esta evidência. Se faltar algo, bloqueie deste jeito.
+Produção. Mainnet. Fundos. Segredos. Orçamento. Release. Risco residual. Waiver. Mudança de poder.
 
-Isso parece simples, mas muda a qualidade da autonomia. O worker pode andar rápido porque a faixa está marcada. E a revisão consegue olhar uma entrega pequena em vez de tentar julgar uma missão nebulosa.
+Ela não deveria chamar você porque esqueceu readback, não anexou prova, deixou review parado ou recebeu entrega rasa de worker. Isso é trabalho dela.
 
-## Onde o humano entra
+Pedido ruim de aprovação:
 
-O humano não deveria ser chamado para limpar bagunça da fábrica.
+> Posso seguir para produção?
 
-Se falta arquivo, readback, evidência, revisão, PDF, link, hash, screenshot, worker result ou reparo interno, a fábrica trabalha.
+Pedido bom:
 
-O humano entra quando a autoridade é dele: produção, mainnet, fundos, segredos, orçamento, release, risco material, waiver, mudança de poder.
+> Você está aprovando o release do onboarding v2 para produção. Inclui cadastro, validação de email e tela de erro. Não inclui pagamento, KYC ou convite por equipe. Provas: testes X, screenshots Y, revisão Z. Risco restante: analytics ainda sem evento de abandono. Se aprovar, faço deploy. Se recusar, mantenho em staging e abro reparo.
 
-E quando entra, a fábrica precisa respeitar o tempo dele. Nada de "aprova?" sem contexto. Nada de JSON cru. Nada de caminho local como se fosse decisão.
-
-Um gate humano bom entrega uma decisão clara:
-
-"Você está aprovando este artefato, com estes riscos, para permitir este próximo passo. Você não está aprovando aquilo. Se recusar, o caminho seguro é este".
+Essa diferença é produto.
 
 ## O que significa pronto
 
-Pronto quer dizer provado.
+Pronto não é "o agente disse que terminou".
 
-Não quer dizer que o agente ficou confiante. Não quer dizer que um arquivo apareceu. Não quer dizer que um teste qualquer passou. Não quer dizer que alguém falou "ok" no chat.
+Pronto é: pedido entendido, trabalho feito, prova anexada, revisão consumida e próximo estado claro.
 
-A fábrica precisa conseguir contar a história:
+O recibo interno disso é o Receipt Five.
 
-"O pedido era este. A fonte usada foi esta. O produto definido foi este. O método escolhido foi este. Estes workers rodaram. Estas provas voltaram. Esta revisão foi consumida. Este gate humano autorizou isto. O que ainda falta é aquilo".
+Ele precisa responder:
 
-Se essa história não existe, a entrega não está pronta. Ela pode estar em revisão, bloqueada, incompleta ou aguardando decisão. Mas pronta, não.
+1. o que foi pedido;
+2. o que foi feito ou decidido;
+3. que prova sustenta isso;
+4. quem revisou e o que disse;
+5. o que ainda falta, bloqueia ou fica como risco.
 
-## O que falta quando a fábrica parece ruim
+Se isso não existe, a entrega pode estar em revisão, bloqueada, parcial ou aguardando decisão. Mas pronta, não.
 
-Quando a documentação, o board ou a execução parecem ruins, normalmente é porque uma dessas coisas sumiu:
+## Onde entra o Hermes
 
-- a dor do operador;
-- a verdade do produto;
-- o motivo de cada fase;
-- a fronteira entre Hermes e fábrica;
-- a diferença entre prova local e entrega viva;
-- a explicação de por que um humano está sendo chamado;
-- a ligação entre worker, evidência, revisão e recibo.
+Hermes é onde o trabalho vivo aparece.
 
-A fábrica não pode virar uma coleção de termos internos. Se o leitor precisa decorar nomes para entender o produto, a documentação falhou.
+Cards, status, dependências, comentários, workspaces, anexos, bloqueios e transições ficam ali.
 
-A versão boa precisa parecer uma conversa séria: simples na superfície, precisa por baixo, honesta sobre o que existe e o que ainda precisa ser provado.
+A Overkill Factory é o contrato de produção em volta desse trabalho: o que precisa existir antes de avançar, quem pode executar, que prova precisa voltar, quem revisa e que decisão exige humano.
+
+Hermes mostra o chão da fábrica. A Factory define as regras para esse chão não virar bagunça.
+
+## O que ela não promete
+
+Ela não promete que agentes nunca erram.
+
+Ela não substitui decisão humana.
+
+Ela não transforma teste local em prova de produto vivo.
+
+Ela não deveria fingir que um pedido vago virou produto completo se ainda faltam fonte, autoridade, capacidade ou evidência.
+
+A promessa é outra: tornar erro, lacuna, risco e bloqueio visíveis cedo o bastante para você não descobrir tarde demais.
+
+## Próximo passo
+
+Se você quer ver o pedido andando por dentro, leia [Como a fábrica trabalha](operating-model.md).
+
+Se quer entender como ela separa entrega real de teatro de progresso, leia [Confiança e prova](trust-and-evidence.md).
+
+Se quer provar o checkout local, vá para [Uso](usage.md).

--- a/docs/pt-BR/operating-model.md
+++ b/docs/pt-BR/operating-model.md
@@ -1,163 +1,165 @@
 # Como a fábrica trabalha
 
-Vamos acompanhar um pedido como ele deveria andar.
+Veja o que acontece quando você manda um pedido.
 
-O operador manda: "quero transformar essa ideia em produto".
+O exemplo aqui é simples:
 
-A resposta errada é abrir uma tarefa gigante e deixar um agente tentar resolver. A resposta certa é a fábrica tratar o pedido como matéria-prima. Matéria-prima ainda não é produto.
+> Quero lançar o onboarding novo amanhã.
 
-## A entrada é só a porta
+A resposta errada é abrir uma tarefa gigante e deixar um agente tentar resolver. Um pedido ainda não é plano. Primeiro a fábrica entende o que você realmente quer construir.
 
-O pedido pode chegar por Telegram, Discord, cockpit, CLI ou outro canal. O canal não manda na fábrica. Ele só recebe o sinal.
+## O que entra
 
-A primeira responsabilidade é guardar a fonte. A mensagem original, o documento, o repo, o link, a conversa, a imagem, o bug, a decisão. Tudo isso precisa existir antes da interpretação.
+O pedido pode chegar por Telegram, Discord, cockpit, terminal, documento, repo, screenshot ou conversa antiga.
 
-Se a fábrica resume cedo demais, perde nuance. Se perde nuance, planeja errado. Se planeja errado, entrega algo convincente e inútil.
+A entrada é só a porta. Ela não decide o produto. Ela não aprova risco. Ela não substitui o Hermes.
 
-Por isso o começo é cuidadoso.
+A primeira obrigação é guardar a fonte: mensagem original, anexos, links, repo, documentos e contexto.
 
-## A fábrica separa o que sabe do que acha
+Se a fábrica resume cedo demais, pode cortar justamente a frase que explicaria uma decisão depois.
 
-Depois de guardar a fonte, a fábrica separa cinco coisas.
+## O que a fábrica responde primeiro
 
-Fato: veio da fonte.
+Uma boa primeira resposta não é "fazendo".
 
-Inferência: parece razoável, mas não foi dito literalmente.
+É algo como:
 
-Decisão: alguém com autoridade já decidiu.
+> Entendi que você quer lançar o onboarding novo. Antes de executar, preciso confirmar o usuário do fluxo, o que conta como sucesso e se isso toca pagamento, carteira, dados sensíveis ou produção. Já preservei a fonte e vou preparar a definição do produto.
 
-Conflito: duas fontes dizem coisas diferentes.
+Essa resposta já mostra três coisas: ela entendeu, não vai assumir no escuro e já sabe o próximo passo seguro.
 
-Lacuna: falta informação para seguir com segurança.
+## Separar fato de palpite
 
-Essa etapa parece pequena. Não é. Ela impede que um palpite vire requisito e que uma lacuna vire trabalho escondido.
+Depois ela separa o que veio da fonte do que seria palpite.
 
-O operador deveria receber uma leitura simples: "entendi isso, falta aquilo, isso aqui não vou assumir".
+Fato: você pediu onboarding novo.
 
-## A fábrica define o produto antes de planejar
+Inferência: talvez seja para usuário final, mas isso precisa de fonte.
 
-O próximo passo é criar a verdade do produto.
+Decisão: se você já aprovou Figma ou escopo em outro documento, isso entra como decisão.
 
-Não é um texto bonito para justificar a execução. É o contrato do que será construído.
+Conflito: se um doc fala em KYC e outro diz sem KYC, isso não pode ser escondido.
 
-Ele responde: qual é o produto, para quem, com que promessa, dentro de que limite, com que risco e com que prova de aceite.
+Lacuna: se ninguém sabe o que conta como sucesso, isso precisa ser resolvido.
 
-Se o pedido é pequeno, essa verdade pode ser curta. Se o pedido é grande, precisa cobrir o escopo inteiro. O importante é não deixar o worker decidir o produto no meio da execução.
+Sem essa separação, o agente pode trabalhar muito em cima de uma suposição.
 
-Quando o produto não está definido, qualquer entrega pode parecer certa.
+## Definir o produto
 
-## A rota escolhe a régua
+Agora a fábrica define o que será entregue.
 
-Com o produto definido, a fábrica escolhe a rota.
+Para o onboarding, ela precisa dizer: quem passa pelo fluxo, onde começa, onde termina, quais telas ou comandos existem, quais estados precisam aparecer, quais riscos importam e que prova fecha o trabalho.
 
-Rota é a resposta para: que tipo de trabalho é esse?
+Essa definição é a verdade do produto. Internamente pode aparecer como Product SOT.
 
-Bug, produto novo, release, incidente, segurança, UX, documentação, integração, migração, agente, Solana, operação viva. Cada um pede uma régua diferente.
+O nome importa menos que a função: impedir que cada worker invente uma versão diferente do produto.
 
-Se é bug, a fábrica precisa de reprodução e regressão.
+## Escolher a régua
 
-Se é release, precisa de prontidão, rollback e dono.
+Depois vem a rota.
 
-Se é interface, precisa de prova da experiência.
+Se o pedido é bug, a régua é reprodução e regressão.
 
-Se é segurança, precisa de fronteira, ameaça e revisão.
+Se é release, é prontidão, rollback, dono e monitoramento.
 
-Se é mainnet ou fundos, precisa de autoridade humana explícita.
+Se é interface, é jornada, estados e prova visual.
 
-A rota impede que tudo vire "manda um agente fazer".
+Se é segurança, é fronteira, ameaça, permissão, segredo e revisão.
 
-## O método diz como provar
+Se toca Solana, carteira, assinatura, fundos ou mainnet, o cuidado sobe.
 
-Depois da rota vem o método.
+A rota diz que tipo de trabalho é. O método diz como provar.
 
-Método bom não é slogan. Ele muda a prova.
+## Checar capacidade e autoridade
 
-Se o método é test-first, precisa ter teste que falha antes ou prova equivalente de regressão.
+Antes de mandar worker, a fábrica confere se tem capacidade e autoridade.
 
-Se é design-first, precisa de estados, jornada, superfície e evidência visual.
+Tem worker certo? Tem acesso? Tem pack para essa superfície? Precisa de especialista? Toca produção? Toca dinheiro? Precisa de decisão humana?
 
-Se é security-first, precisa de fronteira, scan, revisão e decisão sobre risco.
+Se falta capacidade, bloqueia.
 
-Se é incident-first, precisa de contenção, causa e aprendizado.
+Se falta decisão humana, prepara pacote.
 
-Se o método não muda artefato, gate ou evidência, ele não está fazendo nada.
+Se falta só reparo interno, como readback, anexo, revisão ou evidência, a fábrica trabalha. Não joga isso no operador.
 
-## A fábrica checa se tem capacidade
+## Quebrar em trabalho pequeno
 
-Nem todo tipo de produto está igualmente coberto.
+A fábrica então transforma o produto em unidades pequenas.
 
-Web, CLI, cloud, agentes, docs, onboarding e alguns caminhos Solana têm cobertura mais madura no kernel público. Outras áreas podem exigir pacote de capacidade antes: mobile nativo, desktop, game, fintech regulado, hardware, analytics avançado, extensão de navegador.
+Uma unidade boa tem entrada, saída, dono, dependência, prova, reviewer e regra de pronto.
 
-Isso não é fraqueza. É honestidade operacional.
+Uma unidade ruim diz: "construa o onboarding".
 
-Uma fábrica confiável não finge que sabe fazer tudo. Ela diz quando tem cobertura e quando precisa instalar, testar ou revisar um pack antes de execução material.
+Para o exemplo, as unidades poderiam ser:
 
-## O trabalho vira pacote pequeno
+- confirmar escopo e sucesso do onboarding;
+- implementar tela inicial e estados;
+- ligar API necessária;
+- testar jornada feliz e erro;
+- revisar risco;
+- anexar evidência visual;
+- preparar release ou bloqueio.
 
-Agora a fábrica quebra o produto em unidades de trabalho.
+Cada worker recebe só a parte dele e devolve prova.
 
-Uma unidade boa tem entrada, saída, dono, dependência, evidência, reviewer e regra de pronto.
-
-Uma unidade ruim diz "construir o produto".
-
-A diferença é enorme. Trabalho pequeno pode ser executado, cobrado e refeito. Trabalho gigante vira aposta.
-
-O worker recebe só a parte dele. Ele não ganha autoridade para mudar escopo, aprovar risco, tocar segredo, decidir release ou encerrar o card inteiro.
-
-## Hermes Kanban continua sendo a fonte de verdade
+## Onde o trabalho aparece
 
 Hermes Kanban continua sendo a fonte de verdade do runtime.
 
-Cards, dependências, status, workers, comentários, workspaces, anexos, bloqueios e transições precisam aparecer ali.
+O quadro do Hermes é onde o trabalho vivo aparece: cards, dependências, status, workers, workspaces, comentários, anexos, bloqueios e transições.
 
-A fábrica não pode manter um segundo estado escondido e depois tentar sincronizar no fim. Se uma unidade depende de outra, a dependência precisa estar no grafo. Se trabalho obrigatório aparece tarde, entra no grafo antes de a fase seguinte andar.
+A Factory não mantém um quadro secreto por fora. Ela cobra o contrato, mas a execução precisa estar visível no Hermes.
 
-Isso evita uma mentira comum: dizer que a fase terminou enquanto ainda existe trabalho obrigatório fora do quadro.
+## Quando o quadro parece parado
 
-## No-idle observa silêncio perigoso
+Quando o quadro parece parado, a fábrica precisa descobrir se é espera legítima ou travamento.
 
-No-idle não é outro Hermes.
+Se há dependência real, espera.
 
-Ele serve para perceber quando o board está parado de um jeito suspeito. Se há trabalho pronto, despacha. Se há dependência, espera. Se falta pacote de decisão humana, prepara. Se falta readback, artefato ou revisão, repara. Se não consegue reparar, falha de forma visível.
+Se há trabalho pronto, despacha.
 
-O que ele não pode fazer é inventar autoridade. Não aprova gate, não completa tarefa, não chama o humano por preguiça interna.
+Se falta decisão humana e o pacote está pronto, chama o operador.
 
-## Produto visível precisa ser visto
+Se falta readback, artefato, revisão ou evidência, repara.
 
-Quando o trabalho tem interface, a fábrica precisa provar a experiência.
+O guard de no-idle existe para isso. Ele não é outro Hermes e não inventa autoridade.
 
-Para web, isso pode envolver telas, viewports, console, overflow, estados vazios, loading, erro, acessibilidade básica e comparação com a promessa do produto.
+## Como a fábrica prova
 
-Para CLI, envolve instalação, help, comando real, saída, erro e comportamento no terminal.
+A prova muda conforme o trabalho.
 
-Para docs, envolve outra coisa: o texto realmente ajuda alguém a entender e chegar ao primeiro sucesso?
+Para web: screenshots, estados, console, viewport, erro, loading, overflow e jornada.
 
-Uma prova de backend não prova interface. Uma screenshot não prova jornada inteira. Cada superfície precisa de prova própria.
+Para CLI: instalação, help, comando real, saída e erro.
 
-## Revisão só vale quando muda estado
+Para release: prontidão, rollback, dono e decisão.
 
-Revisão que fica parada é decoração.
+Para docs: clareza, navegação e primeiro sucesso do leitor.
 
-Se passou, precisa destravar ou fechar a tarefa certa. Se falhou, precisa criar reparo. Se apontou risco, precisa registrar dono, consequência e decisão. Se o executor revisa a si mesmo num trabalho material, a fábrica está se enganando.
+Prova boa responde ao pedido. Prova ruim só mostra atividade.
 
-A revisão precisa voltar para o fluxo.
+## Como revisão vira avanço
 
-## Gate humano é pacote de decisão
+Review não é comentário decorativo.
 
-Quando a decisão é humana, a fábrica chama o humano.
+Se passa, destrava ou fecha o item certo.
 
-Mas chama direito.
+Se falha, cria reparo.
 
-Ela entrega o artefato ou uma projeção fiel. Explica a decisão. Mostra opções. Diz o que cada opção autoriza. Diz o que não autoriza. Mostra o risco e o próximo passo seguro.
+Se aponta risco, registra dono e consequência.
 
-O humano não deveria aprovar no escuro.
+Se pede decisão, vira pacote humano.
 
-## O fim tem três saídas
+Review que não muda estado não foi consumido.
 
-Entrega: há prova, revisão consumida, gates resolvidos e próximo estado claro.
+## Como termina
 
-Bloqueio: falta prova, acesso, autoridade, capacidade ou segurança. O bloqueio tem dono e menor próximo passo seguro.
+A execução termina em três estados honestos.
 
-Aprendizado: a execução revelou que a própria fábrica precisa melhorar. Isso pode virar teste, doc, skill, worker, gate, issue ou mudança de processo.
+Entregue: há prova, revisão consumida, gates resolvidos e próximo estado claro.
 
-A fábrica boa não força final feliz. Ela fecha quando pode, bloqueia quando deve e aprende quando descobriu algo real.
+Bloqueado: falta prova, acesso, autoridade, capacidade ou segurança. O bloqueio tem dono e menor próximo passo seguro.
+
+Aprendizado: a execução mostrou que a própria fábrica precisa mudar. Isso pode virar teste, doc, skill, worker, gate, issue ou mudança de processo.
+
+A fábrica boa não força final feliz. Ela diz a verdade operacional.

--- a/docs/pt-BR/reference.md
+++ b/docs/pt-BR/reference.md
@@ -1,6 +1,6 @@
 # Referência
 
-Esta página reúne os fatos curtos que uma pessoa normalmente precisa depois do manual. Ela não tenta substituir os registries nem a referência gerada. Ela traduz os nomes mais importantes para uma pessoa que quer operar ou avaliar a fábrica.
+Esta página reúne os fatos curtos para quem já leu o manual e quer se localizar no repo. Não substitui os registries nem a referência gerada; traduz os nomes mais importantes para quem precisa operar ou avaliar a fábrica.
 
 ## Onde cada coisa mora
 

--- a/docs/pt-BR/technical-model.md
+++ b/docs/pt-BR/technical-model.md
@@ -1,6 +1,6 @@
 # Modelo técnico
 
-Esta página explica o modelo de implementação sem fingir que todo leitor quer morar dentro do código.
+O modelo técnico existe para quem precisa manter a fábrica sem transformar o manual público em mapa de código.
 
 A versão curta é esta: Hermes controla estado de runtime. A Overkill Factory controla os contratos de produção em volta desse estado. O repositório guarda scripts, schemas, templates, registries, testes e documentação pública para tornar esse contrato verificável.
 

--- a/docs/pt-BR/trust-and-evidence.md
+++ b/docs/pt-BR/trust-and-evidence.md
@@ -1,60 +1,66 @@
 # Confiança e prova
 
-A pergunta certa é: "como eu sei que isso não é só um agente falando bonito?"
+A pergunta certa é: como eu sei que o agente não está só falando bonito?
 
 A resposta começa por uma verdade incômoda: processo parecendo vivo não é a mesma coisa que progresso.
 
-Um sistema pode ter cards andando, comentários novos, arquivos criados e mensagens confiantes. Ainda assim, o produto pode estar errado.
+Card andando, arquivo criado, teste verde e mensagem confiante podem coexistir com produto errado.
 
-## O que é teatro de progresso
+## Teatro de progresso
 
-Teatro de progresso é quando a aparência de trabalho substitui a entrega.
+Teatro de progresso é a aparência de trabalho substituindo a entrega.
 
 O worker diz "feito", mas não aponta evidência.
 
-O teste passa, mas não testa o risco.
+O teste passa, mas testa o caminho fácil.
 
-A tela existe, mas o fluxo quebra no segundo estado.
+A tela existe, mas quebra no erro.
 
 A revisão aprova, mas não leu o artefato.
 
 O humano aprova, mas não recebeu o material.
 
-O board se move, mas a dependência real ficou de fora.
+O board anda, mas a dependência real ficou fora do grafo.
 
-A fábrica foi criada para tratar isso como falha central, não como detalhe.
+A fábrica trata isso como falha central.
 
-## Prova precisa ter ligação com o pedido
+## Prova solta não resolve
 
-Evidência solta não basta.
+Prova solta não resolve. Ela precisa provar o pedido certo.
 
-Um log, uma screenshot, um diff, um teste, um arquivo ou um link só vale se estiver ligado ao que foi pedido.
+Se o pedido era onboarding, a prova precisa mostrar a jornada.
 
-Se o pedido era provar onboarding, a evidência precisa mostrar a jornada.
-
-Se era release, precisa mostrar prontidão, rollback e decisão.
+Se era release, precisa mostrar prontidão, rollback, dono e decisão.
 
 Se era segurança, precisa mostrar risco, fronteira, revisão e o que ficou aceito.
 
-Se era documentação, precisa mostrar que o leitor consegue entender e usar, não só que o Markdown compila.
+Se era documentação, precisa mostrar que o texto guia uma pessoa de verdade, não só que o Markdown compila.
 
-## Readback: a fábrica lê de volta
+Exemplo fraco:
 
-Readback é simples: a fábrica confere o que foi entregue.
+> Teste passou.
 
-Se um worker disse que criou um documento, a fábrica lê o documento.
+Exemplo bom:
 
-Se disse que anexou prova, a fábrica confere se a prova existe, abre, pode ser relida e não depende de um arquivo temporário.
+> O teste de regressão `test_onboarding_email_error` falhou antes da correção, passou depois e cobre exatamente o erro descrito no pedido.
 
-Se disse que rodou teste, a fábrica olha o teste e o resultado.
+## Readback: reler antes de acreditar
 
-Se disse que a interface está boa, a fábrica olha a superfície.
+Readback é a fábrica relendo o que o worker entregou.
 
-Sem readback, a fábrica fica confiando no próprio processo. E processo pode estar correto enquanto o produto está ruim.
+Se ele disse que criou um documento, a fábrica lê o documento.
 
-## Receipt Five: o recibo do pronto
+Se disse que anexou prova, a fábrica confere se a prova existe, abre, pode ser relida e não vaza segredo.
 
-Receipt Five é o recibo de conclusão.
+Se disse que rodou teste, a fábrica olha o comando e o resultado.
+
+Se disse que a interface ficou boa, a fábrica olha a superfície.
+
+Sem readback, o processo pode estar perfeito e a entrega pode estar ruim.
+
+## Recibo de conclusão
+
+No fim, você recebe um recibo de conclusão. Internamente ele pode aparecer como Receipt Five.
 
 Ele responde cinco perguntas:
 
@@ -64,68 +70,56 @@ Ele responde cinco perguntas:
 4. Quem revisou e o que a revisão disse?
 5. O que ainda falta, bloqueia ou fica como risco?
 
-Se uma resposta importante está vazia, o estado não é pronto.
+Se uma dessas respostas importantes está vazia, não está pronto.
 
-Pode ser "pronto para revisão". Pode ser "bloqueado". Pode ser "parcial". Pode ser "aguardando humano".
+Pode estar pronto para revisão. Pode estar bloqueado. Pode estar parcial. Pode estar aguardando humano. Mas pronto, não.
 
-Mas não é pronto.
+## Review não é carimbo
 
-## Revisão independente precisa ser consumida
+Review precisa mudar o estado do trabalho.
 
-A revisão não existe para enfeitar o processo.
+Se passou, destrava ou fecha o item certo. Se falhou, cria reparo. Se apontou risco, registra dono e consequência. Se pediu decisão, vira pacote humano.
 
-Ela precisa mudar o estado do trabalho.
+Reviewer e executor não deveriam ser a mesma identidade quando o risco é material.
 
-Se passou, destrava. Se falhou, cria reparo. Se encontrou risco, registra. Se pediu decisão, vira pacote humano. Se não foi consumida, não serviu.
+## Bloqueio honesto
 
-E quando o risco é material, o executor não deveria ser o juiz final do próprio trabalho.
+Bloqueio bom diz quatro coisas: o que falta, por que falta, quem é dono e qual é o menor próximo passo seguro.
 
-## Bloqueio precisa ser honesto
+Também diz se precisa do operador.
 
-Bloqueio bom é específico.
+Muita coisa não precisa. Falta de anexo, falta de readback, worker raso, prova quebrada, revisão não consumida. Isso é trabalho da fábrica.
 
-Ele diz o que falta, por que falta, quem é dono e qual é o menor próximo passo seguro.
+O operador entra quando há autoridade real: produção, mainnet, fundos, segredo, orçamento, release, waiver, risco residual.
 
-Também diz se precisa do humano ou não.
+## Gate humano tem que respeitar o humano
 
-Muita coisa não precisa do humano. Falta de readback, falta de anexo, falta de revisão, worker raso, artefato quebrado, prova insuficiente. Isso é trabalho da fábrica.
+Um gate humano não é "aprova aí?".
 
-O humano só deve ser chamado quando existe autoridade real a exercer.
+É um pacote de decisão.
 
-## Gate humano sem material é inválido
+A pessoa precisa receber o artefato ou uma projeção fiel, entender o que está aprovando, quais opções existem, o que cada opção autoriza e qual risco fica.
 
-Um gate humano não é "posso seguir?".
+JSON cru é evidência interna. Não é experiência de aprovação.
 
-É uma decisão com artefato.
+## Segurança não fica para o fim
 
-Se a fábrica pede aprovação de Product SOT, entrega o Product SOT. Se pede release, entrega o pacote de release. Se pede arquitetura, entrega a arquitetura. Se pede risco de segurança, entrega o risco, as opções e a consequência.
+Se o trabalho toca segredo, permissão, supply chain, produção, wallet, assinatura, Solana, fundos ou mainnet, segurança entra cedo.
 
-O operador precisa saber o que aprovar permite e o que aprovar não permite.
+Às vezes como arquitetura. Às vezes como scan. Às vezes como revisão. Às vezes como bloqueio. Às vezes como decisão humana.
 
-A pergunta pode ser curta. O material não pode ser ausente.
-
-## Segurança entra cedo
-
-Segurança não é maquiagem de fim de PR.
-
-Se o trabalho toca segredo, permissão, produção, supply chain, privacidade, wallet, assinatura, Solana, fundos ou mainnet, segurança entra no caminho desde cedo.
-
-Às vezes isso vira arquitetura. Às vezes vira scan. Às vezes vira revisão. Às vezes vira gate humano. Às vezes vira bloqueio.
-
-A fábrica não promete risco zero. Ela promete não esconder risco atrás de um "pass" genérico.
+A fábrica não promete risco zero. Promete não esconder risco atrás de um pass genérico.
 
 ## Prova local não é entrega viva
 
 Um comando local passando prova que o checkout está coerente.
 
-Um estado Hermes vivo prova que o trabalho existiu naquele runtime.
+Um Hermes vivo prova que o trabalho existiu naquele runtime.
 
 Um worker result prova que um worker devolveu algo naquele escopo.
 
 Um Receipt Five bem formado prova que a conclusão foi reconciliada.
 
-Essas coisas não são iguais.
+Essas coisas não são iguais. Smoke local não prova produto entregue. Arquivo existente não prova readback. Aprovação genérica não prova mainnet.
 
-Não dá para usar smoke local como prova de produto entregue. Não dá para usar arquivo existente como prova de readback. Não dá para usar aprovação genérica como autorização de mainnet. Publicação pública também precisa bloquear vazamento de caminhos privados, artefatos humanos, referências internas brutas e segredos.
-
-A fábrica precisa manter essa fronteira visível, mesmo quando seria mais conveniente fingir que está tudo pronto.
+A confiança vem dessa disciplina.

--- a/docs/pt-BR/usage.md
+++ b/docs/pt-BR/usage.md
@@ -1,6 +1,6 @@
 # Uso
 
-Esta página é o caminho prático para um checkout local. Ela não finge que um checkout local é a mesma coisa que um runtime Hermes vivo, do operador. Primeiro ela dá uma prova segura. Depois mostra os checks que deveriam rodar antes de mexer em documentação pública ou em claims públicas.
+Aqui o objetivo é simples: provar que o checkout local está coerente sem fingir que isso equivale a uma execução viva no Hermes do operador. Primeiro vem uma prova segura. Depois vêm os checks que devem rodar antes de mexer em documentação pública ou em claims públicas.
 
 ## Requisitos
 


### PR DESCRIPTION
## Summary
- Rewrites the Portuguese public guide around the operator's real pain: agents that look busy but leave the human acting as QA, auditor, and detective.
- Incorporates the PT Product Narrative Editor, Skeptical Operator Reviewer, and Technical Truth Auditor feedback into the final copy.
- Adds concrete scenes and examples: onboarding request, approval package, weak vs strong proof, local proof vs live delivery.
- Keeps required public-boundary phrases and executable facts while moving internal terms behind human explanations.

## Files
- `docs/pt-BR/index.md`
- `docs/pt-BR/manual.md`
- `docs/pt-BR/operating-model.md`
- `docs/pt-BR/trust-and-evidence.md`
- `docs/pt-BR/lifecycle.md`
- `docs/pt-BR/usage.md`
- `docs/pt-BR/technical-model.md`
- `docs/pt-BR/reference.md`

## Validation
- `git diff --check`
- `python3 -m mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/overkill-docs-pt-editorial-final`
- `cd factory && python3 scripts/generate_factory_reference_docs.py && python3 scripts/generate_factory_reference_docs.py --check`
- `cd factory && python3 scripts/validate_public_json_artifacts.py`
- `cd factory && python3 scripts/validate_public_surface_sync.py`
- `cd factory && python3 scripts/validate_promise_implementation_map.py`
- `cd factory && python3 scripts/validate_worker_profiles.py`
- `cd factory && python3 scripts/public_safety_scan.py`
- `cd factory && python3 scripts/secret_safety_scan.py`
- `cd factory && python3 -m unittest tests.test_open_source_docs tests.test_public_surface_sync tests.test_promise_implementation_map tests.test_generated_factory_reference_docs -q`
- `cd factory && python3 -m unittest discover -s tests -p 'test_*.py' -q` (1249 tests OK, 1 skipped)
