### PR TITLE
fix: ignore readback repair tasks as missing artifact targets

### DIFF
--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -21625,6 +21625,19 @@ def board_reconcile_ready_dispatch_blockers(
     return sorted(set(blockers)), selected_repair_card, selected_repair_ref, selected_repair_action
 
 
+def _task_is_declared_artifact_readback_repair(task: dict[str, Any]) -> bool:
+    for payload in _task_payload_objects(task):
+        candidates: list[dict[str, Any]] = []
+        if isinstance(payload.get("orchestration_result"), dict):
+            candidates.append(payload["orchestration_result"])
+        candidates.append(payload)
+        for candidate in candidates:
+            output = str(candidate.get("required_output") or candidate.get("packet_type") or "").strip()
+            if output == "declared_artifact_readback_repair":
+                return True
+    return False
+
+
 def _declared_artifact_readback_repair_target_fingerprints(done: list[dict[str, Any]]) -> set[str]:
     fingerprints: set[str] = set()
     for task in done:
@@ -21658,6 +21671,8 @@ def board_reconcile_missing_declared_artifact_blockers(
         if _task_has_architecture_review(review_task)
     ]
     for task_index, task in enumerate(done):
+        if _task_is_declared_artifact_readback_repair(task):
+            continue
         if _task_has_failed_architecture_review(task):
             continue
         task_key = _task_temporal_key(task, task_index)

--- a/factory/tests/test_factory_board_reconciler.py
+++ b/factory/tests/test_factory_board_reconciler.py
@@ -701,6 +701,34 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertEqual(blockers, [])
         self.assertIsNone(selected)
 
+    def test_declared_artifact_readback_repair_tasks_are_not_repaired_again(self) -> None:
+        repair = {
+            "id": "repair-fixture",
+            "status": "done",
+            "title": "Repair missing declared artifacts for board",
+            "assignee": "factory-orchestrator",
+            "missing_declared_artifacts": [
+                {"artifact_name": "declared_artifact_readback_repair_fixture.md"},
+            ],
+            "metadata": json.dumps(
+                {
+                    "orchestration_result": {
+                        "packet_type": "declared_artifact_readback_repair",
+                        "target_task_ref": "fixture-rel002",
+                        "target_fingerprint": "abc123",
+                        "readback_verdict": "FAIL_DECLARED_ARTIFACTS_ABSENT",
+                    }
+                }
+            ),
+        }
+
+        blockers, selected = factoryctl.board_reconcile_missing_declared_artifact_blockers(
+            {"done": [repair]}
+        )
+
+        self.assertEqual(blockers, [])
+        self.assertIsNone(selected)
+
     def test_phase_engine_runtime_strict_rejects_template_scaffold_artifacts(self) -> None:
         card = load_vfinal_card()
 


### PR DESCRIPTION
## Summary
- prevents done `declared_artifact_readback_repair` tasks from becoming new missing-artifact repair targets themselves
- adds a regression for the loop where no-idle targets a repair task's own missing readback artifact instead of returning to the real board frontier

## Validation
- RED observed before implementation: `pytest tests/test_factory_board_reconciler.py::FactoryBoardReconcilerTest::test_declared_artifact_readback_repair_tasks_are_not_repaired_again -q`
- GREEN: same test passes
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py tests/test_factory_no_idle_watchdog.py -q`
- `python3 scripts/public_safety_scan.py --summary-json /tmp/public_safety_noidle_loop_fix2_worktree.json`
- `python3 scripts/secret_safety_scan.py --summary-json .tmp/secret-safety-noidle-loop-fix-3.json`
- `git diff --check`

Kanban: stops the `t_2b22b33d`-class self-repair loop after `t_6d73a2f7`/`t_59259fc1` terminal readback repairs.
