### PR TITLE
fix: stop duplicate declared artifact repair loops

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -21625,12 +21625,33 @@ def board_reconcile_ready_dispatch_blockers(
     return sorted(set(blockers)), selected_repair_card, selected_repair_ref, selected_repair_action
 
 
+def _declared_artifact_readback_repair_target_fingerprints(done: list[dict[str, Any]]) -> set[str]:
+    fingerprints: set[str] = set()
+    for task in done:
+        for payload in _task_payload_objects(task):
+            candidates: list[dict[str, Any]] = []
+            if isinstance(payload.get("orchestration_result"), dict):
+                candidates.append(payload["orchestration_result"])
+            if isinstance(payload.get("repair_target"), dict):
+                candidates.append(payload["repair_target"])
+            candidates.append(payload)
+            for candidate in candidates:
+                output = str(candidate.get("required_output") or candidate.get("packet_type") or "").strip()
+                if output != "declared_artifact_readback_repair":
+                    continue
+                fingerprint = str(candidate.get("target_fingerprint") or "").strip()
+                if fingerprint:
+                    fingerprints.add(fingerprint)
+    return fingerprints
+
+
 def board_reconcile_missing_declared_artifact_blockers(
     rows: dict[str, list[dict[str, Any]]],
 ) -> tuple[list[str], dict[str, Any] | None]:
     blockers: list[str] = []
     selected_ref: dict[str, Any] | None = None
     done = rows.get("done", [])
+    repaired_fingerprints = _declared_artifact_readback_repair_target_fingerprints(done)
     architecture_review_keys = [
         _task_temporal_key(review_task, review_index)
         for review_index, review_task in enumerate(done)
@@ -21654,6 +21675,8 @@ def board_reconcile_missing_declared_artifact_blockers(
         target_fingerprint = hashlib.sha256(
             json.dumps(fingerprint_payload, sort_keys=True, default=str).encode("utf-8")
         ).hexdigest()
+        if target_fingerprint in repaired_fingerprints:
+            continue
         names = sorted(
             {
                 str(item.get("artifact_name") or "declared-artifact").strip()

--- a/factory/tests/test_factory_board_reconciler.py
+++ b/factory/tests/test_factory_board_reconciler.py
@@ -652,6 +652,55 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertNotIn("skill(s) not allowed", serialized_plan)
         self.assertNotIn("old-done-repair", serialized_plan)
 
+    def test_declared_artifact_repair_for_same_fingerprint_stops_duplicate_repair_loop(self) -> None:
+        target = {
+            "id": "fixture-rel002",
+            "status": "done",
+            "title": "REL-002 non-production executable package/local smoke proof",
+            "assignee": "test-automation-builder",
+            "missing_declared_artifacts": [
+                {"artifact_name": "rel002_local_smoke_packet_fixture_rel002.json"},
+                {"artifact_name": "rel002_local_smoke_packet_fixture_rel002.md"},
+            ],
+        }
+        fingerprint_payload = {
+            "task_id": target["id"],
+            "title": target["title"],
+            "assignee": target["assignee"],
+            "missing_declared_artifacts": target["missing_declared_artifacts"],
+        }
+        target_fingerprint = factoryctl.hashlib.sha256(
+            json.dumps(fingerprint_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        repair = {
+            "id": "repair-fixture",
+            "status": "done",
+            "title": "Repair missing declared artifacts for board",
+            "assignee": "factory-orchestrator",
+            "metadata": json.dumps(
+                {
+                    "orchestration_result": {
+                        "required_output": "declared_artifact_readback_repair",
+                        "target_task_ref": "fixture-rel002",
+                        "target_fingerprint": target_fingerprint,
+                        "missing_artifact_names": [
+                            "rel002_local_smoke_packet_fixture_rel002.json",
+                            "rel002_local_smoke_packet_fixture_rel002.md",
+                        ],
+                        "readback_verdict": "FAIL_DECLARED_ARTIFACTS_ABSENT",
+                        "status": "READBACK_REPAIR_MATERIALIZED__NO_GATE_APPROVED__TARGET_BYTES_ABSENT",
+                    }
+                }
+            ),
+        }
+
+        blockers, selected = factoryctl.board_reconcile_missing_declared_artifact_blockers(
+            {"done": [target, repair]}
+        )
+
+        self.assertEqual(blockers, [])
+        self.assertIsNone(selected)
+
     def test_phase_engine_runtime_strict_rejects_template_scaffold_artifacts(self) -> None:
         card = load_vfinal_card()
 


### PR DESCRIPTION
## Summary
- prevents no-idle from recreating the same declared-artifact readback repair after a terminal repair already recorded the target fingerprint
- adds a regression for the REL-002-style loop where repair output proves bytes are absent but no-idle keeps opening identical repair cards

## Validation
- RED observed before implementation: `pytest tests/test_factory_board_reconciler.py::FactoryBoardReconcilerTest::test_declared_artifact_repair_for_same_fingerprint_stops_duplicate_repair_loop -q`
- GREEN: same test passes
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q`
- `python3 factory/scripts/validate_public_json_artifacts.py`
- `python3 factory/scripts/public_safety_scan.py --git-ref HEAD --summary-json /tmp/public_safety_noidle_loop_fix_head.json`
- `python3 factory/scripts/secret_safety_scan.py --summary-json factory/.tmp/secret-safety-noidle-loop-fix.json`
- `git diff --check`

Kanban: stops duplicate repair loop after `t_6d73a2f7`; next reducer pass should not create another repair for the same REL-002 target fingerprint.
