### PR TITLE
Require runtime contract repair evidence

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -22198,17 +22198,20 @@ def _board_reconcile_task_contract(
     selected_card: dict[str, Any] | None,
     phase_engine: dict[str, Any] | None,
     factory_help: dict[str, Any] | None,
+    repair_target: dict[str, Any] | None = None,
     reason: str,
     assignee: str = "factory-orchestrator",
 ) -> dict[str, Any]:
     next_artifact = str((phase_engine or {}).get("next_required_artifact") or "canonical_factory_card").strip()
-    if plan_action == "repair_domain_brain_route":
+    if plan_action == "repair_board_contract":
+        next_artifact = "kanban_first_runtime_contract_repair_evidence"
+    elif plan_action == "repair_domain_brain_route":
         next_artifact = "solana_ai_kit_domain_brain_route"
     workflow_template_id = FACTORY_KANBAN_WORKFLOW_TEMPLATE_ID
     current_step_key = factory_workflow_step_key(phase_engine)
     card_id = str((selected_card or {}).get("card_id") or "board").strip() or "board"
     title_action = {
-        "repair_board_contract": "Materialize canonical factory card",
+        "repair_board_contract": "Repair Kanban-first runtime contract",
         "repair_declared_artifacts": "Repair missing declared artifacts",
         "create_next_artifact_task": f"Materialize {next_artifact}",
         "repair_domain_brain_route": "Materialize Solana AI Kit route",
@@ -22217,6 +22220,28 @@ def _board_reconcile_task_contract(
     }.get(plan_action, "Reconcile factory board")
     if plan_action == "repair_declared_artifacts":
         next_artifact = "declared_artifact_readback_repair"
+    allowed_actions = [
+        "inspect Hermes board and durable artifacts",
+        f"create or repair only {next_artifact}",
+        "record fresh evidence or a bounded blocker",
+        "leave downstream phases frozen until factory_phase_engine recomputes the frontier",
+    ]
+    forbidden_actions = [
+        "choose a later phase from title, chat, memory, prose or declared phase alone",
+        "ask for a human gate when phase_engine.human_gate_allowed is false",
+        "approve or waive human gates",
+        "start implementation, deploy, release, spend funds or touch production",
+    ]
+    if plan_action == "repair_board_contract":
+        allowed_actions = [
+            "inspect the exact blocked_reasons and selected repair_target",
+            "repair missing workflow_template_id/current_step_key/kanban_workflow_binding, parent edges, phase children, profile-skill compatibility, or runtime contract metadata named by blocked_reasons",
+            "write blocker-reducing repair evidence that names each before/after field or records a bounded blocker if a field cannot be repaired safely",
+            "rerun no-idle/reconcile after repair so progress is measured by reduced blockers or promoted runnable work",
+        ]
+        forbidden_actions.append(
+            "complete with canonical_factory_card.json/markdown, receipts, hashes, or summaries only while blocked_reasons remain unreduced"
+        )
     return {
         "title": f"{title_action} for {card_id}",
         "assignee": assignee,
@@ -22242,18 +22267,10 @@ def _board_reconcile_task_contract(
             "runtime_authority": "hermes_kanban",
             "local_state_authority": False,
             "agent_may_choose_phase": False,
-            "allowed_actions": [
-                "inspect Hermes board and durable artifacts",
-                f"create or repair only {next_artifact}",
-                "record fresh evidence or a bounded blocker",
-                "leave downstream phases frozen until factory_phase_engine recomputes the frontier",
-            ],
-            "forbidden_actions": [
-                "choose a later phase from title, chat, memory, prose or declared phase alone",
-                "ask for a human gate when phase_engine.human_gate_allowed is false",
-                "approve or waive human gates",
-                "start implementation, deploy, release, spend funds or touch production",
-            ],
+            "repair_target": repair_target,
+            "repair_blocked_reasons": [reason] if reason else [],
+            "allowed_actions": allowed_actions,
+            "forbidden_actions": forbidden_actions,
             "native_dispatch_required_next": True,
         },
     }
@@ -22334,6 +22351,7 @@ def build_board_reconcile_plan(
             board=board,
             selected_card=selected_card,
             phase_engine=phase_engine,
+            repair_target=selected_ref,
             factory_help=factory_help,
             reason=reason,
             assignee="factory-orchestrator",

--- a/factory/tests/test_factory_board_reconciler.py
+++ b/factory/tests/test_factory_board_reconciler.py
@@ -280,7 +280,11 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertTrue(plan["create_task_allowed"])
         self.assertEqual(plan["create_task_contract"]["workflow_template_id"], "overkill-vfinal")
         self.assertEqual(plan["create_task_contract"]["current_step_key"], "F1-intake")
-        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "canonical_factory_card")
+        body = plan["create_task_contract"]["body"]
+        self.assertEqual(body["required_output"], "kanban_first_runtime_contract_repair_evidence")
+        self.assertTrue(
+            any("canonical_factory_card" in item and "blocked_reasons remain unreduced" in item for item in body["forbidden_actions"])
+        )
         self.assertFalse(plan["create_task_contract"]["body"]["agent_may_choose_phase"])
         self.assertFalse(plan["human_gate_required"])
 
@@ -383,7 +387,11 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertTrue(plan["create_task_allowed"])
         self.assertFalse(plan["human_gate_required"])
         self.assertFalse(plan["user_decision_required"])
-        self.assertEqual(plan["create_task_contract"]["body"]["required_output"], "canonical_factory_card")
+        body = plan["create_task_contract"]["body"]
+        self.assertEqual(body["required_output"], "kanban_first_runtime_contract_repair_evidence")
+        self.assertTrue(
+            any("canonical_factory_card" in item and "blocked_reasons remain unreduced" in item for item in body["forbidden_actions"])
+        )
         self.assertTrue(any("bypassed Kanban-first adapter" in item for item in plan["blocked_reasons"]))
         self.assertTrue(any("no native phase children" in item for item in plan["blocked_reasons"]))
         self.assertTrue(any("overkill-factory-product-intake" in item for item in plan["blocked_reasons"]))

--- a/factory/tests/test_hermes_live_kanban_adapter.py
+++ b/factory/tests/test_hermes_live_kanban_adapter.py
@@ -6246,12 +6246,16 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
         self.assertEqual(created_task["status"], "ready")
         body = json.loads(str(created_task["body"]))
         self.assertEqual(body["plan_action"], "repair_board_contract")
+        self.assertEqual(body["required_output"], "kanban_first_runtime_contract_repair_evidence")
         self.assertTrue(body["native_dispatch_required_next"])
         self.assertFalse(body["agent_may_choose_phase"])
         self.assertIn("approve or waive human gates", body["forbidden_actions"])
         self.assertIn(
             "choose a later phase from title, chat, memory, prose or declared phase alone",
             body["forbidden_actions"],
+        )
+        self.assertTrue(
+            any("canonical_factory_card" in item and "blocked_reasons remain unreduced" in item for item in body["forbidden_actions"])
         )
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
@@ -6287,6 +6291,11 @@ class HermesLiveKanbanAdapterTest(unittest.TestCase):
             if json.loads(str(task.get("body") or "{}")).get("marker") == "factory_deterministic_reconcile"
         )
         self.assertEqual(created_task["status"], "ready")
