### PR TITLE
Enforce claim boundary states

### DIFF
--- a/factory/legacy-docs/generated/factory-kernel-reference.md
+++ b/factory/legacy-docs/generated/factory-kernel-reference.md
@@ -36,8 +36,8 @@ Done without evidence is only a claim. Receipt Five, review, runtime state and p
 | Hermes profile bindings | 40 | `agents/hermes-profile-bindings.public.json` |
 | Operating systems | 17 | `templates/factory-operating-system-registry.json` |
 | Method engines | 8 | `templates/method-engine-registry.json` |
-| JSON schemas | 250 | `schemas/*.json` |
-| Templates | 167 | `templates/*` |
+| JSON schemas | 251 | `schemas/*.json` |
+| Templates | 168 | `templates/*` |
 | Public surfaces | 19 | `docs/public-surface.manifest.json` |
 
 ## Factory Phases
@@ -254,6 +254,7 @@ These are the public JSON schemas the factory exposes. They are not decoration; 
 - `schemas/factory-bridge-start-request.schema.json`
 - `schemas/factory-canonical-frontier-policy.schema.json`
 - `schemas/factory-card.schema.json`
+- `schemas/factory-claim-boundary.schema.json`
 - `schemas/factory-command.schema.json`
 - `schemas/factory-completion-audit.schema.json`
 - `schemas/factory-decision-outbox.schema.json`
@@ -496,6 +497,7 @@ Templates are starter records paired with schemas. They are examples of valid sh
 - `templates/factory-bridge-start-request.json`
 - `templates/factory-canonical-frontier-policy.json`
 - `templates/factory-card.json`
+- `templates/factory-claim-boundary.json`
 - `templates/factory-command.json`
 - `templates/factory-decision-outbox.json`
 - `templates/factory-executor-skill-ecosystem-registry.json`

