### PR TITLE
Require Solana capability evidence in worker packets

### DIFF
--- a/factory/schemas/worker-packet.schema.json
+++ b/factory/schemas/worker-packet.schema.json
@@ -427,18 +427,21 @@
         "provider_id",
         "source",
         "pinned_ref",
+        "pinned_commit",
         "required_before_execution",
         "install_modes",
         "load_contract",
         "usage_receipt_required",
         "usage_receipt_field",
-        "precedence_policy"
+        "precedence_policy",
+        "capability_evidence_refs"
       ],
       "properties": {
         "pack_id": { "type": "string", "minLength": 3 },
         "provider_id": { "type": "string", "minLength": 3 },
         "source": { "type": "string", "minLength": 3 },
         "pinned_ref": { "type": "string", "minLength": 1 },
+        "pinned_commit": { "type": "string", "minLength": 7 },
         "required_before_execution": { "type": "boolean" },
         "install_modes": {
           "type": "array",
@@ -456,6 +459,11 @@
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 8 }
+        },
+        "capability_evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
         }
       },
       "additionalProperties": false

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -103,6 +103,10 @@ def default_work_root() -> Path:
         cwd / "examples" / "minimal-hermes-project" / "card.md"
     ).exists():
         return cwd
+    if (CODE_ROOT / "agents" / "hermes-profile-bindings.public.json").exists() and (
+        CODE_ROOT / "examples" / "minimal-hermes-project" / "card.md"
+    ).exists():
+        return CODE_ROOT
     installed_root = installed_asset_root()
     if installed_root is not None:
         return installed_root
@@ -17296,6 +17300,11 @@ def domain_brain_provider_for_worker(worker_id: str, card: dict[str, Any]) -> di
         "usage_receipt_required": provider.get("usage_receipt_required") is True,
         "usage_receipt_field": SOLANA_AI_KIT_USAGE_RECEIPT_FIELD,
         "precedence_policy": _list_items(provider.get("precedence_policy")),
+        "capability_evidence_refs": [
+            f"agents/capability-packs.public.json#packs.{SOLANA_AI_KIT_PACK_ID}",
+            "agents/skill-provider-registry.public.json#providers.solana-ai-kit",
+            "schemas/solana-ai-kit-usage-receipt.schema.json",
+        ],
     }
 
 

--- a/factory/tests/test_factoryctl.py
+++ b/factory/tests/test_factoryctl.py
@@ -726,6 +726,9 @@ PRIVATE_PATH_RE = re.compile(
 
 
 class FactoryCtlTest(unittest.TestCase):
+    def test_imported_source_tree_uses_source_assets_before_installed_assets(self) -> None:
+        self.assertEqual(factoryctl.ROOT, ROOT)
+
     def test_human_gate_packet_schema_requires_push_material_before_question(self) -> None:
         card = load_card("v35_valid_security_with_scan.md")
         packet = human_gate_packet_fixture()
@@ -873,6 +876,21 @@ class FactoryCtlTest(unittest.TestCase):
             packet["input_contract"]["domain_brain_provider_ref"],
             "agents/capability-packs.public.json#packs.solana-ai-kit-core.official_brain_provider",
         )
+        self.assertIn(
+            "agents/skill-provider-registry.public.json#providers.solana-ai-kit",
+            provider["capability_evidence_refs"],
+        )
+
+    def test_solana_worker_packet_with_domain_brain_validates_against_schema(self) -> None:
+        card_path = ROOT / "examples" / "cards" / "v35_valid_onchain_auditor_scan.md"
+        card = factoryctl.load_json_like(card_path)
+        packet = factoryctl.build_worker_packet("solana-quasar-auditor", card, card_path)
+        schemas = factoryctl.bundled_schemas()
+        schema = schemas["worker-packet.schema.json"]
+
+        errors = factoryctl.validate_node(schema, packet, "worker_packet", schemas=schemas, root_schema=schema)
+
+        self.assertEqual(errors, [])
 
     def test_solana_domain_brain_reaches_lifecycle_wallet_and_security_workers(self) -> None:
         card_path = ROOT / "templates" / "vfinal-factory-card.json"


### PR DESCRIPTION
## Summary
- make Solana AI Kit domain-brain worker packets carry explicit capability evidence refs
- require pinned commit and capability evidence refs in worker packet provider records
- keep source-tree schema/test precedence so local validation does not silently use stale installed assets
- add regression tests for schema-valid Solana domain-brain packets and source-tree precedence

## Evidence
This patch was produced by task `t_e86b8ca8` and independently reviewed in task `t_07764ab4`.
Reviewer verdict: PASS for internal factory work product only.
Reviewer evidence: targeted tests, runtime contract validators, capability-acquisition probe, adversarial routing probes, and full factory unittest suite from source cwd: 1240 OK, skipped=1.

## Local validation before PR
- python scripts/validate_public_json_artifacts.py
- python -m pytest tests/test_factoryctl.py -q
- python scripts/factoryctl.py validate-v2-runtime-contracts
- python scripts/factoryctl.py validate-agent-skill-boundaries
- python scripts/factoryctl.py validate-reference-superiority
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.

Refs #592.
