### PR TITLE
Enforce Product SOT excellence depth

### DIFF
--- a/factory/scripts/work_product_quality_firewall.py
+++ b/factory/scripts/work_product_quality_firewall.py
@@ -95,6 +95,10 @@ def validate_product_sot_prd_grade(sot: Mapping[str, Any] | str) -> QualityResul
             "missing_functional_requirements": ["functional requirement", "requisito funcional"],
             "missing_non_functional_requirements": ["non-functional", "não funcional", "nao funcional", "nfr"],
             "missing_state_model": ["state model", "modelo de estado"],
+            "missing_examples": ["example", "exemplo", "for example"],
+            "missing_tradeoffs": ["tradeoff", "trade-off", "trade off", "contrapartida", "compromisso"],
+            "missing_rejected_alternatives": ["rejected alternative", "alternativa rejeitada", "rejeitado"],
+            "missing_failure_states": ["error", "erro", "empty", "vazio", "blocked", "bloqueado"],
             "missing_data_ledger_reconciliation": ["reconciliation", "reconciliação", "reconciliacao", "ledger"],
             "missing_downstream_handoff": ["downstream handoff", "handoff", "arquitetura"],
         }
@@ -120,6 +124,14 @@ def validate_product_sot_prd_grade(sot: Mapping[str, Any] | str) -> QualityResul
             findings.append(_finding("missing_non_functional_requirements", "Product SOT must include non-functional requirements."))
         if _count(data.get("state_model_requirements")) < 5:
             findings.append(_finding("missing_state_model", "Product SOT must include state model requirements."))
+        if _count(data.get("examples_by_flow")) < 2:
+            findings.append(_finding("missing_examples", "Product SOT must include concrete examples by flow, not only generic requirements."))
+        if _count(data.get("tradeoffs")) < 2:
+            findings.append(_finding("missing_tradeoffs", "Product SOT must include tradeoffs so architecture/product decisions are reviewable."))
+        if _count(data.get("rejected_alternatives")) < 1:
+            findings.append(_finding("missing_rejected_alternatives", "Product SOT must record at least one rejected alternative or explain why none exists."))
+        if _count(data.get("failure_empty_blocked_states")) < 3:
+            findings.append(_finding("missing_failure_states", "Product SOT must include empty/error/blocked states for critical flows."))
         if _count(data.get("data_ledger_reconciliation_requirements")) < 1:
             findings.append(_finding("missing_data_ledger_reconciliation", "Product SOT must include data/ledger/reconciliation requirements."))
         if _count(data.get("acceptance_criteria_by_flow")) < 2:

--- a/factory/tests/test_work_product_quality_firewall.py
+++ b/factory/tests/test_work_product_quality_firewall.py
@@ -63,6 +63,18 @@ def test_prd_grade_product_sot_passes_quality_firewall():
         "state_model_requirements": [
             "empty", "loading", "error", "success", "blocked", "pending", "expired", "review"
         ],
+        "examples_by_flow": {
+            "cadastro": ["Example: referral code expired -> user sees blocked state and support path."],
+            "stake": ["Example: wallet event exists but DB row missing -> reconciliation divergence state."],
+        },
+        "tradeoffs": [
+            {"decision": "Use explicit reconciliation state", "cost": "More admin UX", "benefit": "Safer operator recovery"},
+            {"decision": "Separate claim from release", "cost": "More gate work", "benefit": "Prevents accidental production authority"},
+        ],
+        "rejected_alternatives": [
+            {"alternative": "Treat payment success as product readiness", "reason": "Hides ledger/onchain divergence"},
+        ],
+        "failure_empty_blocked_states": ["empty portfolio", "payment error", "admin review blocked"],
         "data_ledger_reconciliation_requirements": [
             "payment intent must reconcile against wallet/onchain/database events",
             "divergence must surface as explicit operational state",
@@ -89,6 +101,44 @@ def test_prd_grade_product_sot_passes_quality_firewall():
     assert result.readback_pass is True
     assert result.quality_pass is True
     assert result.findings == []
+
+
+def test_generic_product_sot_with_counts_but_no_excellence_depth_fails_quality():
+    sot = {
+        "record_type": "product_sot_candidate",
+        "product_intent": "Build a useful DeFi product with onboarding, payments, dashboard, and admin operations.",
+        "source_traceability": [
+            {"source_ref": "chat#1", "requirement_ids": ["REQ-001"]},
+            {"source_ref": "issue#595", "requirement_ids": ["REQ-002"]},
+        ],
+        "personas": ["user", "admin"],
+        "user_journeys": [{"id": "UJ-1"}, {"id": "UJ-2"}],
+        "admin_journeys": [{"id": "AJ-1"}],
+        "functional_requirements": [{"id": "F1"}, {"id": "F2"}, {"id": "F3"}],
+        "non_functional_requirements": [{"id": "N1"}, {"id": "N2"}],
+        "state_model_requirements": ["start", "middle", "done", "pending", "review"],
+        "data_ledger_reconciliation_requirements": ["reconcile data"],
+        "acceptance_criteria_by_flow": {"flow1": ["works"], "flow2": ["works"]},
+        "downstream_handoff": {
+            "architecture": [],
+            "ux": [],
+            "security": [],
+            "implementation": [],
+            "qa": [],
+        },
+    }
+
+    result = quality.validate_product_sot_prd_grade(sot)
+
+    assert result.process_pass is True
+    assert result.readback_pass is True
+    assert result.quality_pass is False
+    codes = {finding.code for finding in result.findings}
+    assert "missing_examples" in codes
+    assert "missing_tradeoffs" in codes
+    assert "missing_rejected_alternatives" in codes
+    assert "missing_failure_states" in codes
+    assert quality.can_promote(result) is False
 
 
 def test_quality_firewall_refuses_process_pass_without_quality_pass():


### PR DESCRIPTION
## Summary
- tightens Product SOT Definition of Excellence checks in the quality firewall
- requires concrete examples, tradeoffs, rejected alternatives, and empty/error/blocked states
- adds an adversarial generic-SOT regression that has counts but lacks excellence depth and cannot promote

## Why
The factory must reject shallow/generic artifacts that satisfy schema/process shape but are not useful enough for downstream architecture, implementation, QA, or human decisions.

## Validation
- python -m pytest tests/test_work_product_quality_firewall.py -q
- python scripts/validate_public_json_artifacts.py
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P09.
