### PR TITLE
Version no-idle stale replacements

### DIFF
--- a/factory/adapters/hermes/live_kanban_adapter.py
+++ b/factory/adapters/hermes/live_kanban_adapter.py
@@ -4751,6 +4751,7 @@ def deterministic_reconcile_task_body(
             "local_state_authority": False,
         }
         task_body["stale_terminal_remediation_replacement"] = True
+        task_body["fresh_replacement_policy_version"] = "v2-distinct-runtime-replacement"
         task_body["supersedes_runtime_task_refs"] = stale_refs
     return task_body
 

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -4788,6 +4788,10 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(len(fresh_tasks), 1)
         fresh_body = adapter.parse_json_object(str(fresh_tasks[0].get("body") or "{}"))
         self.assertTrue(fresh_body.get("stale_terminal_remediation_replacement"))
+        self.assertEqual(
+            fresh_body.get("fresh_replacement_policy_version"),
+            "v2-distinct-runtime-replacement",
+        )
 
     def test_no_idle_creates_materialization_contract_repair_for_internal_missing_inputs(self) -> None:
         fake = FakeHermes()
@@ -6346,6 +6350,10 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(
             replacement_body["runtime_lineage"]["lineage_type"],
             "stale_terminal_remediation_replacement",
+        )
+        self.assertEqual(
+            replacement_body.get("fresh_replacement_policy_version"),
+            "v2-distinct-runtime-replacement",
         )
         self.assertEqual(replacement_body["supersedes_runtime_task_refs"], [stale_id])
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))


### PR DESCRIPTION
## Summary
- add `fresh_replacement_policy_version: v2-distinct-runtime-replacement` to stale terminal no-idle reconcile replacement bodies
- assert the v2 replacement marker in regression tests

## Why
The live KAXIS board had a historical chain of terminal no-idle reconcile cards. Even after PR #612 added distinct replacement titles and lineage, Hermes could still replay old terminal replacements by historical idempotency/body lineage. The replacement body now carries a fresh policy version so the current reducer can break out of the stale historical chain and create a runnable replacement.

## Validation
- python -m pytest tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_no_idle_replaces_more_than_three_stale_reconcile_tasks tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_no_idle_creates_fresh_reconcile_card_when_idempotent_card_is_terminal_stale -q
- python -m pytest tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, signing, custody, release, waiver, or positive Receipt Five authority.
