### PR TITLE
fix: skip generated ruff cache in public safety scan

### DIFF
--- a/factory/scripts/public_safety_scan.py
+++ b/factory/scripts/public_safety_scan.py
@@ -31,6 +31,7 @@ SKIP_PARTS = {
     ".git",
     ".tmp",
     ".pytest_cache",
+    ".ruff_cache",
     ".venv",
     ".worktrees",
     "__pycache__",

--- a/factory/tests/test_public_safety_scan.py
+++ b/factory/tests/test_public_safety_scan.py
@@ -115,12 +115,19 @@ class PublicSafetyScanTest(unittest.TestCase):
     def test_generated_local_build_metadata_is_not_scanned(self) -> None:
         self.assertFalse(public_safety_scan.is_text_rel("overkill_factory.egg-info/PKG-INFO"))
         self.assertFalse(public_safety_scan.is_text_rel(".tmp/quickstart-result.json"))
+        self.assertFalse(public_safety_scan.is_text_rel(".ruff_cache/0.15.10/cache-entry"))
         self.assertFalse(public_safety_scan.is_text_rel("site/index.html"))
         self.assertFalse(public_safety_scan.is_binary_asset_rel("site/webfonts/fa-solid-900.woff2"))
 
     def test_git_ref_scan_skips_public_safety_scanner_itself_from_any_repo_root(self) -> None:
         self.assertFalse(public_safety_scan.is_text_rel("scripts/public_safety_scan.py"))
         self.assertFalse(public_safety_scan.is_text_rel("factory/scripts/public_safety_scan.py"))
+
+    def test_scanner_exemption_does_not_hide_other_scripts(self) -> None:
+        findings = public_safety_scan.scan_text("factory/scripts/publish_example.py", f"private {PRIVATE_MARKER}")
+
+        self.assertTrue(findings)
+        self.assertIn("private_product_marker", findings[0])
 
     def test_worktree_scan_checks_all_sibling_files_and_skips_tmp(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- excludes generated `.ruff_cache` entries from public-safety worktree scans
- adds regression coverage proving the public-safety scanner self-exemption does not hide private markers in other scripts

## Validation
- `python3 -m unittest tests.test_public_safety_scan -v`
- `python3 scripts/public_safety_scan.py --git-ref HEAD --summary-json /tmp/public_safety_ruff_delta_head.json`
- `python3 scripts/public_safety_scan.py --summary-json /tmp/public_safety_ruff_delta_worktree.json`
- `python3 scripts/secret_safety_scan.py --summary-json .tmp/secret-safety-ruff-cache-scan.json`
- `git diff --check`

Kanban: consumes the remaining useful review delta from `t_fc17544a`; main already contains the main QA blocker fixes from #619.
