### PR TITLE
fix: stop legacy artifact history from preempting live frontier

### DIFF
--- a/factory/schemas/factory-board-reconcile-plan.schema.json
+++ b/factory/schemas/factory-board-reconcile-plan.schema.json
@@ -60,6 +60,26 @@
     },
     "reason": { "type": "string", "minLength": 1 },
     "blocked_reasons": { "type": "array", "items": { "type": "string" } },
+    "legacy_missing_declared_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["task_ref", "status", "title", "assignee", "selection_reason"],
+        "properties": {
+          "task_ref": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "assignee": { "type": "string" },
+          "selection_reason": { "type": "string", "minLength": 1 },
+          "target_fingerprint": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "missing_artifact_names": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "selected_card": {
       "type": ["object", "null"],
       "required": ["task_ref", "status", "title", "assignee", "selection_reason"],

--- a/factory/scripts/factoryctl.py
+++ b/factory/scripts/factoryctl.py
@@ -22494,6 +22494,11 @@ def build_board_reconcile_plan(
     ) = board_reconcile_ready_dispatch_blockers(rows)
     runtime_contract_blockers, runtime_contract_ref = board_reconcile_runtime_contract_blockers(rows)
     missing_artifact_blockers, missing_artifact_ref = board_reconcile_missing_declared_artifact_blockers(rows)
+    legacy_missing_declared_artifacts = (
+        [missing_artifact_ref]
+        if unfinished and missing_artifact_ref is not None and missing_artifact_blockers
+        else []
+    )
     canonical_frontier_task, canonical_frontier_ref, canonical_frontier_reasons = (
         select_reconciled_canonical_frontier_task(rows)
     )
@@ -22598,7 +22603,7 @@ def build_board_reconcile_plan(
             assignee=next_owner,
         )
         native_dispatch_required_next = True
-    elif missing_artifact_blockers:
+    elif missing_artifact_blockers and not unfinished:
         selected_ref = missing_artifact_ref
         plan_action = "repair_declared_artifacts"
         reason = "completed Hermes work declared local artifacts that are missing from the runtime"
@@ -22846,6 +22851,7 @@ def build_board_reconcile_plan(
             "plan_action": plan_action,
             "reason": reason,
             "blocked_reasons": sorted(set(blocked_reasons)),
+            "legacy_missing_declared_artifacts": legacy_missing_declared_artifacts,
             "selected_card": selected_ref,
             "phase_engine": phase_engine,
             "factory_help": factory_help,

--- a/factory/tests/test_factory_board_reconciler.py
+++ b/factory/tests/test_factory_board_reconciler.py
@@ -729,6 +729,52 @@ class FactoryBoardReconcilerTest(unittest.TestCase):
         self.assertEqual(blockers, [])
         self.assertIsNone(selected)
 
+
+
+    def test_legacy_missing_declared_artifacts_do_not_preempt_live_frontier(self) -> None:
+        snapshot = {
+            "rows": {
+                "done": [
+                    {
+                        "id": "legacy-evidence",
+                        "status": "done",
+                        "title": "F16 legacy evidence packet",
+                        "assignee": "evidence-reconciler",
+                        "missing_declared_artifacts": [
+                            {"artifact_name": "legacy_f16_packet.json"},
+                        ],
+                    }
+                ],
+                "blocked": [
+                    {
+                        "id": "phase-f23",
+                        "status": "blocked",
+                        "title": "F23 - Operacoes de producao",
+                        "assignee": "release-ops-worker",
+                        "workflow_template_id": "overkill-vfinal",
+                        "current_step_key": "F23-production-operations",
+                    }
+                ],
+                "todo": [
+                    {
+                        "id": "phase-f24",
+                        "status": "todo",
+                        "title": "F24 - Release ou bloqueio",
+                        "workflow_template_id": "overkill-vfinal",
+                        "current_step_key": "F24-release-or-block",
+                    }
+                ],
+            }
+        }
+
+        plan = factoryctl.build_board_reconcile_plan(snapshot, board="product-alpha")
+
+        self.assertNotEqual(plan["plan_action"], "repair_declared_artifacts")
+        self.assertFalse(plan["create_task_allowed"])
+        self.assertIsNone(plan["create_task_contract"])
+        self.assertIn("legacy_missing_declared_artifacts", plan)
+        self.assertEqual(plan["legacy_missing_declared_artifacts"][0]["task_ref"], "legacy-evidence")
+
     def test_phase_engine_runtime_strict_rejects_template_scaffold_artifacts(self) -> None:
         card = load_vfinal_card()
 


### PR DESCRIPTION
## Summary
- records legacy missing declared artifacts on reconcile plans without creating another generic repair when live F23/F24 frontier work exists
- keeps terminal-only boards eligible for declared artifact repair, but stops historic done-task artifacts from preempting active dependency/frontier work
- extends the reconcile plan schema and adds a regression for F23/F24-style live frontier state

## Validation
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_factory_board_reconciler.py::FactoryBoardReconcilerTest::test_legacy_missing_declared_artifacts_do_not_preempt_live_frontier tests/test_factory_board_reconciler.py::FactoryBoardReconcilerTest::test_declared_artifact_repair_for_same_fingerprint_stops_duplicate_repair_loop tests/test_factory_board_reconciler.py::FactoryBoardReconcilerTest::test_declared_artifact_readback_repair_tasks_are_not_repaired_again -q`
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/test_factory_board_reconciler.py tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_no_idle_repairs_done_task_with_missing_declared_artifacts tests/test_hermes_live_kanban_adapter.py::HermesLiveKanbanAdapterTest::test_no_idle_reports_dependency_gated_todo_without_generic_remediation tests/test_factory_no_idle_watchdog.py -q`
- `python3 scripts/validate_public_json_artifacts.py`
- `python3 scripts/public_safety_scan.py --summary-json /tmp/public_safety_artifact_root_fix_final.json`
- `python3 scripts/secret_safety_scan.py --summary-json .tmp/secret-safety-artifact-root-fix-final.json`

Live KAXIS proof before PR: rerunning no-idle after this patch did not increase the generic `Repair missing declared artifacts for board` count (22 before, 22 after), and instead created targeted package/dependency repair `t_c8df3f44`.