--- a/factory/schemas/factory-claim-boundary.schema.json
+++ b/factory/schemas/factory-claim-boundary.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://overkill-factory.dev/schemas/factory-claim-boundary.schema.json",
+  "title": "Factory claim boundary",
+  "type": "object",
+  "required": [
+    "$schema",
+    "record_type",
+    "claim_id",
+    "claimed_state",
+    "source_state",
+    "evidence_refs",
+    "forbidden_promotions",
+    "allowed_next_states"
+  ],
+  "properties": {
+    "$schema": { "const": "https://overkill-factory.dev/schemas/factory-claim-boundary.schema.json" },
+    "record_type": { "const": "factory_claim_boundary" },
+    "claim_id": { "type": "string", "minLength": 1 },
+    "claimed_state": {
+      "enum": [
+        "plan_or_spec",
+        "bounded_proof",
+        "report_only_pass",
+        "qa_pass",
+        "release_readiness",
+        "production_readiness",
+        "receipt_five_ready",
+        "negative_closeout"
+      ]
+    },
+    "source_state": {
+      "enum": [
+        "plan_or_spec",
+        "bounded_proof",
+        "report_only_pass",
+        "qa_pass",
+        "release_readiness",
+        "production_readiness",
+        "receipt_five_ready",
+        "negative_closeout"
+      ]
+    },
+    "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "forbidden_promotions": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "allowed_next_states": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "qa_result_ref": { "type": "string" },
+    "release_evidence_ref": { "type": "string" },
+    "production_evidence_ref": { "type": "string" },
+    "receipt_five_ref": { "type": "string" },
+    "human_gate_ref": { "type": "string" },
+    "known_limits": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -23623,6 +23623,65 @@ READINESS_SCOPE_FOR_STATE = {
 }
 
 
+CLAIM_BOUNDARY_STATES = {
+    "plan_or_spec",
+    "bounded_proof",
+    "report_only_pass",
+    "qa_pass",
+    "release_readiness",
+    "production_readiness",
+    "receipt_five_ready",
+    "negative_closeout",
+}
+CLAIM_PROMOTION_REQUIREMENTS = {
+    "qa_pass": ("qa_result_ref",),
+    "release_readiness": ("qa_result_ref", "release_evidence_ref"),
+    "production_readiness": ("qa_result_ref", "release_evidence_ref", "production_evidence_ref", "human_gate_ref"),
+    "receipt_five_ready": ("qa_result_ref", "release_evidence_ref", "production_evidence_ref", "receipt_five_ref", "human_gate_ref"),
+}
+CLAIM_WEAK_STATES = {"plan_or_spec", "bounded_proof", "report_only_pass", "negative_closeout"}
+CLAIM_STRONG_STATES = {"release_readiness", "production_readiness", "receipt_five_ready"}
+
+
+def validate_factory_claim_boundary(packet: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    schemas = bundled_schemas()
+    schema = schemas.get("factory-claim-boundary.schema.json")
+    if not isinstance(schema, dict):
+        return ["factory-claim-boundary schema is not bundled"]
+    errors.extend(validate_node(schema, packet, "factory_claim_boundary", schemas=schemas, root_schema=schema))
+
+    claimed_state = str(packet.get("claimed_state") or "")
+    source_state = str(packet.get("source_state") or "")
+    forbidden = set(_list_items(packet.get("forbidden_promotions")))
+    allowed = set(_list_items(packet.get("allowed_next_states")))
+    if claimed_state not in CLAIM_BOUNDARY_STATES:
+        return errors
+
+    if source_state in CLAIM_WEAK_STATES and claimed_state in CLAIM_STRONG_STATES:
+        errors.append(
+            f"source_state {source_state} cannot be promoted directly to {claimed_state}; use explicit QA/release/production/Receipt Five evidence"
+        )
+    if claimed_state in CLAIM_WEAK_STATES:
+        missing_forbidden = sorted(CLAIM_STRONG_STATES - forbidden)
+        if missing_forbidden:
+            errors.append(
+                f"claimed_state {claimed_state} must forbid stronger promotions: " + ", ".join(missing_forbidden)
+            )
+    for field in CLAIM_PROMOTION_REQUIREMENTS.get(claimed_state, ()):
+        if not str(packet.get(field) or "").strip():
+            errors.append(f"claimed_state {claimed_state} requires {field}")
+    if claimed_state == "negative_closeout" and CLAIM_STRONG_STATES & allowed:
+        errors.append("negative_closeout cannot list release/production/receipt_five states as allowed_next_states")
+    if claimed_state == "report_only_pass" and not {"qa_pass", "bounded_proof"} & allowed:
+        errors.append("report_only_pass must route to QA/bounded proof next, not closure")
+    return errors
+
+
+def command_validate_claim_boundary(args: argparse.Namespace) -> int:
+    return _print_validation_result(validate_factory_claim_boundary(load_json_like(args.path)))
+
+
 def validate_factory_v2_readiness_claim(packet: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     schemas = bundled_schemas()
@@ -25557,6 +25616,10 @@ def build_parser() -> argparse.ArgumentParser:
     validate_real_effectiveness_parser = sub.add_parser("validate-real-effectiveness")
     validate_real_effectiveness_parser.add_argument("path", type=Path)
     validate_real_effectiveness_parser.set_defaults(func=command_validate_real_effectiveness)
+
+    validate_claim_boundary_parser = sub.add_parser("validate-claim-boundary")
+    validate_claim_boundary_parser.add_argument("path", type=Path)
+    validate_claim_boundary_parser.set_defaults(func=command_validate_claim_boundary)
 
     validate_completion_parser = sub.add_parser("validate-completion")
     validate_completion_parser.add_argument("--card", type=Path, required=True)

--- a/factory/templates/factory-claim-boundary.json
+++ b/factory/templates/factory-claim-boundary.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://overkill-factory.dev/schemas/factory-claim-boundary.schema.json",
+  "record_type": "factory_claim_boundary",
+  "claim_id": "example-report-only-does-not-release",
+  "claimed_state": "report_only_pass",
+  "source_state": "report_only_pass",
+  "evidence_refs": ["worker-result:independent-reviewer:report-only-pass"],
+  "forbidden_promotions": [
+    "release_readiness",
+    "production_readiness",
+    "receipt_five_ready"
+  ],
+  "allowed_next_states": ["qa_pass"],
+  "known_limits": [
+    "Report-only review does not authorize release, production, Receipt Five, Mainnet, funds, custody, signing, or waiver."
+  ]
+}

--- a/factory/tests/test_factory_claim_boundary.py
+++ b/factory/tests/test_factory_claim_boundary.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "factoryctl.py"
+TEMPLATE_PATH = ROOT / "templates" / "factory-claim-boundary.json"
+
+
+def load_factoryctl():
+    spec = importlib.util.spec_from_file_location("factoryctl", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["factoryctl"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_template() -> dict:
+    return json.loads(TEMPLATE_PATH.read_text(encoding="utf-8"))
+
+
+def test_report_only_pass_template_forbids_release_production_and_receipt_five() -> None:
+    factoryctl = load_factoryctl()
+    packet = load_template()
+
+    errors = factoryctl.validate_factory_claim_boundary(packet)
+
+    assert errors == []
+
+
+def test_report_only_pass_cannot_masquerade_as_release_ready() -> None:
+    factoryctl = load_factoryctl()
+    packet = load_template()
+    packet["claimed_state"] = "release_readiness"
+    packet["source_state"] = "report_only_pass"
+    packet["qa_result_ref"] = "worker-result:qa:pass"
+    packet["release_evidence_ref"] = "release-readiness:proof"
+
+    errors = factoryctl.validate_factory_claim_boundary(packet)
+
+    assert any("cannot be promoted directly" in error for error in errors)
+
+
+def test_negative_closeout_cannot_allow_release_or_receipt_five_next() -> None:
+    factoryctl = load_factoryctl()
+    packet = load_template()
+    packet["claimed_state"] = "negative_closeout"
+    packet["source_state"] = "negative_closeout"
+    packet["allowed_next_states"] = ["release_readiness", "receipt_five_ready"]
+
+    errors = factoryctl.validate_factory_claim_boundary(packet)
+
+    assert any("negative_closeout cannot list" in error for error in errors)
+
+
+def test_receipt_five_ready_requires_all_strong_evidence_refs() -> None:
+    factoryctl = load_factoryctl()
+    packet = load_template()
+    packet["claimed_state"] = "receipt_five_ready"
+    packet["source_state"] = "production_readiness"
+    packet["qa_result_ref"] = "worker-result:qa:pass"
+    packet["release_evidence_ref"] = "release:proof"
+    # production_evidence_ref, receipt_five_ref and human_gate_ref intentionally absent.
+
+    errors = factoryctl.validate_factory_claim_boundary(packet)
+
+    assert "claimed_state receipt_five_ready requires production_evidence_ref" in errors
+    assert "claimed_state receipt_five_ready requires receipt_five_ref" in errors
+    assert "claimed_state receipt_five_ready requires human_gate_ref" in errors
+
+
+def test_production_readiness_with_required_refs_passes() -> None:
+    factoryctl = load_factoryctl()
+    packet = copy.deepcopy(load_template())
+    packet.update(
+        {
+            "claim_id": "production-readiness-example",
+            "claimed_state": "production_readiness",
+            "source_state": "release_readiness",
+            "qa_result_ref": "worker-result:qa:pass",
+            "release_evidence_ref": "release-readiness:pass",
+            "production_evidence_ref": "production-readiness:pass",
+            "human_gate_ref": "operator-gate:approved",
+            "forbidden_promotions": ["receipt_five_ready"],
+            "allowed_next_states": ["receipt_five_ready"],
+        }
+    )
+
+    errors = factoryctl.validate_factory_claim_boundary(packet)
+
+    assert errors == []


### PR DESCRIPTION
## Summary
- adds `factory_claim_boundary` schema/template and validator
- enforces distinct states: plan/spec, bounded proof, report-only pass, QA pass, release readiness, production readiness, Receipt Five ready, and negative closeout
- blocks direct promotion from weak states to release/production/Receipt Five claims
- requires explicit QA/release/production/human-gate/Receipt-Five refs for stronger claims
- adds regression coverage for report-only masquerade and negative closeout overreach

## Why
The factory must not let plans, specs, bounded proofs, report-only reviews, or negative closeouts masquerade as product/release/production/Receipt Five readiness.

## Validation
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_factory_claim_boundary.py tests/test_factoryctl.py -q
- python scripts/factoryctl.py validate-claim-boundary templates/factory-claim-boundary.json
- python scripts/generate_factory_reference_docs.py --check
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #595. Implements P11.