+        body = json.loads(str(created_task["body"]))
+        self.assertEqual(body["required_output"], "kanban_first_runtime_contract_repair_evidence")
+        self.assertTrue(
+            any("canonical_factory_card" in item and "blocked_reasons remain unreduced" in item for item in body["forbidden_actions"])
+        )
         self.assertFalse(any(len(call) >= 5 and call[4] == "dispatch" for call in fake.calls))
 
     def test_no_idle_creates_fresh_reconcile_card_when_idempotent_card_is_terminal_stale(self) -> None:


### PR DESCRIPTION
## Summary
- change `repair_board_contract` from another canonical-card materialization into `kanban_first_runtime_contract_repair_evidence`
- require the repair task to target blocker-reducing runtime contract fixes: workflow binding, step key, parent/phase children, profile/skill compatibility, or runtime metadata
- explicitly forbid completing with only `canonical_factory_card` JSON/Markdown, receipts, hashes, or summaries while blockers remain unreduced
- wire normalized `repair_target` into the reconcile contract
- update board reconciler and no-idle regressions

## Why
The live KAXIS board proved that stale-remediation replacement was fixed, but the next loop was process-only: a fresh replacement produced another canonical card and the board stayed at the same blocked/todo counts. A guard running is not progress; generic board-contract repair must demand blocker-reducing runtime repair evidence.

## Validation
- python -m py_compile scripts/factoryctl.py adapters/hermes/live_kanban_adapter.py
- python -m pytest tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q
- python3 factory/scripts/validate_public_json_artifacts.py
- python3 factory/scripts/public_safety_scan.py
- python3 factory/scripts/secret_safety_scan.py
- git diff --check

## Safety boundary
No production, Mainnet, funds, signing, custody, release, waiver, or positive Receipt Five authority.
