### PR TITLE
Ignore non-factory unbound blockers in phase lock

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -21418,6 +21418,8 @@ def board_reconcile_active_phase_blockers(rows: dict[str, list[dict[str, Any]]])
     blocked_items: list[tuple[dict[str, Any], str, int]] = []
     for task in rows.get("blocked", []):
         phase_id = structured_phase_id_from_task(task)
+        if not phase_id and not _looks_like_factory_runtime_task(task):
+            continue
         blocked_items.append((task, phase_id, factory_phase_rank(phase_id)))
 
     blockers: list[str] = []

--- a/factory/tests/test_factory_board_reconciler.py
+++ b/factory/tests/test_factory_board_reconciler.py
@@ -589,6 +589,38 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertFalse(plan["native_dispatch_required_next"])
         self.assertTrue(any("running" in item and "F4" in item and "F2" in item for item in plan["blocked_reasons"]))
 
+    def test_active_phase_ignores_unbound_non_factory_blocked_work(self) -> None:
+        snapshot = {
+            "rows": {
+                "running": [
+                    {
+                        "id": "task-f1-running",
+                        "status": "running",
+                        "title": "Repair factory materialization contracts",
+                        "current_step_key": "F1-intake",
+                        "created_by": "overkill-factory-no-idle",
+                    }
+                ],
+                "blocked": [
+                    {
+                        "id": "task-human-input",
+                        "status": "blocked",
+                        "title": "Define unrelated implementation contract",
+                        "assignee": "agent-runtime-builder",
+                        "created_by": "auto-decomposer",
+                        "body": "waiting for a non-factory input",
+                    }
+                ],
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        self.assertEqual(plan["plan_action"], "observe_running")
+        self.assertFalse(plan["native_dispatch_required_next"])
+        self.assertFalse(plan["blocked_reasons"])
+
     def test_phase_engine_runtime_strict_rejects_template_scaffold_artifacts(self) -> None:
         card = load_vfinal_card()
 


### PR DESCRIPTION
## Summary
- ignores unbound non-factory blocked work when checking active factory phase invariants
- keeps factory-owned/runtime-like unbound blockers strict
- adds a regression proving active factory work is not stopped by unrelated non-factory blocked work without phase binding

## Why
The live KAXIS board had progressed past stale/canonical repair loops, but no-idle still over-classified generic blocked work without workflow metadata as a phase-invariant violation. That kept routing into meta-repair instead of letting the board reach the real blocker frontier.

## Validation
- `pytest tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q` → 232 passed, 5 subtests passed
- `python3 factory/scripts/validate_public_json_artifacts.py` → OK
- `python3 factory/scripts/public_safety_scan.py` → OK
- `python3 factory/scripts/secret_safety_scan.py` → OK
- `git diff --check` → OK
