### PR TITLE
Ignore omitted terminal history in board reconcile

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -21316,7 +21316,7 @@ def board_reconcile_runtime_contract_blockers(
     selected_ref: dict[str, Any] | None = None
     for status, items in rows.items():
         normalized_status = str(status or "").strip().lower()
-        if normalized_status in TERMINAL_BOARD_STATUSES:
+        if normalized_status in TERMINAL_BOARD_STATUSES or normalized_status.startswith("done_"):
             continue
         for task in items:
             task_ref = _task_public_ref(task)

--- a/factory/tests/test_factory_board_reconciler.py
+++ b/factory/tests/test_factory_board_reconciler.py
@@ -621,6 +621,37 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertFalse(plan["native_dispatch_required_next"])
         self.assertFalse(plan["blocked_reasons"])
 
+    def test_reconcile_ignores_terminal_history_omitted_from_enrichment(self) -> None:
+        snapshot = {
+            "rows": {
+                "done_omitted_from_enrichment": [
+                    {
+                        "id": "old-done-repair",
+                        "status": "done",
+                        "title": "Repair F15 blocked work-unit materialization contracts",
+                        "assignee": "factory-orchestrator",
+                        "created_by": "factory-no-idle-repair",
+                        "skills": ["kanban-workflows"],
+                    }
+                ],
+                "todo": [
+                    {
+                        "id": "task-f24",
+                        "status": "todo",
+                        "title": "F24 - Release ou bloqueio",
+                        "current_step_key": "F24-release-or-block",
+                    }
+                ],
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertEqual(factoryctl.validate_board_reconcile_plan(plan), [])
+        serialized_plan = json.dumps(plan, sort_keys=True)
+        self.assertNotIn("skill(s) not allowed", serialized_plan)
+        self.assertNotIn("old-done-repair", serialized_plan)
+
     def test_phase_engine_runtime_strict_rejects_template_scaffold_artifacts(self) -> None:
         card = load_vfinal_card()
 


### PR DESCRIPTION
## Summary
- treats `done_omitted_from_enrichment` rows as terminal history for runtime-contract reconciliation
- prevents old completed tasks with stale/invalid skill refs from forcing `repair_board_contract`
- adds regression coverage so omitted terminal history cannot be selected as the contract-repair target

## Why
The live KAXIS board had moved past false phase-lock blockers, but older completed repair/review tasks omitted from enrichment still carried obsolete skill refs. Those terminal history rows were being treated as active board-contract violations.

## Validation
- `pytest tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q` → 233 passed, 5 subtests passed
- `python3 factory/scripts/validate_public_json_artifacts.py` → OK
- `python3 factory/scripts/public_safety_scan.py` → OK
- `python3 factory/scripts/secret_safety_scan.py` → OK
- `git diff --check` → OK

## Live readback
With this patch, KAXIS no-idle advances from `repair_board_contract` to the next real frontier: `repair_declared_artifacts` for missing declared artifacts.
