### PR TITLE
Create fresh no-idle stale replacements

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -5506,10 +5506,17 @@ def create_deterministic_reconcile_task(
     if body is None:
         return None
     digest = idempotency_digest_fragment(contract_digest(body))
+    stale_refs = [str(ref).strip() for ref in (stale_remediation_task_refs or []) if str(ref).strip()]
+    base_title = str(contract.get("title") or "Materialize canonical factory card for board")
+    title = (
+        f"{base_title} stale-terminal replacement {len(stale_refs)}"
+        if stale_refs
+        else base_title
+    )
     return create_task(
         hermes_bin=hermes_bin,
         board=board,
-        title=str(contract.get("title") or "Factory deterministic reconcile"),
+        title=title,
         body=compact_json_argument(body),
         assignee=str(contract.get("assignee") or "factory-orchestrator"),
         idempotency_key=f"overkill:reconcile:{public_safe_slug(board, fallback='board')}:{digest}",

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4783,9 +4783,11 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         fresh_tasks = [
             task
             for task in fake.tasks.values()
-            if task.get("title") == "Materialize canonical factory card for board" and task.get("status") == "ready"
+            if "stale-terminal replacement" in str(task.get("title") or "") and task.get("status") == "ready"
         ]
         self.assertEqual(len(fresh_tasks), 1)
+        fresh_body = adapter.parse_json_object(str(fresh_tasks[0].get("body") or "{}"))
+        self.assertTrue(fresh_body.get("stale_terminal_remediation_replacement"))
 
     def test_no_idle_creates_materialization_contract_repair_for_internal_missing_inputs(self) -> None:
         fake = FakeHermes()
@@ -6339,6 +6341,7 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             and adapter.parse_json_object(str(task.get("body") or "{}")).get("stale_terminal_remediation_replacement") is True
         ]
         self.assertEqual(len(ready_replacements), 1)
+        self.assertIn("stale-terminal replacement", str(ready_replacements[0].get("title") or ""))
         replacement_body = adapter.parse_json_object(str(ready_replacements[0].get("body") or "{}"))
         self.assertEqual(
             replacement_body["runtime_lineage"]["lineage_type"],


### PR DESCRIPTION
## Summary
- make stale terminal no-idle reconcile replacements use a distinct title as well as distinct body/idempotency digest
- keep lineage metadata marking `stale_terminal_remediation_replacement`
- update regression tests so repeated terminal remediation replay creates a fresh ready replacement instead of silently reusing a done task

## Why
On the live KAXIS board, no-idle reported an idempotent remediation task that was already `done` and did not unblock the queue. A live watchdog process is not progress; when the board is still stuck, the reducer must materialize a fresh replacement task instead of reporting the stale replay.

## Validation
- python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, custody/signing secrets, release, waiver, or positive Receipt Five authority.
