### PR TITLE
fix: address doctor public safety QA blockers

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -3036,7 +3036,7 @@ def build_doctor_report(hermes_home: Path | None = None) -> dict[str, Any]:
             "hermes_runtime_optional",
             "PASS" if hermes_configured else "WARN",
             (
-                f"Hermes home detected at {hermes_path}."
+                "Hermes home detected at public-safe local runtime ref."
                 if hermes_configured
                 else "Hermes runtime was not checked. Local factory validation can run before Hermes integration."
             ),

--- a/factory/scripts/public_safety_scan.py
+++ b/factory/scripts/public_safety_scan.py
@@ -174,7 +174,7 @@ def is_text_rel(rel: str) -> bool:
         return False
     if path.suffix.lower() in SKIP_SUFFIXES:
         return False
-    if rel == "scripts/public_safety_scan.py":
+    if rel == "scripts/public_safety_scan.py" or rel.endswith("/scripts/public_safety_scan.py"):
         return False
     return True
 

--- a/factory/tests/test_operator_experience.py
+++ b/factory/tests/test_operator_experience.py
@@ -549,6 +549,21 @@ class OperatorExperienceTest(unittest.TestCase):
         deferred = next(check for check in payload["checks"] if check["id"] == "hermes_e2e_deferred")
         self.assertEqual(deferred["status"], "INFO")
 
+    def test_doctor_redacts_hermes_home_path_from_json_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir) / "private-hermes-home"
+            hermes_home.mkdir()
+
+            result = run_factoryctl("doctor", "--json", "--hermes-home", str(hermes_home))
+            payload = json.loads(result.stdout)
+            summary_text = json.dumps(payload, sort_keys=True)
+
+        self.assertEqual(payload["result"], "PASS")
+        runtime_check = next(check for check in payload["checks"] if check["id"] == "hermes_runtime_optional")
+        self.assertEqual(runtime_check["status"], "PASS")
+        self.assertIn("public-safe local runtime ref", runtime_check["summary"])
+        self.assertNotIn(str(hermes_home), summary_text)
+
     def test_run_minimal_uses_factoryctl_entrypoint(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)

--- a/factory/tests/test_public_safety_scan.py
+++ b/factory/tests/test_public_safety_scan.py
@@ -118,6 +118,10 @@ class PublicSafetyScanTest(unittest.TestCase):
         self.assertFalse(public_safety_scan.is_text_rel("site/index.html"))
         self.assertFalse(public_safety_scan.is_binary_asset_rel("site/webfonts/fa-solid-900.woff2"))
 
+    def test_git_ref_scan_skips_public_safety_scanner_itself_from_any_repo_root(self) -> None:
+        self.assertFalse(public_safety_scan.is_text_rel("scripts/public_safety_scan.py"))
+        self.assertFalse(public_safety_scan.is_text_rel("factory/scripts/public_safety_scan.py"))
+
     def test_worktree_scan_checks_all_sibling_files_and_skips_tmp(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- fixes public_safety_scan --git-ref HEAD false positive on the scanner's own pattern definitions when repo root is one level above factory/
- redacts the Hermes home path from factoryctl doctor JSON summaries
- adds regression coverage for both QA blockers found by t_01d6d10b

## Validation
- `python3 scripts/public_safety_scan.py --git-ref HEAD --summary-json /tmp/public_safety_after_fix.json`
- `python3 scripts/factoryctl.py doctor --json --hermes-home "$HOME/.hermes"`
- `python3 -m unittest tests.test_public_safety_scan tests.test_operator_experience tests.test_hermes_environment_preflight -v`
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_public_safety_scan.py tests/test_operator_experience.py tests/test_hermes_environment_preflight.py tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q`
- `python3 scripts/secret_safety_scan.py --summary-json .tmp/secret-safety-doctor-public-safety-fix.json`
- `git diff --check`

Kanban: addresses the blockers reported by `t_01d6d10b`.
